### PR TITLE
Introduce include-internal option in ccex test

### DIFF
--- a/infra/scripts/test_run.py
+++ b/infra/scripts/test_run.py
@@ -27,6 +27,12 @@ def main():
     parser.add_argument(
         "-m", "--model", type=str, help="Specify model to run tests on."
     )
+    parser.add_argument(
+        "-i",
+        "--include-internal",
+        action="store_true",
+        help="Include internal-only tests",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose mode")
     args = parser.parse_args()
 
@@ -53,6 +59,9 @@ def main():
                 "Error: Cannot specify both --model and --keyword/--all at the same time."
             )
             sys.exit(1)
+
+    if args.include_internal:
+        os.environ["RUN_INTERNAL_TESTS"] = "1"
 
     ##############
     # Run commands

--- a/test/pt2_to_qcircle_test/builder.py
+++ b/test/pt2_to_qcircle_test/builder.py
@@ -25,6 +25,8 @@ from tico.experimental.quantization.evaluation.evaluate import evaluate
 
 from test.utils.base_builders import TestDictBuilderBase, TestRunnerBase
 
+IS_CI_MODE = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+
 
 class QuantizationTest(TestRunnerBase):
     def __init__(
@@ -46,8 +48,8 @@ class QuantizationTest(TestRunnerBase):
             self.tolerance["peir"] = mod.quantized_peir_tolerance  # type: ignore[assignment]
 
     def make(self):
-        @unittest.skip(
-            "Skip this test until deciding the policy about required dependency and enabling quantization."
+        @unittest.skipIf(
+            not IS_CI_MODE, "Internal test — skipped unless --include-internal is set"
         )
         def wrapper(s):
             self._run()

--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-TODO Enable in the CI.
-"""
-
+import os
 import unittest
 
 import tico
@@ -24,6 +21,8 @@ import torch
 from tico.experimental.quantization import convert, prepare
 from tico.experimental.quantization.config import GPTQConfig, PT2EConfig
 from tico.experimental.quantization.evaluation.evaluate import BACKEND, evaluate
+
+IS_CI_MODE = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
 
 
 class BigLinear(torch.nn.Module):
@@ -46,8 +45,8 @@ class BigLinear(torch.nn.Module):
 
 
 class GPTQTest(unittest.TestCase):
-    @unittest.skip(
-        "Skip this test until deciding the policy about required dependency and enabling quantization."
+    @unittest.skipIf(
+        not IS_CI_MODE, "Internal test — skipped unless --include-internal is set"
     )
     @torch.inference_mode()
     def test_model(self):
@@ -76,8 +75,8 @@ class GPTQTest(unittest.TestCase):
         # TODO Check PEIR.
         # https://github.com/pytorch/pytorch/issues/148171
 
-    @unittest.skip(
-        "Skip this test until deciding the policy about required dependency and enabling quantization."
+    @unittest.skipIf(
+        not IS_CI_MODE, "Internal test — skipped unless --include-internal is set"
     )
     def test_net(self):
         q_m = BigLinear()

--- a/test/quantization/algorithm/test_smooth_quant.py
+++ b/test/quantization/algorithm/test_smooth_quant.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-TODO Enable in the CI.
-"""
-
+import os
 import unittest
 
 import numpy as np
@@ -24,10 +21,12 @@ import torch
 from tico.experimental.quantization import convert, prepare
 from tico.experimental.quantization.config import SmoothQuantConfig
 
+IS_CI_MODE = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+
 
 class SmoothQuantTest(unittest.TestCase):
-    @unittest.skip(
-        "Skip this test until deciding the policy about required dependency and enabling quantization."
+    @unittest.skipIf(
+        not IS_CI_MODE, "Internal test — skipped unless --include-internal is set"
     )
     @torch.inference_mode()
     def test_value(self):

--- a/test/unit_test/quantization_test/test_evaluate.py
+++ b/test/unit_test/quantization_test/test_evaluate.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from typing import Any
 
@@ -21,6 +22,8 @@ from tico.experimental.quantization import convert, prepare
 from tico.experimental.quantization.config import PT2EConfig
 from tico.experimental.quantization.evaluation.backend import BACKEND
 from tico.experimental.quantization.evaluation.evaluate import evaluate
+
+IS_CI_MODE = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
 
 
 class TwoLinear(torch.nn.Module):
@@ -40,8 +43,8 @@ class TwoLinear(torch.nn.Module):
 
 class EvaluateTest(unittest.TestCase):
     # This test needs triv24-toolchain package.
-    @unittest.skip(
-        "Skip this test until deciding the policy about required dependency and enabling quantization."
+    @unittest.skipIf(
+        not IS_CI_MODE, "Internal test — skipped unless --include-internal is set"
     )
     def test_evaluate_simple_linear(self):
         m: Any = TwoLinear().eval()


### PR DESCRIPTION
This commit introduces --include-internal option.

Related: #12 

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>