### PR TITLE
[lint] Fix typo

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -14,7 +14,7 @@ command = [
     'pylint_linter',
     '--',
     '--rcfile=.pylintrc',
-    '--job=0',
+    '--jobs=0',
     '@{{PATHSFILE}}'
 ]
 init_command = [


### PR DESCRIPTION
This commit fixes typo of option name.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>