### PR TITLE
[CI] Upgrade ONE version to 1.30.1

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -84,7 +84,7 @@ jobs:
         with:
           owner: Samsung
           repo: ONE
-          tag: 1.30.0
+          tag: 1.30.1
           filename: one-compiler-deb-${{ steps.os.outputs.codename }}-1.30.0.tar.gz
 
       - name: "Install one-compiler"

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -85,7 +85,7 @@ jobs:
           owner: Samsung
           repo: ONE
           tag: 1.30.1
-          filename: one-compiler-deb-${{ steps.os.outputs.codename }}-1.30.0.tar.gz
+          filename: one-compiler-deb-${{ steps.os.outputs.codename }}-1.30.1.tar.gz
 
       - name: "Install one-compiler"
         working-directory: ./.github/actions/download-release-asset

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -78,20 +78,26 @@ jobs:
           CODENAME=$(lsb_release -cs)
           echo "codename=$CODENAME" >> "$GITHUB_OUTPUT"
 
+      - name: Specify ONE version and binary
+        id: one
+        run: |
+          VERSION=1.30.1
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "filename=one-compiler-${{ steps.os.outputs.codename }}_${VERSION}_amd64.deb" >> "$GITHUB_OUTPUT"
+
       - name: Download one-compiler package
         id: download
         uses: ./.github/actions/download-release-asset
         with:
           owner: Samsung
           repo: ONE
-          tag: 1.30.1
-          filename: one-compiler-deb-${{ steps.os.outputs.codename }}-1.30.1.tar.gz
+          tag: ${{ steps.one.outputs.version }}
+          filename: ${{ steps.one.outputs.filename }}
 
       - name: "Install one-compiler"
         working-directory: ./.github/actions/download-release-asset
         run: |
-          tar -xvzf ${{ steps.download.outputs.filename }}
-          dpkg -i one-compiler_1.30.0_amd64.deb
+          dpkg -i ${{ steps.one.outputs.filename }}
           apt-get install -f -y
           onecc --version || echo "Installation failed."
 


### PR DESCRIPTION
To fix CI failure, this commit upgrades ONE version to 1.30.1

TICO-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

Related https://github.com/Samsung/ONE/issues/16110