### PR TITLE
[passes] Rename variables in DecomposeGroupNorm pass

### DIFF
--- a/tico/passes/decompose_group_norm.py
+++ b/tico/passes/decompose_group_norm.py
@@ -96,16 +96,16 @@ class DecomposeGroupNorm(PassBase):
         mean = graph.call_function(
             torch.ops.aten.mean.dim, (tensor, [-1]), {"keepdim": True}
         )
-        dev = graph.call_function(torch.ops.aten.sub.Tensor, (tensor, mean))
-        sqr = graph.call_function(torch.ops.aten.pow.Tensor_Scalar, (dev, 2))
+        deviation = graph.call_function(torch.ops.aten.sub.Tensor, (tensor, mean))
+        squared = graph.call_function(torch.ops.aten.pow.Tensor_Scalar, (deviation, 2))
         var = graph.call_function(
-            torch.ops.aten.mean.dim, (sqr, [-1]), {"keepdim": True}
+            torch.ops.aten.mean.dim, (squared, [-1]), {"keepdim": True}
         )
-        inv_std = graph.call_function(
+        inverse_std = graph.call_function(
             torch.ops.aten.rsqrt.default,
             (graph.call_function(torch.ops.aten.add.Tensor, (var, eps)),),
         )
-        return graph.call_function(torch.ops.aten.mul.Tensor, (dev, inv_std))
+        return graph.call_function(torch.ops.aten.mul.Tensor, (deviation, inverse_std))
 
     def call(self, exported_program: ExportedProgram) -> PassResult:
         logger = logging.getLogger(__name__)


### PR DESCRIPTION
This commit renames variables in DecomposeGroupNorm pass.

Related: https://github.com/Samsung/TICO/pull/103#discussion_r2099468553
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>