### PR TITLE
[test] Fix SimpleAdd quantization test

### DIFF
--- a/test/modules/op/add.py
+++ b/test/modules/op/add.py
@@ -37,10 +37,10 @@ class SimpleAdd(torch.nn.Module):
         calibration_data = [
             (
                 torch.randn(
-                    (1,),
+                    (1, 2),
                 ),
                 torch.randn(
-                    (1,),
+                    (1, 2),
                 ),
             )
             for i in range(100)


### PR DESCRIPTION
This commit expands a rank of tensors for calibration.

Note that current backend compiler doesn't support 1-rank tensor.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>