### PR TITLE
[ptq] Remove redundant help messages

### DIFF
--- a/tico/experimental/quantization/ptq/examples/compare_ppl.py
+++ b/tico/experimental/quantization/ptq/examples/compare_ppl.py
@@ -77,7 +77,7 @@ def main():
         "--dtype",
         choices=list(DTYPE_MAP.keys()),
         default="float32",
-        help="Model dtype for load (float32|bfloat16|float16).",
+        help=f"Model dtype for load.",
     )
     parser.add_argument(
         "--stride", type=int, default=512, help="Sliding-window stride for perplexity."

--- a/tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
+++ b/tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
@@ -85,7 +85,7 @@ def main():
         "--dtype",
         choices=list(DTYPE_MAP.keys()),
         default="float32",
-        help="Model dtype for load (float32|bfloat16|float16).",
+        help=f"Model dtype for load.",
     )
     parser.add_argument(
         "--stride",


### PR DESCRIPTION
This commit removes redundant help messages.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>