### PR TITLE
[ptq] Fix double iteration of observer

### DIFF
--- a/tico/experimental/quantization/ptq/wrappers/ptq_wrapper.py
+++ b/tico/experimental/quantization/ptq/wrappers/ptq_wrapper.py
@@ -48,7 +48,24 @@ class PTQWrapper(QuantModuleBase):
         return self.wrapped(*args, **kwargs)
 
     def _all_observers(self):
-        yield from self.wrapped._all_observers()
+        """
+        PTQWrapper itself owns NO observers (transparent node).
+        Returning an empty iterator prevents double-processing when parents
+        traverse the tree and then recurse into `self.wrapped`.
+        """
+        return ()  # no local observers
+
+    def named_observers(self):
+        """
+        Proxy to the wrapped module so debugging tools can still enumerate observers.
+        """
+        yield from self.wrapped.named_observers()
+
+    def get_observer(self, name: str):
+        """
+        Proxy to the wrapped module for direct lookup by name.
+        """
+        return self.wrapped.get_observer(name)
 
     def extra_repr(self) -> str:
         return self.wrapped.extra_repr()


### PR DESCRIPTION
This commit fixes double interation issue of PTQ wrapper.

Before this PR, there's a double interation bug when a parent wrapper class iterates subsequent observers. Because the submodule includes not only a quant wrapper module but also its `PTQWrapper` that wraps the module.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>