### PR TITLE
[serialize] Validate shapeSignature

### DIFF
--- a/test/unit_test/serialize_test/test_circle_mapping.py
+++ b/test/unit_test/serialize_test/test_circle_mapping.py
@@ -1,0 +1,22 @@
+import unittest
+
+from tico.serialize.circle_mapping import validate_circle_shape
+
+
+class CircleSerializeTest(unittest.TestCase):
+    def test_validate_circle_shape(self):
+        # static shape
+        validate_circle_shape(shape=[1, 2, 3], shape_signature=None)
+        # dynamic shape
+        validate_circle_shape(shape=[1, 2, 3], shape_signature=[1, -1, 3])
+        validate_circle_shape(shape=[1, 2, 3], shape_signature=[-1, -1, 3])
+
+        # Invalid dynamic shape
+        with self.assertRaises(ValueError):
+            validate_circle_shape(shape=[1, 2, 3], shape_signature=[1, -1, 2])
+        with self.assertRaises(ValueError):
+            validate_circle_shape(shape=[1, 2, 3], shape_signature=[1, -2, 3])
+        with self.assertRaises(ValueError):
+            validate_circle_shape(shape=[1], shape_signature=[-1, -1])
+        with self.assertRaises(ValueError):
+            validate_circle_shape(shape=[1, 2, 3], shape_signature=[])

--- a/test/unit_test/serialize_test/test_circle_mapping.py
+++ b/test/unit_test/serialize_test/test_circle_mapping.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from tico.serialize.circle_mapping import validate_circle_shape

--- a/test/unit_test/serialize_test/test_circle_mapping.py
+++ b/test/unit_test/serialize_test/test_circle_mapping.py
@@ -22,8 +22,8 @@ class CircleSerializeTest(unittest.TestCase):
         # static shape
         validate_circle_shape(shape=[1, 2, 3], shape_signature=None)
         # dynamic shape
-        validate_circle_shape(shape=[1, 2, 3], shape_signature=[1, -1, 3])
-        validate_circle_shape(shape=[1, 2, 3], shape_signature=[-1, -1, 3])
+        validate_circle_shape(shape=[1, 1, 3], shape_signature=[1, -1, 3])
+        validate_circle_shape(shape=[1, 1, 3], shape_signature=[-1, -1, 3])
 
         # Invalid dynamic shape
         with self.assertRaises(ValueError):

--- a/test/unit_test/utils_test/test_serialize.py
+++ b/test/unit_test/utils_test/test_serialize.py
@@ -1,0 +1,33 @@
+import unittest
+
+from tico.serialize.circle_graph import CircleModel, CircleSubgraph
+
+from tico.utils.serialize import validate_tensor_shapes
+
+
+class CircleSerializeTest(unittest.TestCase):
+    def test_validate_circle_shape(self):
+        mod = CircleModel()
+        g = CircleSubgraph(mod)
+        g.add_tensor_from_scratch(
+            prefix="name", shape=[1, 2, 3], shape_signature=None, dtype=0
+        )
+        g.add_tensor_from_scratch(
+            prefix="name", shape=[1, 2, 3], shape_signature=None, dtype=0
+        )
+        validate_tensor_shapes(g)
+
+    def test_validate_tensor_shape_neg(self):
+        mod = CircleModel()
+        g = CircleSubgraph(mod)
+        g.add_tensor_from_scratch(
+            prefix="tensor0",
+            shape=[1, 2, 3],
+            shape_signature=[-1, 0, 0],  # Invalid shape pair
+            dtype=0,
+        )
+        g.add_tensor_from_scratch(
+            prefix="tensor1", shape=[1, 2, 3], shape_signature=None, dtype=0
+        )
+        with self.assertRaises(ValueError):
+            validate_tensor_shapes(g)

--- a/test/unit_test/utils_test/test_serialize.py
+++ b/test/unit_test/utils_test/test_serialize.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from tico.serialize.circle_graph import CircleModel, CircleSubgraph

--- a/tico/serialize/circle_mapping.py
+++ b/tico/serialize/circle_mapping.py
@@ -157,6 +157,10 @@ def validate_circle_shape(shape: List[int], shape_signature: Optional[List[int]]
                 "Invalid circle shape: shape_signature must not be an empty list. "
                 "For static shapes, use None instead of []."
             )
