### PR TITLE
[quantization] Replace deprecated method

### DIFF
--- a/tico/experimental/quantization/evaluation/utils.py
+++ b/tico/experimental/quantization/evaluation/utils.py
@@ -44,7 +44,7 @@ def quantize(
         data = np.array(data)
     # Perfrom quantization
     if not scale:
-        logger.warn("WARNING: scale value is 0. 1e-7 will be used instead.")
+        logger.warning("WARNING: scale value is 0. 1e-7 will be used instead.")
         scale = 1e-7
     rescaled = np.round(data / scale) + zero_point
     # Clamp the values


### PR DESCRIPTION
### What

There appears an warning message when running `test_quantize_zero_scale`.
```bash
./ccex test -k zero_scale
RUN unit tests with -k zero_scale ...
test_quantize_zero_scale (quantization.evaluation.test_evaluation.TestEvaluationUtils)
Test quantize function with zero scale ... WARNING:tico.experimental.quantization.evaluation.utils:WARNING: scale value is 0. 1e-7 will be used instead.
ok

----------------------------------------------------------------------
Ran 1 test in 0.001s

OK
```

### Why

`logger.warn` is deprecated, we should use `logger.warning` instead:   https://docs.python.org/3.10/library/logging.html#logging.Logger.warning

### After this PR
```bash
./ccex test -k zero_scale
RUN unit tests with -k zero_scale ...
test_quantize_zero_scale (quantization.evaluation.test_evaluation.TestEvaluationUtils)
Test quantize function with zero scale ... WARNING:tico.experimental.quantization.evaluation.utils:WARNING: scale value is 0. 1e-7 will be used instead.
ok

----------------------------------------------------------------------
Ran 1 test in 0.001s

OK
```