### PR TITLE
[quantization] Enable Conv's quantization in FPIGPTQ/GPTQ

### DIFF
--- a/test/quantization/algorithm/test_fpi_gptq.py
+++ b/test/quantization/algorithm/test_fpi_gptq.py
@@ -45,6 +45,21 @@ class BigLinear(torch.nn.Module):
         return (torch.randn(1, 2048),), {}
 
 
+class NormConv2D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(128, 256, (3, 3), stride=1)
+        self.conv2 = torch.nn.Conv2d(256, 512, (5, 5), stride=2)
+
+    def forward(self, x):
+        z = self.conv(x)
+        z = self.conv2(z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 128, 32, 32),), {}
+
+
 class FPIGPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -61,6 +76,56 @@ class FPIGPTQTest(unittest.TestCase):
             args, kwargs = ori_m.get_example_inputs()
             q_m(*args, **kwargs)
         convert(q_m, inplace=True)
+
+        # Apply PT2E
+        args, kwargs = ori_m.get_example_inputs()
+        q_m = prepare(q_m, PT2EConfig(), args=args, kwargs=kwargs, inplace=False)
+
+        # Calibration
+        for i in range(100):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+
+        q_m = convert(q_m, inplace=False)
+
+        # Export circle
+        # pt2e exported model doesn't have `eval()` api.
+        q_m.training = False
+        cm = tico.convert(q_m, args, kwargs)
+
+        # Evaluate
+        results = evaluate(ori_m, cm, BACKEND.TRIV24, mode="return")
+        # TODO Parametrize tolerance.
+        tolerance = 0.02
+        assert results is not None
+        assert "peir" in results
+        assert (
+            results["peir"][0] < tolerance
+        ), f"PEIR exceeds tolerance. PEIR:{results['peir'][0]}%, tolerance: {tolerance}%"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv2d(self):
+        q_m = NormConv2D()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, FPIGPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.conv" in q_m.quantizers
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.conv2" in q_m.quantizers
+        ), "second conv node is not quantized"
 
         # Apply PT2E
         args, kwargs = ori_m.get_example_inputs()

--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -45,6 +45,21 @@ class BigLinear(torch.nn.Module):
         return (torch.randn(1, 2048),), {}
 
 
+class NormConv2D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(128, 256, (3, 3), stride=1)
+        self.conv2 = torch.nn.Conv2d(256, 512, (5, 5), stride=2)
+
+    def forward(self, x):
+        z = self.conv(x)
+        z = self.conv2(z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 128, 32, 32),), {}
+
+
 class GPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -104,6 +119,55 @@ class GPTQTest(unittest.TestCase):
 
         q_m = convert(q_m, inplace=False)
 
+        # Export circle
+        # pt2e exported model doesn't have `eval()` api.
+        q_m.training = False
+        cm = tico.convert(q_m, args, kwargs)
+
+        # Evaluate
+        results = evaluate(ori_m, cm, BACKEND.TRIV24, mode="return")
+        # TODO Parametrize tolerance.
+        tolerance = 0.02
+        assert results is not None
+        assert "peir" in results
+        assert (
+            results["peir"][0] < tolerance
+        ), f"PEIR exceeds tolerance. PEIR:{results['peir'][0]}%, tolerance: {tolerance}%"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv2d(self):
+        q_m = NormConv2D()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, GPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.conv" in q_m.quantizers
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.conv2" in q_m.quantizers
+        ), "second conv node is not quantized"
+
+        # Apply PT2E
+        args, kwargs = ori_m.get_example_inputs()
+        q_m = prepare(q_m, PT2EConfig(), args=args, kwargs=kwargs, inplace=False)
+
+        # Calibration
+        for i in range(100):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+
+        q_m = convert(q_m, inplace=False)
         # Export circle
         # pt2e exported model doesn't have `eval()` api.
         q_m.training = False

--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -76,7 +76,16 @@ class FPIGPTQQuantizer(GPTQQuantizer):
             )
         ):
             # 1) Identify quantizable submodules within the layer
-            full = find_layers(layer)
+            full = find_layers(
+                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
+            )
+            # filter out depthwise convolutions and alike
+            full = {
+                key: full[key]
+                for key in full.keys()
+                if not isinstance(full[key], torch.nn.Conv2d) or full[key].groups == 1
+            }
+
             sequential = [list(full.keys())]
 
             # 2) Set up (as in GPTQ)

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -193,7 +193,15 @@ class GPTQQuantizer(BaseQuantizer):
             )
         ):
             # 1) Identify quantizable submodules within the layer
-            full = find_layers(layer)
+            full = find_layers(
+                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
+            )
+            # filter out depthwise convolutions and alike
+            full = {
+                key: full[key]
+                for key in full.keys()
+                if not isinstance(full[key], torch.nn.Conv2d) or full[key].groups == 1
+            }
             sequential = [list(full.keys())]
 
             # 2) Set up GPTQ objects and gather stats


### PR DESCRIPTION
This PR enables quantization of Convolution nodes in FPIGPTQ/GPTQ with tests enabled.

Draft: #398 
Related: #397

<details>
<summary> ./ccex test --include-internal</summary>

<img width="2544" height="646" alt="image" src="https://github.com/user-attachments/assets/82fdf28a-f0ad-4d12-aa80-6e43e0d4b585" />
<img width="2358" height="622" alt="image" src="https://github.com/user-attachments/assets/0a325966-4aec-4f4e-8827-7504ab493e0c" />


</details>

_Note for reviewers: Please let me know if test Conv1d is also in need. Or i should split the PR in two (the first for GPTQ, the scond for FPI_GPTQ ).Or is should exclude Conv1d_

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>