### PR TITLE
[ptq] Support multiple registration

### DIFF
--- a/tico/experimental/quantization/ptq/wrappers/llama/quant_attn.py
+++ b/tico/experimental/quantization/ptq/wrappers/llama/quant_attn.py
@@ -25,7 +25,10 @@ from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
 from tico.experimental.quantization.ptq.wrappers.registry import try_register
 
 
-@try_register("transformers.models.llama.modeling_llama.LlamaAttention")
+@try_register(
+    "transformers.models.llama.modeling_llama.LlamaAttention",
+    "transformers.models.llama.modeling_llama.LlamaSdpaAttention",
+)
 class QuantLlamaAttention(QuantModuleBase):
     def __init__(
         self,


### PR DESCRIPTION
This commit supports multiple registration.

This fixes an error that happened when old `transformers` use `LlamaSdpaAttention` instead of `LlamaAttention` which is used latest `transformers`.
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>