### PR TITLE
[ptq] Introduce Llama decoder layer wrapper

### DIFF
--- a/test/quantization/ptq/wrappers/llama/test_quant_decoder_layer.py
+++ b/test/quantization/ptq/wrappers/llama/test_quant_decoder_layer.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import unittest
+
+import torch
+
+from tico.experimental.quantization.ptq.mode import Mode
+from tico.experimental.quantization.ptq.wrappers.llama.quant_decoder_layer import (
+    QuantLlamaDecoderLayer,
+)
+
+trans_spec = importlib.util.find_spec("transformers")
+skip_msg = "transformers not installed — skipping LlamaDecoderLayer tests"
+
+
+@unittest.skipUnless(trans_spec, skip_msg)
+class TestQuantLlamaDecoderLayer(unittest.TestCase):
+    fp_layer: torch.nn.Module
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers.models.llama.configuration_llama import LlamaConfig
+        from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+
+        cls.cfg = LlamaConfig(  # type: ignore[attr-defined]
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            attention_bias=False,
+            attention_dropout=0.0,
+            attn_implementation="eager",
+        )
+        cls.fp_layer = LlamaDecoderLayer(cls.cfg, layer_idx=0)  # type: ignore[attr-defined]
+
+    # dummy RoPE tables with correct last dim
+    def _rand_rope(self, B, S):
+        h = self.cfg.head_dim  # type: ignore[attr-defined]
+        emb = torch.randn(B, S, h)
+        return emb.cos(), emb.sin()
+
+    def test_mode_transitions(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        self.assertIs(qlayer._mode, Mode.NO_QUANT)
+
+        qlayer.enable_calibration()
+        self.assertIs(qlayer._mode, Mode.CALIB)
+
+        hidden = torch.randn(2, 6, 16)
+        pos = self._rand_rope(2, 6)
+        attn_mask = torch.ones(2, 1, 6, 6, dtype=torch.bool)
+        _ = qlayer(hidden, attention_mask=attn_mask, position_embeddings=pos)
+
+        qlayer.freeze_qparams()
+        self.assertIs(qlayer._mode, Mode.QUANT)
+
+    def test_forward_diff(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        qlayer.enable_calibration()
+        for _ in range(4):
+            hidden = torch.randn(2, 6, 16)
+            pos = self._rand_rope(2, 6)
+            attn_mask = torch.ones(2, 1, 6, 6, dtype=torch.bool)
+            _ = qlayer(hidden, attention_mask=attn_mask, position_embeddings=pos)
+        qlayer.freeze_qparams()
+
+        hidden = torch.randn(2, 6, 16)
+        pos = self._rand_rope(2, 6)
+        attn_mask = torch.ones(2, 1, 6, 6, dtype=torch.bool)
+
+        with torch.no_grad():
+            q_out = qlayer(hidden, attention_mask=attn_mask, position_embeddings=pos)
+            q_out = q_out[0] if isinstance(q_out, tuple) else q_out
+            fp_out = self.fp_layer(
+                hidden, attention_mask=attn_mask, position_embeddings=pos
+            )
+            fp_out = fp_out[0] if isinstance(fp_out, tuple) else fp_out
+
+        diff = (fp_out - q_out).abs().mean().item()
+        self.assertGreater(diff, 0.0)
+        self.assertLess(diff, 0.5)
+        self.assertEqual(fp_out.shape, q_out.shape)
+
+    def test_layernorm_preserved(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        self.assertIsInstance(
+            qlayer.input_layernorm, type(self.fp_layer.input_layernorm)
+        )
+        self.assertIsInstance(
+            qlayer.post_attention_layernorm,
+            type(self.fp_layer.post_attention_layernorm),
+        )

--- a/tico/experimental/quantization/ptq/examples/quantize_llama_decoder_layer.py
+++ b/tico/experimental/quantization/ptq/examples/quantize_llama_decoder_layer.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# POST-TRAINING QUANTIZATION EXAMPLE — Llama Decoder Layer (Self-Attn + MLP)
+# -----------------------------------------------------------------------------
+# This demo shows how to:
+#   1. Replace a single FP32 `LlamaDecoderLayer` with `QuantLlamaDecoderLayer`.
+#   2. Collect activation statistics in one calibration sweep.
+#   3. Freeze scales / zero-points and switch to INT-simulation mode.
+#   4. Compare INT-8 vs FP32 outputs with a quick mean-absolute-diff check.
+#   5. Export the calibrated, quantized block to a Circle model.
+# -----------------------------------------------------------------------------
+# Style / layout is kept identical to the `quantize_llama_attn.py` and
+# `quantize_llama_mlp.py` examples for easy side-by-side reading.
+# =============================================================================
+
+import pathlib
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from tico.experimental.quantization.evaluation.metric import compute_peir
+from tico.experimental.quantization.evaluation.utils import plot_two_outputs
+from tico.experimental.quantization.ptq.mode import Mode
+from tico.experimental.quantization.ptq.wrappers.llama.quant_decoder_layer import (
+    QuantLlamaDecoderLayer,
+)
+from tico.utils.utils import SuppressWarning
+
+MODEL_NAME = "Maykeye/TinyLLama-v0"
+model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+
+model.eval()  # disable dropout, etc.
+rotary = model.model.rotary_emb  # RoPE helper
+
+# -------------------------------------------------------------------------
+# 1. Swap in the quant wrapper
+# -------------------------------------------------------------------------
+fp32_layer = model.model.layers[0]  # keep a reference for diff check
+model.model.layers[0] = QuantLlamaDecoderLayer(
+    fp32_layer
+)  # PTQWrapper(fp32_layer) is also fine
+model.eval()
+
+qlayer = model.model.layers[0]  # alias for brevity
+
+# -------------------------------------------------------------------------
+# 2. Single-pass calibration (gather activation ranges)
+# -------------------------------------------------------------------------
+PROMPTS = [
+    "The quick brown fox jumps over the lazy dog.",
+    "In 2025, AI systems accelerated hardware-software co-design at scale.",
+    "양자화는 왜 어려울까? 분포, 길이, 마스크가 관건이다.",
+    "今日はいい天気ですね。ところでRoPE角度は長さに依存します。",
+    "def quicksort(arr):\n    if len(arr) <= 1: return arr\n    ...",
+    "Prices rose 3.14% — see Figure 2; emails: foo@bar.com!",
+]
+
+with torch.no_grad():
+    qlayer.enable_calibration()
+    for prompt in PROMPTS:
+        ids = tokenizer(prompt, return_tensors="pt")
+        hidden = model.model.embed_tokens(ids["input_ids"])
+        pos = rotary(hidden, ids["input_ids"])  # (cos, sin) tuple
+        S = pos[0].shape[1]
+        attn_mask = torch.zeros(1, 1, S, S)  # causal-mask placeholder
+        _ = qlayer(hidden, attention_mask=attn_mask, position_embeddings=pos)
+    qlayer.freeze_qparams()
+
+assert qlayer._mode is Mode.QUANT, "Quantization mode should be active now."
+
+# -------------------------------------------------------------------------
+# 3. Quick INT-sim vs FP32 sanity check
+# -------------------------------------------------------------------------
+ids = tokenizer("check", return_tensors="pt")
+hidden = model.model.embed_tokens(ids["input_ids"])
+pos = rotary(hidden, ids["input_ids"])
+S = pos[0].shape[1]
+attn_mask = torch.zeros(1, 1, S, S)
+
+with torch.no_grad():
+    int8_out = qlayer(hidden, attention_mask=attn_mask, position_embeddings=pos)
+    int8 = int8_out[0] if isinstance(int8_out, tuple) else int8_out
+    fp32_out = fp32_layer(hidden, attention_mask=attn_mask, position_embeddings=pos)
+    fp32 = fp32_out[0] if isinstance(fp32_out, tuple) else fp32_out
+
+print("┌───────────── Quantization Error Summary ─────────────")
+print(f"│ Mean |diff|: {(int8 - fp32).abs().mean().item():.6f}")
+print(f"│ PEIR       : {compute_peir(fp32, int8) * 100:.6f} %")
+print("└──────────────────────────────────────────────────────")
+print(plot_two_outputs(fp32, int8))
+
+# -------------------------------------------------------------------------
+# 4. Export the calibrated layer to Circle
+# -------------------------------------------------------------------------
+import tico
+
+save_path = pathlib.Path("decoder_layer.q.circle")
+B, S, D = 1, 4, model.config.hidden_size
+example_hidden = torch.randn(B, S, D)
+example_pos = rotary(example_hidden, torch.arange(S)[None, :])
+attn_mask = torch.zeros(1, 1, S, S)
+
+with SuppressWarning(UserWarning, ".*"):
+    cm = tico.convert(
+        qlayer, (example_hidden, attn_mask), {"position_embeddings": example_pos}
+    )
+# Note that the model is not fully quantized.
+cm.save(save_path)
+
+print(f"Quantized Circle model saved to {save_path.resolve()}")

--- a/tico/experimental/quantization/ptq/wrappers/llama/__init__.py
+++ b/tico/experimental/quantization/ptq/wrappers/llama/__init__.py
@@ -1,6 +1,9 @@
 from tico.experimental.quantization.ptq.wrappers.llama.quant_attn import (
     QuantLlamaAttention,
 )
+from tico.experimental.quantization.ptq.wrappers.llama.quant_decoder_layer import (
+    QuantLlamaDecoderLayer,
+)
 from tico.experimental.quantization.ptq.wrappers.llama.quant_mlp import QuantLlamaMLP
 
-__all__ = ["QuantLlamaAttention", "QuantLlamaMLP"]
+__all__ = ["QuantLlamaAttention", "QuantLlamaDecoderLayer", "QuantLlamaMLP"]

--- a/tico/experimental/quantization/ptq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/experimental/quantization/ptq/wrappers/llama/quant_decoder_layer.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.ptq.wrappers.llama.quant_attn import (
+    QuantLlamaAttention,
+)
+from tico.experimental.quantization.ptq.wrappers.llama.quant_mlp import QuantLlamaMLP
+from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
+from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
+    QuantModuleBase,
+)
+from tico.experimental.quantization.ptq.wrappers.registry import try_register
+
+
+@try_register("transformers.models.llama.modeling_llama.LlamaDecoderLayer")
+class QuantLlamaDecoderLayer(QuantModuleBase):
+    """
+    Quant-aware drop-in replacement for HF `LlamaDecoderLayer`.
+    Signature and return-value are identical to the original.
+
+    ▸ Attention & MLP blocks are replaced by their quantized counterparts
+    ▸ LayerNorms remain FP32 (no fake-quant)
+    ▸ A "static" causal mask is pre-built in `__init__` to avoid
+      dynamic boolean-to-float casts inside `forward`.
+
+    Notes on the causal mask
+    ------------------------
+    Building a boolean mask "inside" `forward` would introduce
+    non-deterministic dynamic ops that an integer-only accelerator cannot
+    fuse easily.  Therefore we:
+
+    1. Pre-compute a full upper-triangular mask of size
+       `[1, 1, max_seq, max_seq]` in `__init__`.
+    2. In `forward`, if the caller passes `attention_mask=None`, we
+       slice the pre-computed template to the current sequence length.
+    """
+
+    def __init__(
+        self,
+        fp_layer: nn.Module,
+        *,
+        qcfg: Optional[QuantConfig] = None,
+        fp_name: Optional[str] = None,
+        return_type: Optional[str] = None,
+    ):
+        """
+        Q) Why do we need `return_type`?
+        A) Different versions of `transformers` wrap the decoder output in
+            different containers: a plain Tensor or a tuple.
+        """
+        self.return_type = return_type
+        if self.return_type is None:
+            import transformers
+
+            v = tuple(map(int, transformers.__version__.split(".")[:2]))
+            self.return_type = "tensor" if v >= (4, 54) else "tuple"
+        assert self.return_type is not None
+        super().__init__(qcfg, fp_name=fp_name)
+
+        # Child QuantConfigs -------------------------------------------------
+        attn_cfg = qcfg.child("self_attn") if qcfg else None
+        mlp_cfg = qcfg.child("mlp") if qcfg else None
+
+        # Quantized sub-modules ---------------------------------------------
+        assert hasattr(fp_layer, "self_attn") and isinstance(
+            fp_layer.self_attn, torch.nn.Module
+        )
+        assert hasattr(fp_layer, "mlp") and isinstance(fp_layer.mlp, torch.nn.Module)
+        self.self_attn = PTQWrapper(
+            fp_layer.self_attn, qcfg=attn_cfg, fp_name=f"{fp_name}.self_attn"
+        )
+        self.mlp = PTQWrapper(fp_layer.mlp, qcfg=mlp_cfg, fp_name=f"{fp_name}.mlp")
+
+        # LayerNorms remain FP (copied from fp_layer to keep weights)
+        assert hasattr(fp_layer, "input_layernorm") and isinstance(
+            fp_layer.input_layernorm, torch.nn.Module
+        )
+        assert hasattr(fp_layer, "post_attention_layernorm") and isinstance(
+            fp_layer.post_attention_layernorm, torch.nn.Module
+        )
+        self.input_layernorm = fp_layer.input_layernorm
+        self.post_attention_layernorm = fp_layer.post_attention_layernorm
+
+        # Static causal mask template ---------------------------------------
+        assert hasattr(fp_layer.self_attn, "config") and hasattr(
+            fp_layer.self_attn.config, "max_position_embeddings"
+        )
+        assert isinstance(fp_layer.self_attn.config.max_position_embeddings, int)
+        max_seq = fp_layer.self_attn.config.max_position_embeddings
+        mask = torch.full((1, 1, max_seq, max_seq), float("-120"))
+        mask.triu_(1)
+        self.register_buffer("causal_mask_template", mask, persistent=False)
+
+    def _slice_causal(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        """Return `[1,1,L,L]` causal mask slice on *device*."""
+        assert isinstance(self.causal_mask_template, torch.Tensor)
+        return self.causal_mask_template[..., :seq_len, :seq_len].to(device)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional["Cache"] = None,  # type: ignore[name-defined]
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor] | torch.Tensor:
+        if output_attentions:
+            raise NotImplementedError(
+                "QuantLlamaDecoderLayer does not support output attention yet."
+            )
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        if attention_mask is None or attention_mask.dtype == torch.bool:
+            L = hidden_states.size(1)
+            attention_mask = self._slice_causal(L, hidden_states.device)
+
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # ─── MLP block ─────────────────────────────────────────────────
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        if self.return_type == "tuple":
+            return (hidden_states,)
+        elif self.return_type == "tensor":
+            return hidden_states
+        else:
+            raise RuntimeError("Invalid return type.")
+
+    # No local observers; just recurse into children
+    def _all_observers(self):
+        yield from self.self_attn._all_observers()
+        yield from self.mlp._all_observers()

--- a/tico/experimental/quantization/ptq/wrappers/registry.py
+++ b/tico/experimental/quantization/ptq/wrappers/registry.py
@@ -29,6 +29,7 @@ _CORE_MODULES = (
     "tico.experimental.quantization.ptq.wrappers.nn.quant_linear",
     "tico.experimental.quantization.ptq.wrappers.nn.quant_silu",
     "tico.experimental.quantization.ptq.wrappers.llama.quant_attn",
+    "tico.experimental.quantization.ptq.wrappers.llama.quant_decoder_layer",
     "tico.experimental.quantization.ptq.wrappers.llama.quant_mlp",
     # add future core wrappers here
 )


### PR DESCRIPTION
This commit introduces Llama decoder layer wrapper.

Related: https://github.com/Samsung/TICO/issues/89
Draft: https://github.com/Samsung/TICO/pull/212
```bash
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.015444
│ PEIR       : 6.560064 %
└──────────────────────────────────────────────────────
     ┌───────────────────────────────────────────┐
 1.30┤                                           │
     │                                        •  │
     │                                       •   │
 0.86┤                                    •      │
     │                                  ••       │
     │                               •••         │
     │                             • •           │
 0.41┤                           •••             │
     │                         •••               │
     │                       ••• •               │
-0.04┤                     •••                   │
     │                   •••                     │
     │                 •••                       │
     │               •••                         │
-0.48┤             •••                           │
     │           •••                             │
     │         ••                                │
-0.93┤        •                                  │
     │      •                                    │
     │                                           │
     │  •                                        │
-1.38┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -1.38      -0.71     -0.04      0.63     1.30 

Quantized Circle model saved to /home/seongwoo/TICO/decoder_layer.q.circle
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>