### PR TITLE
Add (-32767,32767) qmin/qmax for int16

### DIFF
--- a/test/unit_test/utils_test/test_utils.py
+++ b/test/unit_test/utils_test/test_utils.py
@@ -20,6 +20,7 @@ from tico.utils.utils import broadcastable, get_quant_dtype
 class TestGetQuantDtype(unittest.TestCase):
     def test_supported_ranges(self):
         self.assertEqual(get_quant_dtype(-32768, 32767), "int16")
+        self.assertEqual(get_quant_dtype(-32767, 32767), "int16")
         self.assertEqual(get_quant_dtype(0, 65535), "uint16")
         self.assertEqual(get_quant_dtype(0, 255), "uint8")
         self.assertEqual(get_quant_dtype(-128, 127), "int8")

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -331,6 +331,7 @@ def get_quant_dtype(qmin: int, qmax: int):
     """
     known_ranges = {
         (-32768, 32767): "int16",
+        (-32767, 32767): "int16",
         (0, 65535): "uint16",
         (-128, 127): "int8",
         (0, 255): "uint8",


### PR DESCRIPTION
This adds (-32767,32767) qmin/qmax for int16.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
To support quest framework