### PR TITLE
[passes] Remove redundant leading one

### DIFF
--- a/tico/passes/remove_redundant_reshape.py
+++ b/tico/passes/remove_redundant_reshape.py
@@ -443,7 +443,7 @@ class RemoveRedundantReshapePattern6(PassBase):
 
     def call(self, ep: ExportedProgram) -> PassResult:
         """
-        Elide a redundant leading-dimension unsqueeze that is immediately
+        Remove a redundant leading-dimension unsqueeze that is immediately
         cancelled later.
 
         [BEFORE]


### PR DESCRIPTION
This commit introduces a pass that removes redundant leading one.

![image](https://github.com/user-attachments/assets/925f906a-64cb-4538-8c5c-7de4e15481d1)

Related: #136, #113
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>