### PR TITLE
[test] Add tests for DecomposeFakeQuantizeTensorQparams

### DIFF
--- a/test/unit_test/pass_test/test_decompose_fake_quantize_tensor_qparam.py
+++ b/test/unit_test/pass_test/test_decompose_fake_quantize_tensor_qparam.py
@@ -128,3 +128,116 @@ class DecomposeFakeQuantizeTensorQParamUint4Dtype(PassTest):
             else:
                 self.assertEqual(n.target, torch.ops.aten.linear.default)
                 self.assertEqual(n.meta[QPARAM_KEY].dtype, "uint8")
+
+
+class FakeQuantizeTensorQParamsCacheMaskModel(torch.nn.Module):
+    def __init__(self, scale_val, zp_val, quant_min, quant_max):
+        super().__init__()
+        self.scale_val = scale_val
+        self.zp_val = zp_val
+        self.quant_min = quant_min
+        self.quant_max = quant_max
+        # These will become lifted tensor constants
+        self.register_buffer("scale_tensor", torch.tensor(scale_val))
+        self.register_buffer("zp_tensor", torch.tensor(zp_val))
+        self.register_buffer("fq_enabled_tensor", torch.tensor(True))
+
+    def forward(self, x):
+        res = torch.ops.aten._fake_quantize_per_tensor_affine_cachemask_tensor_qparams.default(
+            x,
+            self.scale_tensor,
+            self.zp_tensor,
+            self.fq_enabled_tensor,
+            self.quant_min,
+            self.quant_max,
+        )
+        return res[0]
+
+    def get_example_inputs(self):
+        return ((torch.randn(2, 3),), {})
+
+
+class DecomposeFakeQuantizeTensorQParamsCacheMaskTest(SinglePassValueTest):
+    def test_decompose_uint8(self):
+        model = FakeQuantizeTensorQParamsCacheMaskModel(0.1, 0, 0, 255)
+        self.setup(model)
+
+        ep_before = self.exported_program()
+        self.assertEqual(
+            num_of_ops(
+                ep_before,
+                [
+                    torch.ops.aten._fake_quantize_per_tensor_affine_cachemask_tensor_qparams.default
+                ],
+            ),
+            1,
+        )
+        self.assertEqual(
+            num_of_ops(
+                ep_before, [torch.ops.quantized_decomposed.quantize_per_tensor.default]
+            ),
+            0,
+        )
+        self.assertEqual(
+            num_of_ops(
+                ep_before,
+                [torch.ops.quantized_decomposed.dequantize_per_tensor.default],
+            ),
+            0,
+        )
+
+        self.run_value_test(DecomposeFakeQuantizeTensorQParams())
+
+        ep_after = self.exported_program()
+        self.assertEqual(
+            num_of_ops(
+                ep_after,
+                [
+                    torch.ops.aten._fake_quantize_per_tensor_affine_cachemask_tensor_qparams.default
+                ],
+            ),
+            0,
+        )
+        self.assertEqual(
+            num_of_ops(
+                ep_after, [torch.ops.quantized_decomposed.quantize_per_tensor.default]
+            ),
+            1,
+        )
+        self.assertEqual(
+            num_of_ops(
+                ep_after, [torch.ops.quantized_decomposed.dequantize_per_tensor.default]
+            ),
+            1,
+        )
+        # Check dtype inference
+        quant_node = None
+        for n in ep_after.graph_module.graph.nodes:
+            if n.target == torch.ops.quantized_decomposed.quantize_per_tensor.default:
+                quant_node = n
+                break
+        self.assertIsNotNone(quant_node)
+        self.assertEqual(quant_node.kwargs["dtype"], torch.uint8)  # type: ignore[union-attr]
+
+    def test_decompose_int16(self):
+        model = FakeQuantizeTensorQParamsCacheMaskModel(0.05, 0, -32768, 32767)
+        self.setup(model)
+        self.run_value_test(DecomposeFakeQuantizeTensorQParams())
+
+        ep_after = self.exported_program()
+        self.assertEqual(
+            num_of_ops(
+                ep_after,
+                [
+                    torch.ops.aten._fake_quantize_per_tensor_affine_cachemask_tensor_qparams.default
+                ],
+            ),
+            0,
+        )
+        quant_node = None
+        for n in ep_after.graph_module.graph.nodes:
+            if n.target == torch.ops.quantized_decomposed.quantize_per_tensor.default:
+                quant_node = n
+                break
+        self.assertIsNotNone(quant_node)
+        self.assertEqual(quant_node.kwargs["dtype"], torch.int16)  # type: ignore[union-attr]

--- a/tico/passes/decompose_fake_quantize_tensor_qparams.py
+++ b/tico/passes/decompose_fake_quantize_tensor_qparams.py
@@ -245,9 +245,10 @@ class DecomposeFakeQuantizeTensorQParams(PassBase):
                     # mask_user(output).args == (dequantize_per_tensor.tensor, mask)
                     if mask:
                         assert len(mask) == 1
-                        mask_user = list(mask[0].users.keys())[0]
-                        assert len(mask_user.args) == 1
-                        mask_user.args = ((mask_user.args[0][0],),)
+                        if len(mask[0].users) > 0:
+                            mask_user = list(mask[0].users.keys())[0]
+                            assert len(mask_user.args) == 1
+                            mask_user.args = ((mask_user.args[0][0],),)
                 modified = True
             if (
                 node.target


### PR DESCRIPTION
This adds test cases for cache mask op.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/TICO/issues/322