### PR TITLE
[ptq] Rename QuantConfig

### DIFF
--- a/test/quantization/ptq/utils/test_introspection.py
+++ b/test/quantization/ptq/utils/test_introspection.py
@@ -19,8 +19,8 @@ import torch
 import torch.nn as nn
 
 from tico.experimental.quantization import convert, prepare
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.config.smoothquant import SmoothQuantConfig
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.utils.introspection import (
     build_fqn_map,
     compare_layer_outputs,
@@ -121,7 +121,7 @@ class TestSmoothQuantPTQDiff(unittest.TestCase):
         sq_model = convert(sq_model, inplace=True)
 
         # PTQ-wrap first 4 layers
-        qcfg = QuantConfig()
+        qcfg = PTQConfig()
         new_layers = torch.nn.ModuleList()
         for idx, fp_layer in enumerate(sq_model.model.layers):
             if idx >= 4:

--- a/test/quantization/ptq/wrappers/fairseq/test_quant_decoder.py
+++ b/test/quantization/ptq/wrappers/fairseq/test_quant_decoder.py
@@ -17,9 +17,9 @@ from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
+from tico.experimental.quantization.config.ptq import PTQConfig
 
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.fairseq.quant_decoder import (
     QuantFairseqDecoder,
 )
@@ -210,7 +210,7 @@ class TestQuantFairseqDecoder(unittest.TestCase):
             padding_idx=self.pad,
             **fp_kwargs,
         )
-        dec = QuantFairseqDecoder(fp, qcfg=QuantConfig(), fp_name="dec0")
+        dec = QuantFairseqDecoder(fp, qcfg=PTQConfig(), fp_name="dec0")
         return dec, fp
 
     def _mk_inputs(self, pad_last_col: bool = True):

--- a/test/quantization/ptq/wrappers/fairseq/test_quant_decoder_layer.py
+++ b/test/quantization/ptq/wrappers/fairseq/test_quant_decoder_layer.py
@@ -17,9 +17,9 @@ from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
+from tico.experimental.quantization.config.ptq import PTQConfig
 
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 
 from tico.experimental.quantization.ptq.wrappers.fairseq.quant_decoder_layer import (
     QuantFairseqDecoderLayer,
@@ -129,7 +129,7 @@ class TestQuantFairseqDecoderLayer(unittest.TestCase):
         self.B = 3
         self.T = 5
         self.S = 6  # encoder length
-        self.qcfg = QuantConfig()
+        self.qcfg = PTQConfig()
 
     def _mk_inputs(self, T=None, B=None, E=None, S=None):
         T = T or self.T

--- a/test/quantization/ptq/wrappers/fairseq/test_quant_encoder.py
+++ b/test/quantization/ptq/wrappers/fairseq/test_quant_encoder.py
@@ -17,9 +17,9 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
+from tico.experimental.quantization.config.ptq import PTQConfig
 
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.fairseq.quant_encoder import (
     QuantFairseqEncoder,
 )
@@ -83,7 +83,7 @@ class QuantDummyEncoderLayer(QuantModuleBase):
         self,
         fp_layer: DummyFPEncoderLayer,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)
