### PR TITLE
Rename PropagateQuantParam to PropagateQParamForward

### DIFF
--- a/test/quantization/pass/test_propagate_quant_param.py
+++ b/test/quantization/pass/test_propagate_quant_param.py
@@ -18,8 +18,8 @@ import torch
 from tico.experimental.quantization import convert, prepare
 from tico.experimental.quantization.config import PT2EConfig
 from tico.experimental.quantization.passes.fold_quant_ops import FoldQuantOps
-from tico.experimental.quantization.passes.propagate_quant_param import (
-    PropagateQuantParam,
+from tico.experimental.quantization.passes.propagate_qparam_forward import (
+    PropagateQParamForward,
 )
 from tico.passes.convert_view_to_reshape import ConvertViewToReshape
 from tico.serialize.quant_param import QPARAM_KEY, QuantParam
@@ -38,7 +38,7 @@ class LinearPermuteModule(torch.nn.Module):
         return (torch.randn(2, 3),)
 
 
-class PropagateQuantParamTest(unittest.TestCase):
+class PropagateQParamForwardTest(unittest.TestCase):
     def test_pass(self):
         m: LinearPermuteModule | torch.nn.Module = LinearPermuteModule().eval()
         assert isinstance(m, LinearPermuteModule)
@@ -62,7 +62,7 @@ class PropagateQuantParamTest(unittest.TestCase):
                 continue
             if node.target == torch.ops.aten.permute.default:
                 self.assertFalse(QPARAM_KEY in node.meta)
-        target_pass = PropagateQuantParam()
+        target_pass = PropagateQParamForward()
         target_pass.call(ep)
         # After pass
         for node in ep.graph.nodes:
@@ -135,7 +135,7 @@ class SingleOpPropagateQParamForwardTest(unittest.TestCase):
         # Before pass
         self.assertFalse(QPARAM_KEY in self.target.meta)
 
-        target_pass = PropagateQuantParam()
+        target_pass = PropagateQParamForward()
         target_pass.call(self.ep)
 
         # After pass

--- a/tico/experimental/quantization/passes/propagate_qparam_forward.py
+++ b/tico/experimental/quantization/passes/propagate_qparam_forward.py
@@ -35,7 +35,7 @@ from tico.utils.validate_args_kwargs import (
 
 
 @trace_graph_diff_on_pass
-class PropagateQuantParam(PassBase):
+class PropagateQParamForward(PassBase):
     """
     A pass propagates quantization parameters through operations that do not alter them.
 

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -27,8 +27,8 @@ from tico.experimental.quantization.passes.insert_quantize_on_dtype_mismatch imp
 from tico.experimental.quantization.passes.propagate_qparam_backward import (
     PropagateQParamBackward,
 )
-from tico.experimental.quantization.passes.propagate_quant_param import (
-    PropagateQuantParam,
+from tico.experimental.quantization.passes.propagate_qparam_forward import (
+    PropagateQParamForward,
 )
 from tico.experimental.quantization.passes.remove_weight_dequant_op import (
     RemoveWeightDequantOp,
@@ -239,7 +239,7 @@ def convert_exported_module_to_circle(
             passes=[
                 FoldQuantOps(),
                 RemoveWeightDequantOp(),
-                PropagateQuantParam(),
+                PropagateQParamForward(),
                 PropagateQParamBackward(),
                 InsertQuantizeOnDtypeMismatch(),
             ]


### PR DESCRIPTION
This renames PropagateQuantParam to PropagateQParamForward.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>