### PR TITLE
Cast mixed type args of clamp

### DIFF
--- a/test/modules/op/clamp.py
+++ b/test/modules/op/clamp.py
@@ -101,3 +101,15 @@ class DoubleClampsFrom0to6WithBigMax(torch.nn.Module):
 
     def get_example_inputs(self):
         return (torch.randn(5, 3) * 10,)
+
+
+class ClampIntInputFloatMinMax(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = torch.clamp(x, -100.0, 100.0)
+        return x
+
+    def get_example_inputs(self):
+        return (torch.randint(-200, 200, (5, 3)),)

--- a/test/unit_test/pass_test/test_cast_clamp_mixed_type_args.py
+++ b/test/unit_test/pass_test/test_cast_clamp_mixed_type_args.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from tico.passes import ops
+from tico.passes.cast_clamp_mixed_type_args import CastClampMixedTypeArgs
+
+from test.utils.helper import num_of_ops
+from test.utils.pass_value_test import SinglePassValueTest
+
+
+from tico.utils import logging
+from tico.utils.graph import create_node
+from tico.utils.passes import PassBase, PassResult
+from tico.utils.trace_decorators import trace_graph_diff_on_pass
+from tico.utils.utils import is_target_node, set_new_meta_val
+from tico.utils.validate_args_kwargs import ClampArgs
+
+
+class CastClampFloatInputIntMin(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = torch.clamp(x, -10, None)
+        return x
+
+    def get_example_inputs(self):
+        return (torch.randn(5, 3) * 20,)
+
+
+class CastClampFloatInputIntMinTest(SinglePassValueTest):
+    def test_pass(self):
+        self.setup(CastClampFloatInputIntMin())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+
+        self.run_value_test(CastClampMixedTypeArgs())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten._to_copy), 0)
+
+
+class CastClampFloatInputIntMax(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = torch.clamp(x, None, 10)
+        return x
+
+    def get_example_inputs(self):
+        return (torch.randn(5, 3) * 20,)
+
+
+class CastClampFloatInputIntMaxTest(SinglePassValueTest):
+    def test_pass(self):
+        self.setup(CastClampFloatInputIntMax())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+
+        self.run_value_test(CastClampMixedTypeArgs())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten._to_copy), 0)
+
+
+class CastClampIntInputFloatMin(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = torch.clamp(x, -10.0, None)
+        return x
+
+    def get_example_inputs(self):
+        return (torch.randint(-20, 20, (5, 3)),)
+
+
+class CastClampIntInputFloatMinTest(SinglePassValueTest):
+    def test_pass(self):
+        self.setup(CastClampIntInputFloatMin())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+
+        self.run_value_test(CastClampMixedTypeArgs())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten._to_copy), 1)
+
+
+class CastClampIntInputFloatMax(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        x = torch.clamp(x, None, 10.0)
+        return x
+
+    def get_example_inputs(self):
+        return (torch.randint(-20, 20, (5, 3)),)
+
+
+class CastClampIntInputFloatMaxTest(SinglePassValueTest):
+    def test_pass(self):
+        self.setup(CastClampIntInputFloatMax())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+
+        self.run_value_test(CastClampMixedTypeArgs())
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.clamp), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten._to_copy), 1)

--- a/test/unit_test/pass_test/test_cast_clamp_mixed_type_args.py
+++ b/test/unit_test/pass_test/test_cast_clamp_mixed_type_args.py
@@ -20,14 +20,6 @@ from test.utils.helper import num_of_ops
 from test.utils.pass_value_test import SinglePassValueTest
 
 
