### PR TITLE
[ptq] Introduce Debugging APIs

### DIFF
--- a/test/quantization/ptq/utils/test_introspection.py
+++ b/test/quantization/ptq/utils/test_introspection.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import torch
+import torch.nn as nn
+
+from tico.experimental.quantization import convert, prepare
+from tico.experimental.quantization.config import SmoothQuantConfig
+from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.ptq.utils.introspection import (
+    build_fqn_map,
+    compare_layer_outputs,
+    save_fp_outputs,
+)
+from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
+
+IS_CI_MODE = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+
+
+class DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = nn.Linear(4, 4)
+        # nn.Sequential gives us numbered sub-modules (0, 1).
+        self.block = nn.Sequential(
+            nn.Conv2d(3, 8, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+
+
+class TestBuildFqnMap(unittest.TestCase):
+    def setUp(self):
+        # Build the test model once for all test methods.
+        self.model = DummyModel()
+        self.fqn_map = build_fqn_map(self.model)
+
+    # ---------- basic correctness checks ---------- #
+    def test_root_included(self):
+        self.assertIn(self.model, self.fqn_map)
+        self.assertEqual(self.fqn_map[self.model], "")
+
+    def test_direct_child_name(self):
+        self.assertEqual(self.fqn_map[self.model.linear1], "linear1")
+
+    def test_sequential_children(self):
+        conv = self.model.block[0]
+        relu = self.model.block[1]
+        self.assertEqual(self.fqn_map[conv], "block.0")
+        self.assertEqual(self.fqn_map[relu], "block.1")
+
+    # ---------- structural sanity tests ---------- #
+    def test_total_entries(self):
+        expected_count = 5
+        self.assertEqual(len(self.fqn_map), expected_count)
+
+    def test_bidirectional_consistency(self):
+        inverse = {m: n for n, m in self.model.named_modules()}
+        for mod, name in self.fqn_map.items():
+            self.assertEqual(name, inverse[mod])
+
+
+@unittest.skipIf(
+    not IS_CI_MODE, "Internal test — skipped unless --include-internal is set"
+)
+class TestSmoothQuantPTQDiff(unittest.TestCase):
+    """
+    Unit-test: verify that W8A8 SmoothQuant + PTQ does NOT explode layer-wise.
+
+    The test checks per-wrapper activation deltas between
+      • CALIB mode (FP32 pass-through)  vs.
+      • QUANT mode (fake-/real-quant output)
+
+    For speed it uses "Maykeye/TinyLLama-v0" and a single, short input.
+    """
+
+    model_name: str
+    device: torch.device
+    input_ids: torch.Tensor
+    model: torch.nn.Module
+    fp_cache: dict[str, torch.Tensor]
+
+    @classmethod
+    def setUpClass(cls):
+        from datasets import load_dataset
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        cls.model_name = "Maykeye/TinyLLama-v0"
+        cls.device = torch.device("cpu")
+
+        # tiny model + tokenizer
+        tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
+        fp_model = (
+            AutoModelForCausalLM.from_pretrained(cls.model_name).to(cls.device).eval()
+        )
+        fp_model.config.use_cache = False
+        fqn_map = build_fqn_map(fp_model)
+
+        # SmoothQuant calibration
+        sq_model = prepare(fp_model, SmoothQuantConfig(), inplace=True)
+        ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+        with torch.inference_mode():
+            for i in range(5):
+                ids = tokenizer(ds[i]["text"], return_tensors="pt").input_ids.to(
+                    cls.device
+                )
+                sq_model(ids)
+        sq_model = convert(sq_model, inplace=True)
+
+        # PTQ-wrap first 4 layers
+        qcfg = QuantConfig()
+        new_layers = torch.nn.ModuleList()
+        for idx, fp_layer in enumerate(sq_model.model.layers):
+            if idx >= 4:
+                new_layers.append(fp_layer)
+                continue
+            new_layers.append(
+                PTQWrapper(
+                    fp_layer,
+                    qcfg=qcfg.child(f"layer{idx}"),
+                    fp_name=fqn_map.get(fp_layer),
+                )
+            )
+        sq_model.model.layers = new_layers
+        cls.model = sq_model
+
+        # prepare static input & capture FP refs
+        cls.input_ids = tokenizer(
+            "Unit-test input sequence.", return_tensors="pt"
+        ).input_ids.to(cls.device)
+
+        sq_model.model.layers.apply(
+            lambda m: getattr(m, "enable_calibration", lambda: None)()
+        )
+        h_save, cls.fp_cache = save_fp_outputs(cls.model)
+        with torch.no_grad():
+            cls.model(cls.input_ids)
+        for h in h_save:
+            h.remove()
+
+        # switch to QUANT mode
+        sq_model.model.layers.apply(
+            lambda m: getattr(m, "freeze_qparams", lambda: None)()
+        )
+
+    # ------------------------------------------------------------------ #
+    # 1. Original diff-only assertion (updated for nested dict)          #
+    # ------------------------------------------------------------------ #
+    def test_layerwise_diff(self):
+        h_cmp, stats = compare_layer_outputs(
+            self.model,
+            self.fp_cache,
+            metrics=["diff"],
+            rtol=0.0,
+            atol=1.0,
+            collect=True,
+        )
+        with torch.no_grad():
+            self.model(self.input_ids)
+        for h in h_cmp:
+            h.remove()
+
+        for name, metric_dict in stats.items():
+            self.assertLessEqual(
+                metric_dict["diff"],
+                1.0,
+                msg=f"{name}: diff={metric_dict['diff']:.3e} > 1.0",
+            )
+
+    # ------------------------------------------------------------------ #
+    # 2. PEIR metric exists & is finite                                  #
+    # ------------------------------------------------------------------ #
+    def test_layerwise_peir(self):
+        _, stats = compare_layer_outputs(
+            self.model, self.fp_cache, metrics=["peir"], collect=True
+        )
+        for name, metric_dict in stats.items():
+            val = metric_dict["peir"]
+            self.assertTrue(
+                torch.isfinite(torch.tensor(val)),
+                msg=f"{name}: non-finite PEIR",
+            )
+
+    # ------------------------------------------------------------------ #
+    # 3. Subset selection ('diff', 'peir')                               #
+    # ------------------------------------------------------------------ #
+    def test_metric_subset_selection(self):
+        _, stats = compare_layer_outputs(
+            self.model,
+            self.fp_cache,
+            metrics=["diff", "peir"],
+            collect=True,
+        )
+        for metric_dict in stats.values():
+            self.assertEqual(set(metric_dict), {"diff", "peir"})
+
+    # ------------------------------------------------------------------ #
+    # 4. Custom metric (mean-abs-error)                                  #
+    # ------------------------------------------------------------------ #
+    def test_custom_metric(self):
+        def mae(a: torch.Tensor, b: torch.Tensor) -> float:
+            return (a - b).abs().mean().item()
+
+        _, stats = compare_layer_outputs(
+            self.model,
+            self.fp_cache,
+            metrics=["mae"],
+            custom_metrics={"mae": mae},
+            collect=True,
+        )
+        for metric_dict in stats.values():
+            self.assertIn("mae", metric_dict)

--- a/tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
+++ b/tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import tqdm
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.ptq.utils.introspection import (
+    build_fqn_map,
+    compare_layer_outputs,
+    save_fp_outputs,
+)
+from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
+
+# ============================================================================
+# LAYER-WISE DIFF DEBUGGING PIPELINE
+# ----------------------------------------------------------------------------
+# A quantization debugging pipeline that identifies accuracy regressions
+# by comparing UINT vs FP outputs at each layer.
+#
+#   1. Load a full-precision (FP) LLaMA-3-1B model.
+#   2. Wrap each Transformer block with PTQWrapper (activations → fake-quant).
+#   3. Capture reference FP layer outputs before quantization.
+#   4. Calibrate UINT-8 activation observers in a single pass.
+#   5. Freeze quantization parameters (scale, zero-point).
+#   6. Re-run inference and compare UINT-8 vs FP outputs per layer.
+#   7. Report where quantization hurts the most.
+#
+# Use this pipeline to trace precision loss layer by layer, and pinpoint
+# problematic modules during post-training quantization.
+# ============================================================================
+
+# -------------------------------------------------------------------------
+# 0. Global configuration
+# -------------------------------------------------------------------------
+MODEL_NAME = "meta-llama/Meta-Llama-3-1B"
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+STRIDE = 512
+
+# Token-budget presets for activation calibration
+TOKENS: dict[str, int] = {
+    # Smoke test (<1 min turnaround on CPU/GPU)
+    "debug": 2_000,  # ≈16 × 128-seq batches
+    # Good default for 1-7B models (≲3 % ppl delta)
+    "baseline": 50_000,
+    # Production / 4-bit observer smoothing
+    "production": 200_000,
+}
+CALIB_TOKENS = TOKENS["baseline"]
+print(f"Calibrating with {CALIB_TOKENS:,} tokens.\n")
+
+# -------------------------------------------------------------------------
+# 1. Load the FP backbone
+# -------------------------------------------------------------------------
+print("Loading FP model …")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModelForCausalLM.from_pretrained(MODEL_NAME).to(DEVICE).eval()
+model.config.use_cache = False  # disable KV-cache → full forward
+m_to_fqn = build_fqn_map(model)  # map modules → fully-qualified names
+
+# Use Wikitext-2 train split for calibration.
+dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+
+# -------------------------------------------------------------------------
+# 2. Wrap every layer with PTQWrapper (UINT-8 activations)
+# -------------------------------------------------------------------------
+print("Wrapping layers with PTQWrapper …")
+qcfg = QuantConfig()  # default: per-tensor UINT8
+
+new_layers = torch.nn.ModuleList()
+for idx, fp_layer in enumerate(model.model.layers):
+    layer_cfg = qcfg.child(f"layer{idx}")
+    q_layer = PTQWrapper(
+        fp_layer,
+        qcfg=layer_cfg,
+        fp_name=m_to_fqn.get(fp_layer),
+    )
+    new_layers.append(q_layer)
+
+model.model.layers = new_layers  # swap in quant wrappers
+
+# -------------------------------------------------------------------------
+# 3. Activation calibration plus FP-vs-UINT8 diffing
+# -------------------------------------------------------------------------
+print("Calibrating UINT-8 observers …")
+calib_txt = " ".join(dataset["text"])[:CALIB_TOKENS]
+ids = tokenizer(calib_txt, return_tensors="pt").input_ids.to(DEVICE)
+
+# (a) Enable CALIB mode on every QuantModuleBase
+for l in model.model.layers:
+    l.enable_calibration()
+
+# Save reference FP activations before observers clamp/quantize
+save_handles, act_cache = save_fp_outputs(model)
+
+with torch.no_grad():
+    for i in tqdm.trange(0, ids.size(1) - 1, STRIDE, desc="Act-calibration"):
+        inputs = ids[:, i : i + STRIDE]
+        model(inputs)  # observers collect act. ranges
+
+# Remove save hooks now that FP activations are cached
+for h in save_handles:
+    h.remove()
+
+# (b) Freeze (scale, zero-point) after calibration
+for l in model.model.layers:
+    l.freeze_qparams()
+
+# (c) Register diff hooks and measure per-layer deltas
+cmp_handles = compare_layer_outputs(model, act_cache, metrics=["diff", "peir"])
+# Use same inputs for comparison.
+model(inputs)
+
+assert isinstance(cmp_handles, list)
+for h in cmp_handles:
+    h.remove()

--- a/tico/experimental/quantization/ptq/utils/introspection.py
+++ b/tico/experimental/quantization/ptq/utils/introspection.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+
+from tico.experimental.quantization.evaluation.metric import MetricCalculator
+from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
+from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
+    QuantModuleBase,
+)
+
+
+def build_fqn_map(root: torch.nn.Module) -> dict[torch.nn.Module, str]:
+    """
+    Return {module_object: full_qualified_name} without touching the modules.
+    """
+    return {m: n for n, m in root.named_modules()}
+
+
+def save_fp_outputs(
+    model: torch.nn.Module,
+) -> Tuple[List[torch.utils.hooks.RemovableHandle], Dict[str, torch.Tensor]]:
+    """
+    Register forward-hooks on every `QuantModuleBase` wrapper itself (not the
+    wrapped `module`) and cache its output while the wrapper runs in CALIB mode.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model whose wrappers are already switched to CALIB mode
+        (`enable_calibration()` has been called).
+
+    Returns
+    -------
+    handles : list[RemovableHandle]
+        Hook handles; call `.remove()` on each one to detach the hooks.
+    cache : dict[str, torch.Tensor]
+        Mapping "wrapper-name → cached FP32 activation" captured from the first
+        forward pass. Keys default to `wrapper.fp_name`; if that attribute is
+        `None`, the `id(wrapper)` string is used instead.
+    """
+    cache: Dict[str, torch.Tensor] = {}
+    handles: List[torch.utils.hooks.RemovableHandle] = []
+
+    def _save(name: str):
+        def hook(_, __, out: torch.Tensor | Tuple):
+            if isinstance(out, tuple):
+                out = out[0]
+            assert isinstance(out, torch.Tensor)
+            cache[name] = out.detach()
+
+        return hook
+
+    for m in model.modules():
+        if isinstance(m, QuantModuleBase):
+            name = m.fp_name or str(id(m))
+            handles.append(m.register_forward_hook(_save(name)))
+
+    return handles, cache
+
+
+def compare_layer_outputs(
+    model: torch.nn.Module,
+    cache: Dict[str, torch.Tensor],
+    *,
+    metrics: Optional[List[str]] = None,
+    custom_metrics: Optional[Dict[str, Callable]] = None,
+    rtol: float = 1e-3,
+    atol: float = 1e-3,
+    collect: bool = False,
+):
+    """
+    Register forward-hooks on every `QuantModuleBase` wrapper to compare its
+    QUANT-mode output to the FP32 reference saved by `save_fp_outputs()`.
+
+    Each hook prints a per-layer diff report:
+
+        ✓  layer_name  max=1.23e-02  mean=8.45e-04     (within tolerance)
+        ⚠️ layer_name  max=3.07e+00  mean=5.12e-01     (exceeds tolerance)
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model whose wrappers are now in QUANT mode
+        (`freeze_qparams()` has been called).
+    cache : dict[str, torch.Tensor]
+        The reference activations captured during CALIB mode.
+    metrics
+        Metrics to compute. Defaults to `["diff"]`. Add `peir` to print PEIR.
+    custom_metrics
+        Optional user metric functions. Same signature as built-ins.
+    rtol, atol : float, optional
+        Relative / absolute tolerances used to flag large deviations
+        (similar to `torch.allclose` semantics).
+    collect : bool, optional
+        • False (default) → print one-line report per layer, return `None`
+        • True            → suppress printing, return a nested dict
+                                {layer_name -> {metric -> value}}
+
+    Returns
+    -------
+    handles
+        Hook handles; call `.remove()` once diffing is complete.
+    results
+        Only if *collect* is True.
+    """
+    metrics = metrics or ["diff"]
+    calc = MetricCalculator(custom_metrics)
+    handles: List[torch.utils.hooks.RemovableHandle] = []
+    results: Dict[
+        str, Dict[str, float]
+    ] = {}  # Dict[layer_name, Dict[metric_name, value]]
+
+    def _cmp(name: str):
+        ref = cache.get(name)
+
+        def hook(_, __, out):
+            if ref is None:
+                if not collect:
+                    print(f"[{name}]  no cached reference")
+                return
+            if isinstance(out, tuple):
+                out = out[0]
+            assert isinstance(out, torch.Tensor)
+
+            # Compute all requested metrics
+            res = calc.compute([ref], [out], metrics)  # lists with length-1 tensors
+            res = {k: v[0] for k, v in res.items()}  # flatten
+
+            if collect:
+                results[name] = res  # type: ignore[assignment]
+                return
+
+            # Pretty print ------------------------------------------------ #
+            diff_val = res.get("diff") or res.get("max_abs_diff")
+            thresh = atol + rtol * ref.abs().max().item()
+            flag = "⚠️" if (diff_val is not None and diff_val > thresh) else "✓"  # type: ignore[operator]
+
+            pieces = [f"{flag} {name:45s}"]
+            for key, val in res.items():
+                pieces.append(f"{key}={val:<7.4}")
+            print("  ".join(pieces))
+
+        return hook
+
+    for m in model.modules():
+        if isinstance(m, PTQWrapper):
+            # skip the internal fp module inside the wrapper
+            continue
+        if isinstance(m, QuantModuleBase):
+            lname = m.fp_name or str(id(m))
+            handles.append(m.register_forward_hook(_cmp(lname)))
+
+    if collect:
+        return handles, results
+    return handles


### PR DESCRIPTION
This commit introduces debugigng APIs.

```bash
python tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
Calibrating with 50,000 tokens.

Loading FP model …
`rope_scaling`'s original_max_position_embeddings field must be less than max_position_embeddings, got 2048 and max_position_embeddings=2048
Using the latest cached version of the dataset since wikitext couldn't be found on the Hugging Face Hub
Found the latest cached dataset configuration 'wikitext-2-raw-v1' at /home/sw4670.chae/.cache/huggingface/datasets/wikitext/wikitext-2-raw-v1/0.0.0/b08601e04326c79dfdd32d625aee71d232d685c3 (last modified on Fri May  3 21:06:41 2024).
Wrapping layers with PTQWrapper …
Calibrating UINT-8 observers …
Act-calibration: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 22/22 [00:03<00:00,  6.09it/s]
⚠️ model.layers.0.self_attn.q_proj                diff=0.1968   peir=0.004822
⚠️ model.layers.0.self_attn.k_proj                diff=0.1455   peir=0.006057
⚠️ model.layers.0.self_attn.v_proj                diff=0.02336  peir=0.01251
⚠️ model.layers.0.self_attn.o_proj                diff=0.04807  peir=0.05763
⚠️ model.layers.0.self_attn                       diff=0.04807  peir=0.05763
⚠️ model.layers.0.mlp.gate_proj                   diff=1.905    peir=0.1141
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>