### PR TITLE
[test] Use buffer

### DIFF
--- a/test/modules/op/index.py
+++ b/test/modules/op/index.py
@@ -60,11 +60,11 @@ class SimpleIndexTensorBuffer(torch.nn.Module):
 class SimpleIndexTensor(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("idx", torch.tensor([0, 1]))
 
     def forward(self, x, y):
-        idx = torch.tensor([0, 1])
         z = x + y
-        return z[idx]
+        return z[self.idx]
 
     def get_example_inputs(self):
         return (torch.randn(2, 3), torch.randn(2, 3))
@@ -87,10 +87,11 @@ class IndexTensor2x1(torch.nn.Module):
 class IndexTensorAxis1(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("axis", torch.tensor([0, 0]))
 
     def forward(self, x, y):
         z = x + y
-        return z[1, [0, 0]]
+        return z[1, self.axis]
 
     def get_example_inputs(self):
         return (torch.randn(2, 3), torch.randn(2, 3))
@@ -99,9 +100,10 @@ class IndexTensorAxis1(torch.nn.Module):
 class IndexTensorAxis0And1(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("axis", torch.tensor([2, 3]))
 
     def forward(self, x):
-        return x[1, [2, 3]]
+        return x[1, self.axis]
 
     def get_example_inputs(self):
         return (torch.randn(5, 4),)
@@ -110,10 +112,11 @@ class IndexTensorAxis0And1(torch.nn.Module):
 class IndexTensorWithSlice(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("axis", torch.tensor([0, 0]))
 
     def forward(self, x, y):
         z = x + y
-        return z[1:, [0, 0], :, :2]
+        return z[1:, self.axis, :, :2]
 
     def get_example_inputs(self):
         return (

--- a/test/modules/op/index_select.py
+++ b/test/modules/op/index_select.py
@@ -42,9 +42,10 @@ class SimpleIndexSelectWithDim1(torch.nn.Module):
 class SimpleIndexSelectWithConstScalarIndex(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("idx", torch.tensor([3]))
 
     def forward(self, input_):
-        result = torch.index_select(input_, 2, torch.tensor([3]))
+        result = torch.index_select(input_, 2, self.idx)
         return result
 
     def get_example_inputs(self):
@@ -54,9 +55,10 @@ class SimpleIndexSelectWithConstScalarIndex(torch.nn.Module):
 class SimpleIndexSelectWithConstIndex(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("idx", torch.tensor([3, 1, 2]))
 
     def forward(self, x, y):
-        result = torch.index_select(x, 2, torch.tensor([3, 1, 2])) + y
+        result = torch.index_select(x, 2, self.idx) + y
         return result
 
     def get_example_inputs(self):

--- a/test/unit_test/pass_test/test_decompose_fake_quantize.py
+++ b/test/unit_test/pass_test/test_decompose_fake_quantize.py
@@ -23,15 +23,17 @@ class FakeQuantizePerChannel(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.channel = 10
+        self.register_buffer("s", torch.tensor([1.0] * self.channel))
+        self.register_buffer("zp", torch.zeros(self.channel))
 
     def forward(self, input):
-        s = torch.tensor([1.0] * self.channel)
-        zp = torch.zeros(self.channel)
         axis = 1
         qmin = 0
         qmax = 255
 
-        return torch.fake_quantize_per_channel_affine(input, s, zp, axis, qmin, qmax)
+        return torch.fake_quantize_per_channel_affine(
+            input, self.s, self.zp, axis, qmin, qmax
+        )
 
     def get_example_inputs(self):
         return (torch.randn(1, self.channel, 64, 64),)

--- a/test/unit_test/pass_test/test_segment_index_select.py
+++ b/test/unit_test/pass_test/test_segment_index_select.py
@@ -23,9 +23,10 @@ from test.utils.pass_value_test import SinglePassValueTest
 class SimpleIndexSelectWithConstIndex(torch.nn.Module):
     def __init__(self):
         super().__init__()
+        self.register_buffer("idx", torch.tensor([3, 1, 2]))
 
     def forward(self, x, y):
-        result = torch.index_select(x, 2, torch.tensor([3, 1, 2])) + y
+        result = torch.index_select(x, 2, self.idx) + y
         return result
 
     def get_example_inputs(self):


### PR DESCRIPTION
This commit uses buffer instead of in-place tensors.

Related: #159

This change turns off below warnings.
```
/home/seongwoo/TICO/.venv/lib/python3.10/site-packages/torch/fx/graph.py:1801: UserWarning: Node segm_index2_1 target segm_index2 segm_index2 of  does not reference an nn.Module, nn.Parameter, or buffer, which is what 'get_attr' Nodes typically target
  warnings.warn(
ok

```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>