### PR TITLE
[ptq] Introduce MXObserver

### DIFF
--- a/test/quantization/ptq/observers/test_mx.py
+++ b/test/quantization/ptq/observers/test_mx.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from tico.experimental.quantization.ptq.dtypes import DType
+from tico.experimental.quantization.ptq.observers.mx import MXObserver
+from tico.experimental.quantization.ptq.qscheme import QScheme
+
+
+class TestMXObserver(unittest.TestCase):
+    def test_compute_qparams_returns_none_and_collect_noop(self):
+        """
+        MXObserver does not produce affine qparams; compute_qparams() returns None.
+        collect() is a no-op but must respect the 'enabled' flag (no crash).
+        """
+        obs = MXObserver(
+            name="mx",
+            elem_format="int8",
+            axis=1,
+            shared_exp_method="max",
+            round="nearest",
+            # Base kwargs are accepted but not used by MX path
+            dtype=DType.uint(8),
+            qscheme=QScheme.PER_TENSOR_ASYMM,
+            channel_axis=0,
+        )
+
+        # collect() should do nothing regardless of input; just smoke-test
+        obs.collect(torch.randn(2, 3))
+        obs.enabled = False
+        obs.collect(torch.randn(2, 3))  # still no-op
+
+        self.assertIsNone(obs.compute_qparams())
+
+    def test_fake_quant_calls_quantize_mx_with_expected_args(self):
+        """
+        fake_quant(x) must delegate to quantize_mx with the configured arguments.
+        """
+        obs = MXObserver(
+            name="mx",
+            elem_format="int8",
+            axis=1,
+            shared_exp_method="max",
+            round="nearest",
+            dtype=DType.uint(8),
+        )
+        x = torch.randn(4, 5)
+
+        patch_path = "tico.experimental.quantization.ptq.observers.mx.quantize_mx"
+        with patch(patch_path) as qmx:
+            # Return a distinctive tensor so we can assert passthrough
+            qmx.side_effect = lambda input_, **kwargs: input_ * 2
+            y = obs.fake_quant(x)
+
+            self.assertTrue(torch.allclose(y, x * 2))
+
+            # Verify it was called once with the configured kwargs
+            self.assertEqual(qmx.call_count, 1)
+            call = qmx.call_args
+            # Positional arg 0 is the input tensor
+            self.assertTrue(torch.equal(call.args[0], x))
+            # Keyword args should match observer config
+            self.assertEqual(call.kwargs["elem_format"], "int8")
+            self.assertEqual(call.kwargs["axis"], 1)
+            self.assertEqual(call.kwargs["shared_exp_method"], "max")
+            self.assertEqual(call.kwargs["round"], "nearest")
+
+    def test_fake_quant_still_runs_when_disabled(self):
+        """
+        Even when 'enabled' is False (no more stats collection), fake_quant should still run.
+        """
+        obs = MXObserver(name="mx", elem_format="int8", axis=0, dtype=DType.uint(8))
+        obs.enabled = False
+        x = torch.randn(3, 3)
+
+        patch_path = "tico.experimental.quantization.ptq.observers.mx.quantize_mx"
+        with patch(patch_path) as qmx:
+            qmx.side_effect = lambda input_, **kwargs: input_ + 1.0
+            y = obs.fake_quant(x)
+            self.assertTrue(torch.allclose(y, x + 1.0))
+            qmx.assert_called_once()
+
+    def test_axis_is_independent_from_base_channel_axis(self):
+        """
+        MXObserver.axis must be used for shared-exponent grouping regardless of base.channel_axis.
+        """
+        # Intentionally pass a different base channel_axis; MX should use its own 'axis=2'.
+        obs = MXObserver(
+            name="mx",
+            elem_format="int8",
+            axis=2,  # expected to be passed to quantize_mx
+            dtype=DType.uint(8),
+            qscheme=QScheme.PER_CHANNEL_ASYMM,
+            channel_axis=0,  # irrelevant for MX path
+        )
+        x = torch.randn(2, 3, 4)
+
+        patch_path = "tico.experimental.quantization.ptq.observers.mx.quantize_mx"
+        with patch(patch_path) as qmx:
+            qmx.side_effect = lambda input_, **kwargs: input_
+            _ = obs.fake_quant(x)
+            # Ensure 'axis' comes from MXObserver(axis=2), not base channel_axis=0
+            self.assertEqual(qmx.call_args.kwargs["axis"], 2)
+
+    def test_repr_smoke(self):
+        """
+        repr() should include class name and observer name for debugging.
+        """
+        obs = MXObserver(
+            name="mx_debug", elem_format="int8", axis=0, dtype=DType.uint(8)
+        )
+        s = repr(obs)
+        self.assertIn("MXObserver", s)
+        self.assertIn("mx_debug", s)

