### PR TITLE
[passes] ConvertSymSizeToCircleShape

### DIFF
--- a/test/modules/op/sym_size.py
+++ b/test/modules/op/sym_size.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch.export import Dim
+
+from test.modules.base import TestModuleBase
+from test.utils import tag
+
+
+@tag.use_onert
+class SymSizeSimple(TestModuleBase):
+    """
+    Simplest test case for sym_size.int generation.
+    Just returns the batch size (first dimension).
+    """
+
+    def forward(self, x):
+        # Accessing x.shape[0] on a dynamic dimension creates sym_size.int
+        return x.shape[0]
+
+    def get_example_inputs(self):
+        return (torch.randn(2, 4, 4),), {}
+
+    def get_dynamic_shapes(self):
+        batch = Dim("batch", min=1, max=128)
+        return {"x": {0: batch}}

--- a/test/pt2_to_circle_test/builder.py
+++ b/test/pt2_to_circle_test/builder.py
@@ -20,6 +20,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Optional
 
+import torch
+
 from tico.config.base import CompileConfigBase
 from tico.utils.signature import ModelInputSpec
 
@@ -204,8 +206,11 @@ class NNModuleTest(TestRunnerBase):
                 forward_kwargs=deepcopy(self.forward_kwargs),
                 runtime="onert",
             )
