### PR TITLE
Support fake-quantize with uint4 dtype

### DIFF
--- a/test/unit_test/pass_test/test_decompose_fake_quantize.py
+++ b/test/unit_test/pass_test/test_decompose_fake_quantize.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 import torch
+from tico.experimental.quantization.passes.remove_weight_dequant_op import (
+    RemoveWeightDequantOp,
+)
+from tico.passes.const_prop_pass import ConstPropPass
 from tico.passes.decompose_fake_quantize import DecomposeFakeQuantize
 
 from test.utils.helper import num_of_ops
-from test.utils.pass_value_test import SinglePassValueTest
+from test.utils.pass_value_test import PassTest, SinglePassValueTest
 
 
 class FakeQuantizePerChannel(torch.nn.Module):

--- a/test/unit_test/pass_test/test_decompose_fake_quantize.py
+++ b/test/unit_test/pass_test/test_decompose_fake_quantize.py
@@ -13,14 +13,10 @@
 # limitations under the License.
 
 import torch
-from tico.experimental.quantization.passes.remove_weight_dequant_op import (
-    RemoveWeightDequantOp,
-)
-from tico.passes.const_prop_pass import ConstPropPass
 from tico.passes.decompose_fake_quantize import DecomposeFakeQuantize
 
 from test.utils.helper import num_of_ops
-from test.utils.pass_value_test import PassTest, SinglePassValueTest
+from test.utils.pass_value_test import SinglePassValueTest
 
 
 class FakeQuantizePerChannel(torch.nn.Module):

--- a/test/unit_test/pass_test/test_decompose_fake_quantize_tensor_qparam.py
+++ b/test/unit_test/pass_test/test_decompose_fake_quantize_tensor_qparam.py
@@ -108,7 +108,7 @@ class FakeQuantizeTensorQParamUint4Dtype(torch.nn.Module):
         return (torch.randn(1, 5),)
 
 
-class DecomposeUintFakeQuantizeTensorQParam4Dtype(PassTest):
+class DecomposeFakeQuantizeTensorQParamUint4Dtype(PassTest):
     def test_pass(self):
         self.setup(FakeQuantizeTensorQParamUint4Dtype())
         self.run_pass(DecomposeFakeQuantize())

--- a/test/unit_test/pass_test/test_decompose_fake_quantize_tensor_qparam.py
+++ b/test/unit_test/pass_test/test_decompose_fake_quantize_tensor_qparam.py
@@ -13,12 +13,20 @@
 # limitations under the License.
 
 import torch
+from tico.experimental.quantization.passes.fold_quant_ops import FoldQuantOps
+from tico.experimental.quantization.passes.remove_weight_dequant_op import (
+    RemoveWeightDequantOp,
+)
+from tico.passes.const_prop_pass import ConstPropPass
+from tico.passes.decompose_fake_quantize import DecomposeFakeQuantize
 from tico.passes.decompose_fake_quantize_tensor_qparams import (
     DecomposeFakeQuantizeTensorQParams,
 )
+from tico.passes.fill_meta_val import FillMetaVal
+from tico.serialize.quant_param import QPARAM_KEY
 
 from test.utils.helper import num_of_ops
-from test.utils.pass_value_test import SinglePassValueTest
+from test.utils.pass_value_test import PassTest, SinglePassValueTest
 
 
 class FakeQuantizeTensorQParamPerTensor(torch.nn.Module):
@@ -70,3 +78,53 @@ class DecomposeFakeQuantizeTensorQParamPerTensor(SinglePassValueTest):
             ),
             1,
         )
+
+
+class FakeQuantizeTensorQParamUint4Dtype(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(5, 10)
+        self.w_scale = torch.tensor([1.0] * self.linear.out_features)
+        self.w_zp = torch.zeros(self.linear.out_features)
+        self.w_qmin = 0
+        self.w_qmax = 15
+        self.a_qmin = 0
+        self.a_qmax = 255
+
+    def forward(self, input):
+        q_weight = torch.fake_quantize_per_channel_affine(
+            self.linear.weight, self.w_scale, self.w_zp, 0, self.w_qmin, self.w_qmax
+        )
+        quantized_input = torch.fake_quantize_per_tensor_affine(
+            input, torch.tensor(0.1), torch.tensor(0), self.a_qmin, self.a_qmax
+        )
+        linear = torch.nn.functional.linear(quantized_input, q_weight)
+        q_linear = torch.fake_quantize_per_tensor_affine(
+            linear, torch.tensor(0.1), torch.tensor(0), self.a_qmin, self.a_qmax
+        )
+        return q_linear
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 5),)
+
+
+class DecomposeUintFakeQuantizeTensorQParam4Dtype(PassTest):
+    def test_pass(self):
+        self.setup(FakeQuantizeTensorQParamUint4Dtype())
+        self.run_pass(DecomposeFakeQuantize())
+        self.run_pass(DecomposeFakeQuantizeTensorQParams())
+        self.run_pass(ConstPropPass())
+        self.run_pass(FillMetaVal())
+        self.run_pass(FoldQuantOps())
+        self.run_pass(RemoveWeightDequantOp())
+        for n in self.ep.graph.nodes:
+            if QPARAM_KEY not in n.meta:
+                continue
+            if n.op == "placeholder":
+                if n.target == "input":
+                    self.assertEqual(n.meta[QPARAM_KEY].dtype, "uint8")
+                else:  # linear weight
+                    self.assertEqual(n.meta[QPARAM_KEY].dtype, "uint4")
+            else:
+                self.assertEqual(n.target, torch.ops.aten.linear.default)
+                self.assertEqual(n.meta[QPARAM_KEY].dtype, "uint8")

