### PR TITLE
[test] Removed warning in test modules

### DIFF
--- a/test/modules/op/bmm.py
+++ b/test/modules/op/bmm.py
@@ -35,7 +35,8 @@ class SimpleBatchMatMul(TestModuleBase):
 class SimpleSingleBatchLhsConstBmm(TestModuleBase):
     def __init__(self):
         super().__init__()
-        self.const_lhs = torch.randn(1, 4, 5)
+        const_lhs = torch.randn(1, 4, 5)
+        self.register_buffer("const_lhs", const_lhs)
 
     def forward(self, rhs):
         z = torch.bmm(self.const_lhs, rhs)

--- a/test/modules/op/mm.py
+++ b/test/modules/op/mm.py
@@ -35,7 +35,8 @@ class SimpleMatmul(TestModuleBase):
 class SimpleMatmulConstRhs(TestModuleBase):
     def __init__(self):
         super().__init__()
-        self.weight = torch.randn(4, 5)
+        weight = torch.randn(4, 5)
+        self.register_buffer("weight", weight)
 
     def forward(self, lhs):
         out = torch.mm(lhs, self.weight)
@@ -49,7 +50,8 @@ class SimpleMatmulConstRhs(TestModuleBase):
 class SimpleMatmulConstRhsOnert(TestModuleBase):
     def __init__(self):
         super().__init__()
-        self.weight = torch.randn(4, 5)
+        weight = torch.randn(4, 5)
+        self.register_buffer("weight", weight)
 
     def forward(self, lhs):
         out = torch.mm(lhs, self.weight)
@@ -80,7 +82,8 @@ class SimpleMatmulConstLhsOnert(TestModuleBase):
 class SimpleMatmulConstLhsOnertWithLinearConversion(TestModuleBase):
     def __init__(self):
         super().__init__()
-        self.weight = torch.randn(3, 4)
+        weight = torch.randn(3, 4)
+        self.register_buffer("weight", weight)
 
     def forward(self, rhs):
         out = torch.mm(self.weight, rhs)


### PR DESCRIPTION
Changed direct tensor assignments to use register_buffer() for constant tensors in BMM and MatMul test modules.

TICO-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

for https://github.com/Samsung/TICO/issues/159