+        if len(shape) != len(shape_signature):
+            raise ValueError(
+                f"Invalid circle shape: shape and shape_signature must have same length: {shape} {shape_signature}"
+            )
         if not all(isinstance(s, int) for s in shape_signature):
             raise ValueError(
                 f"circle tensor shape_signature must be all integer values. {shape_signature}"

--- a/tico/serialize/circle_mapping.py
+++ b/tico/serialize/circle_mapping.py
@@ -134,16 +134,49 @@ def extract_circle_shape(node: torch.fx.Node) -> Tuple[List[int], Optional[List[
 
 def to_circle_shape(torch_shape: torch.Size) -> Tuple[List[int], Optional[List[int]]]:
     shape: List[int] = list(torch_shape)
-    shapeSignature: Optional[List[int]] = None
+    shape_signature: Optional[List[int]] = None
 
     if any(isinstance(s, torch.SymInt) for s in shape):
-        shapeSignature = shape.copy()
+        shape_signature = shape.copy()
         for idx, s in enumerate(shape):
             if isinstance(s, torch.SymInt):
                 shape[idx] = 1
-                shapeSignature[idx] = -1
+                shape_signature[idx] = -1
 
-    return shape, shapeSignature
+    return shape, shape_signature
+
+
+def validate_circle_shape(shape: List[int], shape_signature: Optional[List[int]]):
+    """
+    Validate circle tensor shape and shape_signature.
+    @ref https://github.com/Samsung/TICO/issues/244
+    """
+    if shape_signature is not None:
+        if len(shape_signature) == 0:
+            raise ValueError(
+                "Invalid circle shape: shape_signature must not be an empty list. "
+                "For static shapes, use None instead of []."
+            )
+        if not all(isinstance(s, int) for s in shape_signature):
+            raise ValueError(
+                f"circle tensor shape_signature must be all integer values. {shape_signature}"
+            )
+        for s, ss in zip(shape, shape_signature):
+            if ss == -1:
+                # dynamic shape dimension
+                if s != 1:
+                    raise ValueError(
+                        f"Invalid circle shape: {s} {ss} {shape} {shape_signature}"
+                    )
+            else:
+                # static shape dimension
+                if s != ss:
+                    raise ValueError(
+                        f"Invalid circle shape: {s} {ss} {shape} {shape_signature}"
+                    )
+
+    if not all(isinstance(s, int) for s in shape):
+        raise ValueError(f"circle tensor shape must be all integer values. {shape}")
 
 
 # Return stride of node

--- a/tico/serialize/circle_serializer.py
+++ b/tico/serialize/circle_serializer.py
@@ -26,7 +26,7 @@ from tico.serialize.circle_graph import CircleModel, CircleSubgraph
 from tico.serialize.operators.hashable_opcode import OpCode
 from tico.serialize.operators.node_visitor import get_node_visitors
 from tico.utils import logging
-from tico.utils.serialize import finalise_tensor_names
+from tico.utils.serialize import finalise_tensor_names, validate_tensor_shapes
 
 
 multiple_output_ops = [
@@ -104,8 +104,10 @@ def build_circle(ep: ExportedProgram) -> bytes:
             graph.add_operator(circle_op)
             logger.debug(f"call_function: {node.name} ({opcode}) Op exported.")
 
-    # Register subgraph
     finalise_tensor_names(graph)
+    validate_tensor_shapes(graph)
+
+    # Register subgraph
     model.subgraphs.append(graph)
 
     # Encode operator codes

--- a/tico/utils/serialize.py
+++ b/tico/utils/serialize.py
@@ -14,6 +14,7 @@
 
 
 from tico.serialize.circle_graph import CircleSubgraph
+from tico.serialize.circle_mapping import validate_circle_shape
 from tico.utils.graph import get_module_name_chain
 
 
@@ -37,3 +38,13 @@ def finalise_tensor_names(
     for tensor in graph.tensors:
         if tensor.name in graph.name_to_node:
             tensor.name = f"{get_module_name_chain(graph.name_to_node[tensor.name])}::{tensor.name}"
+
+
+def validate_tensor_shapes(
+    graph: CircleSubgraph,
+) -> None:
+    """
+    Let's validate all tensors' shapes against their shape signatures.
+    """
+    for tensor in graph.tensors:
+        validate_circle_shape(tensor.shape, tensor.shapeSignature)


### PR DESCRIPTION
Let's validate circle tensor's shape and shape signature values.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee [dayoung.lee@samsung.com](mailto:dayoung.lee@samsung.com)

---

Related to #244