--- a/test/quantization/ptq/observers/test_mx.py
+++ b/test/quantization/ptq/observers/test_mx.py
@@ -34,10 +34,6 @@ class TestMXObserver(unittest.TestCase):
             axis=1,
             shared_exp_method="max",
             round="nearest",
-            # Base kwargs are accepted but not used by MX path
-            dtype=DType.uint(8),
-            qscheme=QScheme.PER_TENSOR_ASYMM,
-            channel_axis=0,
         )
 
         # collect() should do nothing regardless of input; just smoke-test
@@ -57,7 +53,6 @@ class TestMXObserver(unittest.TestCase):
             axis=1,
             shared_exp_method="max",
             round="nearest",
-            dtype=DType.uint(8),
         )
         x = torch.randn(4, 5)
 
@@ -84,7 +79,7 @@ class TestMXObserver(unittest.TestCase):
         """
         Even when 'enabled' is False (no more stats collection), fake_quant should still run.
         """
-        obs = MXObserver(name="mx", elem_format="int8", axis=0, dtype=DType.uint(8))
+        obs = MXObserver(name="mx", elem_format="int8", axis=0)
         obs.enabled = False
         x = torch.randn(3, 3)
 
@@ -104,9 +99,6 @@ class TestMXObserver(unittest.TestCase):
             name="mx",
             elem_format="int8",
             axis=2,  # expected to be passed to quantize_mx
-            dtype=DType.uint(8),
-            qscheme=QScheme.PER_CHANNEL_ASYMM,
-            channel_axis=0,  # irrelevant for MX path
         )
         x = torch.randn(2, 3, 4)
 
@@ -121,9 +113,7 @@ class TestMXObserver(unittest.TestCase):
         """
         repr() should include class name and observer name for debugging.
         """
-        obs = MXObserver(
-            name="mx_debug", elem_format="int8", axis=0, dtype=DType.uint(8)
-        )
+        obs = MXObserver(name="mx_debug", elem_format="int8", axis=0)
         s = repr(obs)
         self.assertIn("MXObserver", s)
         self.assertIn("mx_debug", s)

--- a/tico/experimental/quantization/ptq/observers/__init__.py
+++ b/tico/experimental/quantization/ptq/observers/__init__.py
@@ -3,6 +3,7 @@ from tico.experimental.quantization.ptq.observers.base import ObserverBase
 from tico.experimental.quantization.ptq.observers.ema import EMAObserver
 from tico.experimental.quantization.ptq.observers.identity import IdentityObserver
 from tico.experimental.quantization.ptq.observers.minmax import MinMaxObserver
+from tico.experimental.quantization.ptq.observers.mx import MXObserver
 
 __all__ = [
     "AffineObserverBase",
@@ -10,4 +11,5 @@ __all__ = [
     "EMAObserver",
     "IdentityObserver",
     "MinMaxObserver",
+    "MXObserver",
 ]

--- a/tico/experimental/quantization/ptq/observers/mx.py
+++ b/tico/experimental/quantization/ptq/observers/mx.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from tico.experimental.quantization.ptq.observers.base import ObserverBase
+from tico.utils.mx.mx_ops import quantize_mx
+
+
+class MXObserver(ObserverBase):
+    """MX (micro-scaling) observer: no min/max, no affine qparams."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        elem_format: str = "int8",
+        axis: int = 0,
+        shared_exp_method: str = "max",
+        round: str = "nearest",
+        **base_kwargs,
+    ):
+        super().__init__(name=name, **base_kwargs)
+        self.elem_format = elem_format
+        self.axis = axis
+        self.shared_exp_method = shared_exp_method
+        self.round = round
+
+    def reset(self) -> None:
+        # No state to reset
+        return
+
+    @torch.no_grad()
+    def _update_stats(self, x: torch.Tensor) -> None:
+        # No stats required
+        return None
+
+    def compute_qparams(self):
+        # MX path does not produce affine qparams; keep interface contract.
+        return None
+
+    def fake_quant(self, x: torch.Tensor) -> torch.Tensor:
+        return quantize_mx(
+            x,
+            elem_format=self.elem_format,
+            axis=self.axis,
+            shared_exp_method=self.shared_exp_method,
+            round=self.round,
+        )


### PR DESCRIPTION
This commit introduces MXObserver for MX quantization.

Related: https://github.com/Samsung/TICO/issues/89
Draft: https://github.com/Samsung/TICO/pull/212
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>