### PR TITLE
Remove unused variables

### DIFF
--- a/tico/passes/decompose_addmm.py
+++ b/tico/passes/decompose_addmm.py
@@ -20,7 +20,6 @@ import torch
 from torch.export import ExportedProgram
 
 from tico.serialize.circle_mapping import extract_shape
-from tico.utils import logging
 from tico.utils.graph import add_placeholder, create_node
 from tico.utils.passes import PassBase, PassResult
 from tico.utils.trace_decorators import trace_graph_diff_on_pass
@@ -59,8 +58,6 @@ class DecomposeAddmm(PassBase):
         super().__init__()
 
     def call(self, exported_program: ExportedProgram) -> PassResult:
-        logger = logging.getLogger(__name__)
-
         gm = exported_program.graph_module
         graph: torch.fx.Graph = gm.graph
         modified = False

--- a/tico/passes/decompose_fake_quantize.py
+++ b/tico/passes/decompose_fake_quantize.py
@@ -21,7 +21,6 @@ import torch
 # To import torch.ops.quantized_decomposed related operator
 from torch.export import ExportedProgram
 
-from tico.utils import logging
 from tico.utils.graph import create_node
 from tico.utils.passes import PassBase, PassResult
 from tico.utils.trace_decorators import trace_graph_diff_on_pass
@@ -65,7 +64,6 @@ class DecomposeFakeQuantize(PassBase):
         super().__init__()
 
     def call(self, exported_program: ExportedProgram) -> PassResult:
-        logger = logging.getLogger(__name__)
         modified = False
 
         gm = exported_program.graph_module

--- a/tico/passes/decompose_group_norm.py
+++ b/tico/passes/decompose_group_norm.py
@@ -22,7 +22,6 @@ import torch
 from torch.export import ExportedProgram
 
 from tico.serialize.circle_mapping import extract_shape
-from tico.utils import logging
 from tico.utils.graph import create_node
 from tico.utils.passes import PassBase, PassResult
 from tico.utils.trace_decorators import trace_graph_diff_on_pass
@@ -126,8 +125,6 @@ class DecomposeGroupNorm(PassBase):
         )
 
     def call(self, exported_program: ExportedProgram) -> PassResult:
-        logger = logging.getLogger(__name__)
-
         gm = exported_program.graph_module
         graph: torch.fx.Graph = gm.graph
         modified = False

--- a/tico/passes/legalize_predefined_layout_operators.py
+++ b/tico/passes/legalize_predefined_layout_operators.py
@@ -206,7 +206,6 @@ class LegalizePreDefinedLayoutOperators(PassBase):
 
         args = ConvTranspose2DArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
         input = args.input
-        padding = args.padding
         groups = args.groups
         dilation = args.dilation
 
@@ -288,7 +287,6 @@ class LegalizePreDefinedLayoutOperators(PassBase):
         input = args.input
         weight = args.weight
         bias = args.bias
-        eps = args.eps
 
         running_mean = args.running_mean
         running_var = args.running_var
@@ -350,10 +348,6 @@ class LegalizePreDefinedLayoutOperators(PassBase):
         # max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
         args = MaxPool2dWithIndicesArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
         input_ = args.input
-        kernel_size = args.kernel_size
-        stride = args.stride
-        padding = args.padding
-        dilation = args.dilation
         ceil_mode = args.ceil_mode
         if ceil_mode:
             raise NotYetSupportedError("Only support non-ceil model.")
@@ -402,9 +396,6 @@ class LegalizePreDefinedLayoutOperators(PassBase):
         # avg_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, bool ceil_mode=False, bool count_include_pad=True, int? divisor_override=None) -> (Tensor)
         args = AvgPool2dArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
         input_ = args.input
-        kernel_size = args.kernel_size
-        stride = args.stride
-        padding = args.padding
         ceil_mode = args.ceil_mode
         if ceil_mode:
             raise NotYetSupportedError("Only support non-ceil model.")

--- a/tico/passes/remove_redundant_reshape.py
+++ b/tico/passes/remove_redundant_reshape.py
@@ -90,7 +90,7 @@ class RemoveRedundantReshapePattern1(PassBase):
             if len(permute.users) != 1:
                 continue
             permute_args = PermuteArgs(*permute.args, **permute.kwargs)  # type: ignore[arg-type]
-            permute_input, permute_dims = permute_args.input, permute_args.dims
+            permute_dims = permute_args.dims
             # (1xAxBxC) - `aten.permute` - (1xAxCxB)
             if permute_dims != [0, 1, 3, 2]:
                 continue
@@ -172,7 +172,7 @@ class RemoveRedundantReshapePattern2(PassBase):
             if len(permute.users) != 1:
                 continue
             permute_args = PermuteArgs(*permute.args, **permute.kwargs)  # type: ignore[arg-type]
-            permute_input, permute_dims = permute_args.input, permute_args.dims
+            permute_dims = permute_args.dims
             # (1xAxBxC) - `aten.permute` - (Bx1xAxC)
             if permute_dims != [2, 0, 1, 3]:
                 continue

--- a/tico/serialize/operators/op_any.py
+++ b/tico/serialize/operators/op_any.py
@@ -99,8 +99,6 @@ class AnyVisitor(NodeVisitor):
         keepdim = args.keepdim
 
         input_shape = list(extract_shape(input))
-        output_shape = list(extract_shape(node))
-
         dim_i32 = None
         if dim is None:
             dims = tuple(i for i in range(0, len(input_shape)))

--- a/tico/serialize/operators/op_instance_norm.py
+++ b/tico/serialize/operators/op_instance_norm.py
@@ -73,12 +73,6 @@ class InstanceNormVisitor(NodeVisitor):
         eps = args.eps
 
         # Ignore training-related args
-        running_mean = args.running_mean
-        running_var = args.running_var
-        use_input_stats = args.use_input_stats
-        momentum = args.momentum
-        cudnn_enabled = args.cudnn_enabled
-
         input_shape = list(extract_shape(input))
         assert len(input_shape) == 4, len(input_shape)
 

--- a/tico/serialize/operators/op_mul.py
+++ b/tico/serialize/operators/op_mul.py
@@ -66,10 +66,7 @@ class MulTensorVisitor(BaseMulVisitor):
         self,
         node: torch.fx.Node,
     ) -> circle.Operator.OperatorT:
-        args = MulTensorArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
-        input = args.input
-        other = args.other
-
+        _ = MulTensorArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
         operator = super().define_node(
             node,
         )
@@ -88,10 +85,7 @@ class MulScalarVisitor(BaseMulVisitor):
         self,
         node: torch.fx.Node,
     ) -> circle.Operator.OperatorT:
-        args = MulScalarArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
-        input = args.input
-        other = args.other
-
+        _ = MulScalarArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
         operator = super().define_node(
             node,
         )

--- a/tico/serialize/operators/op_transpose_conv.py
+++ b/tico/serialize/operators/op_transpose_conv.py
@@ -76,9 +76,7 @@ class TransposeConvVisitor(NodeVisitor):
         bias = args.bias
         stride = args.stride
         padding = args.padding
-        output_padding = args.output_padding
         groups = args.groups
-        dilation = args.dilation
 
         assert groups == 1, "Only support group 1"
 


### PR DESCRIPTION
Let's remove unused variables.
For easy check, run `ruff check | grep F841`.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>


---

From #231