### PR TITLE
Convert layout Op to Reshape Op

### DIFF
--- a/test/quantization/pass/test_convert_layout_op_to_reshape.py
+++ b/test/quantization/pass/test_convert_layout_op_to_reshape.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tico.passes import ops
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
+
+from test.modules.op.squeeze import SimpleSqueezeWithDims
+from test.modules.op.unsqueeze import SimpleUnsqueeze
+
+from test.modules.op.view import SimpleView
+from test.utils.helper import num_of_ops
+from test.utils.pass_value_test import SinglePassValueTest
+
+
+class ConvertLayoutOpToReshapeTest(SinglePassValueTest):
+    def test_view(self):
+        self.setup(SimpleView())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.view), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 0)
+
+        self.run_value_test(ConvertLayoutOpToReshape())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.view), 0)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)
+
+    def test_unsqueeze(self):
+        self.setup(SimpleUnsqueeze())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.unsqueeze), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 0)
+
+        self.run_value_test(ConvertLayoutOpToReshape())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.unsqueeze), 0)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)
+
+    def test_squeeze(self):
+        self.setup(SimpleSqueezeWithDims())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.squeeze), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 0)
+
+        self.run_value_test(ConvertLayoutOpToReshape())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.squeeze), 0)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)

--- a/test/quantization/pass/test_insert_quantize_on_dtype_mismatch.py
+++ b/test/quantization/pass/test_insert_quantize_on_dtype_mismatch.py
@@ -18,7 +18,7 @@ import torch
 from tico.experimental.quantization.passes.insert_quantize_on_dtype_mismatch import (
     InsertQuantizeOnDtypeMismatch,
 )
-from tico.passes.convert_view_to_reshape import ConvertViewToReshape
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.serialize.quant_param import QPARAM_KEY, QuantParam
 
 from test.modules.op.bmm import SimpleBatchMatMul
@@ -57,7 +57,7 @@ class InsertQuantizeOnDtypeMismatchTest(unittest.TestCase):
             self.ep = torch.export.export(mod.eval(), self.inputs)
 
         # This is necessary for testing Reshape on torch 2.5
-        ConvertViewToReshape().call(self.ep)
+        ConvertLayoutOpToReshape().call(self.ep)
 
         # Find target node
         target_node = None

--- a/test/quantization/pass/test_propagate_qparam_backward.py
+++ b/test/quantization/pass/test_propagate_qparam_backward.py
@@ -19,7 +19,7 @@ import torch
 from tico.experimental.quantization.passes.propagate_qparam_backward import (
     PropagateQParamBackward,
 )
-from tico.passes.convert_view_to_reshape import ConvertViewToReshape
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.serialize.quant_param import QPARAM_KEY, QuantParam
 from tico.utils.validate_args_kwargs import CatArgs, ReshapeArgs
 
@@ -52,7 +52,7 @@ class SingleOpPropagateQParamBackwardTest(unittest.TestCase):
             self.ep = torch.export.export(mod.eval(), self.inputs)
 
         # This is necessary for testing Reshape on torch 2.5
-        ConvertViewToReshape().call(self.ep)
+        ConvertLayoutOpToReshape().call(self.ep)
 
         # Find target node
         target_node = None

--- a/test/quantization/pass/test_propagate_quant_param.py
+++ b/test/quantization/pass/test_propagate_quant_param.py
@@ -21,7 +21,7 @@ from tico.experimental.quantization.passes.fold_quant_ops import FoldQuantOps
 from tico.experimental.quantization.passes.propagate_qparam_forward import (
     PropagateQParamForward,
 )
-from tico.passes.convert_view_to_reshape import ConvertViewToReshape
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.serialize.quant_param import QPARAM_KEY, QuantParam
 
 
@@ -97,7 +97,7 @@ class SingleOpPropagateQParamForwardTest(unittest.TestCase):
             self.ep = torch.export.export(mod.eval(), self.inputs)
 
         # This is necessary for testing Reshape on torch 2.5
-        ConvertViewToReshape().call(self.ep)
+        ConvertLayoutOpToReshape().call(self.ep)
 
         # Find target node
         target_node = None

--- a/test/unit_test/pass_test/test_fuse_redundant_reshape_to_mean.py
+++ b/test/unit_test/pass_test/test_fuse_redundant_reshape_to_mean.py
@@ -16,7 +16,7 @@ import torch
 from packaging.version import Version
 
 from tico.passes import ops
-from tico.passes.convert_view_to_reshape import ConvertViewToReshape
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.passes.fuse_redundant_reshape_to_mean import FuseRedundantReshapeToMean
 
 from test.utils.helper import num_of_ops
