### PR TITLE
[DRAFT] Introduce FPI_GPTQ

### DIFF
--- a/test_fpi_quantization_on_models.py
+++ b/test_fpi_quantization_on_models.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import contextlib
+import io
+import os
+import time
+from enum import Enum
+
+import torch
+import torch.distributed as dist
+import torchvision
+import torchvision.datasets as datasets
+import torchvision.transforms as transforms
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.fpi_gptq import FPIGPTQConfig
+from tico.quantization.config.gptq import GPTQConfig
+from tico.quantization.config.pt2e import PT2EConfig
+
+list_of_available_models = [
+    "mobilenet_v2",
+    "mobilenet_v3_small",
+    "mobilenet_v3_large",
+    "squeezenet1_1",
+    "shufflenet_v2_x1_5",
+    "convnext_large",
+    "resnext101_64x4d",
+    "vit_l_32",
+]
+
+
+def print_size_of_model(model):
+    torch.save(model.state_dict(), "temp.p")
+    print("Size (MB):", os.path.getsize("temp.p") / 1e6)
+    os.remove("temp.p")
+
+
+def prepare_data_loader(dir):
+    normalize = torchvision.transforms.Normalize(
+        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+    )
+    dataset = datasets.ImageFolder(
+        dir,
+        transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                normalize,
+            ]
+        ),
+    )
+
+    loader = torch.utils.data.DataLoader(
+        dataset, batch_size=1, shuffle=False, pin_memory=True
+    )
+
+    return loader
+
+
+class Summary(Enum):
+    NONE = 0
+    AVERAGE = 1
+    SUM = 2
+    COUNT = 3
+
+
+class AverageMeter(object):
+    """Computes and stores the average and current value"""
+
+    def __init__(self, name, fmt=":f", summary_type=Summary.AVERAGE):
+        self.name = name
+        self.fmt = fmt
+        self.summary_type = summary_type
+        self.reset()
+
+    def reset(self):
+        self.val = 0
+        self.avg = 0
+        self.sum = 0
+        self.count = 0
+
+    def update(self, val, n=1):
+        self.val = val
+        self.sum += val * n
+        self.count += n
+        self.avg = self.sum / self.count  # type: ignore[assignment]
+
+    def __str__(self):
+        fmtstr = "{name} {val" + self.fmt + "} ({avg" + self.fmt + "})"
+        return fmtstr.format(**self.__dict__)
+
+    def summary(self):
+        fmtstr = ""
+        if self.summary_type is Summary.NONE:
+            fmtstr = ""
+        elif self.summary_type is Summary.AVERAGE:
+            fmtstr = "{name} {avg:.3f}"
+        elif self.summary_type is Summary.SUM:
+            fmtstr = "{name} {sum:.3f}"
+        elif self.summary_type is Summary.COUNT:
+            fmtstr = "{name} {count:.3f}"
+        else:
+            raise ValueError("invalid summary type %r" % self.summary_type)
+
+        return fmtstr.format(**self.__dict__)
+
+
+def accuracy(output, target, topk=(1,)):
+    """Computes the accuracy over the k top predictions for the specified values of k"""
+    with torch.no_grad():
+        maxk = max(topk)
+        batch_size = target.size(0)
+
+        _, pred = output.topk(maxk, 1, True, True)
+        pred = pred.t()
+        correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+        res = []
+        for k in topk:
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
+            res.append(correct_k.mul_(100.0 / batch_size))
+        return res
+
+
+class ProgressMeter(object):
+    def __init__(self, num_batches, meters, prefix=""):
+        self.batch_fmtstr = self._get_batch_fmtstr(num_batches)
+        self.meters = meters
+        self.prefix = prefix
+
+    def display(self, batch):
+        entries = [self.prefix + self.batch_fmtstr.format(batch)]
+        entries += [str(meter) for meter in self.meters]
+        print("\t".join(entries))
+
+    def display_summary(self):
+        entries = [" *"]
+        entries += [meter.summary() for meter in self.meters]
+        print(" ".join(entries))
+
+    def _get_batch_fmtstr(self, num_batches):
+        num_digits = len(str(num_batches // 1))
+        fmt = "{:" + str(num_digits) + "d}"
+        return "[" + fmt + "/" + fmt.format(num_batches) + "]"
+
+
+def validate(val_loader, model, criterion, num_of_images=5000):
+
+    device = torch.device("cuda")
+    for param in model.parameters():
+        if hasattr(param, "device"):
+            device = getattr(param, "device")
+            break
+
+    def run_validate(loader, base_progress=0):
+        with torch.no_grad():
+            for i, (images, target) in enumerate(loader):
+                if i > num_of_images:
+                    break
+                i = base_progress + i
+                images = images.to(device)
+                target = target.to(device)
+
+                # compute output
+                output = model(images)
+                loss = criterion(output, target)
+
+                # measure accuracy and record loss
+                acc1, acc5 = accuracy(output, target, topk=(1, 5))
+                losses.update(loss.item(), images.size(0))
+                top1.update(acc1[0], images.size(0))
+                top5.update(acc5[0], images.size(0))
+                # if i % display_progress == 0:
+                #    progress.display(i + 1)
+
+    batch_time = AverageMeter("Time", ":6.3f", Summary.NONE)
+    losses = AverageMeter("Loss", ":.4e", Summary.NONE)
+    top1 = AverageMeter("Acc@1", ":6.2f", Summary.AVERAGE)
+    top5 = AverageMeter("Acc@5", ":6.2f", Summary.AVERAGE)
+    progress = ProgressMeter(
+        len(val_loader), [batch_time, losses, top1, top5], prefix="Test: "
+    )
+
+    run_validate(val_loader)
+
+    progress.display_summary()
+
+    return top1.avg, top5.avg
+
+
+def get_model(model_name: str):
+    if model_name == "mobilenet_v2":
+        model = torchvision.models.mobilenet_v2(
+            weights=torchvision.models.MobileNet_V2_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "mobilenet_v3_small":
+        model = torchvision.models.mobilenet_v3_small(
+            weights=torchvision.models.MobileNet_V3_Small_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "mobilenet_v3_large":
+        model = torchvision.models.mobilenet_v3_large(
+            weights=torchvision.models.MobileNet_V3_Large_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "squeezenet1_1":
+        model = torchvision.models.squeezenet1_1(
+            weights=torchvision.models.SqueezeNet1_1_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "shufflenet_v2_x1_5":
+        model = torchvision.models.shufflenet_v2_x1_5(
+            weights=torchvision.models.ShuffleNet_V2_X1_5_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "convnext_large":
+        model = torchvision.models.convnext_large(
+            weights=torchvision.models.ConvNeXt_Large_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "resnext101_64x4d":
+        model = torchvision.models.resnext101_64x4d(
+            weights=torchvision.models.ResNeXt101_64X4D_Weights.IMAGENET1K_V1
+        )
+    elif model_name == "vit_l_32":
+        model = torchvision.models.vit_l_32(
+            weights=torchvision.models.ViT_L_32_Weights.IMAGENET1K_V1
+        )
+    else:
+        assert False
+
+    model.eval()
+
+    return model
+
+
+def get_statistics_of_model_quantization(
+    model,
+    data_loader,
+    weight_config,
+    num_of_images_for_gptq_calibration=100,
+    dev: str = "cuda",
+):
+
+    input_0, _ = next(iter(data_loader))
+
+    model.eval()
+
+    prepare(model, weight_config, args=(input_0.to(dev),), inplace=True)
+
+    num_of_images_for_calibration = num_of_images_for_gptq_calibration
+    for index, (image, _) in enumerate(data_loader):
+        if index >= num_of_images_for_calibration:
+            break
+        with torch.no_grad():
+            model(image.to(dev))
+
+    tick = time.time()
+    convert(model, inplace=True)
+    q_time = time.time() - tick
+
+    # Evaluate the quantized model
+    acc1_quantized, acc5_quantized = validate(
+        data_loader, model, criterion=torch.nn.CrossEntropyLoss().to(dev)
+    )
+
+    return q_time, acc1_quantized, acc5_quantized
+
+
+def compare_FPI_quantization_of_model(
+    model_name,
+    data_loader,
+    num_of_images_for_gptq_calibration,
+    num_of_validation_images,
+    dev: str = "cuda",
+):
+    with io.StringIO() as buffer, contextlib.redirect_stdout(
+        buffer
+    ), contextlib.redirect_stderr(buffer):
+
+        model = get_model(model_name).to(dev)
+
+        acc1_original, acc5_original = validate(
+            data_loader,
+            model,
+            criterion=torch.nn.CrossEntropyLoss().to(dev),
+            num_of_images=num_of_validation_images,
+        )
+        # no need to load_model as validate above does not change model
+        model = model.to(dev)
+        (
+            q_FPI_time,
+            acc1_FPI_quantized,
+            acc5_FPI_quantized,
+        ) = get_statistics_of_model_quantization(
+            model,
+            data_loader,
+            weight_config=FPIGPTQConfig(),
+            num_of_images_for_gptq_calibration=num_of_images_for_gptq_calibration,
+            dev=dev,
+        )
+
+        model = get_model(model_name).to(dev)
+        (
+            q_NFPI_time,
+            acc1_NFPI_quantized,
+            acc5_NFPI_quantized,
+        ) = get_statistics_of_model_quantization(
+            model,
+            data_loader,
+            weight_config=GPTQConfig(),
+            num_of_images_for_gptq_calibration=num_of_images_for_gptq_calibration,
+            dev=dev,
+        )
+
+    print(f"resuts_of_comparison_for {model_name}")
+    print(f"acc1_original  {acc1_original:.4f} acc5_original  {acc5_original:.4f}")
+    print(
+        f"acc1_quantized {acc1_FPI_quantized:.4f} acc5_quantized {acc5_FPI_quantized:.4f} time_of_quantization {q_FPI_time:.4f} - FPI "
+    )
+    print(
+        f"acc1_quantized {acc1_NFPI_quantized:.4f} acc5_quantized {acc5_NFPI_quantized:.4f} time_of_quantization {q_NFPI_time:.4f} - NOFPI "
+    )
+    print(f"{100 * (1.0 - q_FPI_time / q_NFPI_time):.2f}% speed-up for {model_name}")
+    print("")
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        type=str,
+        default=["all"],
+        help="Possible models that can be used for comparison\n"
+        "'all' - all of the below models\n"
+        "'mobilenet_v2'\n"
+        "'mobilenet_v3_small'\n"
+        "'mobilenet_v3_large'\n"
+        "'squeezenet1_1'\n"
+        "'shufflenet_v2_x1_5'\n"
+        "'convnext_large'\n"
+        "'resnext101_64x4d'\n"
+        "'vit_l_32'\n",
+    )
+    parser.add_argument(
+        "--num_of_calibration_images",
+        type=int,
+        default=100,
+        help="number of images to calibrate gptq",
+    )
+    parser.add_argument(
+        "--num_of_validation_images",
+        type=int,
+        default=5000,
+        help="number of images to vaidate result",
+    )
+    parser.add_argument(
+        "--device", type=str, default="cuda", help="device for inference cuda/cpu"
+    )
+
+    args = parser.parse_args()
+    models = []
+    for name in args.models:
+        assert name == "all" or name in list_of_available_models
+        if name == "all":
+            models.extend(list_of_available_models)
+        else:
+            models.append(name)
+
+    data_loader = prepare_data_loader(dir="/mnt/storage/datasets/imagenet/val")
+    for model_name in models:
+        compare_FPI_quantization_of_model(
+            model_name,
+            data_loader,
+            num_of_images_for_gptq_calibration=args.num_of_calibration_images,
+            num_of_validation_images=args.num_of_validation_images,
+            dev=args.device,
+        )

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -183,6 +183,7 @@ class GPTQQuantizer(BaseQuantizer):
         else:
             target_layers = [model]
 
+        num_of_quant_elems = 0
         quantizers: Dict[str, Any] = {}
         for l_idx, layer in enumerate(
             tqdm(
@@ -193,7 +194,15 @@ class GPTQQuantizer(BaseQuantizer):
             )
         ):
             # 1) Identify quantizable submodules within the layer
-            full = find_layers(layer)
+            full = find_layers(
+                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
+            )
+            # filter out depthwise convolutions and alike
+            full = {
+                key: full[key]
+                for key in full.keys()
+                if not isinstance(full[key], torch.nn.Conv2d) or full[key].groups == 1
+            }
             sequential = [list(full.keys())]
 
             # 2) Set up GPTQ objects and gather stats
@@ -204,8 +213,14 @@ class GPTQQuantizer(BaseQuantizer):
                 for name in subset:
                     gptq[name] = GPTQ(subset[name])
                     gptq[name].quantizer.configure(
-                        bits=8, perchannel=True, sym=False, mse=False
+                        # bits=2, perchannel=True, sym=False, mse=False
+                        # bits=4, perchannel=True, sym=False, mse=False
+                        bits=4,
+                        perchannel=True,
+                        sym=False,
+                        mse=False,
                     )
+                    num_of_quant_elems += subset[name].weight.numel()
 
                 # Hook to collect (inp, out) for GPTQ
                 def add_batch(name):
@@ -281,6 +296,9 @@ class GPTQQuantizer(BaseQuantizer):
         # Restore the original cache configuration.
         if orig_use_cache is not None:
             model.config.use_cache = orig_use_cache
+
+        if gptq_conf.verbose:
+            print(f"num_of_quanized_elements {num_of_quant_elems / (1024 * 1024)} MiB")
 
         # Clear caches to free memory
         self.cache_args.clear()

--- a/tico/quantization/config/ptq.py
+++ b/tico/quantization/config/ptq.py
@@ -71,7 +71,8 @@ class PTQConfig(BaseConfig):
     ```
     """
 
-    default_dtype: DType = DType.uint(8)
+    # just for testing
+    default_dtype: DType = DType.int(16)  # DType.uint(8)
     default_observer: Type[ObserverBase] = MinMaxObserver
     default_qscheme: QScheme = QScheme.PER_TENSOR_ASYMM
     overrides: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)

--- a/tico/quantization/wrapq/examples/quantize_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_with_gptq.py
@@ -34,6 +34,7 @@ from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from tico.quantization import convert, prepare
+from tico.quantization.config.fpi_gptq import FPIGPTQConfig
 from tico.quantization.config.gptq import GPTQConfig
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
@@ -181,12 +182,14 @@ def main():
             torch_dtype=dtype,
             trust_remote_code=args.trust_remote_code,
             token=args.hf_token,
+            cache_dir="/mnt/storage/transformers_cache",
         )
         .to(device)
         .eval()
     )
 
     model.config.use_cache = args.use_cache
+    model.config.max_position_embeddings = 2048
 
     # Build module -> FQN map BEFORE wrapping
     m_to_fqn = build_fqn_map(model)
@@ -194,20 +197,58 @@ def main():
     # -------------------------------------------------------------------------
     # 3. Run GPTQ (weight-only) pass
     # -------------------------------------------------------------------------
+    dataset_test = load_dataset(DATASET_NAME, DATASET_CONFIG, split=TEST_SPLIT)
+    enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
+    ppl_original = perplexity(
+        model, enc, device, stride=model.config.max_position_embeddings
+    )
+    print("\n┌── Wikitext-2 test perplexity ─────────────")
+    print(f"│ Original: {ppl_original:8.2f}")
+    print("└───────────────────────────────────────────")
+
+    import random
+
+    dataset_train = load_dataset(DATASET_NAME, DATASET_CONFIG, split=TRAIN_SPLIT)
+    calib_txt = " ".join(dataset_train["text"])
+    train_ids = tokenizer(calib_txt, return_tensors="pt").input_ids.to(device)
+
+    import time
+
+    tick = time.time()
     print("Applying GPTQ …")
     dataset_test = load_dataset(DATASET_NAME, DATASET_CONFIG, split=TEST_SPLIT)
-    q_m = prepare(model, GPTQConfig(), inplace=True)
+    # just for testing
+    q_m = prepare(model, FPIGPTQConfig(), inplace=True)
+    # q_m = prepare(model, GPTQConfig(), inplace=True)
 
     it = (
         dataset_test
         if args.no_tqdm
         else tqdm.tqdm(dataset_test, desc="GPTQ calibration")
     )
-    for d in it:
-        ids = tokenizer(d["text"], return_tensors="pt").input_ids.to(device)
-        q_m(ids)  # observers gather weight stats
+
+    nsamples = 128
+    seqlen = q_m.config.max_position_embeddings
+    for _ in range(nsamples):
+        i = random.randint(0, train_ids.shape[1] - seqlen - 1)
+        j = i + seqlen
+        inp = train_ids[:, i:j]
+        with torch.no_grad():
+            q_m(inp)
+
+    # index = 0
+    # for d in it:
+    #     ids = tokenizer(d["text"], return_tensors="pt").input_ids.to(device)
+    #     if ids.dtype != torch.int64:
+    #         continue
+    #     q_m(ids)  # observers gather weight stats
+    #     index += 1
+    #     if index > 128:
+    #         break
 
     q_m = convert(q_m, inplace=True)  # materialize INT-weight tensors
+    q_time = time.time() - tick
+    print(f"time_of_quantization {q_time}")
 
     # -------------------------------------------------------------------------
     # 4. Wrap every layer with PTQWrapper (activation UINT-8)
@@ -250,7 +291,9 @@ def main():
     # -------------------------------------------------------------------------
     print("\nCalculating perplexities …")
     enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
-    ppl_uint8 = perplexity(q_m, enc, device, stride=args.stride)
+    ppl_uint8 = perplexity(
+        q_m, enc, device, stride=model.config.max_position_embeddings
+    )
 
     print("\n┌── Wikitext-2 test perplexity ─────────────")
     print(f"│ UINT-8 : {ppl_uint8:8.2f}")


### PR DESCRIPTION
This PR introduces Fixed Point Iteration for GPTQ.

Using `test_fpi_quantization_on_models.py` we can get the following results:

|model| FPI_speedup (%)|time_FPI_GPTQ (s)|time_GPTQ (s)|acc1_original|acc5_original|acc1_FPI_GPTQ|acc5_FPI_GPTQ|acc1_GPTQ|acc5_GPTQ|
|-|-|-|-|-|-|-|-|-|-|
|mobilenet_v2| **58.85**|1.7400|4.2287|78.5643|93.4613|76.8246|92.9014|76.9646|92.8614|
|mobilenet_v3_small| **48.21**|1.6642|3.2133|75.0050|91.0218|68.5263|87.2426|68.5863 | 87.1426|
|mobilenet_v3_large| **61.87**| 1.9597|5.1391|79.7041|94.6411|76.1648|92.3615|76.0848|92.4415|
|squeezenet1_1| **63.12**| 0.8621|2.3374|67.4265| 85.9028|66.3467|85.0630|66.3267|85.1030|
|shufflenet_v2_x1_5| **51.69**| 1.7218|3.5639|80.3839| 94.5411|77.8844|93.5213|77.9444|93.5013|
|convnext_large| **79.80**| 8.2193|40.6873|88.2423 |  98.1004|88.1024 | 98.1604|88.1024 | 98.1804|
|resnext101_64x4d| **77.96**| 4.3780|19.8659|87.2825 |  97.8204|86.9226 | 97.7005|86.9626 | 97.6605|
|vit_l_32| **80.07**| 6.9739|34.9904|81.6037 |  95.1210|81.8036 | 95.4809|81.6437 | 95.3209|

_Speed-up is measured as `speed_up = 100 * (1.0 - time_of_FPI_GPTQ/time_oF_GPTQ)`. Quantized nodes are (torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d).
All nodes are quantized to uint4. Activations are left unchanged.
Accuracy is measured on 5000 images of `imagenet/val`. GPU - is `cuda`_

Issue: https://github.com/Samsung/TICO/issues/397

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>