### PR TITLE
Insert Quantize Op On Dtype Mismatch

### DIFF
--- a/test/quantization/pass/test_insert_quantize_on_dtype_mismatch.py
+++ b/test/quantization/pass/test_insert_quantize_on_dtype_mismatch.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from tico.experimental.quantization.passes.insert_quantize_on_dtype_mismatch import (
+    InsertQuantizeOnDtypeMismatch,
+)
+from tico.passes.convert_view_to_reshape import ConvertViewToReshape
+from tico.serialize.quant_param import QPARAM_KEY, QuantParam
+
+from test.modules.op.bmm import SimpleBatchMatMul
+from test.modules.op.linear import SimpleLinear
+from test.modules.op.mul import SimpleMulWithTensor
+from test.modules.op.permute import SimplePermute
+
+
+class InsertQuantizeOnDtypeMismatchTest(unittest.TestCase):
+    """
+    This class runs a test for InsertQuantizeOpOnDtypeMismatch pass
+    - Set up a network with target_op and dtype of input. Target node's
+      dtype is set differently from input dtype
+    - After the pass runs, node's dtype must be the same with its input
+
+    How to use?
+
+    Example)
+
+    class DummyTest(InsertQuantizeOpOnDtypeMismatchTest):
+        def test_pass(self):
+            self.setup(DummyNet(), target_op=torch.ops.aten.reshape.default, dtype="uint8")
+            self.run_test()
+    """
+
+    initialized: bool = False
+
+    def setup(self, mod: torch.nn.Module, target_op, scale=1.0, zp=0, dtype="uint8"):
+        assert hasattr(mod, "get_example_inputs")
+        self.inputs = mod.get_example_inputs()  # type: ignore[operator]
+        self.scale = scale
+        self.zp = zp
+        self.dtype = dtype
+
+        with torch.no_grad():
+            self.ep = torch.export.export(mod.eval(), self.inputs)
+
+        # This is necessary for testing Reshape on torch 2.5
+        ConvertViewToReshape().call(self.ep)
+
+        # Find target node
+        target_node = None
+        for node in self.ep.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target == target_op:
+                target_node = node
+                break
+
+        assert target_node is not None
+        self.target = target_node
+
+        # Set qparam to all input nodes
+        user_inputs = []
+        for node in self.ep.graph.nodes:
+            if node.op != "placeholder":
+                continue
+            if node.name in self.ep.graph_signature.user_inputs:
+                user_inputs.append(node)
+
+        assert len(user_inputs) > 0
+
+        for user_input in user_inputs:
+            qparam = QuantParam()
+            qparam.scale = [self.scale]
+            qparam.zero_point = [self.zp]
+            qparam.dtype = self.dtype
+
+            user_input.meta[QPARAM_KEY] = qparam
+
+        node_qparam = QuantParam()
+        if self.dtype == "int16":
+            node_qparam.scale = [1.0]
+            node_qparam.zero_point = [0]
+            node_qparam.dtype = "uint8"
+        elif self.dtype == "uint8":
+            node_qparam.scale = [1.0]
+            node_qparam.zero_point = [0]
+            node_qparam.dtype = "int16"
+        else:
+            raise RuntimeError("Unsupported dtype")
+
+        self.target.meta[QPARAM_KEY] = node_qparam
+
+        self.initialized = True
+
+    def run_test(self):
+        # Before pass
+        self.assertNotEqual(self.target.meta[QPARAM_KEY].dtype, self.dtype)
+
+        target_pass = InsertQuantizeOnDtypeMismatch()
+        target_pass.call(self.ep)
+
+        # After pass
+        self.assertEqual(self.target.meta[QPARAM_KEY].dtype, self.dtype)
+
+
+class PermuteTest(InsertQuantizeOnDtypeMismatchTest):
+    def test_i8o16(self):
+        self.setup(SimplePermute(), torch.ops.aten.permute.default, dtype="uint8")
+        self.run_test()
+
+    def test_i16o8(self):
+        self.setup(SimplePermute(), torch.ops.aten.permute.default, dtype="int16")
+        self.run_test()
+
+
+class LinearTest(InsertQuantizeOnDtypeMismatchTest):
+    def test_i8o16(self):
+        self.setup(SimpleLinear(), torch.ops.aten.linear.default, dtype="uint8")
+        self.run_test()
+
+
+class MulTest(InsertQuantizeOnDtypeMismatchTest):
+    def test_i16o8(self):
+        self.setup(SimpleMulWithTensor(), torch.ops.aten.mul.Tensor, dtype="int16")
+        self.run_test()
+
+
+class BMMTest(InsertQuantizeOnDtypeMismatchTest):
+    def test_i16o8(self):
+        self.setup(SimpleBatchMatMul(), torch.ops.aten.bmm.default, dtype="int16")
+        self.run_test()

