### PR TITLE
[utils] Check the number of passed args

### DIFF
--- a/test/unit_test/utils_test/test_signature.py
+++ b/test/unit_test/utils_test/test_signature.py
@@ -72,7 +72,9 @@ class UtilsSignatureTest(unittest.TestCase):
             "lin": torch.randn(2, 2, dtype=torch.float32),
             "x1": torch.randn(2, 3),
         }
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(
+            TypeError, "type torch.int64 != expected torch.float32"
+        ):
             spec.bind(args, kwargs, check=True)
 
     def test_bind_shape_check_fail(self):
@@ -82,7 +84,7 @@ class UtilsSignatureTest(unittest.TestCase):
             "lin": torch.randn(20, 20, dtype=torch.float32),
             "x1": torch.randn(2, 3),
         }  # shape mismatch
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "wrong dimension"):
             spec.bind(args, kwargs, check=True)
 
     def test_bind_missing_arg_fail(self):
@@ -91,7 +93,7 @@ class UtilsSignatureTest(unittest.TestCase):
         kwargs = {
             "x1": torch.randn(2, 3),
         }  # 'lin' is missing
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "arguments are not the same"):
             spec.bind(args, kwargs, check=True)
 
     def test_bind_too_many_positional_fail(self):
@@ -102,7 +104,7 @@ class UtilsSignatureTest(unittest.TestCase):
             torch.randn(2, 3),
             torch.randn(2, 3),
         )  # Too many args
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "arguments are not the same"):
             spec.bind(args, {}, check=True)
 
     def test_bind_multiple_values_fail(self):
@@ -115,7 +117,7 @@ class UtilsSignatureTest(unittest.TestCase):
             "x1": torch.randn(2, 3),  # x1 !! multiple value for x1
             "lin": torch.randn(20, 20, dtype=torch.float32),
         }  # shape mismatch
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(ValueError, "arguments are not the same"):
             spec.bind(args, kwargs, check=True)
 
     def test_bind_tuple(self):
@@ -173,3 +175,12 @@ class UtilsSignatureTest(unittest.TestCase):
         assert inputs[0].shape == torch.Size([2, 3])
         assert inputs[1].shape == torch.Size([2, 3])
         assert inputs[2].shape == torch.Size([2, 2])
+
+    def test_bind_input_num_mismatch(self):
+        spec = ModelInputSpec(self.circle_model.circle_binary)
+        args = (torch.randn(2, 3, dtype=torch.float32),)
+        kwargs = {
+            "lin": torch.randn(2, 2, dtype=torch.float32),
+        }
+        with self.assertRaisesRegex(ValueError, "arguments are not the same"):
+            spec.bind(args, kwargs, check=True)

--- a/tico/utils/signature.py
+++ b/tico/utils/signature.py
@@ -141,22 +141,21 @@ class ModelInputSpec:
         args = flatten_and_convert_args(args)
         kwargs = flatten_and_convert_kwargs(kwargs)
 
+        arg_num = len(args) + len(kwargs)
+        m_input_num = len(self.names)
+        if arg_num != m_input_num:
+            raise ValueError(
+                f"Mismatch: number of model inputs and number of passed arguments are not the same: inputs({m_input_num}) != passed({arg_num}), input spec: {self.names}"
+            )
+
         # 1. positional arguments
         for i, val in enumerate(args):
-            if i >= len(self.names):
-                raise ValueError(f"Too many positional arguments ({i+1}).")
             name = self.names[i]
-            if name in kwargs:
-                raise TypeError(
-                    f"Got multiple values for argument '{name}' (positional and keyword)."
-                )
             inputs.append(val)
 
         # 2. keyword arguments
         for idx in range(len(args), len(self.names)):
             name = self.names[idx]
-            if name not in kwargs:
-                raise ValueError(f"Missing argument for input '{name}'.")
             inputs.append(kwargs[name])
 
         if check:


### PR DESCRIPTION
This commit checks the number of passed args when binding.

Related: https://github.com/Samsung/TICO/pull/347#issuecomment-3300913765
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>