### PR TITLE
[passes] Print unsupported value

### DIFF
--- a/tico/passes/decompose_fake_quantize_tensor_qparams.py
+++ b/tico/passes/decompose_fake_quantize_tensor_qparams.py
@@ -51,7 +51,7 @@ def get_quant_type(min: int, max: int) -> torch.dtype:
     if min == -32767 and max == 32767:
         return torch.int16
 
-    raise RuntimeError("Not supported min/max values")
+    raise RuntimeError(f"Not supported min/max values: {min}/{max}")
 
 
 def get_constant_from_tensor(


### PR DESCRIPTION
This commit prints unsupported min/max values for debugging.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>