### PR TITLE
Preserve linear during decomposition

### DIFF
--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -103,6 +103,7 @@ def traced_run_decompositions(exported_program: ExportedProgram):
             torch.ops.aten.instance_norm.default,
             torch.ops.aten._safe_softmax.default,
             torch.ops.aten.relu6.default,  # Do not decompose to hardtanh
+            torch.ops.aten.linear.default,
         )
         ep = ep.run_decompositions(_preserve_ops=_preserve_ops)
 
@@ -119,6 +120,7 @@ def traced_run_decompositions(exported_program: ExportedProgram):
             torch.ops.aten._safe_softmax.default,
             torch.ops.aten.relu6.default,  # Do not decompose to hardtanh
             torch.ops.aten.prelu.default,
+            torch.ops.aten.linear.default,
         )
         for op in _preserve_ops:
             if op in _decomp_table:


### PR DESCRIPTION
This preserves linear Op during decomposition.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>