### PR TITLE
Fix mising condition of RemoveRedundantToCopy pass

### DIFF
--- a/test/unit_test/pass_test/test_remove_redundant_to_copy.py
+++ b/test/unit_test/pass_test/test_remove_redundant_to_copy.py
@@ -54,9 +54,9 @@ class NonRedundantToCopyNet(torch.nn.Module):
 
 
 class NonRedundantToCopyTest(SinglePassValueTest):
-    def test_pass(self):
+    def test_pass_neg(self):
         self.setup(NonRedundantToCopyNet())
         self.assertEqual(num_of_ops(self.exported_program(), ops.aten.to_copy), 1)
 
         self.run_value_test(RemoveRedundantToCopy())
-        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.to_copy), 0)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.to_copy), 1)

--- a/tico/passes/remove_redundant_to_copy.py
+++ b/tico/passes/remove_redundant_to_copy.py
@@ -70,6 +70,10 @@ class RemoveRedundantToCopy(PassBase):
                 if input_dtype != target_dtype:
                     continue
 
+            if hasattr(args, "memory_format") and args.memory_format is not None:
+                if args.memory_format != torch.contiguous_format:
+                    continue
+
             node.replace_all_uses_with(input_, propagate_meta=False)
 
             modified = True


### PR DESCRIPTION
This commit considers memory_format in RemoveRedundantToCopy pass and fix related test.

We are supporting only contiguous format now.
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>