-            torch_shape = torch_result[0].shape
-            circle_result[0] = circle_result[0].reshape(torch_shape)
+            for idx, (tr, cr) in enumerate(zip(torch_result, circle_result)):
+                if isinstance(tr, torch.Tensor):
+                    circle_result[idx] = circle_result[idx].reshape(tr.shape)
+                else:  # if torch result is scalar
+                    torch_result[idx] = torch.tensor([tr], dtype=torch.int32)
         else:
             circle_result = infer_circle(
                 circle_model_path,

--- a/tico/passes/convert_sym_size_to_circle_shape.py
+++ b/tico/passes/convert_sym_size_to_circle_shape.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.fx
+import torch
+from torch.export import ExportedProgram
+
+from tico.utils import logging
+from tico.utils.graph import create_node
+from tico.utils.passes import PassBase, PassResult
+from tico.utils.trace_decorators import trace_graph_diff_on_pass
+
+
+@trace_graph_diff_on_pass
+class ConvertSymSizeToCircleShape(PassBase):
+    """
+    This pass converts torch.ops.aten.sym_size.int operations to circle_custom::shape.
+
+    The circle_custom::shape operator allows preserving dynamic shape information
+    in the Circle model. This is essential for models with dynamic batch sizes or other dynamic dimensions.
+
+    Example:
+        Before: %sym_size_int_1 = call_function[target=torch.ops.aten.sym_size.int](args=(%x, 0))
+        After:  %shape_0 = call_function[target=torch.ops.circle_custom.shape](args=(%x,))
+                %slice_0 = call_function[target=torch.ops.aten.slice.Tensor](args=(%shape_0, 0, 0, 1, 1))
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def call(self, exported_program: ExportedProgram) -> PassResult:
+        logger = logging.getLogger(__name__)
+
+        graph_module = exported_program.graph_module
+        graph = graph_module.graph
+        modified = False
+
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+
+            if node.target == torch.ops.aten.sym_size.int:
+                # sym_size.int has args: (input, dim)
+                input_tensor = node.args[0]
+                dim = node.args[1]
+
+                # Create circle_custom::shape node
+                with graph.inserting_after(node):
+                    shape_node = create_node(
+                        graph,
+                        torch.ops.circle_custom.shape,
+                        args=(input_tensor,),
+                    )
+
+                # Set metadata for shape_node
+                if "val" in input_tensor.meta:
+                    input_val = input_tensor.meta["val"]
+                    rank = len(input_val.shape)
+                    # shape output is a 1D tensor of size rank, dtype int32
+                    # We use a real tensor here as a placeholder for metadata
+                    shape_node.meta["val"] = torch.zeros(rank, dtype=torch.int32)
+
+                # Extract the specific dimension using slice
+                with graph.inserting_after(shape_node):
+                    slice_node = create_node(
+                        graph,
+                        torch.ops.aten.slice.Tensor,
+                        args=(shape_node, 0, dim, dim + 1, 1),
+                    )
+                    # slice output is 1D tensor of size 1
+                    slice_node.meta["val"] = torch.zeros(1, dtype=torch.int32)
+
+                # Replace all uses
+                node.replace_all_uses_with(slice_node, propagate_meta=False)
+                modified = True
+
+                logger.debug(
+                    f"Converted {node.name} (sym_size.int) to {shape_node.name} (circle_custom::shape) + {slice_node.name} (slice)"
+                )
+
+        graph.eliminate_dead_code()
+        graph.lint()
+        graph_module.recompile()
+
+        return PassResult(modified)

--- a/tico/serialize/operators/op_circle_shape.py
+++ b/tico/serialize/operators/op_circle_shape.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch._ops
+    import torch.fx
+import torch
+from circle_schema import circle
+
+from tico.serialize.circle_graph import CircleSubgraph
+from tico.serialize.operators.hashable_opcode import OpCode
+from tico.serialize.operators.node_visitor import NodeVisitor, register_node_visitor
+from tico.serialize.operators.utils import create_builtin_operator, get_op_index
+
+
+@register_node_visitor
+class CircleShapeVisitor(NodeVisitor):
+    """
+    Visitor for circle_custom::shape operator.
+
+    This operator extracts the shape of a tensor.
+    It's implemented using Circle's SHAPE operator.
+    """
+
+    target: List[torch._ops.OpOverload] = [
+        torch.ops.circle_custom.shape,
+    ]
+
+    def __init__(self, op_codes: Dict[OpCode, int], graph: CircleSubgraph):
+        super().__init__(op_codes, graph)
+
+    def define_node(
+        self,
+        node: torch.fx.Node,
+    ) -> circle.Operator.OperatorT:
+        # Args: (input)
+        input_node = node.args[0]
+
+        # SHAPE operator to get the full shape of input
+        op_index = get_op_index(
+            circle.BuiltinOperator.BuiltinOperator.SHAPE, self._op_codes
+        )
+
+        inputs = [input_node]
+        outputs = [node]
+        operator = create_builtin_operator(self.graph, op_index, inputs, outputs)
+        operator.builtinOptionsType = circle.BuiltinOptions.BuiltinOptions.ShapeOptions
+        operator.builtinOptions = circle.ShapeOptions.ShapeOptionsT()
+        operator.builtinOptions.outType = circle.TensorType.TensorType.INT32
+
+        return operator

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -29,6 +29,7 @@ from tico.passes.convert_expand_to_slice_cat import ConvertExpandToSliceCat
 from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.passes.convert_matmul_to_linear import ConvertMatmulToLinear
 from tico.passes.convert_repeat_to_expand_copy import ConvertRepeatToExpandCopy
+from tico.passes.convert_sym_size_to_circle_shape import ConvertSymSizeToCircleShape
 from tico.passes.convert_to_relu6 import ConvertToReLU6
 from tico.passes.decompose_addmm import DecomposeAddmm
 from tico.passes.decompose_batch_norm import DecomposeBatchNorm
@@ -226,6 +227,7 @@ def convert_exported_module_to_circle(
             ExtractDtypeKwargsPass(),
             RemoveNop(),
             LowerCopy(),
+            ConvertSymSizeToCircleShape(),
             ConvertLayoutOpToReshape(),
             RestoreLinear(),
             ConvertToReLU6(),

--- a/tico/utils/register_custom_op.py
+++ b/tico/utils/register_custom_op.py
@@ -761,6 +761,33 @@ def CircleAttention():
         return hidden_states
 
 
+def CircleShape():
+    """
+    Custom operator to extract the shape of a tensor.
+    This is similar to TensorFlow's shape operator and is used to preserve
+    dynamic shape information in the Circle model.
+
+    Args:
+        input_: Input tensor
+
+    Returns:
+        A 1D tensor containing the shape of the input tensor
+    """
+
+    @custom_op("circle_custom::shape", mutates_args=())
+    def shape(input_: torch.Tensor) -> torch.Tensor:
+        # Return the shape of the input tensor as a 1D tensor
+        shape_val = list(input_.size())
+        return torch.tensor(shape_val, dtype=torch.int32)
+
+    @register_fake("circle_custom::shape")
+    def _(input_: torch.Tensor) -> torch.Tensor:
+        # Return a 1D tensor with symbolic shape
+        # The actual value will be determined at runtime
+        rank = len(input_.size())
+        return torch.empty([rank], dtype=torch.int32)
+
+
 # Add custom ops to the torch namespace
 def RegisterOps():
     CircleResizeNearestNeighbor()
@@ -775,3 +802,4 @@ def RegisterOps():
     CircleQuantizeMX()
     CircleRMSNorm()
     CircleAttention()
+    CircleShape()

--- a/tico/utils/validate_args_kwargs.py
+++ b/tico/utils/validate_args_kwargs.py
@@ -950,7 +950,7 @@ class RepeatArgs:
     """
 
     input: torch.fx.Node
-    repeats: List[int]
+    repeats: List[Union[int, torch.SymInt, torch.fx.Node]]
 
 
 @enforce_type
@@ -958,10 +958,14 @@ class RepeatArgs:
 class ReshapeArgs:
     """
     reshape(Tensor(a) self, SymInt[] shape) -> Tensor(a)
+
+    Note: After PrepareReshapeDynamicShape pass, shape can be either:
+    - A list of int/SymInt/Node (original or static)
+    - A single Node (dynamic shape tensor prepared by the pass)
     """
 
     input: torch.fx.Node
-    shape: List[int]
+    shape: Union[List[Union[int, torch.SymInt, torch.fx.Node]], torch.fx.Node]
 
 
 @enforce_type
@@ -1097,7 +1101,7 @@ class SplitWithSizesArgs:
     """
 
     input: torch.fx.Node
-    split_sizes: List[int]
+    split_sizes: List[Union[int, torch.SymInt, torch.fx.Node]]
     dim: int = 0
 
 
@@ -1238,7 +1242,7 @@ class ViewArgs:
     """
 
     input: torch.fx.Node
-    size: List[int]
+    size: List[Union[int, torch.SymInt, torch.fx.Node]]
 
 
 @enforce_type


### PR DESCRIPTION
Let's support 'sym_size.int' torch ir which represents dynamic shape.

TICO-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>