--- a/test/unit_test/utils_test/test_utils.py
+++ b/test/unit_test/utils_test/test_utils.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tico.utils.utils import get_quant_dtype
+
+
+class TestGetQuantDtype(unittest.TestCase):
+    def test_supported_ranges(self):
+        self.assertEqual(get_quant_dtype(-32768, 32767), "int16")
+        self.assertEqual(get_quant_dtype(0, 65535), "uint16")
+        self.assertEqual(get_quant_dtype(0, 255), "uint8")
+        self.assertEqual(get_quant_dtype(-128, 127), "int8")
+        self.assertEqual(get_quant_dtype(-8, 7), "int4")
+        self.assertEqual(get_quant_dtype(0, 15), "uint4")
+
+    def test_unsupported_ranges(self):
+        with self.assertRaises(ValueError):
+            get_quant_dtype(0, 10)
+        with self.assertRaises(ValueError):
+            get_quant_dtype(-100, 100)
+        with self.assertRaises(ValueError):
+            get_quant_dtype(256, 512)
+        with self.assertRaises(ValueError):
+            get_quant_dtype(-32768, 32768)

--- a/tico/experimental/quantization/passes/fold_quant_ops.py
+++ b/tico/experimental/quantization/passes/fold_quant_ops.py
@@ -23,6 +23,7 @@ from tico.serialize.quant_param import QPARAM_KEY, QuantParam, to_qparam_dtype
 from tico.utils import logging
 from tico.utils.passes import PassBase, PassResult
 from tico.utils.trace_decorators import trace_graph_diff_on_pass
+from tico.utils.utils import get_quant_dtype
 from tico.utils.validate_args_kwargs import (
     DequantizePerTensorArgs,
     QuantizePerTensorArgs,
@@ -81,8 +82,7 @@ class FoldQuantOps(PassBase):
                 qparam = QuantParam()
                 qparam.scale = [q_args.scale]
                 qparam.zero_point = [q_args.zero_p]
-                assert "val" in q.meta and hasattr(q.meta["val"], "dtype")
-                qparam.dtype = to_qparam_dtype(q.meta["val"].dtype)
+                qparam.dtype = get_quant_dtype(q_args.quant_min, q_args.quant_max)
                 op.meta[QPARAM_KEY] = qparam
 
             dq.replace_all_uses_with(op, propagate_meta=False)

--- a/tico/experimental/quantization/passes/remove_weight_dequant_op.py
+++ b/tico/experimental/quantization/passes/remove_weight_dequant_op.py
@@ -116,12 +116,12 @@ class RemoveWeightDequantOp(PassBase):
                 dq.target
                 == torch.ops.quantized_decomposed.dequantize_per_channel.default
             ):
-                dq_args = DequantizePerChannelArgs(*dq.args, *dq.kwargs)
+                dq_args = DequantizePerChannelArgs(*dq.args, **dq.kwargs)
             elif (
                 dq.target
                 == torch.ops.quantized_decomposed.dequantize_per_tensor.default
             ):
-                dq_args = DequantizePerTensorArgs(*dq.args, *dq.kwargs)
+                dq_args = DequantizePerTensorArgs(*dq.args, **dq.kwargs)
             else:
                 raise RuntimeError(f"Invalid DQ target: {dq.target}")
 

--- a/tico/passes/decompose_fake_quantize.py
+++ b/tico/passes/decompose_fake_quantize.py
@@ -29,6 +29,10 @@ from tico.utils.validate_args_kwargs import FakeQuantizePerChannelArgs
 
 
 def get_quant_type(min: int, max: int) -> torch.dtype:
+    if min == 0 and max == 15:
+        # torch can't represent "uint4".
+        # Let's set torch.uint8 and infer dtype with quant_min/quant_max instead.
+        return torch.uint8
     if min == 0 and max == 255:
         return torch.uint8
     if min == -32768 and max == 32767:
@@ -36,7 +40,7 @@ def get_quant_type(min: int, max: int) -> torch.dtype:
     if min == -32767 and max == 32767:
         return torch.int16
 
-    raise RuntimeError("Not supported min/max values")
+    raise RuntimeError(f"Not supported min/max values: {min}/{max}")
 
 
 @trace_graph_diff_on_pass

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -312,3 +312,32 @@ def quant_min_max(dtype: str):
         return (-32768, 32767)
     else:
         raise NotImplementedError(f"NYI dtype: {dtype}")
+
+
+def get_quant_dtype(qmin: int, qmax: int):
+    """
+    Returns the string representation of the quantized data type based on qmin and qmax.
+
+    Args:
+        qmin (int): Minimum quantized value.
+        qmax (int): Maximum quantized value.
+
+    Returns:
+        str: A string representing the quantized data type, such as "int8", "uint4", etc.
+
+    Raises:
+        ValueError: If the (qmin, qmax) pair is not supported.
+    """
+    known_ranges = {
+        (-32768, 32767): "int16",
+        (0, 65535): "uint16",
+        (-128, 127): "int8",
+        (0, 255): "uint8",
+        (-8, 7): "int4",
+        (0, 15): "uint4",
+    }
+
+    if (qmin, qmax) in known_ranges:
+        return known_ranges[(qmin, qmax)]
+    else:
+        raise ValueError(f"Unsupported qunatization range: ({qmin}, {qmax})")


### PR DESCRIPTION
This commit supports fake-quantized module with uint4 dtype.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>