### PR TITLE
Revise CircleRMSNormArgs

### DIFF
--- a/tico/utils/register_custom_op.py
+++ b/tico/utils/register_custom_op.py
@@ -707,7 +707,7 @@ def CircleRMSNorm():
     @custom_op("circle_custom::rms_norm", mutates_args=())
     def rms_norm(
         hidden_states: torch.Tensor,
-        weight: Optional[torch.Tensor] = None,
+        weight: torch.Tensor,
         eps: float = 1e-05,
     ) -> torch.Tensor:
         input_dtype = hidden_states.dtype
@@ -719,7 +719,7 @@ def CircleRMSNorm():
     @register_fake("circle_custom::rms_norm")
     def _(
         hidden_states: torch.Tensor,
-        weight: Optional[torch.Tensor] = None,
+        weight: torch.Tensor,
         eps: float = 1e-05,
     ) -> torch.Tensor:
         return hidden_states.new_empty(hidden_states.size())

--- a/tico/utils/validate_args_kwargs.py
+++ b/tico/utils/validate_args_kwargs.py
@@ -175,13 +175,12 @@ class CatArgs:
 @dataclass
 class CircleRMSNormArgs:
     """
-    This is not aten ops but custom op for RMSNorm.
-    circle_custom.rms_norm(Tensor input, Tensor? weight=None, float? eps=None) -> Tensor
+    For circle.BuiltinOperator.BuiltinOperator.RMS_NORM
     """
 
     input: torch.fx.Node
-    weight: Optional[torch.fx.Node]
-    eps: Optional[float]
+    weight: torch.fx.Node
+    eps: float
 
 
 @enforce_type


### PR DESCRIPTION
Let's revise CircleRMSNormArgs to match with circle serialization.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>