### PR TITLE
[test+operators] Fuse attention to circle attention

### DIFF
--- a/test/modules/model/LlamaDecoderLayerWithKVCacheAndFusedAttention/model.py
+++ b/test/modules/model/LlamaDecoderLayerWithKVCacheAndFusedAttention/model.py
@@ -1,0 +1,156 @@
+# User input
+prompt = "Lily picked up a flower."
+model_name = "Maykeye/TinyLLama-v0"
+
+captured_input = ()
+
+import copy, inspect, types
+
+from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+forward_org = LlamaDecoderLayer.forward
+
+
+def capture_and_forward(self, *args, **kwargs):
+    global captured_input
+
+    # Prepare args tuple for TICO.convert()
+    # Get arg_names in positional args order using inspect
+    sig = inspect.signature(forward_org)
+    args_names = [
+        # signature includes `self`` and `kwargs``.
+        # Just retrieve the ordinary positional inputs only
+        name
+        for name in sig.parameters.keys()
+        if name not in ("self", "kwargs")
+    ]
+
+    args_dict = dict(zip(args_names, args))
+    args_dict.update(kwargs)
+
+    def populate_args(args_dict, filter):
+        for key in filter:
+            args_dict.pop(key, None)
+        args_tuple = tuple(args_dict.get(name, None) for name in args_names)
+        return copy.deepcopy(args_tuple)
+
+    if len(args_dict["past_key_value"].key_cache) != 0:
+        input_to_remove = ["use_cache"]
+        captured_input = populate_args(args_dict, input_to_remove)
+
+    return forward_org(self, *args, **kwargs)
+
+
+# Tokenizer
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+tokenizer.pad_token = tokenizer.eos_token
+tokenizer.padding_side = "right"
+inputs = tokenizer(
+    prompt,
+    return_tensors="pt",
+    padding="max_length",
+    max_length=32,
+    truncation=True,
+)
+
+
+# Generator
+import torch
+
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained(model_name)
+model.eval()
+model.model.layers[0].forward = types.MethodType(
+    capture_and_forward, model.model.layers[0]
+)
+with torch.no_grad():
+    outputs = model.generate(
+        **inputs,
+        max_new_tokens=32,
+        do_sample=False,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+generated_text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+print(generated_text)
+
+
+# ATTENTION FUSER
+
+from typing import Optional, List
+
+
+@torch.library.impl("circle::attention.llama", "CPU")
+def attention_llama_cpu(
+    hidden_states,
+    position_cos,
+    position_sin,
+    attention_mask,
+    past_key,
+    past_value,
+    layer_idx,
+    cache_position,
+):
+    return hidden_states
+
+
+@torch.library.register_fake("circle::attention.llama")
+def attention_llama(*args, **kwargs):
+    (
+        hidden_states,
+        position_cos,
+        position_sin,
+        attention_mask,
+        past_key,
+        past_value,
+        layer_idx,
+        cache_position,
+    ) = args
+    return hidden_states
+
+
+from transformers.models.llama.modeling_llama import LlamaAttention
+from transformers.cache_utils import DynamicCache
+
+def forward_adapter(
+    self: LlamaAttention,
+    hidden_states: torch.Tensor,
+    position_embeddings: List[torch.Tensor],
+    attention_mask: Optional[torch.Tensor],
+    past_key_value: Optional[DynamicCache],
+    cache_position: torch.Tensor,
+    **kwargs
+):
+    # past_key_value is a dict with key_cache and value_cache.
+    # It needs to be decomposed for tico and circle which does not know dict.
+    key_cache = past_key_value.key_cache
+    value_cache = past_key_value.value_cache
+    return (
+        torch.ops.circle.attention.llama(
+            hidden_states,
+            position_embeddings[0], # cos
+            position_embeddings[1], # sin
+            attention_mask,
+            # key_cache is a list of cache for each decoder layer.
+            # Assumtion: key cache is continuous
+            #
+            #    k_cache[0] | k_cache[1] | ...  | k_cache[n]
+            key_cache[0],
+            value_cache[0], # Same to value_cache
+            self.layer_idx,
+            cache_position,
+        ),
+        None,
+    )
+
+LlamaAttention.forward = forward_adapter
+
+# Tico
+import tico
+
+model = AutoModelForCausalLM.from_pretrained(model_name)
+model.eval()
+circle_model = tico.convert(model.model.layers[0], captured_input)
+circle_model.save(f"tinyllama.attn.circle")

--- a/test/modules/model/LlamaDecoderLayerWithKVCacheAndFusedAttention/requirements.txt
+++ b/test/modules/model/LlamaDecoderLayerWithKVCacheAndFusedAttention/requirements.txt
@@ -1,0 +1,1 @@
+transformers>=4.50.1

--- a/tico/serialize/operators/op_circle_attention.py
+++ b/tico/serialize/operators/op_circle_attention.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch._ops
+    import torch.fx
+import torch
+from circle_schema import circle
+
+from tico.serialize.circle_graph import CircleSubgraph, extract_shape
+from tico.serialize.operators.hashable_opcode import OpCode
+from tico.serialize.operators.node_visitor import NodeVisitor, register_node_visitor
+from tico.serialize.operators.utils import create_builtin_operator, get_op_index
+
+from torch.library import Library
+
+lib = Library("circle", "DEF")
+lib.define("""
+attention.llama(
+    Tensor hidden_states,
+    Tensor position_cos,
+    Tensor position_sin,
+    Tensor? attention_mask,
+    Tensor past_key,
+    Tensor past_value,
+    int layer_idx,
+    Tensor cache_position
+) -> Tensor
+""")
+
+@register_node_visitor
+class AttentionVisitor(NodeVisitor):
+    target: List[torch._ops.OpOverload] = [
+        torch.ops.circle.attention.llama,
+    ]
+
+    def __init__(self, op_codes: Dict[OpCode, int], graph: CircleSubgraph):
+        super().__init__(op_codes, graph)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+    ) -> circle.Operator.OperatorT:
+        (
+            hidden_states,
+            position_cos,
+            position_sin,
+            attention_mask,
+            past_key,
+            past_value,
+            cache_position,
+            layer_idx,
+        ) = node.args
+
+        inputs = node.args
+        outputs = [node]
+
+        op_index = get_op_index(
+            circle.BuiltinOperator.BuiltinOperator.ATTENTION, self._op_codes
+        )
+
+        inputs = node.args
+        outputs = [node]
+        operator = create_builtin_operator(self.graph, op_index, inputs, outputs)
+
+        # Op-specific option
+        operator.builtinOptionsType = (
+            circle.BuiltinOptions.BuiltinOptions.AttentionOptions
+        )
+        option = circle.AttentionOptions.AttentionOptionsT()
+        option.layer_idx = layer_idx
+
+        operator.builtinOptions = option
+
+        return operator


### PR DESCRIPTION
It introduces circle_attention op, and add tests which fuse attention from LlamaDecoderLayers.

TICO-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

It is another fuser. It does not use pattern match, but it adds an operator using decorator.
You can run the code using

```
python test/modules/model/LlamaDecoderLayerWithKVCache/model.py
```