### PR TITLE
[passes] Introduce LowerIndexSelectToSlice

### DIFF
--- a/test/modules/op/index.py
+++ b/test/modules/op/index.py
@@ -107,7 +107,7 @@ class IndexTensorAxis0And1(torch.nn.Module):
         return (torch.randn(5, 4),)
 
 
-class IndexTensorAxis0And12(torch.nn.Module):
+class IndexTensorWithSlice(torch.nn.Module):
     def __init__(self):
         super().__init__()
 

--- a/test/modules/op/index.py
+++ b/test/modules/op/index.py
@@ -57,9 +57,6 @@ class SimpleIndexTensorBuffer(torch.nn.Module):
         return (torch.randn(2, 3), torch.randn(2, 3))
 
 
-# Without buffer, there is `aten_clone_default` op which is converted to `CircleTranspose`.
-# But, circle-interpreter doesn't support the `CircleTranspose` whose type is int64.
-@tag.skip(reason="Not Support Operator")
 class SimpleIndexTensor(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -87,8 +84,6 @@ class IndexTensor2x1(torch.nn.Module):
         return (torch.randn(2, 3), torch.randn(2, 3))
 
 
-# circle-interpreter doesn't support the `CircleTranspose` whose type is int64.
-@tag.skip(reason="Not Support Operator")
 class IndexTensorAxis1(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -99,3 +94,29 @@ class IndexTensorAxis1(torch.nn.Module):
 
     def get_example_inputs(self):
         return (torch.randn(2, 3), torch.randn(2, 3))
+
+
+class IndexTensorAxis0And1(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x[1, [2, 3]]
+
+    def get_example_inputs(self):
+        return (torch.randn(5, 4),)
+
+
+class IndexTensorAxis0And12(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        z = x + y
+        return z[1:, [0, 0], :, :2]
+
+    def get_example_inputs(self):
+        return (
+            torch.randn(3, 3, 6, 6),
+            torch.randn(3, 3, 6, 6),
+        )

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -58,7 +58,7 @@ from tico.passes.legalize_predefined_layout_operators import (
 )
 from tico.passes.lower_pow2_to_mul import LowerPow2ToMul
 from tico.passes.lower_to_resize_nearest_neighbor import LowerToResizeNearestNeighbor
-from tico.passes.lower_to_slice import LowerToSlice
+from tico.passes.lower_to_slice import passes as LowerToSlicePasses
 from tico.passes.merge_consecutive_cat import MergeConsecutiveCat
 from tico.passes.remove_nop import RemoveNop
 from tico.passes.remove_redundant_assert_nodes import RemoveRedundantAssertionNodes
@@ -224,7 +224,7 @@ def convert_exported_module_to_circle(
             LegalizePreDefinedLayoutOperators(),
             LowerPow2ToMul(),
             ConvertConv1dToConv2d(),
-            LowerToSlice(),
+            *LowerToSlicePasses(),
         ]
     )
     circle_legalize.run(exported_program)


### PR DESCRIPTION
Let's introduce LowerIndexSelectToSlice.
It lowers index_select op to slice `selectively` when its index is constant tensor.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>