### PR TITLE
[test] Add EfficientFormerL1

### DIFF
--- a/test/modules/model/EfficientFormerL1/model.py
+++ b/test/modules/model/EfficientFormerL1/model.py
@@ -1,0 +1,19 @@
+import timm
+import torch
+
+
+class EfficientFormerL1(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model: timm.models.efficientformer.EfficientFormer = (
+            timm.create_model("efficientformer_l1", pretrained=True).to("cpu").eval()
+        )
+        self.rtol = 1e-4
+        self.atol = 1e-4
+
+    def forward(self, x: torch.Tensor):
+        return self.model.forward(x)
+
+    def get_example_inputs(self):
+        torch.manual_seed(1)
+        return (torch.randn(1, 3, 224, 224),)

--- a/test/modules/model/EfficientFormerL1/requirements.txt
+++ b/test/modules/model/EfficientFormerL1/requirements.txt
@@ -1,0 +1,2 @@
+torchvision
+timm


### PR DESCRIPTION
Let's add EfficientFormerL1 for our test model set.
Plus, use deep-copied model for export in test, because some model with BatchNorm have some issue to result in FakeTensor for inference.

---

From #93