@@ -42,7 +42,7 @@ class FuseRedundantReshapeToMeanTest(SinglePassValueTest):
         self.setup(MeanRedundantViewNet())
 
         if Version(torch.__version__) <= Version("2.6.0.dev20241015"):
-            self.run_value_test(ConvertViewToReshape())
+            self.run_value_test(ConvertLayoutOpToReshape())
 
         self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)
 

--- a/test/unit_test/pass_test/test_remove_redundant_reshape.py
+++ b/test/unit_test/pass_test/test_remove_redundant_reshape.py
@@ -16,7 +16,7 @@ import torch
 from packaging.version import Version
 
 from tico.passes import ops
-from tico.passes.convert_view_to_reshape import ConvertViewToReshape
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.passes.remove_redundant_reshape import (
     RemoveRedundantReshapePattern1,
     RemoveRedundantReshapePattern2,
@@ -52,7 +52,7 @@ class RemoveRedundantReshapePattern1Test(SinglePassValueTest):
         self.setup(RedundantReshapePattern1())
 
         if Version(torch.__version__) <= Version("2.6.0.dev20241015"):
-            self.run_value_test(ConvertViewToReshape())
+            self.run_value_test(ConvertLayoutOpToReshape())
 
         self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 2)
 
@@ -90,7 +90,7 @@ class RemoveRedundantReshapePattern2Test(SinglePassValueTest):
         self.setup(RedundantReshapePattern2())
 
         if Version(torch.__version__) <= Version("2.6.0.dev20241015"):
-            self.run_value_test(ConvertViewToReshape())
+            self.run_value_test(ConvertLayoutOpToReshape())
 
         self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 2)
 
@@ -126,7 +126,7 @@ class RemoveRedundantReshapePattern3Test(SinglePassValueTest):
         self.setup(RedundantReshapePattern3())
 
         if Version(torch.__version__) <= Version("2.6.0.dev20241015"):
-            self.run_value_test(ConvertViewToReshape())
+            self.run_value_test(ConvertLayoutOpToReshape())
 
         self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 3)
 
@@ -172,7 +172,7 @@ class RemoveRedundantReshapePattern4Test(SinglePassValueTest):
         self.setup(RedundantReshapePattern4())
 
         if Version(torch.__version__) <= Version("2.6.0.dev20241015"):
-            self.run_value_test(ConvertViewToReshape())
+            self.run_value_test(ConvertLayoutOpToReshape())
 
         self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 2)
 

--- a/tico/passes/ops.py
+++ b/tico/passes/ops.py
@@ -55,10 +55,15 @@ class AtenOps:
         self.select = [torch.ops.aten.select_copy.int, torch.ops.aten.select.int]
         self.slice = [torch.ops.aten.slice.Tensor, torch.ops.aten.slice_copy.Tensor]
         self.softmax = [torch.ops.aten._softmax.default]
+        self.squeeze = [torch.ops.aten.squeeze.dims, torch.ops.aten.squeeze_copy.dims]
         self.to_copy = [
             torch.ops.aten._to_copy.default,
             torch.ops.aten.to.dtype,
             torch.ops.aten.to.dtype_layout,
+        ]
+        self.unsqueeze = [
+            torch.ops.aten.unsqueeze.default,
+            torch.ops.aten.unsqueeze_copy.default,
         ]
         self.view = [
             torch.ops.aten.view,

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -40,9 +40,9 @@ from tico.passes.convert_conv1d_to_conv2d import ConvertConv1dToConv2d
 from tico.passes.convert_index_to_resize_nearest_neighbor import (
     ConvertIndexToResizeNearestNeighbor,
 )
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.passes.convert_repeat_to_expand_copy import ConvertRepeatToExpandCopy
 from tico.passes.convert_to_relu6 import ConvertToReLU6
-from tico.passes.convert_view_to_reshape import ConvertViewToReshape
 from tico.passes.decompose_addmm import DecomposeAddmm
 from tico.passes.decompose_batch_norm import DecomposeBatchNorm
 from tico.passes.decompose_fake_quantize import DecomposeFakeQuantize
@@ -191,7 +191,7 @@ def convert_exported_module_to_circle(
             FillMetaVal(),
             ExtractDtypeKwargsPass(),
             RemoveNop(),
-            ConvertViewToReshape(),
+            ConvertLayoutOpToReshape(),
             RestoreLinear(),
             ConvertToReLU6(),
             DecomposeAddmm(),


### PR DESCRIPTION
This converts layout Op to Reshape Op.
- Squeeze and Unsuqeeze are additionally converted.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/TICO/issues/21