### PR TITLE
[passes] Set propagate_meta=True

### DIFF
--- a/tico/passes/lower_to_slice.py
+++ b/tico/passes/lower_to_slice.py
@@ -117,9 +117,8 @@ class LowerSelectCopyToSlice(PassBase):
                     graph,
                     torch.ops.aten.reshape.default,
                     args=reshape_args,
-                    origin=node,
                 )
-                node.replace_all_uses_with(reshape_node, propagate_meta=False)
+                node.replace_all_uses_with(reshape_node, propagate_meta=True)
 
             modified = True
             logger.debug(


### PR DESCRIPTION
This commit sets propagate_meta=True for the replacing node.

Related: https://github.com/Samsung/TICO/pull/147/files/a94e308324ebd3a639ced15537b19930ff823013#r2151454889
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>