### PR TITLE
[test] Fix high vulnerability alerts from huggingface transformers

### DIFF
--- a/test/modules/model/GPT2/requirements.txt
+++ b/test/modules/model/GPT2/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.24.1
-transformers==4.46.3
+transformers==4.52.4

--- a/test/modules/model/Llama/requirements.txt
+++ b/test/modules/model/Llama/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.24.1
-transformers==4.46.3
+transformers==4.52.4

--- a/test/modules/model/LlamaWithGQA/requirements.txt
+++ b/test/modules/model/LlamaWithGQA/requirements.txt
@@ -1,2 +1,2 @@
 numpy==1.24.1
-transformers==4.46.3
+transformers==4.52.4

--- a/test/modules/model/TinyLlama/requirements.txt
+++ b/test/modules/model/TinyLlama/requirements.txt
@@ -1,1 +1,1 @@
-transformers==4.47.1
+transformers==4.52.4


### PR DESCRIPTION
We've got high vulnerability alerts in model tests like TinyLlama, so transformers is updated to 4.52.4 to remove high alerts.

TICO-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

for https://github.com/Samsung/TICO/issues/392