### PR TITLE
Do not decompose aten.upsample_nearest2d

### DIFF
--- a/test/modules/op/interpolate.py
+++ b/test/modules/op/interpolate.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import torch
-from tico.utils.utils import HAS_TORCH_OVER_28_DEV
-
-from test.utils import tag
 
 
 class InterpolateDouble(torch.nn.Module):
@@ -40,10 +37,6 @@ class InterpolateThreeTimes(torch.nn.Module):
         return (torch.randn(1, 2, 3, 4),)
 
 
-@tag.skip_if(
-    not HAS_TORCH_OVER_28_DEV,
-    reason="The case isn't supported yet. It will be supported from torch 2.8.0.dev",
-)
 class InterpolateOnePointFive(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -106,6 +106,7 @@ def traced_run_decompositions(exported_program: ExportedProgram):
             torch.ops.aten._safe_softmax.default,
             torch.ops.aten.relu6.default,  # Do not decompose to hardtanh
             torch.ops.aten.linear.default,
+            torch.ops.aten.upsample_nearest2d.vec,
         )
         ep = ep.run_decompositions(_preserve_ops=_preserve_ops)
 
@@ -124,6 +125,7 @@ def traced_run_decompositions(exported_program: ExportedProgram):
             torch.ops.aten.relu6.default,  # Do not decompose to hardtanh
             torch.ops.aten.prelu.default,
             torch.ops.aten.linear.default,
+            torch.ops.aten.upsample_nearest2d.vec,
         )
         for op in _preserve_ops:
             if op in _decomp_table:

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -29,9 +29,6 @@ from torch.utils import _pytree as pytree
 from tico.serialize.quant_param import QuantParam
 
 
-HAS_TORCH_OVER_28_DEV = Version(torch.__version__) >= Version("2.8.0.dev")
-
-
 def get_fake_mode(exported_program: ExportedProgram):
     fake_mode = detect_fake_mode(
         tuple(


### PR DESCRIPTION
This commit adds an aten.upsample_nearest2d to preserve op list.

We don't have to check the version with this patch.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>