### PR TITLE
Check training op at the end of the convert

### DIFF
--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -186,7 +186,6 @@ def convert_exported_module_to_circle(
     logger.debug("Input ExportedProgram (must be core aten)")
     logger.debug(exported_program)
 
-    check_training_ops(exported_program)
     # PRE-EDGE PASSES
     #
     # Here are the passes that run before to_edge() conversion.
@@ -275,6 +274,7 @@ def convert_exported_module_to_circle(
         quantize_graph.run(exported_program)
 
     check_unsupported_target(exported_program)
+    check_training_ops(exported_program)
     circle_program = build_circle(exported_program)
 
     return circle_program


### PR DESCRIPTION
This commit moves check_training_op call to the end.

Turns out that dropout can be remained after `eval()` but it has `train=False` argument, which is same with identity. Therefore, it will be removed with constant folding pass.
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>