### PR TITLE
[ptq] Add more observers

### DIFF
--- a/test/quantization/ptq/observers/test_ema.py
+++ b/test/quantization/ptq/observers/test_ema.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from tico.experimental.quantization.ptq.dtypes import DType
+from tico.experimental.quantization.ptq.observers.ema import EMAObserver
+from tico.experimental.quantization.ptq.qscheme import QScheme
+
+
+class TestEMAObserver(unittest.TestCase):
+    def test_ema_updates(self):
+        torch.manual_seed(0)
+        obs = EMAObserver(
+            name="dummy",
+            dtype=DType.uint(8),
+            qscheme=QScheme.PER_TENSOR_ASYMM,
+            momentum=0.5,
+        )
+
+        # First batch initialises stats hard
+        obs.collect(torch.tensor([-1.0, 2.0, 3.0]))
+        self.assertAlmostEqual(obs.min_val.item(), -1.0)
+        self.assertAlmostEqual(obs.max_val.item(), 3.0)
+
+        # Second batch updates via EMA
+        obs.collect(torch.tensor([-9.0, 9.0]))
+        # new_min = 0.5 * (-1) + 0.5 * (-9) = -5
+        # new_max = 0.5 * 3   + 0.5 * 9     =  6
+        self.assertAlmostEqual(obs.min_val.item(), -5.0)
+        self.assertAlmostEqual(obs.max_val.item(), 6.0)
+
+    def test_per_channel_ema(self):
+        x1 = torch.tensor([[1.0, -2.0], [3.0, -4.0]])  # shape (C=2, N=2)
+        x2 = torch.tensor([[10.0, -10.0], [5.0, -5.0]])
+        obs = EMAObserver(
+            name="dummy",
+            dtype=DType.int(4),
+            qscheme=QScheme.PER_CHANNEL_ASYMM,
+            channel_axis=0,
+            momentum=0.5,
+        )
+
+        obs.collect(x1)
+        self.assertTrue(
+            torch.equal(obs.min_val, torch.tensor([-2.0, -4.0])),
+            f"obs.min_val: {obs.min_val}",
+        )
+        self.assertTrue(
+            torch.equal(obs.max_val, torch.tensor([1.0, 3.0])),
+            f"obs.max_val: {obs.max_val}",
+        )
+
+        obs.collect(x2)
+        # Manual EMA check
+        expected_min = 0.5 * torch.tensor([-2.0, -4.0]) + 0.5 * torch.tensor(
+            [-10.0, -5.0]
+        )
+        expected_max = 0.5 * torch.tensor([1.0, 3.0]) + 0.5 * torch.tensor([10.0, 5.0])
+        self.assertTrue(
+            torch.allclose(obs.min_val, expected_min),
+            f"{obs.min_val} != {expected_min}",
+        )
+        self.assertTrue(
+            torch.allclose(obs.max_val, expected_max),
+            f"{obs.max_val} != {expected_max}",
+        )
+
+    def test_first_batch(self):
+        x = torch.randn(10)
+        obs = EMAObserver(name="dummy", momentum=0.9, channel_axis=None)
+        obs.collect(x)
+        self.assertFalse(torch.isinf(obs.min_val).any())
+        self.assertFalse(torch.isinf(obs.max_val).any())

--- a/test/quantization/ptq/observers/test_identity.py
+++ b/test/quantization/ptq/observers/test_identity.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+
+from tico.experimental.quantization.ptq.observers.identity import IdentityObserver
+
+
+class TestIdentityObserver(unittest.TestCase):
+    """Verify that IdentityObserver behaves as a transparent FP-pass."""
+
+    def setUp(self):
+        self.obs = IdentityObserver(name="act_fp32")
+
+    def test_initial_state(self):
+        self.assertFalse(self.obs.enabled, msg="Observer must start disabled")
+        self.assertTrue(self.obs.has_qparams, msg="Scale / ZP should be pre-cached")
+        self.assertEqual(self.obs._cached_scale.item(), 1.0)
+        self.assertEqual(self.obs._cached_zp.item(), 0)
+
+    def test_collect_is_noop(self):
+        x = torch.randn(8, 16)
+        self.obs.collect(x)  # should have *no* effect
+        self.assertFalse(self.obs.enabled, msg="`enabled` flag must stay False")
+        # Scale / ZP remain unchanged
+        self.assertEqual(self.obs._cached_scale.item(), 1.0)
+        self.assertEqual(self.obs._cached_zp.item(), 0)
+
+    def test_compute_qparams_constant(self):
+        scale, zp = self.obs.compute_qparams()
+        self.assertEqual(scale.item(), 1.0)
+        self.assertEqual(zp.item(), 0)
+
+    def test_fake_quant_identity(self):
+        x = torch.randn(4, 4)
+        y = self.obs.fake_quant(x)
+        # IdentityObserver returns the *same* object, not a clone
+        self.assertIs(y, x)
+        # Values must of course be identical
+        self.assertTrue(torch.allclose(y, x))

