### PR TITLE
Handle dynamic shape after serialize

### DIFF
--- a/tico/serialize/circle_graph.py
+++ b/tico/serialize/circle_graph.py
@@ -152,15 +152,6 @@ class CircleSubgraph(circle.SubGraph.SubGraphT):
         assert node.meta.get("val") is not None
         tensor.type = extract_circle_dtype(node)
         tensor.shape = list(extract_shape(node))
-
-        # Handle dynamic shape
-        if any(isinstance(s, torch.SymInt) for s in tensor.shape):
-            tensor.shapeSignature = tensor.shape.copy()
-            for idx, s in enumerate(tensor.shape):
-                if isinstance(s, torch.SymInt):
-                    tensor.shape[idx] = 1
-                    tensor.shapeSignature[idx] = -1
-
         if QPARAM_KEY in node.meta:
             tensor.quantization = to_circle_qparam(node.meta[QPARAM_KEY])
             tensor.type = str_to_circle_dtype(node.meta[QPARAM_KEY].dtype)
@@ -250,15 +241,6 @@ class CircleSubgraph(circle.SubGraph.SubGraphT):
         if source_node is not None:
             self.name_to_node[tensor.name] = source_node
         tensor.shape = shape
-
-        # Handle dynamic shape
-        if any(isinstance(s, torch.SymInt) for s in tensor.shape):
-            tensor.shapeSignature = tensor.shape.copy()
-            for idx, s in enumerate(tensor.shape):
-                if isinstance(s, torch.SymInt):
-                    tensor.shape[idx] = 1
-                    tensor.shapeSignature[idx] = -1
-
         if qparam is not None:
             tensor.quantization = to_circle_qparam(qparam)
             tensor.type = str_to_circle_dtype(qparam.dtype)


### PR DESCRIPTION
Let's fix it to re-interpret the dynamic shape after serialization.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>


---

### WHY?

`add_tensor_from_node` is called when `tensors are exported to node before serialization`.
Then, each `operator serialization` is performed. The input of the operator could be circle-interpreted symbolic shape, which has lost its dynamic shape information. It will mislead **all the add_tensor_from_scratch operators used in operator visitor**.

For example,
```py
lass BasePowVisitor(NodeVisitor):
    def __init__(self, op_codes: Dict[OpCode, int], graph: CircleSubgraph):
        super().__init__(op_codes, graph)

    def cast_to_float(self, node: torch.fx.Node) -> circle.Tensor.TensorT:
        assert isinstance(node, torch.fx.Node), type(node)
        node_tensor: circle.Tensor.TensorT = self.graph.get_tensor(node)
        node_shape: List[int] = node_tensor.shape # <------- Already interpreted as circle shape. [s0, 3, 3, 4] -> [1, 3, 3, 4]
        op_index = get_op_index(
            circle.BuiltinOperator.BuiltinOperator.CAST, self._op_codes
        )
        cast_name = f"{node.name}_cast"
        cast_dtype = circle.TensorType.TensorType.FLOAT32
        cast_tensor = self.graph.add_tensor_from_scratch(
            prefix=cast_name,
            dtype=cast_dtype,
            shape=node_shape, # <----- [1, 3, 3, 4] is given. `cast_tensor` never know it is dynamic shape.
            source_node=node,
        )
```

Therefore, conversion of torch symbolic integer into circle dynamic shape schema must be performed at the end of `build_circle`.