### PR TITLE
Remove Redundant Reshape when exporting GroupNorm

### DIFF
--- a/test/modules/op/native_group_norm.py
+++ b/test/modules/op/native_group_norm.py
@@ -69,6 +69,30 @@ class SimpleNativeGroupNormWithoutWeightBias(torch.nn.Module):
         )
 
 
+class SimpleNativeGroupNormRedundantReshape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.N = 20
+        self.C = 1
+        self.H = 512
+
+    def forward(self, tensor, group, eps):
+        z = torch.native_group_norm(
+            tensor, None, None, self.N, self.C, self.H, group, eps
+        )[0]
+        return (z,)
+
+    def get_example_inputs(self):
+        tensor = torch.randn(self.N, self.C, self.H)
+        group = 1
+        eps = 1e-5
+        return (
+            tensor,
+            group,
+            eps,
+        )
+
+
 class SimpleNativeGroupNormWithLayerNormClass(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/modules/op/native_layer_norm.py
+++ b/test/modules/op/native_layer_norm.py
@@ -67,6 +67,30 @@ class SimpleNativeLayerNormWithoutWeightBias(torch.nn.Module):
         )
 
 
+class SimpleNativeLayerNormRedundantReshape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, tensor, normalized_shape, eps):
+        z = torch.native_layer_norm(tensor, normalized_shape, None, None, eps)[0]
+        return (z,)
+
+    def get_example_inputs(self):
+        N = 4
+        H = 3
+        W = 2
+        C = 1
+
+        tensor = torch.randn(N, H, W, C)
+        normalized_shape = [C]
+        eps = 1e-5
+        return (
+            tensor,
+            normalized_shape,
+            eps,
+        )
+
+
 class NativeLayerNormChannelLastInput(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/tico/passes/decompose_group_norm.py
+++ b/tico/passes/decompose_group_norm.py
@@ -88,6 +88,25 @@ class DecomposeGroupNorm(PassBase):
     def __init__(self):
         super().__init__()
 
+    def _insert_norm(self, graph, tensor, eps):
+        """
+        Insert (tensor - mean) / sqrt(var + eps)) into the graph
+          and return the normalized tensor node.
+        """
+        mean = graph.call_function(
+            torch.ops.aten.mean.dim, (tensor, [-1]), {"keepdim": True}
+        )
+        dev = graph.call_function(torch.ops.aten.sub.Tensor, (tensor, mean))
+        sqr = graph.call_function(torch.ops.aten.pow.Tensor_Scalar, (dev, 2))
+        var = graph.call_function(
+            torch.ops.aten.mean.dim, (sqr, [-1]), {"keepdim": True}
+        )
+        inv_std = graph.call_function(
+            torch.ops.aten.rsqrt.default,
+            (graph.call_function(torch.ops.aten.add.Tensor, (var, eps)),),
+        )
+        return graph.call_function(torch.ops.aten.mul.Tensor, (dev, inv_std))
+
     def call(self, exported_program: ExportedProgram) -> PassResult:
         logger = logging.getLogger(__name__)
 
@@ -155,85 +174,20 @@ class DecomposeGroupNorm(PassBase):
             pack_shape = [layer_size, norm_size]
 
             with gm.graph.inserting_before(node):
-                # Skip reshape if norm size matches the last dim of the input.
-                if norm_size == x_shape[-1]:
-                    layer_mean = graph.call_function(
-                        torch.ops.aten.mean.dim,
-                        (x, [-1]),
-                        {"keepdim": True},
+                # Branch only on whether a reshape is needed; the normalization is shared.
+                if norm_size != x_shape[-1]:
+                    # Pack groups so that the last dimension equals norm_size.
+                    packed = graph.call_function(
+                        torch.ops.aten.reshape.default, (x, pack_shape)
                     )
-                    layer_deviation = graph.call_function(
-                        torch.ops.aten.sub.Tensor,
-                        (x, layer_mean),
-                    )
-                    layer_sqr_diff = graph.call_function(
-                        torch.ops.aten.pow.Tensor_Scalar,
-                        (layer_deviation, 2),
-                    )
-                    var = graph.call_function(
-                        torch.ops.aten.mean.dim,
-                        (layer_sqr_diff, [-1]),
-                        {"keepdim": True},
-                    )
-                    var_eps = graph.call_function(
-                        torch.ops.aten.add.Tensor,
-                        (var, eps),
-                    )
-                    rsqrt = graph.call_function(
-                        torch.ops.aten.rsqrt.default,
-                        (var_eps,),
-                    )
+                    normed = self._insert_norm(graph, packed, eps)
+                    # Restore the original shape after normalization.
                     layer_norm = graph.call_function(
-                        torch.ops.aten.mul.Tensor,
-                        (layer_deviation, rsqrt),
+                        torch.ops.aten.reshape.default, (normed, x_shape)
                     )
                 else:
-                    layer = graph.call_function(
-                        # Sometimes, `x` has a stride for NHWC, which can't be reshaped with `aten.view.default`.
-                        # TODO Find out how to process such case properly.
-                        torch.ops.aten.reshape.default,
-                        (x, pack_shape),
-                    )
-                    layer_mean = graph.call_function(
-                        torch.ops.aten.mean.dim,
-                        (layer, [-1]),
-                    )
-                    layer_mean_reshape = graph.call_function(
-                        torch.ops.aten.view.default,
-                        (layer_mean, [layer_size, 1]),
-                    )
-                    layer_deviation = graph.call_function(
-                        torch.ops.aten.sub.Tensor,
-                        (layer, layer_mean_reshape),
-                    )
-                    layer_sqr_diff = graph.call_function(
-                        torch.ops.aten.pow.Tensor_Scalar,
-                        (layer_deviation, 2),
-                    )
-                    var = graph.call_function(
-                        torch.ops.aten.mean.dim,
-                        (layer_sqr_diff, [-1]),
-                    )
-                    var_eps = graph.call_function(
-                        torch.ops.aten.add.Tensor,
-                        (var, eps),
-                    )
-                    rstd = graph.call_function(
-                        torch.ops.aten.rsqrt.default,
-                        (var_eps,),
-                    )
-                    rstd_reshape = graph.call_function(
-                        torch.ops.aten.view.default,
-                        (rstd, [layer_size, 1]),
-                    )
-                    layer_norm = graph.call_function(
-                        torch.ops.aten.mul.Tensor,
-                        (layer_deviation, rstd_reshape),
-                    )
-                    layer_norm = graph.call_function(
-                        torch.ops.aten.view.default,
-                        (layer_norm, x_shape),
-                    )
+                    # The input already has norm_size in the last dimension.
+                    layer_norm = self._insert_norm(graph, x, eps)
 
                 # weight
                 if weight:

--- a/tico/serialize/operators/op_mean.py
+++ b/tico/serialize/operators/op_mean.py
@@ -45,7 +45,7 @@ class MeanVisitor(NodeVisitor):
         args = MeanDimArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
         input = args.input
         dim = args.dim
-        keep_dims = args.keep_dims
+        keep_dims = args.keepdim
 
         dim_i32 = circle_legalize_dtype_to(dim, dtype=torch.int32)
         inputs = [input, dim_i32]

--- a/tico/utils/validate_args_kwargs.py
+++ b/tico/utils/validate_args_kwargs.py
@@ -599,7 +599,7 @@ class MeanDimArgs:
 
     input: torch.fx.Node
     dim: List[int]
-    keep_dims: bool = False
+    keepdim: bool = False
     dtype: Optional[torch.dtype] = None
 
 


### PR DESCRIPTION
This commit removes redundant reshapes when exporting GroupNorm.

Related: #97 
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>