--- a/tico/experimental/quantization/ptq/observers/__init__.py
+++ b/tico/experimental/quantization/ptq/observers/__init__.py
@@ -1,9 +1,13 @@
 from tico.experimental.quantization.ptq.observers.affine_base import AffineObserverBase
 from tico.experimental.quantization.ptq.observers.base import ObserverBase
+from tico.experimental.quantization.ptq.observers.ema import EMAObserver
+from tico.experimental.quantization.ptq.observers.identity import IdentityObserver
 from tico.experimental.quantization.ptq.observers.minmax import MinMaxObserver
 
 __all__ = [
     "AffineObserverBase",
     "ObserverBase",
+    "EMAObserver",
+    "IdentityObserver",
     "MinMaxObserver",
 ]

--- a/tico/experimental/quantization/ptq/observers/ema.py
+++ b/tico/experimental/quantization/ptq/observers/ema.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from tico.experimental.quantization.ptq.observers.affine_base import AffineObserverBase
+from tico.experimental.quantization.ptq.utils import channelwise_minmax
+
+
+class EMAObserver(AffineObserverBase):
+    """
+    Exponential-Moving-Average min/max tracker.
+
+    Why?
+    -----
+    • Smoother than raw MinMax (reduces outlier shock).
+    • Much cheaper than histogram/MSE observers.
+
+    The update rule follows the common "momentum" form:
+
+        ema = momentum * ema + (1 - momentum) * new_value
+
+    With momentum → 0: *fast* adaptation, momentum → 1: *slow* adaptation.
+    """
+
+    def __init__(
+        self,
+        *,
+        momentum: float = 0.9,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        assert 0.0 < momentum < 1.0, "momentum must be in (0, 1)"
+        self.momentum = momentum
+
+    @torch.no_grad()
+    def _update_stats(self, x: torch.Tensor):
+        if self.channel_axis is None:
+            curr_min, curr_max = x.min(), x.max()
+        else:
+            curr_min, curr_max = channelwise_minmax(x, self.channel_axis)
+
+        if (
+            torch.isinf(self.min_val).any() and torch.isinf(self.max_val).any()
+        ):  # first batch → hard init
+            self.min_val, self.max_val = curr_min, curr_max
+            return
+
+        m = self.momentum
+        self.min_val = m * self.min_val + (1 - m) * curr_min
+        self.max_val = m * self.max_val + (1 - m) * curr_max

--- a/tico/experimental/quantization/ptq/observers/identity.py
+++ b/tico/experimental/quantization/ptq/observers/identity.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+IdentityObserver: a *no-op* observer for FP-only modules.
+
+Motivation
+----------
+Some layers should stay in full precision even when the rest of the model
+is quantized.  Attaching an `IdentityObserver` satisfies the wrapper API
+(`_update_stats()`, `compute_qparams()`, `fake_quant()`) without actually
+performing any statistics gathering or fake-quantization.
+"""
+import torch
+
+from tico.experimental.quantization.ptq.observers.affine_base import AffineObserverBase
+
+
+class IdentityObserver(AffineObserverBase):
+    """
+    Passthrough observer that **never** alters the tensor.
+
+    • `_update_stats()`   → does nothing
+    • `compute_qparams()` → returns (1.0, 0) *dummy* q-params
+    • `fake_quant()`      → returns *x* unchanged
+    """
+
+    def __init__(self, **kwargs):
+        # Call parent so the usual fields (`dtype`, `qscheme`, …) exist,
+        # but immediately disable any stateful behaviour.
+        super().__init__(**kwargs)
+
+        # Deactivate statistics collection permanently.
+        self.enabled = False
+
+        # Pre-cache sentinel q-params so wrapper code that blindly
+        # accesses them won't crash.
+        self._cached_scale = torch.tensor(1.0)
+        self._cached_zp = torch.tensor(0, dtype=torch.int)
+
+    def reset(self) -> None:  # (simple override – nothing to do)
+        """No internal state to reset."""
+        pass
+
+    def _update_stats(self, x: torch.Tensor) -> None:
+        """Skip statistic collection entirely."""
+        return
+
+    def compute_qparams(self):
+        """
+        Return the pre-cached (scale, zero_point) tuple.
+
+        Keeping the signature identical to other observers allows uniform
+        lifecycle management in wrapper code.
+        """
+        return self._cached_scale, self._cached_zp
+
+    def fake_quant(self, x: torch.Tensor):
+        """Identity mapping — leaves *x* in FP."""
+        return x
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"


### PR DESCRIPTION
This commit adds more observers that are commonly used.

- Percentile
- EMA
- Identity

Related: https://github.com/Samsung/TICO/issues/89
Draft: https://github.com/Samsung/TICO/pull/212
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>