### PR TITLE
[test] Infer before export

### DIFF
--- a/test/pt2_to_circle_test/builder.py
+++ b/test/pt2_to_circle_test/builder.py
@@ -93,6 +93,12 @@ class NNModuleTest(TestRunnerBase):
         opt_circle_model_path = str(test_prefix) + ".opt.circle"
         pt2_model_path = str(test_prefix) + ".pt2"
 
+        # Let's infer torch model before `export`
+        # WHY?
+        #   Some model changes its state during export (e.g., EfficientFormerL1)
+        #   See https://github.com/pytorch/pytorch/issues/155114
+        torch_result = infer_nnmodule(self.nnmodule, self.example_inputs)
+
         if without_pt2:
             # torch.nn.Module --> ExportedProgram --> pt2 ----- (ExportedProgram) ------- > circle
             #                                       (--> load_from_pt2_file -->)
@@ -114,7 +120,6 @@ class NNModuleTest(TestRunnerBase):
 
         verify_circle(circle_model_path, opt_circle_model_path)
 
-        torch_result = infer_nnmodule(self.nnmodule, self.example_inputs)
         USE_ONERT = os.environ.get("CCEX_RUNTIME") == "onert" or dynamic
         if self.use_onert or USE_ONERT:
             circle_result = infer_circle(

--- a/test/pt2_to_circle_test/test_pt2_to_circle.py
+++ b/test/pt2_to_circle_test/test_pt2_to_circle.py
@@ -140,6 +140,10 @@ def verify_circle(circle_model_path: str, opt_circle_model_str: str):
 @print_name_on_exception
 def infer_nnmodule(model: torch.nn.Module, example_inputs: tuple):
     with torch.no_grad():
+        # Model should be frozen to compare the result with others.
+        # e.g. BatchNorm running_mean/running_var will be updated during training mode, thus changing the model behavior.
+        model.eval()
+
         _args, _kwargs = helper.get_args_kwargs(example_inputs)
         torch_result = model.forward(*_args, **_kwargs)
 


### PR DESCRIPTION
Let's infer before export, to avoid the model's internal state change due to 'export leakage'.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

#129