### PR TITLE
Update `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ $ pip install -r test/modules/model/<model_name>/requirements.txt
 # Run test for a single model
 $ ./ccex test -m <model_name>
 # Run models whose names contain "Llama" (e.g., Llama, LlamaDecoderLayer, LlamaWithGQA, etc.)
-$ ./ccex test -m Llama*
+# Note that you should use quotes for the wildcard(*) pattern
+$ ./ccex test -m "Llama*"
 ```
 
 For example, to run a single model


### PR DESCRIPTION
Let's prevent misuse of new feature.

### Example
```bash
./ccex test -m L*
RUN unit tests for model LICENSE ...

./ccex test -m "L*"
RUN unit tests for model L* ...
```
Since there exists `LISENSE` at the project root directory, `L*` becomes `LISENSE` before passing to python.