--- a/tico/experimental/quantization/passes/insert_quantize_on_dtype_mismatch.py
+++ b/tico/experimental/quantization/passes/insert_quantize_on_dtype_mismatch.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.fx
+import copy
+
+import torch
+from torch.export import ExportedProgram
+
+from tico.serialize.quant_param import QPARAM_KEY, QuantParam
+from tico.utils import logging
+from tico.utils.errors import NotYetSupportedError
+from tico.utils.passes import PassBase, PassResult
+from tico.utils.trace_decorators import trace_graph_diff_on_pass
+from tico.utils.utils import set_new_meta_val
+from tico.utils.validate_args_kwargs import (
+    BmmArgs,
+    LinearArgs,
+    MulTensorArgs,
+    PermuteArgs,
+)
+
+
+def _dtype(node: torch.fx.Node) -> str:
+    assert QPARAM_KEY in node.meta
+    return node.meta[QPARAM_KEY].dtype
+
+
+# Convert i16 qparam to u8 qparam
+# scale and zero_point are inferred from i16 qparam
+def _i16_to_u8(qparam: QuantParam) -> QuantParam:
+    # Assume per-tensor quantization
+    assert qparam.scale is not None and len(qparam.scale) == 1
+    assert qparam.dtype == "int16"
+
+    s16_scale = qparam.scale[0]
+    max_ = s16_scale * 32767  # numeric_limits<int16>
+    min_ = -max_
+
+    u8_scale = (max_ - min_) / 255
+    u8_zerop = round(-min_ / u8_scale)
+
+    new_qparam = QuantParam()
+    new_qparam.scale = [u8_scale]
+    new_qparam.zero_point = [u8_zerop]
+    new_qparam.dtype = "uint8"
+
+    return new_qparam
+
+
+# Convert u8 qparam to i16 qparam
+# scale is inferred from u8 qparam
+def _u8_to_i16(qparam: QuantParam) -> QuantParam:
+    # Assume per-tensor quantization
+    assert qparam.scale is not None and len(qparam.scale) == 1
+    assert qparam.zero_point is not None and len(qparam.zero_point) == 1
+    assert qparam.dtype == "uint8"
+
+    u8_scale = qparam.scale[0]
+    u8_zerop = qparam.zero_point[0]
+    max_ = u8_scale * (255 - u8_zerop)
+    min_ = u8_scale * (-u8_zerop)
+
+    abs_max = max([max_, min_], key=abs)
+    s16_scale = abs_max / 32767
+    s16_zerop = 0
+
+    new_qparam = QuantParam()
+    new_qparam.scale = [s16_scale]
+    new_qparam.zero_point = [s16_zerop]
+    new_qparam.dtype = "int16"
+
+    return new_qparam
+
+
+@trace_graph_diff_on_pass
+class InsertQuantizeOnDtypeMismatch(PassBase):
+    """
+    Insert quantize Op in the operators where circle's type inference is violated.
+    Example. FullyConnected
+    [BEFORE]
+      Op (uint8) -  aten.linear.default (int16)
+    [AFTER]
+      Op (uint8) -  aten.linear.default (uint8) - quantized_decomposed.quantize_per_tensor.default (int16)
+    Why is this pass necessary?
+    - For some operators, circle's type inference pass overwrites the input's dtype to
+    the output's dtype. For the above example, fully-connected layer (aten.linear.default)'s
+    output dtype (int16) is updated to the input dtype (uint8), which breaks the semantics.
+    This problem can occur in the tools (ex: circle2circle) that automatically apply type inference.
+    - To resolve the issue, we insert quantize operators not to violate circle's type inference logic.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, exported_program: ExportedProgram) -> PassResult:
+        logger = logging.getLogger(__name__)
+
+        graph_module = exported_program.graph_module
+        graph: torch.fx.Graph = graph_module.graph
+
+        def _insert_quantize_op_before(node, inp):
+            qparam: QuantParam = node.meta[QPARAM_KEY]
+            assert qparam.scale is not None
+            assert qparam.zero_point is not None
+            scale = qparam.scale[0]
+            zerop = qparam.zero_point[0]
+            min_ = qparam.min[0] if qparam.min is not None else 0
+            max_ = qparam.max[0] if qparam.max is not None else 0
+            dtype = getattr(torch, qparam.dtype)
+
+            with graph.inserting_before(node):
+                q_args = (inp, scale, zerop, min_, max_, dtype)
+                quantize = graph.call_function(
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default,
+                    args=q_args,
+                )
+                set_new_meta_val(quantize)
+
+            node.replace_input_with(inp, quantize)
+
+            return quantize
+
+        def _insert_quantize_op_after(node):
+            qparam: QuantParam = node.meta[QPARAM_KEY]
+            assert qparam.scale is not None
+            assert qparam.zero_point is not None
+            scale = qparam.scale[0]
+            zerop = qparam.zero_point[0]
+            min_ = qparam.min[0] if qparam.min is not None else 0
+            max_ = qparam.max[0] if qparam.max is not None else 0
+            dtype = getattr(torch, qparam.dtype)
+            with graph.inserting_after(node):
+                q_args = (node, scale, zerop, min_, max_, dtype)
+                quantize = graph.call_function(
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default,
+                    args=q_args,
+                )
+
+            node.replace_all_uses_with(quantize, propagate_meta=True)
+            quantize.replace_input_with(quantize, node)
+
+            return quantize
+
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target == torch.ops.aten.linear.default:
+                lin_args = LinearArgs(*node.args, **node.kwargs)
+                inp = lin_args.input
+
+                if QPARAM_KEY not in inp.meta:
+                    continue
+
+                if QPARAM_KEY not in node.meta:
+                    continue
+
+                if _dtype(inp) == _dtype(node):
+                    continue
+
+                if _dtype(inp) == "uint8" and _dtype(node) == "int16":
+                    quantize = _insert_quantize_op_after(node)
+
+                    quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
+
+                    # Update node's qparam from i16 to u8
+                    # NOTE This would severely degrade accuracy. It is
+                    # important to mitigate this accuracy drop in backend.
+                    node.meta[QPARAM_KEY] = _i16_to_u8(node.meta[QPARAM_KEY])
+                    logger.debug(
+                        f"quantize_per_tensor.default is inserted after {node.name}."
+                    )
+                else:
+                    raise NotYetSupportedError("Unsupported dtype")
+
+            elif node.target == torch.ops.aten.mul.Tensor:
+                mul_args = MulTensorArgs(*node.args, **node.kwargs)
+                x = mul_args.input
+                y = mul_args.other
+
+                if not isinstance(x, torch.fx.Node):
+                    continue
+                if not isinstance(y, torch.fx.Node):
+                    continue
+
+                if QPARAM_KEY not in x.meta:
+                    continue
+                if QPARAM_KEY not in y.meta:
+                    continue
+                if QPARAM_KEY not in node.meta:
+                    continue
+
+                if _dtype(x) == _dtype(node):
+                    continue
+
+                if _dtype(x) == "int16" and _dtype(node) == "uint8":
+                    quantize = _insert_quantize_op_after(node)
+
+                    quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
+                    node.meta[QPARAM_KEY] = _u8_to_i16(node.meta[QPARAM_KEY])
+                    logger.debug(
+                        f"quantize_per_tensor.default is inserted after {node.name}."
+                    )
+                else:
+                    raise NotYetSupportedError("Unsupported dtype")
+
+            elif node.target == torch.ops.aten.bmm.default:
+                bmm_args = BmmArgs(*node.args, **node.kwargs)
+                x = bmm_args.input
+                y = bmm_args.mat2
+
+                if QPARAM_KEY not in x.meta:
+                    continue
+                if QPARAM_KEY not in y.meta:
+                    continue
+                if QPARAM_KEY not in node.meta:
+                    continue
+
+                if _dtype(x) == _dtype(node):
+                    continue
+
+                if _dtype(x) == "int16" and _dtype(node) == "uint8":
+                    quantize = _insert_quantize_op_after(node)
+
+                    quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
+                    node.meta[QPARAM_KEY] = _u8_to_i16(node.meta[QPARAM_KEY])
+                    logger.debug(
+                        f"quantize_per_tensor.default is inserted after {node.name}."
+                    )
+                else:
+                    raise NotYetSupportedError("Unsupported dtype")
+
+            elif node.target == torch.ops.aten.permute.default:
+                per_args = PermuteArgs(*node.args, **node.kwargs)
+                inp = per_args.input
+
+                if QPARAM_KEY not in inp.meta:
+                    continue
+
+                if QPARAM_KEY not in node.meta:
+                    continue
+
+                if _dtype(inp) == _dtype(node):
+                    continue
+
+                if _dtype(inp) == "int16" and _dtype(node) == "uint8":
+                    # A new Quantize Op (s16 to u8) is inserted before (not after)
+                    # permute Op to reduce tensor size ealier
+                    quantize = _insert_quantize_op_before(node, inp)
+
+                    quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
+                    node.meta[QPARAM_KEY] = _u8_to_i16(node.meta[QPARAM_KEY])
+                    logger.debug(
+                        f"quantize_per_tensor.default is inserted before {node.name}."
+                    )
+                elif _dtype(inp) == "uint8" and _dtype(node) == "int16":
+                    quantize = _insert_quantize_op_after(node)
+
+                    quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
+                    node.meta[QPARAM_KEY] = _i16_to_u8(node.meta[QPARAM_KEY])
+                    logger.debug(
+                        f"quantize_per_tensor.default is inserted after {node.name}."
+                    )
+                else:
+                    raise NotYetSupportedError("Unsupported dtype")
+
+            # TODO Support more ops.
+
+        graph.eliminate_dead_code()
+        graph.lint()
+        graph_module.recompile()
+
+        # Run only once.
+        return PassResult(False)

--- a/tico/experimental/quantization/passes/insert_quantize_on_dtype_mismatch.py
+++ b/tico/experimental/quantization/passes/insert_quantize_on_dtype_mismatch.py
@@ -35,7 +35,7 @@ from tico.utils.validate_args_kwargs import (
 )
 
 
-def _dtype(node: torch.fx.Node) -> str:
+def qparam_dtype(node: torch.fx.Node) -> str:
     assert QPARAM_KEY in node.meta
     return node.meta[QPARAM_KEY].dtype
 
@@ -169,10 +169,10 @@ class InsertQuantizeOnDtypeMismatch(PassBase):
                 if QPARAM_KEY not in node.meta:
                     continue
 
-                if _dtype(inp) == _dtype(node):
+                if qparam_dtype(inp) == qparam_dtype(node):
                     continue
 
-                if _dtype(inp) == "uint8" and _dtype(node) == "int16":
+                if qparam_dtype(inp) == "uint8" and qparam_dtype(node) == "int16":
                     quantize = _insert_quantize_op_after(node)
 
                     quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
@@ -204,10 +204,10 @@ class InsertQuantizeOnDtypeMismatch(PassBase):
                 if QPARAM_KEY not in node.meta:
                     continue
 
-                if _dtype(x) == _dtype(node):
+                if qparam_dtype(x) == qparam_dtype(node):
                     continue
 
-                if _dtype(x) == "int16" and _dtype(node) == "uint8":
+                if qparam_dtype(x) == "int16" and qparam_dtype(node) == "uint8":
                     quantize = _insert_quantize_op_after(node)
 
                     quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
@@ -230,10 +230,10 @@ class InsertQuantizeOnDtypeMismatch(PassBase):
                 if QPARAM_KEY not in node.meta:
                     continue
 
-                if _dtype(x) == _dtype(node):
+                if qparam_dtype(x) == qparam_dtype(node):
                     continue
 
-                if _dtype(x) == "int16" and _dtype(node) == "uint8":
+                if qparam_dtype(x) == "int16" and qparam_dtype(node) == "uint8":
                     quantize = _insert_quantize_op_after(node)
 
                     quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
@@ -254,10 +254,10 @@ class InsertQuantizeOnDtypeMismatch(PassBase):
                 if QPARAM_KEY not in node.meta:
                     continue
 
-                if _dtype(inp) == _dtype(node):
+                if qparam_dtype(inp) == qparam_dtype(node):
                     continue
 
-                if _dtype(inp) == "int16" and _dtype(node) == "uint8":
+                if qparam_dtype(inp) == "int16" and qparam_dtype(node) == "uint8":
                     # A new Quantize Op (s16 to u8) is inserted before (not after)
                     # permute Op to reduce tensor size ealier
                     quantize = _insert_quantize_op_before(node, inp)
@@ -267,7 +267,7 @@ class InsertQuantizeOnDtypeMismatch(PassBase):
                     logger.debug(
                         f"quantize_per_tensor.default is inserted before {node.name}."
                     )
-                elif _dtype(inp) == "uint8" and _dtype(node) == "int16":
+                elif qparam_dtype(inp) == "uint8" and qparam_dtype(node) == "int16":
                     quantize = _insert_quantize_op_after(node)
 
                     quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -22,6 +22,9 @@ from torch.export import export, ExportedProgram
 from tico.config import CompileConfigBase, get_default_config
 from tico.experimental.quantization.passes.fill_meta_quant_val import FillMetaQuantVal
 from tico.experimental.quantization.passes.fold_quant_ops import FoldQuantOps
+from tico.experimental.quantization.passes.insert_quantize_on_dtype_mismatch import (
+    InsertQuantizeOnDtypeMismatch,
+)
 from tico.experimental.quantization.passes.propagate_qparam_backward import (
     PropagateQParamBackward,
 )
@@ -246,6 +249,7 @@ def convert_exported_module_to_circle(
             FillMetaQuantVal(),
             PropagateQuantParam(),
             PropagateQParamBackward(),
+            InsertQuantizeOnDtypeMismatch(),
         ]
     )
     if enable_quantization:


### PR DESCRIPTION
This inserts Quantize Op into the place where dtype of input and node mismatch.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: Support crispy-quantized Llama 3.2