### PR TITLE
Add capabilities to test models with dynamic inputs

### DIFF
--- a/test/modules/op/dyn_shapes/README.md
+++ b/test/modules/op/dyn_shapes/README.md
@@ -1,0 +1,27 @@
+It can be accessed as a module as `test.modules.op.dyn_shapes*`
+
+## How to test models with inputs which have dynamic shapes?
+
+The folder contains tests for single-op models that have dynamic inputs.
+Such test requires adding additional method `get_input_dynamic_shapes` to a test class inheriting from `nn.Module`.
+The format of value returned by `get_input_dynamic_shapes` should match an `dynamic_shapes` argument of [torch.export](https://pytorch.org/docs/stable/export.html) function.
+
+
+### An example:
+```py
+from torch.export import Dim
+
+class TwoInputsDynSimpleAdd(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        z = x + y
+        return z
+
+    def get_example_inputs(self):
+        return (torch.ones(1, 2, 3), torch.ones(1, 2, 3))
+
+    def get_input_dynamic_shapes(self):
+        return (1, Dim("d2"), Dim("d3")), (1, Dim("d2"), Dim("d3"))
+```

--- a/test/modules/op/dyn_shapes/add.py
+++ b/test/modules/op/dyn_shapes/add.py
@@ -1,0 +1,50 @@
+import torch
+from torch.export import Dim
+
+from test.utils import tag
+
+
+class SingleInputDynSimpleAdd(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        z = x + y
+        return z
+
+    def get_example_inputs(self):
+        return (torch.ones(4, 5, 6), torch.ones(1, 1, 1))
+
+    def get_input_dynamic_shapes(self):
+        return (4, Dim("d2"), Dim("d3")), (1, 1, 1)
+
+
+class TwoInputsDynSimpleAdd(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        z = x + y
+        return z
+
+    def get_example_inputs(self):
+        return (torch.ones(1, 2, 3), torch.ones(1, 2, 3))
+
+    def get_input_dynamic_shapes(self):
+        return (1, Dim("d2"), Dim("d3")), (1, Dim("d2"), Dim("d3"))
+
+
+@tag.test_negative(expected_err=f"Failed running call_function")
+class DynSimpleAddNotMatchedShape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        z = x + y
+        return z
+
+    def get_example_inputs(self):
+        return (torch.ones(1, 2, 3), torch.ones(1, 4, 3))
+
+    def get_input_dynamic_shapes(self):
+        return (1, Dim("d"), 3), (1, Dim("d"), 3)

--- a/test/pt2_to_circle_test/__init__.py
+++ b/test/pt2_to_circle_test/__init__.py
@@ -23,7 +23,7 @@ def load_tests(loader, standard_tests, pattern):
 
     # Add test files to be found by `unittest`
     # WHY? Not to include other files by mistake and to make it clear which files are being tested
-    for testfile in ["test_net.py", "test_op.py"]:
+    for testfile in ["test_net.py", "test_op.py", "test_dyn_op.py"]:
         package_tests = loader.discover(start_dir=this_dir, pattern=testfile)
         standard_tests.addTests(package_tests)
 

--- a/test/pt2_to_circle_test/test_dyn_op.py
+++ b/test/pt2_to_circle_test/test_dyn_op.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from test.pt2_to_circle_test.builder import NormalTestDictBuilder
+from test.utils.helper import declare_unittests
+
+# NOTE Thie file's name must start with `test_` to be found by unittest
+
+
+declare_unittests(globals(), "test.modules.op.dyn_shapes", NormalTestDictBuilder)

--- a/test/utils/base_builders.py
+++ b/test/utils/base_builders.py
@@ -28,6 +28,10 @@ class TestRunnerBase:
         assert hasattr(nnmodule, "get_example_inputs")
         assert isinstance(nnmodule.get_example_inputs(), tuple)  # type: ignore[operator]
 
+        self.dynamic_shapes = None
+        if hasattr(nnmodule, "get_input_dynamic_shapes"):
+            self.dynamic_shapes = nnmodule.get_input_dynamic_shapes()  # type: ignore[operator]
+
         self.nnmodule = nnmodule
         self.example_inputs = nnmodule.get_example_inputs()  # type: ignore[operator]
 


### PR DESCRIPTION
This commit adds capabilities to test models which have inputs with dynamic shapes. It requires an additional step in circle compilation pipeline - model resizing via circle-resizer.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>