-from tico.utils import logging
-from tico.utils.graph import create_node
-from tico.utils.passes import PassBase, PassResult
-from tico.utils.trace_decorators import trace_graph_diff_on_pass
-from tico.utils.utils import is_target_node, set_new_meta_val
-from tico.utils.validate_args_kwargs import ClampArgs
-
-
 class CastClampFloatInputIntMin(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/tico/passes/cast_clamp_mixed_type_args.py
+++ b/tico/passes/cast_clamp_mixed_type_args.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.fx
+import torch
+from torch.export import ExportedProgram
+
+from tico.utils import logging
+from tico.utils.graph import create_node
+from tico.utils.passes import PassBase, PassResult
+from tico.utils.trace_decorators import trace_graph_diff_on_pass
+from tico.utils.utils import is_target_node, set_new_meta_val
+from tico.utils.validate_args_kwargs import ClampArgs
+
+
+@trace_graph_diff_on_pass
+class CastClampMixedTypeArgs(PassBase):
+    """
+    This pass ensures consistent dtypes for clamp operations by:
+    1. Converting min/max arguments to match output dtype when provided
+    2. Inserting cast operations when input dtype differs from output dtype
+
+    Behavior Examples:
+    - When input dtype differs from output:
+        Inserts _to_copy operation to convert input
+    - When min/max dtype differs from output:
+        Converts min/max values to output dtype
+
+    [before, if input dtype is different from output dtype]
+
+            input               min(or max)
+           (dtype=int)         (dtype=float)
+              |                    |
+            clamp <----------------+
+              |
+            output
+           (dtype=float)
+
+    [after]
+
+            input             min(or max)
+           (dtype=int)       (dtype=float)
+              |                  |
+            cast                 |
+          (in=int, out=float)    |
+              |                  |
+            clamp <--------------+
+              |
+            output
+           (dtype=float)
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def convert(self, exported_program: ExportedProgram, node: torch.fx.Node) -> bool:
+        logger = logging.getLogger(__name__)
+        modified = False
+
+        graph_module = exported_program.graph_module
+        graph = graph_module.graph
+
+        # clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
+        args = ClampArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
+
+        input = args.input
+        min = args.min
+        max = args.max
+
+        if "val" not in input.meta or "val" not in node.meta:
+            logger.warning(f"Missing meta['val'] for node {node.name}")
+            return False
+
+        input_dtype = input.meta["val"].dtype
+        output_dtype = node.meta["val"].dtype
+
+        def _convert_arg(arg, arg_name: str):
+            if arg is None:
+                return False
+
+            arg_dtype = torch.tensor(arg).dtype
+            arg_idx = node.args.index(arg)
+            if arg_dtype != output_dtype:
+                if output_dtype == torch.float32 or output_dtype == torch.float:
+                    arg = float(arg)
+                else:
+                    arg = int(arg)
+                node.update_arg(arg_idx, arg)
+                logger.info(
+                    f"Converted {arg_name} value from {arg_dtype} to {output_dtype} for clamp operation at {node.name}"
+                )
+                return True
+            return False
+
+        modified |= _convert_arg(min, "min")
+        modified |= _convert_arg(max, "max")
+
+        if input_dtype != output_dtype:
+            logger.info(
+                f"Inserting cast from {input_dtype} to {output_dtype} for input {input.name}"
+            )
+            with graph.inserting_after(input):
+                to_copy = create_node(
+                    graph,
+                    torch.ops.aten._to_copy.default,
+                    (input,),
+                    {"dtype": output_dtype},
+                    origin=input,
+                )
+                set_new_meta_val(to_copy)
+                node.update_arg(node.args.index(input), to_copy)
+
+            modified = True
+
+        return modified
+
+    def call(self, exported_program: ExportedProgram) -> PassResult:
+        target_op = [torch.ops.aten.clamp.default, torch.ops.aten.clamp.Tensor]
+
+        graph_module = exported_program.graph_module
+        graph = graph_module.graph
+        modified = False
+        for node in graph.nodes:
+            if not is_target_node(node, target_op):
+                continue
+
+            modified |= self.convert(exported_program, node)
+
+        graph.eliminate_dead_code()
+        graph.lint()
+        graph_module.recompile()
+
+        return PassResult(modified)

--- a/tico/passes/cast_clamp_mixed_type_args.py
+++ b/tico/passes/cast_clamp_mixed_type_args.py
@@ -43,7 +43,8 @@ class CastClampMixedTypeArgs(PassBase):
     - When min/max dtype differs from output:
         Converts min/max values to output dtype
 
-    [before, if input dtype is different from output dtype]
+    (Case 1, if input dtype is different from output dtype)
+    [before]
 
             input               min(or max)
            (dtype=int)         (dtype=float)
@@ -60,6 +61,27 @@ class CastClampMixedTypeArgs(PassBase):
               |                  |
             cast                 |
           (in=int, out=float)    |
+              |                  |
+            clamp <--------------+
+              |
+            output
+           (dtype=float)
+
+    (Case 2, if min(or max) dtype is different from output dtype)
+    [before]
+
+            input               min(or max)
+           (dtype=float)       (dtype=int)
+              |                    |
+            clamp <----------------+
+              |
+            output
+           (dtype=float)
+
+    [after]
+
+            input             min(or max)
+           (dtype=float)     (dtype=float)
               |                  |
             clamp <--------------+
               |

--- a/tico/passes/cast_clamp_mixed_type_args.py
+++ b/tico/passes/cast_clamp_mixed_type_args.py
@@ -100,7 +100,7 @@ class CastClampMixedTypeArgs(PassBase):
                 else:
                     arg = int(arg)
                 node.update_arg(arg_idx, arg)
-                logger.info(
+                logger.debug(
                     f"Converted {arg_name} value from {arg_dtype} to {output_dtype} for clamp operation at {node.name}"
                 )
                 return True
@@ -110,7 +110,7 @@ class CastClampMixedTypeArgs(PassBase):
         modified |= _convert_arg(max, "max")
 
         if input_dtype != output_dtype:
-            logger.info(
+            logger.debug(
                 f"Inserting cast from {input_dtype} to {output_dtype} for input {input.name}"
             )
             with graph.inserting_after(input):

--- a/tico/passes/ops.py
+++ b/tico/passes/ops.py
@@ -73,6 +73,7 @@ class AtenOps:
             torch.ops.aten.view.default,
             torch.ops.aten.view_copy.default,
         ]
+        self._to_copy = [torch.ops.aten._to_copy.default]
 
 
 aten = AtenOps()

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -35,6 +35,7 @@ from tico.experimental.quantization.passes.remove_weight_dequant_op import (
     RemoveWeightDequantOp,
 )
 from tico.passes.cast_aten_where_arg_type import CastATenWhereArgType
+from tico.passes.cast_clamp_mixed_type_args import CastClampMixedTypeArgs
 from tico.passes.cast_mixed_type_args import CastMixedTypeArgs
 from tico.passes.const_prop_pass import ConstPropPass
 from tico.passes.convert_conv1d_to_conv2d import ConvertConv1dToConv2d
@@ -246,6 +247,7 @@ def convert_exported_module_to_circle(
             ConvertConv1dToConv2d(),
             *LowerToSlicePasses(),
             FuseLeadingUnsqueezeReshape(),
+            CastClampMixedTypeArgs(),
         ]
     )
     circle_legalize.run(exported_program)


### PR DESCRIPTION
This pass ensures consistent dtypes for clamp operations by:
    1. Converting min/max arguments to match output dtype when provided
    2. Inserting cast operations when input dtype differs from output dtype

TICO-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

for https://github.com/Samsung/TICO/issues/179#issuecomment-3047972123