### PR TITLE
[quantization] Enable groupwise Conv2D in GPTQs

### DIFF
--- a/test/quantization/algorithm/test_fpi_gptq.py
+++ b/test/quantization/algorithm/test_fpi_gptq.py
@@ -66,6 +66,26 @@ class NormConv2D(torch.nn.Module):
         return (torch.zeros(1, 128, 32, 32),), {}
 
 
+class GroupwiseConv2D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.conv = torch.nn.Conv2d(
+            32, 32, (2, 2), stride=1, groups=32
+        )  # depthwise (groups == in_channels)
+        self.conv2 = torch.nn.Conv2d(
+            32, 16, (3, 3), stride=1, groups=2
+        )  # general depthwise
+
+    def forward(self, x):
+        z = self.conv(x)
+        z = self.conv2(z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 32, 16, 16),), {}
+
+
 class FPIGPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -191,3 +211,29 @@ class FPIGPTQTest(unittest.TestCase):
             q_m(*args, **kwargs)
         convert(q_m, inplace=True)
         assert torch.sum(q_m.conv.weight != 0) > 0, "weights should not be all zeros"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_groupwise_conv2d(self):
+        q_m = GroupwiseConv2D()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply FPIGPTQ
+        q_m = prepare(q_m, FPIGPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.conv" in q_m.quantizers
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.conv2" in q_m.quantizers
+        ), "second conv node is not quantized"
+
+        # TODO add PT2E quantization (currently it can't be evaluated on backend)

--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -77,12 +77,6 @@ class FPIGPTQQuantizer(GPTQQuantizer):
         ):
             # 1) Identify quantizable submodules within the layer
             full = find_layers(layer, layers=[torch.nn.Linear, torch.nn.Conv2d])
-            # filter out depthwise convolutions and alike
-            full = {
-                key: full[key]
-                for key in full.keys()
-                if not isinstance(full[key], torch.nn.Conv2d) or full[key].groups == 1
-            }
 
             sequential = [list(full.keys())]
 

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -65,9 +65,30 @@ class GPTQ:
                 stride=self.layer.stride,
             )
 
-            inp = unfold(inp)
-            inp = inp.permute([1, 0, 2])
-            inp = inp.flatten(1)
+            if self.layer.groups != 1:
+                # the idea behind conversion of depthwise convolution to matmul is described here
+                # https://discuss.pytorch.org/t/conv1d-implementation-using-torch-nn-functional-unfold/109643/2
+                # although depthwise convolution is equal to a set of MatMuls
+                # (please note `w.view(1, groups, out_channels // groups, -1)` in the reference above is not just w.flatten(1))
+                # we can approximate groupwise Hessians with their mean
+                # so that we will have just a single Hessian and the usual GPTQ applies
+                inp = inp.reshape(
+                    inp.size(0) * self.layer.groups,
+                    inp.size(1) // self.layer.groups,
+                    inp.shape[2],
+                    inp.shape[3],
+                )  # inp.shape == (batch*groups, in_channels / groups, H, W) to meet Groupwise-wise Convolution, so that each group is colvolved with its own filter
+
+            inp = unfold(
+                inp
+            )  # inp.shape == (batch*groups, k_h*k_w*in_channels / groups, flattened_patches)
+            inp = inp.permute(
+                [1, 0, 2]
+            )  # inp.shape == (k_h*k_w*in_channels / groups, batch * groups, flattened_patches)
+            inp = inp.flatten(
+                1
+            )  # inp.shape == (k_h*k_w*in_channels / groups, batch * groups * flattened_patches)
+            # so inp.matmul(inp.t()).shape == (k_x*k_y*in_channels / groups, k_x*k_y*in_channels / groups) == W.flatten(1)
 
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -194,12 +194,6 @@ class GPTQQuantizer(BaseQuantizer):
         ):
             # 1) Identify quantizable submodules within the layer
             full = find_layers(layer, layers=[torch.nn.Linear, torch.nn.Conv2d])
-            # filter out depthwise convolutions and alike
-            full = {
-                key: full[key]
-                for key in full.keys()
-                if not isinstance(full[key], torch.nn.Conv2d) or full[key].groups == 1
-            }
             sequential = [list(full.keys())]
 
             # 2) Set up GPTQ objects and gather stats


### PR DESCRIPTION
This PR makes it possible to quantize `Conv2D` with `groups != 1` using `FPIGPTQ/GPTQ`.

<details> <summary> ./ccex test --include-internal -k test_gptq </summary>

```

UN unit tests with -k test_gptq ...
/mnt/storage/slow_repos/TICO/.venv/lib/python3.10/site-packages/torch/backends/__init__.py:46: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:80.)
  self.setter(val)
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 6 tests in 40.611s

OK
```

</details>

<details> <summary> ./ccex test --include-internal -k test_fpi_gptq </summary>

```
RUN unit tests with -k test_fpi_gptq ...
/mnt/storage/slow_repos/TICO/.venv/lib/python3.10/site-packages/torch/backends/__init__.py:46: UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /pytorch/aten/src/ATen/Context.cpp:80.)
  self.setter(val)
test_groupwise_conv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_net (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok

----------------------------------------------------------------------
Ran 5 tests in 56.207s

OK
```

</details>

Results of `python test_depthwise_quantization.py` (`bits=8`, `calibration_samples = 100`):
[test_depthwise_quantization.py.txt](https://github.com/user-attachments/files/23601512/test_depthwise_quantization.py.txt)

|model| FPI_speedup (%)|time_FPI_GPTQ (s)|time_GPTQ (s)|acc1_original|acc5_original|acc1_FPI_GPTQ|acc5_FPI_GPTQ|acc1_GPTQ|acc5_GPTQ|
|-|-|-|-|-|-|-|-|-|-|
|mobilenet_v2| **38.02**|3.77|6.08|78.56|93.46|78.64 | 93.48| 78.66 | 93.48|
|mobilenet_v3_small| **39.54**|2.48|4.10|75.01|91.02|74.65 | 91.02 |74.63 | 91.02 |
|mobilenet_v3_large| **46.04**| 3.59|6.65|79.70|94.64|79.62 | 94.68 |79.60| 94.70|
|shufflenet_v2_x1_5| **38.07**| 3.07|4.96|80.38| 94.54|80.20 | 94.48 |80.22 | 94.50 |
|swin_v2_b| **71.86**| 8.50|30.20|88.02 |  98.00|88.06 | 98.02 |88.06 | 98.02|
|swin_v2_t| **71.86**| 3.80 |12.87|86.30 | 97.44|86.26 |97.44 |86.26 | 97.46|

_Speed-up is measured as `speed_up = 100 * (1.0 - time_of_FPI_GPTQ/time_oF_GPTQ)`.

Draft: #415 
Issue: #397

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>