### PR TITLE
Move pyyaml to test dependency

### DIFF
--- a/infra/scripts/install_requirements_2_5.txt
+++ b/infra/scripts/install_requirements_2_5.txt
@@ -6,4 +6,3 @@ circle_schema
 torch==2.5.0
 cffi==1.17.1
 packaging==25.0
-pyyaml==6.0.2

--- a/infra/scripts/install_requirements_2_6.txt
+++ b/infra/scripts/install_requirements_2_6.txt
@@ -6,4 +6,3 @@ circle_schema
 torch==2.6.0
 cffi==1.17.1
 packaging==25.0
-pyyaml==6.0.2

--- a/infra/scripts/install_requirements_dev.txt
+++ b/infra/scripts/install_requirements_dev.txt
@@ -7,4 +7,3 @@ circle_schema
 
 cffi==1.17.1
 packaging==25.0
-pyyaml==6.0.2

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
     license_files=("LICENSE",),
     packages=find_packages(include=["tico*"]),
     entry_points={"console_scripts": ["pt2-to-circle = tico.pt2_to_circle:main"]},
-    install_requires=["circle-schema", "packaging", "cffi", "torch", "pyyaml"],
+    install_requires=["circle-schema", "packaging", "cffi", "torch"],
 )

--- a/test/requirements_2_5.txt
+++ b/test/requirements_2_5.txt
@@ -1,1 +1,2 @@
 torchvision==0.20.0
+pyyaml==6.0.2

--- a/test/requirements_2_6.txt
+++ b/test/requirements_2_6.txt
@@ -1,1 +1,2 @@
 torchvision==0.21.0
+pyyaml==6.0.2

--- a/test/requirements_dev.txt
+++ b/test/requirements_dev.txt
@@ -1,1 +1,2 @@
 -r ../infra/dependency/torchvision_dev.txt
+pyyaml==6.0.2


### PR DESCRIPTION
This commit moves pyyaml to test dependency from install one.

Related: https://github.com/Samsung/TICO/pull/70#discussion_r2067861031

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>