### PR TITLE
Support ccex format -d

### DIFF
--- a/infra/style/format.sh
+++ b/infra/style/format.sh
@@ -10,7 +10,7 @@ while [[ "$#" -gt 0 ]]; do
       APPLY_PATCH_OPTION=""
       shift
       ;;
-    --diff-only)
+    -d|--diff-only)
       CHECK_DIFF_ONLY="1"
       shift
       ;;


### PR DESCRIPTION
This adds aliasing -d for --diff-only.

TICO-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>