### PR TITLE
Support i8o16 bmm in InsertQuantizeOpPass.

### DIFF
--- a/test/quantization/pass/test_insert_quantize_on_dtype_mismatch.py
+++ b/test/quantization/pass/test_insert_quantize_on_dtype_mismatch.py
@@ -192,6 +192,15 @@ class BMMTest(InsertQuantizeOnDtypeMismatchTest):
         )
         self.run_test()
 
+    def test_i8o16(self):
+        self.setup(
+            SimpleBatchMatMul(),
+            torch.ops.aten.bmm.default,
+            input_dtype="uint8",
+            desired_dtype="uint8",
+        )
+        self.run_test()
+
 
 class ReshapeTest(InsertQuantizeOnDtypeMismatchTest):
     def test_i8o16(self):

--- a/tico/experimental/quantization/passes/insert_quantize_on_dtype_mismatch.py
+++ b/tico/experimental/quantization/passes/insert_quantize_on_dtype_mismatch.py
@@ -287,6 +287,12 @@ def _bmm_handler(node, logger):
         quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
         node.meta[QPARAM_KEY] = _u8_to_i16(node.meta[QPARAM_KEY])
         logger.debug(f"quantize_per_tensor.default is inserted after {node.name}.")
+    elif qparam_dtype(x) == "uint8" and qparam_dtype(node) == "int16":
+        quantize = _insert_quantize_op_after(node)
+
+        quantize.meta[QPARAM_KEY] = copy.deepcopy(node.meta[QPARAM_KEY])
+        node.meta[QPARAM_KEY] = _i16_to_u8(node.meta[QPARAM_KEY])
+        logger.debug(f"quantize_per_tensor.default is inserted after {node.name}.")
     else:
         raise NotYetSupportedError("Unsupported dtype")
 


### PR DESCRIPTION
This supports i8o16 bmm in InsertQuantizeOpPass.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>