### PR TITLE
[quantization] Fix for GPTQs on zero inputs

### DIFF
--- a/test/quantization/algorithm/test_fpi_gptq.py
+++ b/test/quantization/algorithm/test_fpi_gptq.py
@@ -44,6 +44,9 @@ class BigLinear(torch.nn.Module):
     def get_example_inputs(self):
         return (torch.randn(1, 2048),), {}
 
+    def get_zero_inputs(self):
+        return (torch.zeros(1, 2048),), {}
+
 
 class NormConv2D(torch.nn.Module):
     def __init__(self):
@@ -58,6 +61,9 @@ class NormConv2D(torch.nn.Module):
 
     def get_example_inputs(self):
         return (torch.randn(1, 128, 32, 32),), {}
+
+    def get_zero_inputs(self):
+        return (torch.zeros(1, 128, 32, 32),), {}
 
 
 class FPIGPTQTest(unittest.TestCase):
@@ -152,3 +158,36 @@ class FPIGPTQTest(unittest.TestCase):
         assert (
             results["peir"][0] < tolerance
         ), f"PEIR exceeds tolerance. PEIR:{results['peir'][0]}%, tolerance: {tolerance}%"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_net_on_zero_inputs(self):
+        q_m = BigLinear()
+        q_m.eval()
+        ori_m = q_m
+
+        # Apply GPTQ
+        q_m = prepare(q_m, FPIGPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_zero_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+
+        assert torch.sum(q_m.linear.weight != 0) > 0, "weights should not be all zeros"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv2d_on_zero_inputs(self):
+        q_m = NormConv2D()
+        q_m.eval()
+        ori_m = q_m
+
+        # Apply GPTQ
+        q_m = prepare(q_m, FPIGPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_zero_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        assert torch.sum(q_m.conv.weight != 0) > 0, "weights should not be all zeros"

--- a/tico/quantization/algorithm/fpi_gptq/fpi_gptq.py
+++ b/tico/quantization/algorithm/fpi_gptq/fpi_gptq.py
@@ -151,6 +151,21 @@ class FPI_GPTQ:
 
         Q = Q[:, invperm]
 
+        if isinstance(self.layer, nn.Conv2d):
+            Q[:, dead] = quantize(
+                self.layer.weight.flatten(1)[:, dead],
+                self.quantizer.scale,
+                self.quantizer.zero,
+                self.quantizer.maxq,
+            )
+        else:
+            Q[:, dead] = quantize(
+                self.layer.weight[:, dead],
+                self.quantizer.scale,
+                self.quantizer.zero,
+                self.quantizer.maxq,
+            )
+
         self.layer.weight.data = Q.reshape(self.layer.weight.shape).to(
             self.layer.weight.data.dtype
         )


### PR DESCRIPTION
This PR fixes FPIGPTQ/GPTQ quantization algorithms on zero Hessian by using RTN quantizer on `dead` columns and adds tests for it.

<details><summary>./ccex test --include-internal -k test_gptq </summary>

```
RUN unit tests with -k test_gptq ...
/mnt/storage/slow_repos/TICO/.venv/lib/python3.10/site-packages/torch/backends/__init__.py:46: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:80.)
  self.setter(val)
test_model (quantization.algorithm.test_gptq.GPTQTest) ... You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 5 tests in 39.942s

OK
```

</details>

<details><summary>./ccex test --include-internal -k test_fpi_gptq</summary>

```
RUN unit tests with -k test_fpi_gptq ...
/mnt/storage/slow_repos/TICO/.venv/lib/python3.10/site-packages/torch/backends/__init__.py:46: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:80.)
  self.setter(val)
test_net (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok

----------------------------------------------------------------------
Ran 4 tests in 55.476s

OK
```

</details>

Note for reviewers:
_Should i split it in two parts (FPIGPTQ and GPTQ) ? or in four parts (FPI_conv/...) ?_
Issue: #412
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>