### PR TITLE
[quantization] Disable conv1d for GPTQFPI/ GPTQ

### DIFF
--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -76,9 +76,7 @@ class FPIGPTQQuantizer(GPTQQuantizer):
             )
         ):
             # 1) Identify quantizable submodules within the layer
-            full = find_layers(
-                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
-            )
+            full = find_layers(layer, layers=[torch.nn.Linear, torch.nn.Conv2d])
             # filter out depthwise convolutions and alike
             full = {
                 key: full[key]

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -193,9 +193,7 @@ class GPTQQuantizer(BaseQuantizer):
             )
         ):
             # 1) Identify quantizable submodules within the layer
-            full = find_layers(
-                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
-            )
+            full = find_layers(layer, layers=[torch.nn.Linear, torch.nn.Conv2d])
             # filter out depthwise convolutions and alike
             full = {
                 key: full[key]


### PR DESCRIPTION
This PR disables `conv1d` nodes for further investigation.

Note for reviewers: _Please see https://github.com/Samsung/TICO/pull/408#discussion_r2501939391 and https://github.com/Samsung/TICO/pull/408#discussion_r2502187143._

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>