### PR TITLE
Use proper quantization parameters

### DIFF
--- a/tico/serialize/operators/op_quantize_per_tensor.py
+++ b/tico/serialize/operators/op_quantize_per_tensor.py
@@ -48,13 +48,17 @@ class QuantizePerTensorDefaultVisitor(NodeVisitor):
         quant_max = args.quant_max
 
         output_tensor: circle.Tensor.TensorT = self.graph.get_tensor(node)
-        assert not output_tensor.quantization
-        quant_param = circle.QuantizationParameters.QuantizationParametersT()
-        quant_param.min = [quant_min]
-        quant_param.max = [quant_max]
-        quant_param.scale = [scale]
-        quant_param.zeroPoint = [zero_p]
-        output_tensor.quantization = quant_param
+        assert output_tensor.quantization is not None
+
+        # Tensor should have qparam when it's exported
+        # The qparam must match with the arguments of this Op
+        assert output_tensor.quantization.scale[0] == scale
+        assert output_tensor.quantization.zeroPoint[0] == zero_p
+
+        if output_tensor.type == circle.TensorType.TensorType.UINT8:
+            assert quant_min == 0 and quant_max == 255
+        elif output_tensor.type == circle.TensorType.TensorType.INT16:
+            assert quant_min == -32767 and quant_max == 32767
 
         inputs = [tensor]
         outputs = [node]

--- a/tico/serialize/operators/op_quantize_per_tensor.py
+++ b/tico/serialize/operators/op_quantize_per_tensor.py
@@ -58,7 +58,8 @@ class QuantizePerTensorDefaultVisitor(NodeVisitor):
         if output_tensor.type == circle.TensorType.TensorType.UINT8:
             assert quant_min == 0 and quant_max == 255
         elif output_tensor.type == circle.TensorType.TensorType.INT16:
-            assert quant_min == -32767 and quant_max == 32767
+            # Some frameworks use -32767 as quant_min of int16
+            assert quant_min in (-32768, -32767) and quant_max == 32767
 
         inputs = [tensor]
         outputs = [node]

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -308,6 +308,6 @@ def quant_min_max(dtype: str):
     if dtype == "uint8":
         return (0, 255)
     elif dtype == "int16":
-        return (-32767, 32767)
+        return (-32768, 32767)
     else:
         raise NotImplementedError(f"NYI dtype: {dtype}")

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -302,3 +302,12 @@ def to_circle_qparam(qparam: QuantParam):
         circle_qparam.max = qparam.max
 
     return circle_qparam
+
+
+def quant_min_max(dtype: str):
+    if dtype == "uint8":
+        return (0, 255)
+    elif dtype == "int16":
+        return (-32767, 32767)
+    else:
+        raise NotImplementedError(f"NYI dtype: {dtype}")


### PR DESCRIPTION
This includes the following changes.
- quant_min and quant_max are properly set.
- use circle tensor's qparam in quantize_per_tensor.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>