### PR TITLE
Bump setuptools from 69.2.0 to 78.1.1

### DIFF
--- a/infra/scripts/install_requirements_2_5.txt
+++ b/infra/scripts/install_requirements_2_5.txt
@@ -1,4 +1,4 @@
-setuptools==69.2.0
+setuptools==78.1.1
 wheel==0.43.0
 
 circle_schema

--- a/infra/scripts/install_requirements_2_6.txt
+++ b/infra/scripts/install_requirements_2_6.txt
@@ -1,4 +1,4 @@
-setuptools==69.2.0
+setuptools==78.1.1
 wheel==0.43.0
 
 circle_schema

--- a/infra/scripts/install_requirements_dev.txt
+++ b/infra/scripts/install_requirements_dev.txt
@@ -1,4 +1,4 @@
-setuptools==69.2.0
+setuptools==78.1.1
 wheel==0.43.0
 
 circle_schema


### PR DESCRIPTION
This commit resolves a security vulnerability.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>