### PR TITLE
Support TopK operator

### DIFF
--- a/test/modules/op/to.py
+++ b/test/modules/op/to.py
@@ -85,3 +85,14 @@ class ToWithIntegerPlusFloat(TestModuleBase):
 
     def get_example_inputs(self):
         return (torch.randn(1, 3),), {}
+
+
+class SimpleToForCast(TestModuleBase):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x.to(torch.int32)
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 3),), {}

--- a/test/modules/op/top_k.py
+++ b/test/modules/op/top_k.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from test.modules.base import TestModuleBase
+from test.utils.tag import use_onert
+
+# luci-interpreter doesn't support TopK operator yet
+@use_onert
+class SimpleTopK(TestModuleBase):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        values, indices = torch.topk(x, 2)
+        return values, indices
+
+    def get_example_inputs(self):
+        batch_size = 1
+        seq_len = 63
+        num_experts = 8
+        return (torch.randn(batch_size * seq_len, num_experts),), {}

--- a/tico/serialize/circle_serializer.py
+++ b/tico/serialize/circle_serializer.py
@@ -32,6 +32,8 @@ from tico.utils.serialize import finalise_tensor_names, validate_tensor_shapes
 multiple_output_ops = [
     torch.ops.aten.split_with_sizes.default,
     torch.ops.aten.max.dim,
+    torch.ops.aten.topk.default,
+    torch.ops.circle_custom.top_k,
 ]
 
 

--- a/tico/serialize/operators/op_topk.py
+++ b/tico/serialize/operators/op_topk.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.fx
+import torch
+from circle_schema import circle
+
+from tico.serialize.circle_graph import CircleSubgraph
+from tico.serialize.circle_mapping import (
+    circle_legalize_dtype_to,
+    extract_circle_shape,
+    extract_shape,
+    extract_torch_dtype,
+)
+from tico.serialize.operators.hashable_opcode import OpCode
+from tico.serialize.operators.node_visitor import NodeVisitor, register_node_visitor
+from tico.serialize.operators.utils import create_builtin_operator, get_op_index
+from tico.utils.validate_args_kwargs import TopKArgs
+
+
+@register_node_visitor
+class TopkVisitor(NodeVisitor):
+    """ """
+
+    target: List[torch._ops.OpOverload] = [
+        torch.ops.circle_custom.top_k,
+    ]
+
+    def __init__(self, op_codes: Dict[OpCode, int], graph: CircleSubgraph):
+        super().__init__(op_codes, graph)
+
+    def define_topk_node(
+        self, inputs: List, outputs: List
+    ) -> circle.Operator.OperatorT:
+        op_index = get_op_index(
+            circle.BuiltinOperator.BuiltinOperator.TOPK_V2, self._op_codes
+        )
+
+        operator = create_builtin_operator(self.graph, op_index, inputs, outputs)
+
+        operator.builtinOptionsType = circle.BuiltinOptions.BuiltinOptions.TopKV2Options
+        option = circle.TopKV2Options.TopKV2OptionsT()
+        operator.builtinOptions = option
+
+        return operator
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+    ) -> circle.Operator.OperatorT:
+        args = TopKArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
+        input = args.input
+        k = args.k
+
+        input_shape = extract_circle_shape(input)
+        k_i32 = circle_legalize_dtype_to(k, dtype=torch.int32)
+        assert args.dim == -1 or args.dim == len(input_shape) - 1
+
+        inputs = [input, k_i32]
+
+        outputs = [i for i in node.users.keys()]
+
+        topk_node: circle.Operator.OperatorT = self.define_topk_node(inputs, outputs)
+
+        return topk_node

--- a/tico/utils/graph.py
+++ b/tico/utils/graph.py
@@ -273,10 +273,6 @@ def create_node(
     torch.fx.Node
         The freshly inserted node with fully-populated `.meta`.
     """
-    assert isinstance(target, torch._ops.OpOverload) or (
-        target is getitem
-    ), f"Invalid target {target}"
-
     new_node = graph.call_function(target, args=args, kwargs=kwargs)
     if origin:
         assert isinstance(origin, torch.fx.Node), type(origin)

--- a/tico/utils/register_custom_op.py
+++ b/tico/utils/register_custom_op.py
@@ -19,6 +19,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 from torch.library import custom_op, register_fake
 
 from tico.utils.mx.mx_ops import _quantize_mx
+from tico.utils.validate_args_kwargs import TopKArgs
 
 # Note that an operator assumes input tensor has NHWC format.
 def CircleResizeNearestNeighbor():
@@ -662,6 +663,50 @@ def CircleInstanceNorm():
         return input.new_empty(input.size())
 
 
+def CircleTopK():
+    @custom_op(
+        "circle_custom::top_k",
+        mutates_args=(),
+        schema="(Tensor input, int k) -> (Tensor, Tensor)",
+    )
+    def top_k(
+        input: torch.Tensor,
+        k: int,
+        dim: int = -1,
+        largest: bool = True,
+        sorted: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert (dim == -1) or (dim == len(input.size()) - 1)
+        assert largest is True
+        assert sorted is True
+
+        topk_out_0, topk_out_1 = torch.ops.aten.topk.default(input, k, dim)
+        topk_out_1_int32 = torch.ops.aten.to.dtype(topk_out_1, dtype=torch.int32)
+
+        return (
+            topk_out_0,
+            topk_out_1_int32,
+        )
+
+    @register_fake("circle_custom::top_k")
+    def _(
+        input: FakeTensor,
+        k: int,
+        dim: int = -1,
+        largest: bool = True,
+        sorted: bool = True,
+    ) -> tuple[FakeTensor, FakeTensor]:
+        assert (dim == -1) or (dim == len(input.size()) - 1)
+        assert largest is True
+        assert sorted is True
+        topk_out0, topk_out1 = torch.ops.aten.topk.default(input, k, dim)
+
+        return (
+            topk_out0,
+            topk_out1.new_empty(size=topk_out1.size(), dtype=torch.int32),
+        )
+
+
 def CircleQuantizeMX():
     # This operator conducts fake-quantization of microscaling
     # NOTE Why using "quantize"_mx not "fake_quantize"_mx?
@@ -738,3 +783,4 @@ def RegisterOps():
     CircleInstanceNorm()
     CircleQuantizeMX()
     CircleRMSNorm()
+    CircleTopK()

--- a/tico/utils/validate_args_kwargs.py
+++ b/tico/utils/validate_args_kwargs.py
@@ -1176,6 +1176,24 @@ class ToDtypeLayoutArgs:
 
 @enforce_type
 @dataclass
+class TopKArgs:
+    """
+    topk(Tensor self, SymInt k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
+    """
+
+    input: torch.fx.Node
+    k: int
+    dim: int = -1
+    largest: bool = True
+    sorted: bool = True
+
+    def __post_init__(self):
+        assert self.largest is True, "Only support largest=True"
+        assert self.sorted is True, "Only support sorted=True"
+
+
+@enforce_type
+@dataclass
 class UnSqueezeArgs:
     """
     unsqueeze(Tensor(a) self, int dim) -> Tensor(a)


### PR DESCRIPTION
Let's compile torch.topk to circle TOP_K_V2 operator.


----


> 😭 Circle TOP_K_V2 Operator is supported neither in luci-interpreter nor in onert.
> 
> I posted an issue https://github.com/Samsung/ONE/issues

🎉 Resolved! ~~Let's run the CI on 13th Aug.~~ It requires another official release of onert.