### PR TITLE
[serialize] Fix type annotation

### DIFF
--- a/tico/serialize/circle_graph.py
+++ b/tico/serialize/circle_graph.py
@@ -151,7 +151,7 @@ class CircleSubgraph(circle.SubGraph.SubGraphT):
         self.name_to_node[tensor.name] = node
         assert node.meta.get("val") is not None
         tensor.type = extract_circle_dtype(node)
-        tensor.shape, tensor.shapeSignature = extract_circle_shape(node)
+        tensor.shape, tensor.shapeSignature = extract_circle_shape(node)  # type: ignore[assignment]
 
         if QPARAM_KEY in node.meta:
             tensor.quantization = to_circle_qparam(node.meta[QPARAM_KEY])

--- a/tico/serialize/operators/op_copy.py
+++ b/tico/serialize/operators/op_copy.py
@@ -110,7 +110,7 @@ class CopyVisitor(NodeVisitor):
         # To connect 'dst' to Reshape node in the graph, 'dst' must be converted to Shape op.
         dst_tensor: circle.Tensor.TensorT = self.graph.get_tensor(dst)
         dst_shape: List[int] = dst_tensor.shape
-        dst_shape_signature: List[int] = dst_tensor.shapeSignature
+        dst_shape_signature: Optional[List[int]] = dst_tensor.shapeSignature
 
         if dst_shape_signature is not None:
             # TODO: support dynamic shape
@@ -134,7 +134,7 @@ class CopyVisitor(NodeVisitor):
 
         src_tensor: circle.Tensor.TensorT = self.graph.get_tensor(src)
         src_shape: List[int] = src_tensor.shape
-        src_shape_signature: List[int] = src_tensor.shapeSignature
+        src_shape_signature: Optional[List[int]] = src_tensor.shapeSignature
 
         if src_shape_signature is not None:
             # TODO: support dynamic shape

--- a/tico/serialize/operators/op_cumsum.py
+++ b/tico/serialize/operators/op_cumsum.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import torch._ops
@@ -57,7 +57,7 @@ class CumsumVisitor(NodeVisitor):
         if input_dtype == torch.int32:
             input_tensor: circle.Tensor.TensorT = self.graph.get_tensor(input)
             input_shape: List[int] = input_tensor.shape
-            input_shape_signature: List[int] = input_tensor.shapeSignature
+            input_shape_signature: Optional[List[int]] = input_tensor.shapeSignature
             cast_op_index = get_op_index(
                 circle.BuiltinOperator.BuiltinOperator.CAST, self._op_codes
             )

--- a/tico/serialize/operators/op_pow.py
+++ b/tico/serialize/operators/op_pow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import torch._ops
@@ -36,7 +36,7 @@ class BasePowVisitor(NodeVisitor):
         assert isinstance(node, torch.fx.Node), type(node)
         node_tensor: circle.Tensor.TensorT = self.graph.get_tensor(node)
         node_shape: List[int] = node_tensor.shape
-        node_shape_signature: List[int] = node_tensor.shapeSignature
+        node_shape_signature: Optional[List[int]] = node_tensor.shapeSignature
         op_index = get_op_index(
             circle.BuiltinOperator.BuiltinOperator.CAST, self._op_codes
         )


### PR DESCRIPTION
Let's fix type annotation of Tensor.shapeSignature. NOTE: Tensor.shapeSignature has type of Optional[List[int]]. Flatbuffers fails in type annotation, generating it as List[int].

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>


---

Related to https://github.com/Samsung/TICO/issues/244

> Never use [] for shape_signature. Always use None for static shapes.
> If you get typing errors from this, just add a # type: ignore comment to suppress mypy warnings.