### PR TITLE
Make one-compiler an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ designed for optimized on-device neural network inference.
 
 - Python 3.10
 - (Optional) [one-compiler 1.30.0](https://github.com/Samsung/ONE/releases/tag/1.30.0)
-  - It's only required if you want to run inference with the converted Circle model. If you're
-   only converting models and don't plan to run them, this dependency is not needed.
+  - It is only required if you intend to run inference with the converted Circle model. If you are only converting models without running them, this dependency is not needed.
 
 We highly recommend to use a virtual env, e.g., conda.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ designed for optimized on-device neural network inference.
 0. Prerequisites
 
 - Python 3.10
-- [one-compiler 1.30.0](https://github.com/Samsung/ONE/releases/tag/1.30.0)
+- (Optional) [one-compiler 1.30.0](https://github.com/Samsung/ONE/releases/tag/1.30.0)
+  - It's only required if you want to run inference with the converted Circle model. If you're
+   only converting models and don't plan to run them, this dependency is not needed.
 
 We highly recommend to use a virtual env, e.g., conda.
 


### PR DESCRIPTION
This commit adds some description to make one-compiler an optional. It's more like a testing thing.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>