### PR TITLE
[passes] Introduce LegalizeAvgpool2d

### DIFF
--- a/test/modules/op/avg_pool2d.py
+++ b/test/modules/op/avg_pool2d.py
@@ -96,3 +96,18 @@ class AvgPoolNonSquareWindow(torch.nn.Module):
 
     def get_example_inputs(self):
         return (torch.randn(2, 4, 8, 16),)
+
+
+class AvgPoolWithNoCountIncludePad(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.avgpool = torch.nn.AvgPool2d(
+            kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), count_include_pad=False
+        )
+
+    def forward(self, tensor):
+        result = self.avgpool(tensor)
+        return result
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 3, 56, 56),)

--- a/tico/serialize/operators/op_avg_pool2d.py
+++ b/tico/serialize/operators/op_avg_pool2d.py
@@ -46,6 +46,10 @@ class AvgPool2DVisitor(NodeVisitor):
         stride = args.stride
         padding = args.padding
 
+        if args.count_include_pad == False:
+            # count_include_pad must be legalized by LegalizeAvgPool2D pass
+            raise ValueError("count_include_pad must be True")
+
         avgpool_input: torch.fx.Node | circle.Tensor.TensorT = input
 
         def define_padding_node():

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -52,6 +52,7 @@ from tico.passes.decompose_slice_scatter import DecomposeSliceScatter
 from tico.passes.extract_dtype_kwargs import ExtractDtypeKwargsPass
 from tico.passes.fill_meta_val import FillMetaVal
 from tico.passes.fuse_redundant_reshape_to_mean import FuseRedundantReshapeToMean
+from tico.passes.legalize_avgpool2d import LegalizeAvgpool2D
 from tico.passes.legalize_causal_mask_value import LegalizeCausalMaskValue
 from tico.passes.legalize_predefined_layout_operators import (
     LegalizePreDefinedLayoutOperators,
@@ -208,6 +209,7 @@ def convert_exported_module_to_circle(
             DecomposeGroupedConv2d(),
             CastATenWhereArgType(),
             ConvertRepeatToExpandCopy(),
+            LegalizeAvgpool2D(),
             *RemoveRedundantPermutePasses(),
             RemoveRedundantAssertionNodes(),
             RemoveRedundantExpand(),


### PR DESCRIPTION
This commit is to accept torch.nn.AvgPool2d(count_include_pad = False). count_include_pad must be true for Circle Avgpool2D. Therefore, generate mask to make equivalent operation.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

From #93