### PR TITLE
[ptq] Introduce a wrapping helper class

### DIFF
--- a/test/quantization/ptq/wrappers/test_ptq_wrapper.py
+++ b/test/quantization/ptq/wrappers/test_ptq_wrapper.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Optional
+
+import torch
+from tico.experimental.quantization.ptq.dtypes import DType
+from tico.experimental.quantization.ptq.mode import Mode
+from tico.experimental.quantization.ptq.observers import IdentityObserver
+from tico.experimental.quantization.ptq.observers.affine_base import AffineObserverBase
+from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.ptq.wrappers.nn.quant_linear import QuantLinear
+from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
+from torch.utils.data import DataLoader, TensorDataset
+
+from test.modules.op.linear import SimpleLinear
+
+
+class TestPTQWrapper(unittest.TestCase):
+    def _build(self, qcfg: Optional[QuantConfig] = None):
+        torch.manual_seed(42)
+        self.fp32 = torch.nn.Linear(4, 2)
+        self.input = torch.randn(32, 4)
+        self.qcfg = qcfg or QuantConfig(default_dtype=DType.uint(8))
+        self.wrapper = PTQWrapper(self.fp32, qcfg=self.qcfg)
+
+    def setUp(self):
+        self._build()
+
+    def test_default_mode_is_no_quant(self):
+        self.assertIs(self.wrapper._mode, Mode.NO_QUANT)
+
+    def test_mode_transitions(self):
+        self.wrapper.enable_calibration()
+        self.assertIs(self.wrapper._mode, Mode.CALIB)
+        self.wrapper.freeze_qparams()
+        self.assertIs(self.wrapper._mode, Mode.QUANT)
+
+    def test_switch_activation_observer(self):
+        # ----- pass #1: MinMax (default) ---------------------------
+        self.wrapper.enable_calibration()
+        _ = self.wrapper(self.input)
+        self.wrapper.freeze_qparams()
+        out_mm = self.wrapper(self.input)
+
+        # ----- pass #2: Identity via QuantConfig override --------
+        pct_cfg = QuantConfig(
+            default_dtype=DType.uint(8),
+            overrides={
+                # LinearQuant uses act_in / act_out
+                "act_in": {
+                    "observer": IdentityObserver,
+                    "dtype": DType.uint(8),
+                },
+                "act_out": {
+                    "observer": IdentityObserver,
+                    "dtype": DType.uint(8),
+                },
+            },
+        )
+        self._build(qcfg=pct_cfg)
+        self.wrapper.enable_calibration()
+        _ = self.wrapper(self.input)
+        self.wrapper.freeze_qparams()
+        out_pct = self.wrapper(self.input)
+
+        diff = (out_mm - out_pct).abs().mean().item()
+        self.assertGreater(diff, 0.0)
+        self.assertLess(diff, 0.5)
+
+    def test_weight_fake_quant_channelwise(self):
+        self.wrapper.enable_calibration()  # collects weight stats now
+        self.wrapper.freeze_qparams()
+
+        assert isinstance(self.wrapper.wrapped, QuantLinear)
+        assert isinstance(self.wrapper.wrapped.weight_obs, AffineObserverBase)
+        w_obs = self.wrapper.wrapped.weight_obs
+        w_fp = self.fp32.weight.data
+        fq_w = w_obs.fake_quant(w_fp)
+
+        scale, zp = w_obs.compute_qparams()
+        ref = torch.empty_like(w_fp)
+        for c in range(w_fp.size(0)):
+            q = torch.round(w_fp[c] / scale[c]) + zp[c]
+            q = q.clamp(w_obs.dtype.qmin, w_obs.dtype.qmax)
+            ref[c] = scale[c] * (q - zp[c])
+
+        self.assertTrue(torch.allclose(fq_w, ref, atol=1e-6))
+        self.assertFalse(torch.allclose(fq_w, w_fp, atol=1e-6))
+
+
+class TestPTQSmoke(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.model = SimpleLinear().eval()
+
+        data = torch.randn(128, 3) * 2
+        self.calib_loader = DataLoader(TensorDataset(data), batch_size=32)
+
+        qcfg = QuantConfig(default_dtype=DType.uint(8))
+        self.model.linear = PTQWrapper(self.model.linear, qcfg=qcfg)
+
+    def test_smoke_forward_quantized(self):
+        self.model.linear.enable_calibration()
+        for (x,) in self.calib_loader:
+            _ = self.model(x)
+        self.model.linear.freeze_qparams()
+        self.assertIs(self.model.linear._mode, Mode.QUANT)
+
+        inp, _ = self.model.get_example_inputs()
+        with torch.no_grad():
+            assert hasattr(self.model.linear.wrapped, "module")
+            assert isinstance(self.model.linear.wrapped.module, torch.nn.Linear)
+            fp32_out = self.model.linear.wrapped.module(*inp)
+            q_out = self.model(*inp)
+
+        diff = (fp32_out - q_out).abs().mean().item()
+        self.assertGreater(diff, 0.0)
+        self.assertLess(diff, 0.5)
+        self.assertEqual(fp32_out.shape, q_out.shape)

--- a/test/quantization/ptq/wrappers/test_ptq_wrapper.py
+++ b/test/quantization/ptq/wrappers/test_ptq_wrapper.py
@@ -82,6 +82,7 @@ class TestPTQWrapper(unittest.TestCase):
 
     def test_weight_fake_quant_channelwise(self):
         self.wrapper.enable_calibration()  # collects weight stats now
+        _ = self.wrapper(self.input)
         self.wrapper.freeze_qparams()
 
         assert isinstance(self.wrapper.wrapped, QuantLinear)

--- a/tico/experimental/quantization/ptq/wrappers/ptq_wrapper.py
+++ b/tico/experimental/quantization/ptq/wrappers/ptq_wrapper.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+
+from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
+    QuantModuleBase,
+)
+from tico.experimental.quantization.ptq.wrappers.registry import lookup
+
+
+class PTQWrapper(QuantModuleBase):
+    """
+    Adapter that turns a fp module into its quantized counterpart.
+
+    It is itself a QuantModuleBase so composite wrappers can treat
+     it exactly like any other quant module.
+    """
+
+    def __init__(
+        self,
+        module: torch.nn.Module,
+        qcfg: Optional[QuantConfig] = None,
+        *,
+        fp_name: Optional[str] = None,
+    ):
+        super().__init__(qcfg)
+        wrapped_cls = lookup(type(module))
+        if wrapped_cls is None:
+            raise NotImplementedError(f"No quant wrapper for {type(module).__name__}")
+        self.wrapped: QuantModuleBase = wrapped_cls(module, qcfg=qcfg, fp_name=fp_name)  # type: ignore[arg-type, misc]
+
+    def forward(self, *args, **kwargs):
+        return self.wrapped(*args, **kwargs)
+
+    def _all_observers(self):
+        yield from self.wrapped._all_observers()
+
+    def extra_repr(self) -> str:
+        return self.wrapped.extra_repr()


### PR DESCRIPTION
This commit introduces a wrapping helper class.

Without this class, users should import quant wrapper class for each torch modules.

Related: https://github.com/Samsung/TICO/issues/89
Draft: https://github.com/Samsung/TICO/pull/212
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>