### PR TITLE
[test] Fix requirement.txt for BitNet test

### DIFF
--- a/test/modules/model/BitNet_b1_58/requirements.txt
+++ b/test/modules/model/BitNet_b1_58/requirements.txt
@@ -1,2 +1,2 @@
-transformers>=4.52.1
+transformers==4.55.4
 accelerate


### PR DESCRIPTION
BitNet test fails with latest transformers(4.56), so it fixes transformers version to 4.55.4

TICO-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com