### PR TITLE
[test] Fix qcircle test

### DIFF
--- a/test/pt2_to_qcircle_test/builder.py
+++ b/test/pt2_to_qcircle_test/builder.py
@@ -63,12 +63,14 @@ class QuantizationTest(TestRunnerBase):
         original_mod = mod
 
         cal_args_0, cal_kwargs_0 = next(original_mod.get_calibration_data())  # type: ignore[operator]
-        mod = prepare(mod, self.config, args=cal_args_0, kwargs=cal_kwargs_0)
+        mod = prepare(
+            mod, self.config, args=cal_args_0, kwargs=cal_kwargs_0, inplace=False
+        )
 
         for c_args, c_kwargs in original_mod.get_calibration_data():  # type: ignore[operator]
             mod(*c_args, **c_kwargs)
 
-        mod = convert(mod)
+        mod = convert(mod, inplace=False)
 
         # pt2e module doesn't have `eval()` api.
         mod.training = False

--- a/tico/experimental/quantization/README.md
+++ b/tico/experimental/quantization/README.md
@@ -57,20 +57,21 @@ q_model = prepare(
     model,
     activation_config,
     args=(input_tensor,),
-    kwargs={'kwarg': value}
+    kwargs={'kwarg': value},
+    inplace=False
 )
 
 # Perform calibration using your calibration routine (e.g., run_fn(model)).
 run_fn(q_model)
 
 # Convert the model after calibration.
-q_model = convert(q_model, activation_config)
+q_model = convert(q_model, activation_config, inplace=False)
 
 # Example for Weight Quantization using GPTQ:
 weight_config = GPTQConfig()
-prepare(q_model, weight_config, inplace=True)
+prepare(q_model, weight_config)
 run_fn(q_model)
-convert(q_model, weight_config, inplace=True)
+convert(q_model, weight_config)
 
 # Evaluate the quantized model
 eval(q_model)


### PR DESCRIPTION
This commit fixes qcircle test. The default value of `inplace` has been changed recently.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>