### PR TITLE
[serialize] Set qparams for Conv and MaxPool padding

### DIFF
--- a/test/unit_test/serialize_test/operator/test_utils.py
+++ b/test/unit_test/serialize_test/operator/test_utils.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tico.serialize.operators.utils import get_integer_dtype_min
+
+
+class TestGetIntegerDtypeMin(unittest.TestCase):
+    def test_signed_types(self):
+        self.assertEqual(get_integer_dtype_min("int2"), -2)
+        self.assertEqual(get_integer_dtype_min("int3"), -4)
+        self.assertEqual(get_integer_dtype_min("int4"), -8)
+        self.assertEqual(get_integer_dtype_min("int8"), -128)
+        self.assertEqual(get_integer_dtype_min("int16"), -32768)
+
+    def test_unsigned_types(self):
+        self.assertEqual(get_integer_dtype_min("uint2"), 0)
+        self.assertEqual(get_integer_dtype_min("uint4"), 0)
+        self.assertEqual(get_integer_dtype_min("uint8"), 0)
+        self.assertEqual(get_integer_dtype_min("uint16"), 0)
+
+    def test_invalid_format(self):
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("float32")
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("int")
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("intXYZ")
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("")
+
+    def test_too_small_bitwidth(self):
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("int0")
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("uint1")
+        with self.assertRaises(ValueError):
+            get_integer_dtype_min("int1")

--- a/tico/serialize/circle_graph.py
+++ b/tico/serialize/circle_graph.py
@@ -29,7 +29,7 @@ from tico.serialize.circle_mapping import (
     to_circle_dtype,
 )
 from tico.serialize.pack import pack_buffer
-from tico.serialize.quant_param import QPARAM_KEY
+from tico.serialize.quant_param import QPARAM_KEY, QuantParam
 from tico.utils.utils import to_circle_qparam
 
 """
@@ -184,13 +184,21 @@ class CircleSubgraph(circle.SubGraph.SubGraphT):
         return tensor
 
     def add_tensor_from_scratch(
-        self, prefix: str, shape: List[int], dtype: int
+        self,
+        prefix: str,
+        shape: List[int],
+        dtype: int,
+        qparam: Optional[QuantParam] = None,
     ) -> circle.Tensor.TensorT:
         assert isinstance(dtype, int), f"{dtype} must be integer. Use to_circle_dtype."
         tensor = circle.Tensor.TensorT()
         tensor.name = self._gen_unique_name_with_prefix(prefix)
-        tensor.type = dtype
         tensor.shape = shape
+        if qparam is not None:
+            tensor.quantization = to_circle_qparam(qparam)
+            tensor.type = str_to_circle_dtype(qparam.dtype)
+        else:
+            tensor.type = dtype
 
         buffer = circle.Buffer.BufferT()
         bid = self.model.add_buffer(buffer)

--- a/tico/serialize/operators/utils.py
+++ b/tico/serialize/operators/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Dict, List
 
 from circle_schema import circle
@@ -49,3 +50,45 @@ def create_builtin_operator(
     operator.inputs = [graph.get_tid(input) for input in inputs]
     operator.outputs = [graph.get_tid(output) for output in outputs]
     return operator
+
+
+def get_integer_dtype_min(dtype_str: str):
+    """
+    Returns the minimum representable value for a given integer dtype string.
+
+    Supports "intN" and "uintN" where N >= 2 and uses two's complement for
+     signed integers.
+
+    Args:
+        dtype_str (str): A string representing the integer dtype.
+                         Must be in the format "intN" or "uintN" where N is the bit width.
+
+    Returns:
+        int: The minimum representable integer value for the given dtype.
+
+    Raises:
+        ValueError: If the dtype format is invalid or bit width is less then 2.
+
+    Examples:
+        >>> get_integer_dtype_min("int8")
+        -128
+        >>> get_integer_dtype_min("uint4")
+        0
+        >>> get_integer_dtype_min("int4")
+        -8
+    """
+    match = re.fullmatch(r"(u?)int(\d+)", dtype_str)
+
+    if not match:
+        raise ValueError(f"Unsupported or malformed dtype: {dtype_str}")
+
+    is_unsigned = match.group(1) == "u"
+    bits = int(match.group(2))
+
+    if bits < 2:
+        raise ValueError(f"Bit width too small: {bits} bits")
+
+    if is_unsigned:
+        return 0
+    else:
+        return -(2 ** (bits - 1))


### PR DESCRIPTION
This commit propagates input qparam across 1:N mapping ops during Aten-to-Circle lowering.

Related: #100 
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>