@@ -186,7 +186,7 @@ class TestQuantFairseqEncoder(unittest.TestCase):
         )
         enc = QuantFairseqEncoder(
             fp,
-            qcfg=QuantConfig(),
+            qcfg=PTQConfig(),
             fp_name="enc",
             use_external_inputs=False,
             return_type="dict",

--- a/test/quantization/ptq/wrappers/fairseq/test_quant_mha.py
+++ b/test/quantization/ptq/wrappers/fairseq/test_quant_mha.py
@@ -17,9 +17,9 @@ from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
-from tico.experimental.quantization.ptq.mode import Mode
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
+from tico.experimental.quantization.ptq.mode import Mode
 from tico.experimental.quantization.ptq.wrappers.fairseq.quant_mha import (
     QuantFairseqMultiheadAttention,
 )
@@ -73,7 +73,7 @@ class TestQuantFairseqMHA(unittest.TestCase):
         self.Dh = self.E // self.H
         self.B = 3  # batch
         self.T = 4  # sequence length
-        self.qcfg = QuantConfig()
+        self.qcfg = PTQConfig()
 
     def _make_inputs(self, Tq=None, Tk=None, Tv=None):
         Tq = Tq or self.T

--- a/test/quantization/ptq/wrappers/llama/test_quant_attn.py
+++ b/test/quantization/ptq/wrappers/llama/test_quant_attn.py
@@ -21,10 +21,10 @@ import importlib.util
 import unittest
 
 import torch
+from tico.experimental.quantization.config.ptq import PTQConfig
 
 from tico.experimental.quantization.ptq.dtypes import DType
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.llama.quant_attn import (
     QuantLlamaAttention,
 )
@@ -99,7 +99,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         self.assertEqual(fp_out.shape, q_out.shape)
 
     def test_per_projection_override(self):
-        cfg = QuantConfig(
+        cfg = PTQConfig(
             default_dtype=DType.uint(8),
             overrides={
                 "q_proj": {
@@ -206,8 +206,8 @@ class TestQuantLlamaAttention(unittest.TestCase):
                     self.k = k
                     self.v = v
                 else:
-                    self.k = torch.cat([self.k, k], dim=2)
-                    self.v = torch.cat([self.v, v], dim=2)
+                    self.k = torch.cat([self.k, k], dim=2)  # type: ignore[list-item]
+                    self.v = torch.cat([self.v, v], dim=2)  # type: ignore[list-item]
                 return self.k, self.v
 
         torch.manual_seed(1)

--- a/test/quantization/ptq/wrappers/nn/test_quant_layernorm.py
+++ b/test/quantization/ptq/wrappers/nn/test_quant_layernorm.py
@@ -17,10 +17,10 @@ import unittest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.dtypes import DType
 from tico.experimental.quantization.ptq.mode import Mode
 from tico.experimental.quantization.ptq.observers.affine_base import AffineObserverBase
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.nn.quant_layernorm import (
     QuantLayerNorm,
 )
@@ -96,7 +96,7 @@ class TestQuantLayerNorm(unittest.TestCase):
         self.assertTrue(torch.allclose(pre_scale, post_scale))
 
     def test_dtype_override(self):
-        cfg = QuantConfig(
+        cfg = PTQConfig(
             default_dtype=DType.uint(8),
             overrides={
                 "act_in": {"dtype": DType.uint(4)},

--- a/test/quantization/ptq/wrappers/nn/test_quant_linear.py
+++ b/test/quantization/ptq/wrappers/nn/test_quant_linear.py
@@ -16,10 +16,10 @@ import unittest
 
 import torch
 import torch.nn.functional as F
+from tico.experimental.quantization.config.ptq import PTQConfig
 
 from tico.experimental.quantization.ptq.dtypes import DType
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.nn.quant_linear import QuantLinear
 
 
@@ -69,7 +69,7 @@ class TestQuantLinear(unittest.TestCase):
         self.assertTrue(torch.allclose(pre_scale, post_scale))
 
     def test_dtype_override(self):
-        cfg = QuantConfig(
+        cfg = PTQConfig(
             default_dtype=DType.uint(8),
             overrides={
                 "act_in": {"dtype": DType.uint(4)},

--- a/test/quantization/ptq/wrappers/nn/test_quant_silu.py
+++ b/test/quantization/ptq/wrappers/nn/test_quant_silu.py
@@ -16,9 +16,9 @@ import unittest
 
 import torch
 import torch.nn as nn
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.dtypes import DType
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.nn.quant_silu import QuantSiLU
 
 
@@ -51,7 +51,7 @@ class TestQuantSiLU(unittest.TestCase):
         self.assertLess(diff, 0.3)  # acceptably close
 
     def test_dtype_override(self):
-        cfg = QuantConfig(
+        cfg = PTQConfig(
             default_dtype=DType.uint(8),
             overrides={
                 "sigmoid": {"dtype": DType.uint(4)},

--- a/test/quantization/ptq/wrappers/test_quant_elementwise.py
+++ b/test/quantization/ptq/wrappers/test_quant_elementwise.py
@@ -19,7 +19,7 @@ We verify for each wrapper:
   1.  It is discoverable via the registry & PTQWrapper factory
   2.  Mode transitions NO_QUANT → CALIB → QUANT
   3.  Quantized output differs from—but stays close to—FP
-  4.  QuantConfig overrides propagate to observers
+  4.  PTQConfig overrides propagate to observers
 """
 
 import inspect
@@ -27,9 +27,9 @@ import unittest
 from typing import Callable, List, Tuple, Type
 
 import torch
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.dtypes import DType
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 from tico.experimental.quantization.ptq.wrappers.quant_elementwise import (
     QuantElementwise,
@@ -99,7 +99,7 @@ class TestElementwiseWrappers(unittest.TestCase):
         }
 
         for fp32_mod, _, _ in ACTIVATIONS:
-            cfg = QuantConfig(default_dtype=DType.uint(8), overrides=override)
+            cfg = PTQConfig(default_dtype=DType.uint(8), overrides=override)
             qw = PTQWrapper(fp32_mod, qcfg=cfg)
             wrapped = qw.wrapped  # QuantElementwise subclass
 

--- a/tico/experimental/quantization/config/ptq.py
+++ b/tico/experimental/quantization/config/ptq.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Type
 
+from tico.experimental.quantization.config.base import BaseConfig
 from tico.experimental.quantization.ptq.dtypes import DType
 from tico.experimental.quantization.ptq.observers.base import ObserverBase
 from tico.experimental.quantization.ptq.observers.minmax import MinMaxObserver
@@ -22,7 +23,7 @@ from tico.experimental.quantization.ptq.qscheme import QScheme
 
 
 @dataclass
-class QuantConfig:
+class PTQConfig(BaseConfig):
     """
     One object describes the quantization preferences for a single wrapper
     and its descendants.
@@ -56,7 +57,7 @@ class QuantConfig:
     ```python
     from ptq.observers import PercentileObserver
 
-    cfg = QuantConfig(
+    cfg = PTQConfig(
         default_dtype   = DType.uint(8),
         default_qscheme  = QScheme.PER_TENSOR_SYMM,        # <- global scheme
         default_observer = PercentileObserver,             # <- global algorithm
@@ -75,6 +76,10 @@ class QuantConfig:
     default_qscheme: QScheme = QScheme.PER_TENSOR_ASYMM
     overrides: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
 
+    @property
+    def name(self) -> str:
+        return "ptq"
+
     def get_kwargs(self, obs_name: str) -> Dict[str, Any]:
         """
         Return user-specified kwargs for *obs_name* inside **this** wrapper.
@@ -87,7 +92,7 @@ class QuantConfig:
         """
         return dict(self.overrides.get(obs_name, {}))
 
-    def child(self, scope: str) -> "QuantConfig":
+    def child(self, scope: str) -> "PTQConfig":
         """
         Produce a *view* for a child wrapper.
 
@@ -100,7 +105,7 @@ class QuantConfig:
         Other scopes remain invisible to the child.
         """
         sub_overrides = self.overrides.get(scope, {})
-        return QuantConfig(
+        return PTQConfig(
             self.default_dtype,
             self.default_observer,
             default_qscheme=self.default_qscheme,
@@ -108,4 +113,4 @@ class QuantConfig:
         )
 
     def __repr__(self):
-        return f"QuantConfig(default_dtype={self.default_dtype}, default_observer={self.default_observer}, default_qscheme={self.default_qscheme}, overrides={dict(self.overrides)})"
+        return f"PTQConfig(default_dtype={self.default_dtype}, default_observer={self.default_observer}, default_qscheme={self.default_qscheme}, overrides={dict(self.overrides)})"

--- a/tico/experimental/quantization/ptq/examples/compare_ppl.py
+++ b/tico/experimental/quantization/ptq/examples/compare_ppl.py
@@ -29,7 +29,7 @@ import tqdm
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.utils.metrics import perplexity
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 
@@ -165,7 +165,7 @@ def main():
         # ---------------------------------------------------------------------
         # 2. Wrap every Transformer layer with PTQWrapper
         # ---------------------------------------------------------------------
-        qcfg = QuantConfig()  # all-uint8 defaults
+        qcfg = PTQConfig()  # all-uint8 defaults
 
         wrapped_layers = torch.nn.ModuleList()
         for idx, layer in enumerate(uint8_model.model.layers):

--- a/tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
+++ b/tico/experimental/quantization/ptq/examples/debug_quant_outputs.py
@@ -38,7 +38,7 @@ import tqdm
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.utils.introspection import (
     build_fqn_map,
     compare_layer_outputs,
@@ -176,7 +176,7 @@ def main():
     # 2. Wrap every layer with PTQWrapper (UINT-8 activations)
     # -------------------------------------------------------------------------
     print("Wrapping layers with PTQWrapper …")
-    qcfg = QuantConfig()  # default: per-tensor UINT8
+    qcfg = PTQConfig()  # default: per-tensor UINT8
 
     new_layers = torch.nn.ModuleList()
     for idx, fp_layer in enumerate(model.model.layers):

--- a/tico/experimental/quantization/ptq/examples/quantize_llama_mlp.py
+++ b/tico/experimental/quantization/ptq/examples/quantize_llama_mlp.py
@@ -18,12 +18,12 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import tico
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.evaluation.metric import compute_peir
 from tico.experimental.quantization.evaluation.utils import plot_two_outputs
 from tico.experimental.quantization.ptq.dtypes import INT16
 from tico.experimental.quantization.ptq.mode import Mode
 from tico.experimental.quantization.ptq.qscheme import QScheme
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.llama.quant_mlp import QuantLlamaMLP
 from tico.utils.utils import SuppressWarning
 
@@ -38,7 +38,7 @@ model.eval()
 fp32_mlp = model.model.layers[0].mlp
 model.model.layers[0].mlp = QuantLlamaMLP(
     fp32_mlp,
-    qcfg=QuantConfig(default_dtype=INT16, default_qscheme=QScheme.PER_TENSOR_SYMM),
+    qcfg=PTQConfig(default_dtype=INT16, default_qscheme=QScheme.PER_TENSOR_SYMM),
 )  # PTQWrapper(fp32_mlp) is also fine
 model.eval()
 

--- a/tico/experimental/quantization/ptq/examples/quantize_with_gptq.py
+++ b/tico/experimental/quantization/ptq/examples/quantize_with_gptq.py
@@ -35,8 +35,8 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from tico.experimental.quantization import convert, prepare
 from tico.experimental.quantization.config.gptq import GPTQConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.observers.affine_base import AffineObserverBase
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.utils.introspection import build_fqn_map
 from tico.experimental.quantization.ptq.utils.metrics import perplexity
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
@@ -219,7 +219,7 @@ def main():
     if not isinstance(layers, (list, torch.nn.ModuleList)):
         raise TypeError(f"'model.layers' must be list/ModuleList, got {type(layers)}")
 
-    qcfg = QuantConfig()  # default: per-tensor UINT8
+    qcfg = PTQConfig()  # default: per-tensor UINT8
     wrapped = torch.nn.ModuleList()
     for idx, fp_layer in enumerate(layers):
         layer_cfg = qcfg.child(f"layer{idx}")

--- a/tico/experimental/quantization/ptq/wrappers/fairseq/quant_decoder.py
+++ b/tico/experimental/quantization/ptq/wrappers/fairseq/quant_decoder.py
@@ -25,7 +25,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn, Tensor
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
@@ -53,7 +53,7 @@ class QuantFairseqDecoder(QuantModuleBase):
         self,
         fp_decoder: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)
@@ -116,7 +116,7 @@ class QuantFairseqDecoder(QuantModuleBase):
 
         prefix = _safe_prefix(fp_name)
 
-        # Prepare child QuantConfig namespaces: layers/<idx>
+        # Prepare child PTQConfig namespaces: layers/<idx>
         layers_qcfg = qcfg.child("layers") if qcfg else None
         for i, layer in enumerate(fp_layers):
             child_cfg = layers_qcfg.child(str(i)) if layers_qcfg else None

--- a/tico/experimental/quantization/ptq/wrappers/fairseq/quant_decoder_layer.py
+++ b/tico/experimental/quantization/ptq/wrappers/fairseq/quant_decoder_layer.py
@@ -23,7 +23,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 import torch
 from torch import nn, Tensor
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.fairseq.quant_mha import (
     QuantFairseqMultiheadAttention,
 )
@@ -55,7 +55,7 @@ class QuantFairseqDecoderLayer(QuantModuleBase):
         self,
         fp_layer: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/fairseq/quant_encoder.py
+++ b/tico/experimental/quantization/ptq/wrappers/fairseq/quant_encoder.py
@@ -25,7 +25,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
@@ -56,7 +56,7 @@ class QuantFairseqEncoder(QuantModuleBase):
         self,
         fp_encoder: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
         use_external_inputs: bool = False,  # export-mode flag
         return_type: Literal["tensor", "dict"] = "dict",
@@ -100,7 +100,7 @@ class QuantFairseqEncoder(QuantModuleBase):
         fp_layers = list(fp_encoder.layers)  # type: ignore[arg-type]
         self.layers = nn.ModuleList()
 
-        # Prepare child QuantConfig namespaces: layers/<idx>
+        # Prepare child PTQConfig namespaces: layers/<idx>
         layers_qcfg = qcfg.child("layers") if qcfg else None
         for i, layer in enumerate(fp_layers):
             child_cfg = layers_qcfg.child(str(i)) if layers_qcfg else None

--- a/tico/experimental/quantization/ptq/wrappers/fairseq/quant_encoder_layer.py
+++ b/tico/experimental/quantization/ptq/wrappers/fairseq/quant_encoder_layer.py
@@ -23,7 +23,7 @@ from typing import Optional
 import torch.nn as nn
 from torch import Tensor
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.fairseq.quant_mha import (
     QuantFairseqMultiheadAttention,
 )
@@ -49,7 +49,7 @@ class QuantFairseqEncoderLayer(QuantModuleBase):
         self,
         fp_layer: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/fairseq/quant_mha.py
+++ b/tico/experimental/quantization/ptq/wrappers/fairseq/quant_mha.py
@@ -24,7 +24,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
@@ -59,7 +59,7 @@ class QuantFairseqMultiheadAttention(QuantModuleBase):
         self,
         fp_attn: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
         max_seq: int = 4096,
         use_static_causal: bool = False,

--- a/tico/experimental/quantization/ptq/wrappers/llama/quant_attn.py
+++ b/tico/experimental/quantization/ptq/wrappers/llama/quant_attn.py
@@ -17,7 +17,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
@@ -34,7 +34,7 @@ class QuantLlamaAttention(QuantModuleBase):
         self,
         fp_attn: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/experimental/quantization/ptq/wrappers/llama/quant_decoder_layer.py
@@ -17,7 +17,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.llama.quant_attn import (
     QuantLlamaAttention,
 )
@@ -56,7 +56,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         self,
         fp_layer: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
         return_type: Optional[str] = None,
     ):
@@ -165,7 +165,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         # - If use_cache: always return (hidden_states, present_key_value)
         # - Else: return as configured (tuple/tensor) for HF compatibility
         if use_cache:
-            return hidden_states, present_key_value
+            return hidden_states, present_key_value  # type: ignore[return-value]
 
         if self.return_type == "tuple":
             return (hidden_states,)

--- a/tico/experimental/quantization/ptq/wrappers/llama/quant_mlp.py
+++ b/tico/experimental/quantization/ptq/wrappers/llama/quant_mlp.py
@@ -17,7 +17,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.ptq_wrapper import PTQWrapper
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
@@ -31,7 +31,7 @@ class QuantLlamaMLP(QuantModuleBase):
         self,
         mlp_fp: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/nn/quant_layernorm.py
+++ b/tico/experimental/quantization/ptq/wrappers/nn/quant_layernorm.py
@@ -17,8 +17,9 @@ from typing import Iterable, Optional, Tuple
 import torch
 import torch.nn as nn
 
+from tico.experimental.quantization.config.ptq import PTQConfig
+
 from tico.experimental.quantization.ptq.mode import Mode
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
 )
@@ -46,7 +47,7 @@ class QuantLayerNorm(QuantModuleBase):
         self,
         fp: nn.LayerNorm,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/nn/quant_linear.py
+++ b/tico/experimental/quantization/ptq/wrappers/nn/quant_linear.py
@@ -17,9 +17,10 @@ from typing import Optional
 import torch.nn as nn
 import torch.nn.functional as F
 
+from tico.experimental.quantization.config.ptq import PTQConfig
+
 from tico.experimental.quantization.ptq.mode import Mode
 from tico.experimental.quantization.ptq.qscheme import QScheme
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
 )
@@ -34,7 +35,7 @@ class QuantLinear(QuantModuleBase):
         self,
         fp: nn.Linear,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/nn/quant_silu.py
+++ b/tico/experimental/quantization/ptq/wrappers/nn/quant_silu.py
@@ -17,7 +17,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
 )
@@ -37,7 +37,7 @@ class QuantSiLU(QuantModuleBase):
         self,
         fp: nn.SiLU,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/ptq_wrapper.py
+++ b/tico/experimental/quantization/ptq/wrappers/ptq_wrapper.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import torch
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
 )
@@ -34,7 +34,7 @@ class PTQWrapper(QuantModuleBase):
     def __init__(
         self,
         module: torch.nn.Module,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         *,
         fp_name: Optional[str] = None,
     ):

--- a/tico/experimental/quantization/ptq/wrappers/quant_elementwise.py
+++ b/tico/experimental/quantization/ptq/wrappers/quant_elementwise.py
@@ -17,7 +17,7 @@ from typing import Callable, Optional
 import torch
 import torch.nn as nn
 
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
+from tico.experimental.quantization.config.ptq import PTQConfig
 from tico.experimental.quantization.ptq.wrappers.quant_module_base import (
     QuantModuleBase,
 )
@@ -48,7 +48,7 @@ class QuantElementwise(QuantModuleBase):
         self,
         fp_module: nn.Module,
         *,
-        qcfg: Optional[QuantConfig] = None,
+        qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)

--- a/tico/experimental/quantization/ptq/wrappers/quant_module_base.py
+++ b/tico/experimental/quantization/ptq/wrappers/quant_module_base.py
@@ -17,9 +17,10 @@ from typing import Iterable, Optional, Tuple
 
 import torch.nn as nn
 
+from tico.experimental.quantization.config.ptq import PTQConfig
+
 from tico.experimental.quantization.ptq.mode import Mode
 from tico.experimental.quantization.ptq.observers.base import ObserverBase
-from tico.experimental.quantization.ptq.quant_config import QuantConfig
 
 
 class QuantModuleBase(nn.Module, ABC):
@@ -29,7 +30,7 @@ class QuantModuleBase(nn.Module, ABC):
     Responsibilities
     ----------------
     • Own *one* Mode enum (`NO_QUANT / CALIB / QUANT`)
-    • Own a QuantConfig describing default / per-observer dtypes
+    • Own a PTQConfig describing default / per-observer dtypes
     • Expose a canonical lifecycle:
           enable_calibration()
           freeze_qparams()
@@ -38,10 +39,10 @@ class QuantModuleBase(nn.Module, ABC):
     """
 
     def __init__(
-        self, qcfg: Optional[QuantConfig] = None, *, fp_name: Optional[str] = None
+        self, qcfg: Optional[PTQConfig] = None, *, fp_name: Optional[str] = None
     ) -> None:
         super().__init__()
-        self.qcfg = qcfg or QuantConfig()
+        self.qcfg = qcfg or PTQConfig()
         self._mode: Mode = Mode.NO_QUANT  # default state
         self.fp_name = fp_name
 
@@ -118,9 +119,9 @@ class QuantModuleBase(nn.Module, ABC):
         Instantiate an observer named *name*.
 
         Precedence (3-tier) for keys:
-           • observer:  user > wrapper-default > QuantConfig.default_observer
-           • dtype:     user > wrapper-default > QuantConfig.default_dtype
-           • qscheme:   user > wrapper-default > QuantConfig.default_qscheme
+           • observer:  user > wrapper-default > PTQConfig.default_observer
+           • dtype:     user > wrapper-default > PTQConfig.default_dtype
+           • qscheme:   user > wrapper-default > PTQConfig.default_qscheme
 
         Other kwargs (e.g., qscheme, channel_axis, etc.) remain:
            user override > wrapper-default


### PR DESCRIPTION
This commit renames QuantConfig to PTQConfig. Now, this class inherits from `BaseConfig`, which is needed to use PTQ module with public quantization API.

Related: #375
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>