### PR TITLE
[passes] Support quantized type for uint4 in DecomposeFakeQuantize pass

### DIFF
--- a/tico/passes/decompose_fake_quantize.py
+++ b/tico/passes/decompose_fake_quantize.py
@@ -31,6 +31,8 @@ from tico.utils.validate_args_kwargs import FakeQuantizePerChannelArgs
 def get_quant_type(min: int, max: int) -> torch.dtype:
     if min == 0 and max == 255:
         return torch.uint8
+    if min == 0 and max == 15:
+        return torch.uint8
     if min == -32768 and max == 32767:
         return torch.int16
     if min == -32767 and max == 32767:


### PR DESCRIPTION
This commit introduces quantized type for uint4 in DecomposeFakeQuantize pass.

for issue:
- #107 

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>