### PR TITLE
Remove unused sorted function

### DIFF
--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -174,7 +174,7 @@ def check_training_ops(exported_program: ExportedProgram):
 
     if found:
         raise RuntimeError(
-            f"Detected training-mode ops {sorted(found)}. Call `model.eval()` before export."
+            f"Detected training-mode ops {found}. Call `model.eval()` before export."
         )
 
 


### PR DESCRIPTION
This commit removes sorted call because targets don't have comparing function.

Related: https://github.com/Samsung/TICO/pull/175#discussion_r2171195187
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>