### PR TITLE
[passes] Add missing assert keyword

### DIFF
--- a/tico/passes/decompose_fake_quantize_tensor_qparams.py
+++ b/tico/passes/decompose_fake_quantize_tensor_qparams.py
@@ -244,7 +244,7 @@ class DecomposeFakeQuantizeTensorQParams(PassBase):
                     # So, let's remove `mask` from the output.args first.
                     # mask_user(output).args == (dequantize_per_tensor.tensor, mask)
                     if mask:
-                        len(mask) == 1
+                        assert len(mask) == 1
                         mask_user = list(mask[0].users.keys())[0]
                         assert len(mask_user.args) == 1
                         mask_user.args = ((mask_user.args[0][0],),)


### PR DESCRIPTION
This commit adds missing assert keyword.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>