### PR TITLE
[DRAFT] Enable GPTQs fror ConvTranspose2D

### DIFF
--- a/test/quantization/algorithm/test_fpi_gptq.py
+++ b/test/quantization/algorithm/test_fpi_gptq.py
@@ -119,6 +119,24 @@ class GroupwiseConv1D(torch.nn.Module):
         return (torch.randn(1, 32, 16),), {}
 
 
+class TransposedConv2DGeneral(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.tconv = torch.nn.ConvTranspose2d(16, 32, (2, 2), stride=2, groups=1)
+        self.tconv2 = torch.nn.ConvTranspose2d(
+            32, 16, (3, 3), stride=4, groups=2
+        )  # general groupwise
+
+    def forward(self, x):
+        z = self.tconv(x)
+        z = self.tconv2(z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 16, 7, 7),), {}
+
+
 class FPIGPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -318,6 +336,32 @@ class FPIGPTQTest(unittest.TestCase):
         ), "first conv node is not quantized"
         assert (
             "model.layers.0.conv2" in q_m.quantizers
+        ), "second conv node is not quantized"
+
+        # TODO add PT2E quantization (right now it can't be evaluated on backend)
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_transposed_conv2d(self):
+        q_m = TransposedConv2DGeneral()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, FPIGPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.tconv" in q_m.quantizers
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.tconv2" in q_m.quantizers
         ), "second conv node is not quantized"
 
         # TODO add PT2E quantization (right now it can't be evaluated on backend)

--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -119,6 +119,24 @@ class GroupwiseConv1D(torch.nn.Module):
         return (torch.randn(1, 32, 16),), {}
 
 
+class TransposedConv2DGeneral(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.tconv = torch.nn.ConvTranspose2d(16, 32, (2, 2), stride=2, groups=1)
+        self.tconv2 = torch.nn.ConvTranspose2d(
+            32, 16, (3, 3), stride=4, groups=2
+        )  # general groupwise
+
+    def forward(self, x):
+        z = self.tconv(x)
+        z = self.tconv2(z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 16, 7, 7),), {}
+
+
 class GPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -349,6 +367,32 @@ class GPTQTest(unittest.TestCase):
         ), "first conv node is not quantized"
         assert (
             "model.layers.0.conv2" in q_m.quantizers
+        ), "second conv node is not quantized"
+
+        # TODO add PT2E quantization (right now it can't be evaluated on backend)
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_transposed_conv2d(self):
+        q_m = TransposedConv2DGeneral()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, GPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.tconv" in q_m.quantizers
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.tconv2" in q_m.quantizers
         ), "second conv node is not quantized"
 
         # TODO add PT2E quantization (right now it can't be evaluated on backend)

--- a/test_tconv_GPTQ.py
+++ b/test_tconv_GPTQ.py
@@ -1,0 +1,1052 @@
+import argparse
+import contextlib
+import copy
+import datetime
+import io
+import os
+import time
+from collections import defaultdict, deque
+from contextlib import redirect_stdout
+
+import numpy as np
+
+# from pycocotools import mask as coco_mask
+import pycocotools.mask as mask_util
+import test_tconv_transforms as T
+import torch
+import torchvision
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+from tico.quantization import convert, prepare
+from tico.quantization.config.fpi_gptq import FPIGPTQConfig
+from tico.quantization.config.gptq import GPTQConfig
+from tico.quantization.config.rtn import RTNConfig
+
+# from torchmetrics.detection import MeanAveragePrecision
+
+# from torchvision.io.image import decode_image
+# from torchvision.models.detection import *
+from torchvision.models.detection import (
+    fasterrcnn_resnet50_fpn,
+    fasterrcnn_resnet50_fpn_v2,
+    FasterRCNN_ResNet50_FPN_V2_Weights,
+    FasterRCNN_ResNet50_FPN_Weights,
+    keypointrcnn_resnet50_fpn,
+    KeypointRCNN_ResNet50_FPN_Weights,
+    maskrcnn_resnet50_fpn,
+    maskrcnn_resnet50_fpn_v2,
+    MaskRCNN_ResNet50_FPN_V2_Weights,
+    MaskRCNN_ResNet50_FPN_Weights,
+    ssd300_vgg16,
+    SSD300_VGG16_Weights,
+)
+from torchvision.models.resnet import ResNet50_Weights
+
+from torchvision.models.segmentation import fcn_resnet50, FCN_ResNet50_Weights
+
+list_of_available_models = [
+    "maskrcnn_resnet50_fpn",
+    "maskrcnn_resnet50_fpn_v2",
+    "keypointrcnn_resnet50_legacy",
+    # "keypointrcnn_resnet50_fpn",
+]
+
+
+def get_torch_model_name_and_weights(model_name: str):
+    torch_model_name = None
+    weights_name = None
+    if model_name == "maskrcnn_resnet50_fpn":
+        torch_model_name = "maskrcnn_resnet50_fpn"
+        weights_name = MaskRCNN_ResNet50_FPN_Weights.COCO_V1
+    elif model_name == "maskrcnn_resnet50_fpn_v2":
+        torch_model_name = "maskrcnn_resnet50_fpn_v2"
+        weights_name = MaskRCNN_ResNet50_FPN_V2_Weights.COCO_V1
+    elif model_name == "keypointrcnn_resnet50_legacy":
+        torch_model_name = "keypointrcnn_resnet50_fpn"
+        weights_name = KeypointRCNN_ResNet50_FPN_Weights.COCO_LEGACY
+    elif model_name == "keypointrcnn_resnet50_fpn":
+        torch_model_name = "keypointrcnn_resnet50_fpn"
+        weights_name = KeypointRCNN_ResNet50_FPN_Weights.COCO_V1
+    else:
+        assert False
+
+    return torch_model_name, weights_name
+
+
+def convert_coco_poly_to_mask(segmentations, height, width):
+    masks = []
+    for polygons in segmentations:
+        rles = mask_util.frPyObjects(polygons, height, width)
+        mask = mask_util.decode(rles)
+        if len(mask.shape) < 3:
+            mask = mask[..., None]
+        mask = torch.as_tensor(mask, dtype=torch.uint8)
+        mask = mask.any(dim=2)
+        masks.append(mask)
+    if masks:
+        masks = torch.stack(masks, dim=0)
+    else:
+        masks = torch.zeros((0, height, width), dtype=torch.uint8)
+    return masks
+
+
+class ConvertCocoPolysToMask:
+    def __call__(self, image, target):
+        w, h = image.size
+
+        image_id = target["image_id"]
+
+        anno = target["annotations"]
+
+        anno = [obj for obj in anno if obj["iscrowd"] == 0]
+
+        boxes = [obj["bbox"] for obj in anno]
+        # guard against no boxes via resizing
+        boxes = torch.as_tensor(boxes, dtype=torch.float32).reshape(-1, 4)
+        boxes[:, 2:] += boxes[:, :2]
+        boxes[:, 0::2].clamp_(min=0, max=w)
+        boxes[:, 1::2].clamp_(min=0, max=h)
+
+        classes = [obj["category_id"] for obj in anno]
+        classes = torch.tensor(classes, dtype=torch.int64)
+
+        segmentations = [obj["segmentation"] for obj in anno]
+        masks = convert_coco_poly_to_mask(segmentations, h, w)
+
+        keypoints = None
+        if anno and "keypoints" in anno[0]:
+            keypoints = [obj["keypoints"] for obj in anno]
+            keypoints = torch.as_tensor(keypoints, dtype=torch.float32)
+            num_keypoints = keypoints.shape[0]
+            if num_keypoints:
+                keypoints = keypoints.view(num_keypoints, -1, 3)
+
+        keep = (boxes[:, 3] > boxes[:, 1]) & (boxes[:, 2] > boxes[:, 0])
+        boxes = boxes[keep]
+        classes = classes[keep]
+        masks = masks[keep]
+        if keypoints is not None:
+            keypoints = keypoints[keep]
+
+        target = {}
+        target["boxes"] = boxes
+        target["labels"] = classes
+        target["masks"] = masks
+        target["image_id"] = image_id
+        if keypoints is not None:
+            target["keypoints"] = keypoints
+
+        # for conversion to coco api
+        area = torch.tensor([obj["area"] for obj in anno])
+        iscrowd = torch.tensor([obj["iscrowd"] for obj in anno])
+        target["area"] = area
+        target["iscrowd"] = iscrowd
+
+        return image, target
+
+
+def _coco_remove_images_without_annotations(dataset, cat_list=None):
+    def _has_only_empty_bbox(anno):
+        return all(any(o <= 1 for o in obj["bbox"][2:]) for obj in anno)
+
+    def _count_visible_keypoints(anno):
+        return sum(sum(1 for v in ann["keypoints"][2::3] if v > 0) for ann in anno)
+
+    min_keypoints_per_image = 10
+
+    def _has_valid_annotation(anno):
+        # if it's empty, there is no annotation
+        if len(anno) == 0:
+            return False
+        # if all boxes have close to zero area, there is no annotation
+        if _has_only_empty_bbox(anno):
+            return False
+        # keypoints task have a slight different criteria for considering
+        # if an annotation is valid
+        if "keypoints" not in anno[0]:
+            return True
+        # for keypoint detection tasks, only consider valid images those
+        # containing at least min_keypoints_per_image
+        if _count_visible_keypoints(anno) >= min_keypoints_per_image:
+            return True
+        return False
+
+    ids = []
+    for ds_idx, img_id in enumerate(dataset.ids):
+        ann_ids = dataset.coco.getAnnIds(imgIds=img_id, iscrowd=None)
+        anno = dataset.coco.loadAnns(ann_ids)
+        if cat_list:
+            anno = [obj for obj in anno if obj["category_id"] in cat_list]
+        if _has_valid_annotation(anno):
+            ids.append(ds_idx)
+
+    dataset = torch.utils.data.Subset(dataset, ids)
+    return dataset
+
+
+def convert_to_coco_api(ds):
+    coco_ds = COCO()
+    # annotation IDs need to start at 1, not 0, see torchvision issue #1530
+    ann_id = 1
+    dataset = {"images": [], "categories": [], "annotations": [], "info": {}}
+    categories = set()
+    for img_idx in range(len(ds)):
+        # find better way to get target
+        # targets = ds.get_annotations(img_idx)
+        img, targets = ds[img_idx]
+        image_id = targets["image_id"]
+        img_dict = {}
+        img_dict["id"] = image_id
+        img_dict["height"] = img.shape[-2]
+        img_dict["width"] = img.shape[-1]
+        dataset["images"].append(img_dict)
+        bboxes = targets["boxes"].clone()
+        bboxes[:, 2:] -= bboxes[:, :2]
+        bboxes = bboxes.tolist()
+        labels = targets["labels"].tolist()
+        areas = targets["area"].tolist()
+        iscrowd = targets["iscrowd"].tolist()
+        if "masks" in targets:
+            masks = targets["masks"]
+            # make masks Fortran contiguous for mask_util
+            masks = masks.permute(0, 2, 1).contiguous().permute(0, 2, 1)
+        if "keypoints" in targets:
+            keypoints = targets["keypoints"]
+            keypoints = keypoints.reshape(keypoints.shape[0], -1).tolist()
+        num_objs = len(bboxes)
+        for i in range(num_objs):
+            ann = {}
+            ann["image_id"] = image_id
+            ann["bbox"] = bboxes[i]
+            ann["category_id"] = labels[i]
+            categories.add(labels[i])
+            ann["area"] = areas[i]
+            ann["iscrowd"] = iscrowd[i]
+            ann["id"] = ann_id
+            if "masks" in targets:
+                ann["segmentation"] = mask_util.encode(masks[i].numpy())
+            if "keypoints" in targets:
+                ann["keypoints"] = keypoints[i]
+                ann["num_keypoints"] = sum(k != 0 for k in keypoints[i][2::3])
+            dataset["annotations"].append(ann)
+            ann_id += 1
+    dataset["categories"] = [{"id": i} for i in sorted(categories)]
+    coco_ds.dataset = dataset
+    coco_ds.createIndex()
+    return coco_ds
+
+
+def get_coco_api_from_dataset(dataset):
+    # FIXME: This is... awful?
+    for _ in range(10):
+        if isinstance(dataset, torchvision.datasets.CocoDetection):
+            break
+        if isinstance(dataset, torch.utils.data.Subset):
+            dataset = dataset.dataset
+    if isinstance(dataset, torchvision.datasets.CocoDetection):
+        return dataset.coco
+    return convert_to_coco_api(dataset)
+
+
+class CocoDetection(torchvision.datasets.CocoDetection):
+    def __init__(self, img_folder, ann_file, transforms):
+        super().__init__(img_folder, ann_file)
+        self._transforms = transforms
+
+    def __getitem__(self, idx):
+        img, target = super().__getitem__(idx)
+        image_id = self.ids[idx]
+        target = dict(image_id=image_id, annotations=target)
+        if self._transforms is not None:
+            img, target = self._transforms(img, target)
+        return img, target
+
+
+def get_coco(
+    root,
+    image_set,
+    transforms,
+    mode="instances",
+    use_v2=False,
+    with_masks=False,
+    num_samples=-1,
+):
+    anno_file_template = "{}_{}2017.json"
+    PATHS = {
+        "train": (
+            "train2017",
+            os.path.join("annotations", anno_file_template.format(mode, "train")),
+        ),
+        "val": (
+            "val2017",
+            os.path.join("annotations", anno_file_template.format(mode, "val")),
+        ),
+        # "train": ("val2017", os.path.join("annotations", anno_file_template.format(mode, "val")))
+    }
+
+    img_folder, ann_file = PATHS[image_set]
+    img_folder = os.path.join(root, img_folder)
+    ann_file = os.path.join(root, ann_file)
+
+    if use_v2:
+        from torchvision.datasets import wrap_dataset_for_transforms_v2
+
+        dataset = torchvision.datasets.CocoDetection(
+            img_folder, ann_file, transforms=transforms
+        )
+        target_keys = ["boxes", "labels", "image_id"]
+        if with_masks:
+            target_keys += ["masks"]
+        dataset = wrap_dataset_for_transforms_v2(dataset, target_keys=target_keys)
+    else:
+        # TODO: handle with_masks for V1?
+        t = [ConvertCocoPolysToMask()]
+        if transforms is not None:
+            t.append(transforms)
+        transforms = T.Compose(t)
+
+        dataset = CocoDetection(img_folder, ann_file, transforms=transforms)
+
+    if num_samples > 0 and num_samples < len(dataset):
+        dataset = torch.utils.data.Subset(dataset, [i for i in range(num_samples)])
+
+    return dataset
+
+
+def get_dataset(args, model, model_weights, num_samples=-1):
+    image_set = "val"
+    dataset = "coco_kp" if "keypoint" in model else "coco"
+    num_classes, mode = {"coco": (91, "instances"), "coco_kp": (2, "person_keypoints")}[
+        dataset
+    ]
+    with_masks = "mask" in model
+    ds = get_coco(
+        root=args.data_path,
+        image_set=image_set,
+        transforms=get_transform(model_weights),
+        mode=mode,
+        use_v2=args.use_v2,
+        with_masks=with_masks,
+        num_samples=num_samples,
+    )
+    return ds, num_classes
+
+
+def get_modules(use_v2):
+    # We need a protected import to avoid the V2 warning in case just V1 is used
+    if use_v2:
+        import torchvision.transforms.v2
+        import torchvision.tv_tensors
+
+        return torchvision.transforms.v2, torchvision.tv_tensors
+    else:
+        import test_tconv_transforms as reference_transforms
+
+        return reference_transforms, None
+
+
+class DetectionPresetEval:
+    def __init__(self, backend="pil", use_v2=False):
+        T, _ = get_modules(use_v2)
+        transforms = []
+        backend = backend.lower()
+        if backend == "pil":
+            # Note: we could just convert to pure tensors even in v2?
+            transforms += [T.ToImage() if use_v2 else T.PILToTensor()]
+        elif backend == "tensor":
+            transforms += [T.PILToTensor()]
+        elif backend == "tv_tensor":
+            transforms += [T.ToImage()]
+        else:
+            raise ValueError(
+                f"backend can be 'tv_tensor', 'tensor' or 'pil', but got {backend}"
+            )
+
+        transforms += [T.ToDtype(torch.float, scale=True)]
+
+        if use_v2:
+            transforms += [T.ToPureTensor()]
+
+        self.transforms = T.Compose(transforms)
+
+    def __call__(self, img, target):
+        return self.transforms(img, target)
+
+
+def get_transform(weights):
+    weights = torchvision.models.get_weight(weights)
+    trans = weights.transforms()
+    return lambda img, target: (trans(img), target)
+
+
+def _get_iou_types(model):
+    model_without_ddp = model
+    if isinstance(model, torch.nn.parallel.DistributedDataParallel):
+        model_without_ddp = model.module
+    iou_types = ["bbox"]
+    if isinstance(model_without_ddp, torchvision.models.detection.MaskRCNN):
+        iou_types.append("segm")
+    if isinstance(model_without_ddp, torchvision.models.detection.KeypointRCNN):
+        iou_types.append("keypoints")
+    return iou_types
+
+
+class SmoothedValue:
+    """Track a series of values and provide access to smoothed values over a
+    window or the global series average.
+    """
+
+    def __init__(self, window_size=20, fmt=None):
+        if fmt is None:
+            fmt = "{median:.4f} ({global_avg:.4f})"
+        self.deque = deque(maxlen=window_size)
+        self.total = 0.0
+        self.count = 0
+        self.fmt = fmt
+
+    def update(self, value, n=1):
+        self.deque.append(value)
+        self.count += n
+        self.total += value * n
+
+    @property
+    def median(self):
+        d = torch.tensor(list(self.deque))
+        return d.median().item()
+
+    @property
+    def avg(self):
+        d = torch.tensor(list(self.deque), dtype=torch.float32)
+        return d.mean().item()
+
+    @property
+    def global_avg(self):
+        return self.total / self.count
+
+    @property
+    def max(self):
+        return max(self.deque)
+
+    @property
+    def value(self):
+        return self.deque[-1]
+
+    def __str__(self):
+        return self.fmt.format(
+            median=self.median,
+            avg=self.avg,
+            global_avg=self.global_avg,
+            max=self.max,
+            value=self.value,
+        )
+
+
+def all_gather(data):
+    """
+    Run all_gather on arbitrary picklable data (not necessarily tensors)
+    Args:
+        data: any picklable object
+    Returns:
+        list[data]: list of data gathered from each rank
+    """
+    return [data]
+
+
+def reduce_dict(input_dict, average=True):
+    """
+    Args:
+        input_dict (dict): all the values will be reduced
+        average (bool): whether to do average or sum
+    Reduce the values in the dictionary from all processes so that all processes
+    have the averaged results. Returns a dict with the same fields as
+    input_dict, after reduction.
+    """
+    world_size = 1
+    if world_size < 2:
+        return input_dict
+    # with torch.inference_mode():
+    #    names = []
+    #    values = []
+    #    # sort the keys so that they are consistent across processes
+    #    for k in sorted(input_dict.keys()):
+    #        names.append(k)
+    #        values.append(input_dict[k])
+    #    values = torch.stack(values, dim=0)
+    #    dist.all_reduce(values)
+    #    if average:
+    #        values /= world_size
+    #    reduced_dict = {k: v for k, v in zip(names, values)}
+    # return reduced_dict
+
+
+class MetricLogger:
+    def __init__(self, delimiter="\t"):
+        self.meters = defaultdict(SmoothedValue)
+        self.delimiter = delimiter
+
+    def update(self, **kwargs):
+        for k, v in kwargs.items():
+            if isinstance(v, torch.Tensor):
+                v = v.item()
+            assert isinstance(v, (float, int))
+            self.meters[k].update(v)
+
+    def __getattr__(self, attr):
+        if attr in self.meters:
+            return self.meters[attr]
+        if attr in self.__dict__:
+            return self.__dict__[attr]
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{attr}'"
+        )
+
+    def __str__(self):
+        loss_str = []
+        for name, meter in self.meters.items():
+            loss_str.append(f"{name}: {str(meter)}")
+        return self.delimiter.join(loss_str)
+
+    def add_meter(self, name, meter):
+        self.meters[name] = meter
+
+    def log_every(self, iterable, print_freq, header=None):
+        i = 0
+        if not header:
+            header = ""
+        start_time = time.time()
+        end = time.time()
+        iter_time = SmoothedValue(fmt="{avg:.4f}")
+        data_time = SmoothedValue(fmt="{avg:.4f}")
+        space_fmt = ":" + str(len(str(len(iterable)))) + "d"
+        if torch.cuda.is_available():
+            log_msg = self.delimiter.join(
+                [
+                    header,
+                    "[{0" + space_fmt + "}/{1}]",
+                    "eta: {eta}",
+                    "{meters}",
+                    "time: {time}",
+                    "data: {data}",
+                    "max mem: {memory:.0f}",
+                ]
+            )
+        else:
+            log_msg = self.delimiter.join(
+                [
+                    header,
+                    "[{0" + space_fmt + "}/{1}]",
+                    "eta: {eta}",
+                    "{meters}",
+                    "time: {time}",
+                    "data: {data}",
+                ]
+            )
+        MB = 1024.0 * 1024.0
+        for obj in iterable:
+            data_time.update(time.time() - end)
+            yield obj
+            iter_time.update(time.time() - end)
+            if i % print_freq == 0 or i == len(iterable) - 1:
+                eta_seconds = iter_time.global_avg * (len(iterable) - i)
+                eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
+                if torch.cuda.is_available():
+                    print(
+                        log_msg.format(
+                            i,
+                            len(iterable),
+                            eta=eta_string,
+                            meters=str(self),
+                            time=str(iter_time),
+                            data=str(data_time),
+                            memory=torch.cuda.max_memory_allocated() / MB,
+                        )
+                    )
+                else:
+                    print(
+                        log_msg.format(
+                            i,
+                            len(iterable),
+                            eta=eta_string,
+                            meters=str(self),
+                            time=str(iter_time),
+                            data=str(data_time),
+                        )
+                    )
+            i += 1
+            end = time.time()
+        total_time = time.time() - start_time
+        total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+        print(
+            f"{header} Total time: {total_time_str} ({total_time / len(iterable):.4f} s / it)"
+        )
+
+
+def merge(img_ids, eval_imgs):
+    all_img_ids = all_gather(img_ids)
+    all_eval_imgs = all_gather(eval_imgs)
+
+    merged_img_ids = []
+    for p in all_img_ids:
+        merged_img_ids.extend(p)
+
+    merged_eval_imgs = []
+    for p in all_eval_imgs:
+        merged_eval_imgs.append(p)
+
+    merged_img_ids = np.array(merged_img_ids)
+    merged_eval_imgs = np.concatenate(merged_eval_imgs, 2)
+
+    # keep only unique (and in sorted order) images
+    merged_img_ids, idx = np.unique(merged_img_ids, return_index=True)
+    merged_eval_imgs = merged_eval_imgs[..., idx]
+
+    return merged_img_ids, merged_eval_imgs
+
+
+def create_common_coco_eval(coco_eval, img_ids, eval_imgs):
+    img_ids, eval_imgs = merge(img_ids, eval_imgs)
+    img_ids = list(img_ids)
+    eval_imgs = list(eval_imgs.flatten())
+
+    coco_eval.evalImgs = eval_imgs
+    coco_eval.params.imgIds = img_ids
+    coco_eval._paramsEval = copy.deepcopy(coco_eval.params)
+
+
+class CocoEvaluator:
+    def __init__(self, coco_gt, iou_types):
+        if not isinstance(iou_types, (list, tuple)):
+            raise TypeError(
+                f"This constructor expects iou_types of type list or tuple, instead  got {type(iou_types)}"
+            )
+        coco_gt = copy.deepcopy(coco_gt)
+        self.coco_gt = coco_gt
+
+        self.iou_types = iou_types
+        self.coco_eval = {}
+        for iou_type in iou_types:
+            self.coco_eval[iou_type] = COCOeval(coco_gt, iouType=iou_type)
+
+        self.img_ids = []
+        self.eval_imgs = {k: [] for k in iou_types}
+
+    def evaluate(self, imgs):
+        with redirect_stdout(io.StringIO()):
+            imgs.evaluate()
+        return imgs.params.imgIds, np.asarray(imgs.evalImgs).reshape(
+            -1, len(imgs.params.areaRng), len(imgs.params.imgIds)
+        )
+
+    def update(self, predictions):
+        img_ids = list(np.unique(list(predictions.keys())))
+        self.img_ids.extend(img_ids)
+
+        for iou_type in self.iou_types:
+            results = self.prepare(predictions, iou_type)
+            with redirect_stdout(io.StringIO()):
+                coco_dt = COCO.loadRes(self.coco_gt, results) if results else COCO()
+            coco_eval = self.coco_eval[iou_type]
+
+            coco_eval.cocoDt = coco_dt
+            coco_eval.params.imgIds = list(img_ids)
+            img_ids, eval_imgs = self.evaluate(coco_eval)
+
+            self.eval_imgs[iou_type].append(eval_imgs)
+
+    def synchronize_between_processes(self):
+        for iou_type in self.iou_types:
+            self.eval_imgs[iou_type] = np.concatenate(self.eval_imgs[iou_type], 2)
+            create_common_coco_eval(
+                self.coco_eval[iou_type], self.img_ids, self.eval_imgs[iou_type]
+            )
+
+    def accumulate(self):
+        for coco_eval in self.coco_eval.values():
+            coco_eval.accumulate()
+
+    def summarize(self):
+        for iou_type, coco_eval in self.coco_eval.items():
+            print(f"IoU metric: {iou_type}")
+            coco_eval.summarize()
+
+    def prepare(self, predictions, iou_type):
+        if iou_type == "bbox":
+            return self.prepare_for_coco_detection(predictions)
+        if iou_type == "segm":
+            return self.prepare_for_coco_segmentation(predictions)
+        if iou_type == "keypoints":
+            return self.prepare_for_coco_keypoint(predictions)
+        raise ValueError(f"Unknown iou type {iou_type}")
+
+    def prepare_for_coco_detection(self, predictions):
+        coco_results = []
+        for original_id, prediction in predictions.items():
+            if len(prediction) == 0:
+                continue
+
+            boxes = prediction["boxes"]
+            boxes = convert_to_xywh(boxes).tolist()
+            scores = prediction["scores"].tolist()
+            labels = prediction["labels"].tolist()
+
+            coco_results.extend(
+                [
+                    {
+                        "image_id": original_id,
+                        "category_id": labels[k],
+                        "bbox": box,
+                        "score": scores[k],
+                    }
+                    for k, box in enumerate(boxes)
+                ]
+            )
+        return coco_results
+
+    def prepare_for_coco_segmentation(self, predictions):
+        coco_results = []
+        for original_id, prediction in predictions.items():
+            if len(prediction) == 0:
+                continue
+
+            scores = prediction["scores"]
+            labels = prediction["labels"]
+            masks = prediction["masks"]
+
+            masks = masks > 0.5
+
+            scores = prediction["scores"].tolist()
+            labels = prediction["labels"].tolist()
+
+            rles = [
+                mask_util.encode(
+                    np.array(mask[0, :, :, np.newaxis], dtype=np.uint8, order="F")
+                )[0]
+                for mask in masks
+            ]
+            for rle in rles:
+                rle["counts"] = rle["counts"].decode("utf-8")
+
+            coco_results.extend(
+                [
+                    {
+                        "image_id": original_id,
+                        "category_id": labels[k],
+                        "segmentation": rle,
+                        "score": scores[k],
+                    }
+                    for k, rle in enumerate(rles)
+                ]
+            )
+        return coco_results
+
+    def prepare_for_coco_keypoint(self, predictions):
+        coco_results = []
+        for original_id, prediction in predictions.items():
+            if len(prediction) == 0:
+                continue
+
+            boxes = prediction["boxes"]
+            boxes = convert_to_xywh(boxes).tolist()
+            scores = prediction["scores"].tolist()
+            labels = prediction["labels"].tolist()
+            keypoints = prediction["keypoints"]
+            keypoints = keypoints.flatten(start_dim=1).tolist()
+
+            coco_results.extend(
+                [
+                    {
+                        "image_id": original_id,
+                        "category_id": labels[k],
+                        "keypoints": keypoint,
+                        "score": scores[k],
+                    }
+                    for k, keypoint in enumerate(keypoints)
+                ]
+            )
+        return coco_results
+
+
+def convert_to_xywh(boxes):
+    xmin, ymin, xmax, ymax = boxes.unbind(1)
+    return torch.stack((xmin, ymin, xmax - xmin, ymax - ymin), dim=1)
+
+
+@torch.inference_mode()
+def evaluate(model, data_loader, device):
+    model.to(device)
+    n_threads = torch.get_num_threads()
+    # FIXME remove this and make paste_masks_in_image run on the GPU
+    torch.set_num_threads(1)
+    cpu_device = torch.device("cpu")
+    model.eval()
+    metric_logger = MetricLogger(delimiter="  ")
+    header = "Test:"
+
+    coco = get_coco_api_from_dataset(data_loader.dataset)
+    iou_types = _get_iou_types(model)
+    coco_evaluator = CocoEvaluator(coco, iou_types)
+
+    for images, targets in metric_logger.log_every(data_loader, 100, header):
+        images = list(img.to(device) for img in images)
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        model_time = time.time()
+        outputs = model(images)
+
+        outputs = [{k: v.to(cpu_device) for k, v in t.items()} for t in outputs]
+        model_time = time.time() - model_time
+
+        res = {target["image_id"]: output for target, output in zip(targets, outputs)}
+        evaluator_time = time.time()
+        coco_evaluator.update(res)
+        evaluator_time = time.time() - evaluator_time
+        metric_logger.update(model_time=model_time, evaluator_time=evaluator_time)
+
+    print("Averaged stats:", metric_logger)
+    coco_evaluator.synchronize_between_processes()
+
+    # accumulate predictions from all images
+    coco_evaluator.accumulate()
+    coco_evaluator.summarize()
+    torch.set_num_threads(n_threads)
+    return coco_evaluator
+
+
+def collate_fn(batch):
+    return tuple(zip(*batch))
+
+
+def validate(data_loader, model, dev):
+    # evaluate
+    prev_deterministic = torch.backends.cudnn.deterministic
+    torch.backends.cudnn.deterministic = True
+    evaluator = evaluate(model, data_loader, device=dev)
+    accuracy = {}
+    for key in evaluator.coco_eval:
+        accuracy[key] = evaluator.coco_eval[key].stats[0]
+        print(f"{key} accuracy - {evaluator.coco_eval[key].stats[0]:.3f}")
+
+    torch.backends.cudnn.deterministic = prev_deterministic
+    return accuracy
+
+
+def get_statistics_of_model_quantization(
+    model,
+    data_loader,
+    weight_config,
+    num_of_images_for_gptq_calibration=100,
+    dev: str = "cuda",
+):
+    model.eval()
+    input_0, _ = next(iter(data_loader))
+    input_0 = list(img.to(dev) for img in input_0)
+    prepare(model, weight_config, args=input_0, inplace=True)
+
+    for index, (images, _) in enumerate(data_loader):
+        if index >= num_of_images_for_gptq_calibration:
+            break
+        with torch.no_grad():
+            input = list(img.to(dev) for img in images)
+            model(input)
+
+    # quantize
+    tick = time.time()
+    convert(model, inplace=True)
+    q_time = time.time() - tick
+    print(f"time of quantization {q_time}")
+
+    # evaluate
+    accuracy = validate(data_loader, model, dev)
+
+    return q_time, accuracy
+
+
+def compare_FPI_quantization_of_model(
+    args,
+    model_name,
+    num_of_images_for_gptq_calibration,
+    num_of_validation_images,
+    dev: str = "cuda",
+):
+    with io.StringIO() as buffer, contextlib.redirect_stdout(
+        buffer
+    ), contextlib.redirect_stderr(buffer):
+        torch_model_name, weights_name = get_torch_model_name_and_weights(model_name)
+        dataset_test, num_classes = get_dataset(
+            args=args,
+            model=torch_model_name,
+            model_weights=str(weights_name),
+            num_samples=num_of_validation_images,
+        )
+
+        data_loader = torch.utils.data.DataLoader(
+            dataset_test,
+            batch_size=1,
+            sampler=torch.utils.data.SequentialSampler(dataset_test),
+            num_workers=4,
+            collate_fn=collate_fn,
+        )
+
+        model = torchvision.models.get_model(
+            torch_model_name,
+            weights=str(weights_name),
+            weights_backbone=None,
+            num_classes=num_classes,
+        )
+        # is_conv3d = False
+        # for name, module in model.named_modules():
+        #    if isinstance(module, torch.nn.ConvTranspose2d) or isinstance(module, torch.nn.ConvTranspose1d) or isinstance(module, torch.nn.ConvTranspose3d):
+        #        is_conv3d = True
+
+        accuracy_original = validate(data_loader, model, dev)
+        del model
+        model = None
+        # no need to load_model as validate above does not change model
+        model = torchvision.models.get_model(
+            torch_model_name,
+            weights=str(weights_name),
+            weights_backbone=None,
+            num_classes=num_classes,
+        ).to(dev)
+        (q_RTN_time, accuracy_RTN_quantized,) = get_statistics_of_model_quantization(
+            model,
+            data_loader,
+            weight_config=RTNConfig(),
+            num_of_images_for_gptq_calibration=num_of_images_for_gptq_calibration,
+            dev=dev,
+        )
+        del model
+        model = None
+        model = torchvision.models.get_model(
+            torch_model_name,
+            weights=str(weights_name),
+            weights_backbone=None,
+            num_classes=num_classes,
+        ).to(dev)
+        (q_GPTQ_time, accuracy_GPTQ_quantized) = get_statistics_of_model_quantization(
+            model,
+            data_loader,
+            weight_config=GPTQConfig(),
+            num_of_images_for_gptq_calibration=num_of_images_for_gptq_calibration,
+            dev=dev,
+        )
+
+        model = torchvision.models.get_model(
+            torch_model_name,
+            weights=str(weights_name),
+            weights_backbone=None,
+            num_classes=num_classes,
+        ).to(dev)
+        (
+            q_FPI_GPTQ_time,
+            accuracy_FPI_GPTQ_quantized,
+        ) = get_statistics_of_model_quantization(
+            model,
+            data_loader,
+            weight_config=FPIGPTQConfig(),
+            num_of_images_for_gptq_calibration=num_of_images_for_gptq_calibration,
+            dev=dev,
+        )
+        del model
+        model = None
+
+    print(f"resuts_of_comparison_for {model_name}")
+    acc_original = ", ".join(
+        f"{key}: {value:.3f}" for key, value in accuracy_original.items()
+    )
+    print(acc_original)
+    acc_RTN = ", ".join(
+        f"{key}: {value:.3f}" for key, value in accuracy_RTN_quantized.items()
+    )
+    print(f"{acc_RTN} time_of_quantization {q_RTN_time:.4f} - RTN")
+    acc_FPI_GPTQ = ", ".join(
+        f"{key}: {value:.3f}" for key, value in accuracy_FPI_GPTQ_quantized.items()
+    )
+    print(f"{acc_FPI_GPTQ} time_of_quantization {q_FPI_GPTQ_time:.4f} - FPI_GPTQ")
+    acc_GPTQ = ", ".join(
+        f"{key}: {value:.3f}" for key, value in accuracy_GPTQ_quantized.items()
+    )
+    print(f"{acc_GPTQ} time_of_quantization {q_GPTQ_time:.4f} - GPTQ")
+    print(
+        f"{100 * (1.0 - q_FPI_GPTQ_time / q_GPTQ_time):.2f}% speed-up for {model_name}"
+    )
+
+    print("")
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "--data-path",
+        default="/mnt/storage/datasets/ms_coco",
+        type=str,
+        help="dataset path",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="coco",
+        type=str,
+        help="dataset name. Use coco for object detection and instance segmentation and coco_kp for Keypoint detection",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        type=str,
+        default=["all"],
+        help="Possible models that can be used for comparison\n"
+        "'all' - almost all of the below models\n"
+        "'maskrcnn_resnet50_fpn'\n"
+        "'maskrcnn_resnet50_fpn_v2'\n"
+        "'keypointrcnn_resnet50_legacy'\n"
+        "'keypointrcnn_resnet50_fpn'\n",
+    )
+
+    # parser.add_argument("--model", default="maskrcnn_resnet50_fpn", type=str, help="model name")
+    # parser.add_argument("--model", default="maskrcnn_resnet50_fpn_v2", type=str, help="model name")
+    # parser.add_argument("--model", default="keypointrcnn_resnet50_fpn", type=str, help="model name")
+
+    # parser.add_argument("--weights", default=None, type=str, help="the weights enum name to load")
+    # parser.add_argument("--weights-backbone", default=None, type=str, help="the backbone weights enum name to load")
+    parser.add_argument(
+        "--num_of_calibration_images",
+        type=int,
+        default=100,
+        help="number of images to calibrate gptq",
+    )
+    parser.add_argument(
+        "--num_of_validation_images",
+        type=int,
+        default=5000,
+        help="number of images to vaidate result",
+    )
+    parser.add_argument(
+        "--device", type=str, default="cuda", help="device for inference cuda/cpu"
+    )
+    parser.add_argument("--use-v2", action="store_true", help="Use V2 transforms")
+    parser.add_argument(
+        "--rpn-score-thresh",
+        default=None,
+        type=float,
+        help="rpn score threshold for faster-rcnn",
+    )
+
+    args = parser.parse_args()
+    print(args)
+    model_names = []
+    for name in args.models:
+        assert name == "all" or name in list_of_available_models
+        if name == "all":
+            model_names.extend(list_of_available_models)
+        else:
+            model_names.append(name)
+
+    for model_name in model_names:
+        compare_FPI_quantization_of_model(
+            args,
+            model_name,
+            args.num_of_calibration_images,
+            args.num_of_validation_images,
+            dev=args.device,
+        )

--- a/test_tconv_transforms.py
+++ b/test_tconv_transforms.py
@@ -1,0 +1,664 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import torch
+import torchvision
+from torch import nn, Tensor
+from torchvision import ops
+from torchvision.transforms import functional as F, InterpolationMode, transforms as T
+
+
+def _flip_coco_person_keypoints(kps, width):
+    flip_inds = [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
+    flipped_data = kps[:, flip_inds]
+    flipped_data[..., 0] = width - flipped_data[..., 0]
+    # Maintain COCO convention that if visibility == 0, then x, y = 0
+    inds = flipped_data[..., 2] == 0
+    flipped_data[inds] = 0
+    return flipped_data
+
+
+class Compose:
+    def __init__(self, transforms):
+        self.transforms = transforms
+
+    def __call__(self, image, target):
+        for t in self.transforms:
+            image, target = t(image, target)
+        return image, target
+
+
+class RandomHorizontalFlip(T.RandomHorizontalFlip):
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        if torch.rand(1) < self.p:
+            image = F.hflip(image)
+            if target is not None:
+                _, _, width = F.get_dimensions(image)
+                target["boxes"][:, [0, 2]] = width - target["boxes"][:, [2, 0]]
+                if "masks" in target:
+                    target["masks"] = target["masks"].flip(-1)
+                if "keypoints" in target:
+                    keypoints = target["keypoints"]
+                    keypoints = _flip_coco_person_keypoints(keypoints, width)
+                    target["keypoints"] = keypoints
+        return image, target
+
+
+class PILToTensor(nn.Module):
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        image = F.pil_to_tensor(image)
+        return image, target
+
+
+class ToDtype(nn.Module):
+    def __init__(self, dtype: torch.dtype, scale: bool = False) -> None:
+        super().__init__()
+        self.dtype = dtype
+        self.scale = scale
+
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        if not self.scale:
+            return image.to(dtype=self.dtype), target
+        image = F.convert_image_dtype(image, self.dtype)
+        return image, target
+
+
+class RandomIoUCrop(nn.Module):
+    def __init__(
+        self,
+        min_scale: float = 0.3,
+        max_scale: float = 1.0,
+        min_aspect_ratio: float = 0.5,
+        max_aspect_ratio: float = 2.0,
+        sampler_options: Optional[List[float]] = None,
+        trials: int = 40,
+    ):
+        super().__init__()
+        # Configuration similar to https://github.com/weiliu89/caffe/blob/ssd/examples/ssd/ssd_coco.py#L89-L174
+        self.min_scale = min_scale
+        self.max_scale = max_scale
+        self.min_aspect_ratio = min_aspect_ratio
+        self.max_aspect_ratio = max_aspect_ratio
+        if sampler_options is None:
+            sampler_options = [0.0, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0]
+        self.options = sampler_options
+        self.trials = trials
+
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        if target is None:
+            raise ValueError("The targets can't be None for this transform.")
+
+        if isinstance(image, torch.Tensor):
+            if image.ndimension() not in {2, 3}:
+                raise ValueError(
+                    f"image should be 2/3 dimensional. Got {image.ndimension()} dimensions."
+                )
+            elif image.ndimension() == 2:
+                image = image.unsqueeze(0)
+
+        _, orig_h, orig_w = F.get_dimensions(image)
+
+        while True:
+            # sample an option
+            idx = int(torch.randint(low=0, high=len(self.options), size=(1,)))
+            min_jaccard_overlap = self.options[idx]
+            if (
+                min_jaccard_overlap >= 1.0
+            ):  # a value larger than 1 encodes the leave as-is option
+                return image, target
+
+            for _ in range(self.trials):
+                # check the aspect ratio limitations
+                r = self.min_scale + (self.max_scale - self.min_scale) * torch.rand(2)
+                new_w = int(orig_w * r[0])
+                new_h = int(orig_h * r[1])
+                aspect_ratio = new_w / new_h
+                if not (self.min_aspect_ratio <= aspect_ratio <= self.max_aspect_ratio):
+                    continue
+
+                # check for 0 area crops
+                r = torch.rand(2)
+                left = int((orig_w - new_w) * r[0])
+                top = int((orig_h - new_h) * r[1])
+                right = left + new_w
+                bottom = top + new_h
+                if left == right or top == bottom:
+                    continue
+
+                # check for any valid boxes with centers within the crop area
+                cx = 0.5 * (target["boxes"][:, 0] + target["boxes"][:, 2])
+                cy = 0.5 * (target["boxes"][:, 1] + target["boxes"][:, 3])
+                is_within_crop_area = (
+                    (left < cx) & (cx < right) & (top < cy) & (cy < bottom)
+                )
+                if not is_within_crop_area.any():
+                    continue
+
+                # check at least 1 box with jaccard limitations
+                boxes = target["boxes"][is_within_crop_area]
+                ious = torchvision.ops.boxes.box_iou(
+                    boxes,
+                    torch.tensor(
+                        [[left, top, right, bottom]],
+                        dtype=boxes.dtype,
+                        device=boxes.device,
+                    ),
+                )
+                if ious.max() < min_jaccard_overlap:
+                    continue
+
+                # keep only valid boxes and perform cropping
+                target["boxes"] = boxes
+                target["labels"] = target["labels"][is_within_crop_area]
+                target["boxes"][:, 0::2] -= left
+                target["boxes"][:, 1::2] -= top
+                target["boxes"][:, 0::2].clamp_(min=0, max=new_w)
+                target["boxes"][:, 1::2].clamp_(min=0, max=new_h)
+                image = F.crop(image, top, left, new_h, new_w)
+
+                return image, target
+
+
+class RandomZoomOut(nn.Module):
+    def __init__(
+        self,
+        fill: Optional[List[float]] = None,
+        side_range: Tuple[float, float] = (1.0, 4.0),
+        p: float = 0.5,
+    ):
+        super().__init__()
+        if fill is None:
+            fill = [0.0, 0.0, 0.0]
+        self.fill = fill
+        self.side_range = side_range
+        if side_range[0] < 1.0 or side_range[0] > side_range[1]:
+            raise ValueError(f"Invalid canvas side range provided {side_range}.")
+        self.p = p
+
+    @torch.jit.unused
+    def _get_fill_value(self, is_pil):
+        # type: (bool) -> int
+        # We fake the type to make it work on JIT
+        return tuple(int(x) for x in self.fill) if is_pil else 0
+
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        if isinstance(image, torch.Tensor):
+            if image.ndimension() not in {2, 3}:
+                raise ValueError(
+                    f"image should be 2/3 dimensional. Got {image.ndimension()} dimensions."
+                )
+            elif image.ndimension() == 2:
+                image = image.unsqueeze(0)
+
+        if torch.rand(1) >= self.p:
+            return image, target
+
+        _, orig_h, orig_w = F.get_dimensions(image)
+
+        r = self.side_range[0] + torch.rand(1) * (
+            self.side_range[1] - self.side_range[0]
+        )
+        canvas_width = int(orig_w * r)
+        canvas_height = int(orig_h * r)
+
+        r = torch.rand(2)
+        left = int((canvas_width - orig_w) * r[0])
+        top = int((canvas_height - orig_h) * r[1])
+        right = canvas_width - (left + orig_w)
+        bottom = canvas_height - (top + orig_h)
+
+        if torch.jit.is_scripting():
+            fill = 0
+        else:
+            fill = self._get_fill_value(F._is_pil_image(image))
+
+        image = F.pad(image, [left, top, right, bottom], fill=fill)
+        if isinstance(image, torch.Tensor):
+            # PyTorch's pad supports only integers on fill. So we need to overwrite the colour
+            v = torch.tensor(self.fill, device=image.device, dtype=image.dtype).view(
+                -1, 1, 1
+            )
+            image[..., :top, :] = image[..., :, :left] = image[
+                ..., (top + orig_h) :, :
+            ] = image[..., :, (left + orig_w) :] = v
+
+        if target is not None:
+            target["boxes"][:, 0::2] += left
+            target["boxes"][:, 1::2] += top
+
+        return image, target
+
+
+class RandomPhotometricDistort(nn.Module):
+    def __init__(
+        self,
+        contrast: Tuple[float, float] = (0.5, 1.5),
+        saturation: Tuple[float, float] = (0.5, 1.5),
+        hue: Tuple[float, float] = (-0.05, 0.05),
+        brightness: Tuple[float, float] = (0.875, 1.125),
+        p: float = 0.5,
+    ):
+        super().__init__()
+        self._brightness = T.ColorJitter(brightness=brightness)
+        self._contrast = T.ColorJitter(contrast=contrast)
+        self._hue = T.ColorJitter(hue=hue)
+        self._saturation = T.ColorJitter(saturation=saturation)
+        self.p = p
+
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        if isinstance(image, torch.Tensor):
+            if image.ndimension() not in {2, 3}:
+                raise ValueError(
+                    f"image should be 2/3 dimensional. Got {image.ndimension()} dimensions."
+                )
+            elif image.ndimension() == 2:
+                image = image.unsqueeze(0)
+
+        r = torch.rand(7)
+
+        if r[0] < self.p:
+            image = self._brightness(image)
+
+        contrast_before = r[1] < 0.5
+        if contrast_before:
+            if r[2] < self.p:
+                image = self._contrast(image)
+
+        if r[3] < self.p:
+            image = self._saturation(image)
+
+        if r[4] < self.p:
+            image = self._hue(image)
+
+        if not contrast_before:
+            if r[5] < self.p:
+                image = self._contrast(image)
+
+        if r[6] < self.p:
+            channels, _, _ = F.get_dimensions(image)
+            permutation = torch.randperm(channels)
+
+            is_pil = F._is_pil_image(image)
+            if is_pil:
+                image = F.pil_to_tensor(image)
+                image = F.convert_image_dtype(image)
+            image = image[..., permutation, :, :]
+            if is_pil:
+                image = F.to_pil_image(image)
+
+        return image, target
+
+
+class ScaleJitter(nn.Module):
+    """Randomly resizes the image and its bounding boxes  within the specified scale range.
+    The class implements the Scale Jitter augmentation as described in the paper
+    `"Simple Copy-Paste is a Strong Data Augmentation Method for Instance Segmentation" <https://arxiv.org/abs/2012.07177>`_.
+
+    Args:
+        target_size (tuple of ints): The target size for the transform provided in (height, weight) format.
+        scale_range (tuple of ints): scaling factor interval, e.g (a, b), then scale is randomly sampled from the
+            range a <= scale <= b.
+        interpolation (InterpolationMode): Desired interpolation enum defined by
+            :class:`torchvision.transforms.InterpolationMode`. Default is ``InterpolationMode.BILINEAR``.
+    """
+
+    def __init__(
+        self,
+        target_size: Tuple[int, int],
+        scale_range: Tuple[float, float] = (0.1, 2.0),
+        interpolation: InterpolationMode = InterpolationMode.BILINEAR,
+        antialias=True,
+    ):
+        super().__init__()
+        self.target_size = target_size
+        self.scale_range = scale_range
+        self.interpolation = interpolation
+        self.antialias = antialias
+
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        if isinstance(image, torch.Tensor):
+            if image.ndimension() not in {2, 3}:
+                raise ValueError(
+                    f"image should be 2/3 dimensional. Got {image.ndimension()} dimensions."
+                )
+            elif image.ndimension() == 2:
+                image = image.unsqueeze(0)
+
+        _, orig_height, orig_width = F.get_dimensions(image)
+
+        scale = self.scale_range[0] + torch.rand(1) * (
+            self.scale_range[1] - self.scale_range[0]
+        )
+        r = (
+            min(self.target_size[1] / orig_height, self.target_size[0] / orig_width)
+            * scale
+        )
+        new_width = int(orig_width * r)
+        new_height = int(orig_height * r)
+
+        image = F.resize(
+            image,
+            [new_height, new_width],
+            interpolation=self.interpolation,
+            antialias=self.antialias,
+        )
+
+        if target is not None:
+            target["boxes"][:, 0::2] *= new_width / orig_width
+            target["boxes"][:, 1::2] *= new_height / orig_height
+            if "masks" in target:
+                target["masks"] = F.resize(
+                    target["masks"],
+                    [new_height, new_width],
+                    interpolation=InterpolationMode.NEAREST,
+                    antialias=self.antialias,
+                )
+
+        return image, target
+
+
+class FixedSizeCrop(nn.Module):
+    def __init__(self, size, fill=0, padding_mode="constant"):
+        super().__init__()
+        size = tuple(
+            T._setup_size(
+                size, error_msg="Please provide only two dimensions (h, w) for size."
+            )
+        )
+        self.crop_height = size[0]
+        self.crop_width = size[1]
+        self.fill = (
+            fill  # TODO: Fill is currently respected only on PIL. Apply tensor patch.
+        )
+        self.padding_mode = padding_mode
+
+    def _pad(self, img, target, padding):
+        # Taken from the functional_tensor.py pad
+        if isinstance(padding, int):
+            pad_left = pad_right = pad_top = pad_bottom = padding
+        elif len(padding) == 1:
+            pad_left = pad_right = pad_top = pad_bottom = padding[0]
+        elif len(padding) == 2:
+            pad_left = pad_right = padding[0]
+            pad_top = pad_bottom = padding[1]
+        else:
+            pad_left = padding[0]
+            pad_top = padding[1]
+            pad_right = padding[2]
+            pad_bottom = padding[3]
+
+        padding = [pad_left, pad_top, pad_right, pad_bottom]
+        img = F.pad(img, padding, self.fill, self.padding_mode)
+        if target is not None:
+            target["boxes"][:, 0::2] += pad_left
+            target["boxes"][:, 1::2] += pad_top
+            if "masks" in target:
+                target["masks"] = F.pad(target["masks"], padding, 0, "constant")
+
+        return img, target
+
+    def _crop(self, img, target, top, left, height, width):
+        img = F.crop(img, top, left, height, width)
+        if target is not None:
+            boxes = target["boxes"]
+            boxes[:, 0::2] -= left
+            boxes[:, 1::2] -= top
+            boxes[:, 0::2].clamp_(min=0, max=width)
+            boxes[:, 1::2].clamp_(min=0, max=height)
+
+            is_valid = (boxes[:, 0] < boxes[:, 2]) & (boxes[:, 1] < boxes[:, 3])
+
+            target["boxes"] = boxes[is_valid]
+            target["labels"] = target["labels"][is_valid]
+            if "masks" in target:
+                target["masks"] = F.crop(
+                    target["masks"][is_valid], top, left, height, width
+                )
+
+        return img, target
+
+    def forward(self, img, target=None):
+        _, height, width = F.get_dimensions(img)
+        new_height = min(height, self.crop_height)
+        new_width = min(width, self.crop_width)
+
+        if new_height != height or new_width != width:
+            offset_height = max(height - self.crop_height, 0)
+            offset_width = max(width - self.crop_width, 0)
+
+            r = torch.rand(1)
+            top = int(offset_height * r)
+            left = int(offset_width * r)
+
+            img, target = self._crop(img, target, top, left, new_height, new_width)
+
+        pad_bottom = max(self.crop_height - new_height, 0)
+        pad_right = max(self.crop_width - new_width, 0)
+        if pad_bottom != 0 or pad_right != 0:
+            img, target = self._pad(img, target, [0, 0, pad_right, pad_bottom])
+
+        return img, target
+
+
+class RandomShortestSize(nn.Module):
+    def __init__(
+        self,
+        min_size: Union[List[int], Tuple[int], int],
+        max_size: int,
+        interpolation: InterpolationMode = InterpolationMode.BILINEAR,
+    ):
+        super().__init__()
+        self.min_size = [min_size] if isinstance(min_size, int) else list(min_size)
+        self.max_size = max_size
+        self.interpolation = interpolation
+
+    def forward(
+        self, image: Tensor, target: Optional[Dict[str, Tensor]] = None
+    ) -> Tuple[Tensor, Optional[Dict[str, Tensor]]]:
+        _, orig_height, orig_width = F.get_dimensions(image)
+
+        min_size = self.min_size[torch.randint(len(self.min_size), (1,)).item()]
+        r = min(
+            min_size / min(orig_height, orig_width),
+            self.max_size / max(orig_height, orig_width),
+        )
+
+        new_width = int(orig_width * r)
+        new_height = int(orig_height * r)
+
+        image = F.resize(
+            image, [new_height, new_width], interpolation=self.interpolation
+        )
+
+        if target is not None:
+            target["boxes"][:, 0::2] *= new_width / orig_width
+            target["boxes"][:, 1::2] *= new_height / orig_height
+            if "masks" in target:
+                target["masks"] = F.resize(
+                    target["masks"],
+                    [new_height, new_width],
+                    interpolation=InterpolationMode.NEAREST,
+                )
+
+        return image, target
+
+
+def _copy_paste(
+    image: torch.Tensor,
+    target: Dict[str, Tensor],
+    paste_image: torch.Tensor,
+    paste_target: Dict[str, Tensor],
+    blending: bool = True,
+    resize_interpolation: F.InterpolationMode = F.InterpolationMode.BILINEAR,
+) -> Tuple[torch.Tensor, Dict[str, Tensor]]:
+
+    # Random paste targets selection:
+    num_masks = len(paste_target["masks"])
+
+    if num_masks < 1:
+        # Such degerante case with num_masks=0 can happen with LSJ
+        # Let's just return (image, target)
+        return image, target
+
+    # We have to please torch script by explicitly specifying dtype as torch.long
+    random_selection = torch.randint(
+        0, num_masks, (num_masks,), device=paste_image.device
+    )
+    random_selection = torch.unique(random_selection).to(torch.long)
+
+    paste_masks = paste_target["masks"][random_selection]
+    paste_boxes = paste_target["boxes"][random_selection]
+    paste_labels = paste_target["labels"][random_selection]
+
+    masks = target["masks"]
+
+    # We resize source and paste data if they have different sizes
+    # This is something we introduced here as originally the algorithm works
+    # on equal-sized data (for example, coming from LSJ data augmentations)
+    size1 = image.shape[-2:]
+    size2 = paste_image.shape[-2:]
+    if size1 != size2:
+        paste_image = F.resize(paste_image, size1, interpolation=resize_interpolation)
+        paste_masks = F.resize(
+            paste_masks, size1, interpolation=F.InterpolationMode.NEAREST
+        )
+        # resize bboxes:
+        ratios = torch.tensor(
+            (size1[1] / size2[1], size1[0] / size2[0]), device=paste_boxes.device
+        )
+        paste_boxes = paste_boxes.view(-1, 2, 2).mul(ratios).view(paste_boxes.shape)
+
+    paste_alpha_mask = paste_masks.sum(dim=0) > 0
+
+    if blending:
+        paste_alpha_mask = F.gaussian_blur(
+            paste_alpha_mask.unsqueeze(0),
+            kernel_size=(5, 5),
+            sigma=[
+                2.0,
+            ],
+        )
+
+    # Copy-paste images:
+    image = (image * (~paste_alpha_mask)) + (paste_image * paste_alpha_mask)
+
+    # Copy-paste masks:
+    masks = masks * (~paste_alpha_mask)
+    non_all_zero_masks = masks.sum((-1, -2)) > 0
+    masks = masks[non_all_zero_masks]
+
+    # Do a shallow copy of the target dict
+    out_target = {k: v for k, v in target.items()}
+
+    out_target["masks"] = torch.cat([masks, paste_masks])
+
+    # Copy-paste boxes and labels
+    boxes = ops.masks_to_boxes(masks)
+    out_target["boxes"] = torch.cat([boxes, paste_boxes])
+
+    labels = target["labels"][non_all_zero_masks]
+    out_target["labels"] = torch.cat([labels, paste_labels])
+
+    # Update additional optional keys: area and iscrowd if exist
+    if "area" in target:
+        out_target["area"] = out_target["masks"].sum((-1, -2)).to(torch.float32)
+
+    if "iscrowd" in target and "iscrowd" in paste_target:
+        # target['iscrowd'] size can be differ from mask size (non_all_zero_masks)
+        # For example, if previous transforms geometrically modifies masks/boxes/labels but
+        # does not update "iscrowd"
+        if len(target["iscrowd"]) == len(non_all_zero_masks):
+            iscrowd = target["iscrowd"][non_all_zero_masks]
+            paste_iscrowd = paste_target["iscrowd"][random_selection]
+            out_target["iscrowd"] = torch.cat([iscrowd, paste_iscrowd])
+
+    # Check for degenerated boxes and remove them
+    boxes = out_target["boxes"]
+    degenerate_boxes = boxes[:, 2:] <= boxes[:, :2]
+    if degenerate_boxes.any():
+        valid_targets = ~degenerate_boxes.any(dim=1)
+
+        out_target["boxes"] = boxes[valid_targets]
+        out_target["masks"] = out_target["masks"][valid_targets]
+        out_target["labels"] = out_target["labels"][valid_targets]
+
+        if "area" in out_target:
+            out_target["area"] = out_target["area"][valid_targets]
+        if "iscrowd" in out_target and len(out_target["iscrowd"]) == len(valid_targets):
+            out_target["iscrowd"] = out_target["iscrowd"][valid_targets]
+
+    return image, out_target
+
+
+class SimpleCopyPaste(torch.nn.Module):
+    def __init__(
+        self, blending=True, resize_interpolation=F.InterpolationMode.BILINEAR
+    ):
+        super().__init__()
+        self.resize_interpolation = resize_interpolation
+        self.blending = blending
+
+    def forward(
+        self, images: List[torch.Tensor], targets: List[Dict[str, Tensor]]
+    ) -> Tuple[List[torch.Tensor], List[Dict[str, Tensor]]]:
+        torch._assert(
+            isinstance(images, (list, tuple))
+            and all([isinstance(v, torch.Tensor) for v in images]),
+            "images should be a list of tensors",
+        )
+        torch._assert(
+            isinstance(targets, (list, tuple)) and len(images) == len(targets),
+            "targets should be a list of the same size as images",
+        )
+        for target in targets:
+            # Can not check for instance type dict with inside torch.jit.script
+            # torch._assert(isinstance(target, dict), "targets item should be a dict")
+            for k in ["masks", "boxes", "labels"]:
+                torch._assert(k in target, f"Key {k} should be present in targets")
+                torch._assert(
+                    isinstance(target[k], torch.Tensor),
+                    f"Value for the key {k} should be a tensor",
+                )
+
+        # images = [t1, t2, ..., tN]
+        # Let's define paste_images as shifted list of input images
+        # paste_images = [t2, t3, ..., tN, t1]
+        # FYI: in TF they mix data on the dataset level
+        images_rolled = images[-1:] + images[:-1]
+        targets_rolled = targets[-1:] + targets[:-1]
+
+        output_images: List[torch.Tensor] = []
+        output_targets: List[Dict[str, Tensor]] = []
+
+        for image, target, paste_image, paste_target in zip(
+            images, targets, images_rolled, targets_rolled
+        ):
+            output_image, output_data = _copy_paste(
+                image,
+                target,
+                paste_image,
+                paste_target,
+                blending=self.blending,
+                resize_interpolation=self.resize_interpolation,
+            )
+            output_images.append(output_image)
+            output_targets.append(output_data)
+
+        return output_images, output_targets
+
+    def __repr__(self) -> str:
+        s = f"{self.__class__.__name__}(blending={self.blending}, resize_interpolation={self.resize_interpolation})"
+        return s

--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -66,6 +66,7 @@ class FPIGPTQQuantizer(GPTQQuantizer):
         else:
             target_layers = [model]
 
+        num_of_quant_elems = 0
         quantizers: Dict[str, Any] = {}
         for l_idx, layer in enumerate(
             tqdm(
@@ -77,7 +78,13 @@ class FPIGPTQQuantizer(GPTQQuantizer):
         ):
             # 1) Identify quantizable submodules within the layer
             full = find_layers(
-                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
+                layer,
+                layers=[
+                    torch.nn.Linear,
+                    torch.nn.Conv2d,
+                    torch.nn.Conv1d,
+                    torch.nn.ConvTranspose2d,
+                ],
             )
             sequential = [list(full.keys())]
 
@@ -89,8 +96,9 @@ class FPIGPTQQuantizer(GPTQQuantizer):
                 for name in subset:
                     gptq[name] = FPI_GPTQ(subset[name])
                     gptq[name].quantizer.configure(
-                        bits=8, perchannel=True, sym=False, mse=False
+                        bits=3, perchannel=True, sym=False, mse=False
                     )
+                    num_of_quant_elems += subset[name].weight.numel()
 
                 # Hook to collect (inp, out) for GPTQ
                 def add_batch(name):
@@ -163,6 +171,9 @@ class FPIGPTQQuantizer(GPTQQuantizer):
         # Restore the original cache configuration.
         if orig_use_cache is not None:
             model.config.use_cache = orig_use_cache
+
+        if gptq_conf.verbose:
+            print(f"num_of_quantized_elements {num_of_quant_elems / (1024 * 1024)} MiB")
 
         # Clear caches to free memory
         self.cache_args.clear()

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -31,6 +31,136 @@ torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False
 
 
+def convtranspose2d_weights_to_conv2d_weights(layer, w) -> torch.Tensor:
+    if layer.groups == 1:
+        # the last two dimensions of w is (k_h, k_w) to get equivalent Conv2D we need to flip them to get `w_conv2D_equivalent_to_w[i, j] = w_conv[k_h - i - 1, k_w - j - 1]`
+        # the first two dimensions of w is (input_channels, output_channels), so we need to transpose them as Conv2D weights should be in the (output_channels, input_channels) form
+        # please see https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L1059-L1061 for additional info
+        w_conv_transposed = w.transpose(1, 0).flip((-2, -1))
+    else:
+        # basically it's the same as for `layer.groups == 1` but groupwise
+        in_channels, out_channels, kernel_h, kernel_w = layer.weight.shape
+        out_channels *= layer.groups
+        w_conv_transposed = torch.zeros(
+            out_channels, in_channels // layer.groups, kernel_h, kernel_w
+        )
+        for i in range(0, layer.groups):
+            w_conv_transposed[
+                i
+                * out_channels
+                // layer.groups : (i + 1)
+                * out_channels
+                // layer.groups,
+                :,
+                :,
+                :,
+            ] = (
+                w[
+                    i
+                    * in_channels
+                    // layer.groups : (i + 1)
+                    * in_channels
+                    // layer.groups,
+                    :,
+                    :,
+                    :,
+                ]
+                .transpose(1, 0)
+                .flip((-2, -1))
+            )
+
+    return w_conv_transposed
+
+
+def conv2d_weights_to_convtranspose2d_weights(orig_layer, w) -> torch.Tensor:
+    # this is just an inverse of convtranspose2d_weights_to_conv2d_weights
+    if orig_layer.groups > 1:
+        in_channels, out_channels, _, _ = orig_layer.weight.shape
+        out_channels *= orig_layer.groups
+        w_conv_transposed = torch.zeros_like(orig_layer.weight)
+        for i in range(0, orig_layer.groups):
+            w_conv_transposed[
+                i
+                * in_channels
+                // orig_layer.groups : (i + 1)
+                * in_channels
+                // orig_layer.groups,
+                :,
+                :,
+                :,
+            ] = (
+                w[
+                    i
+                    * out_channels
+                    // orig_layer.groups : (i + 1)
+                    * out_channels
+                    // orig_layer.groups,
+                    :,
+                    :,
+                    :,
+                ]
+                .transpose(1, 0)
+                .flip((-2, -1))
+            )
+    else:
+        w_conv_transposed = w.transpose(1, 0).flip((-2, -1))
+
+    return w_conv_transposed
+
+
+def get_matmul_input_for_convtranspose2d(layer, inp):
+    # Please see https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L996-L998 for padding
+    strided_pad = (
+        layer.dilation[0] * (layer.kernel_size[0] - 1) - layer.padding[0],
+        layer.dilation[1] * (layer.kernel_size[1] - 1) - layer.padding[1],
+    )
+
+    # interleave input with zero rows and columns according to stride
+    # Please see https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L991-L994 for more info
+    inp_strided = torch.zeros(
+        inp.shape[0],
+        inp.shape[1],
+        layer.stride[0] * (inp.shape[2] - 1) + 2 * strided_pad[0] + 1,
+        layer.stride[1] * (inp.shape[3] - 1) + 2 * strided_pad[1] + 1,
+        device=inp.device,
+    )
+
+    indices = torch.arange(0, inp.shape[2], device=inp.device)
+    # insert original input values according to stride to meet https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L991-L994
+    inp_strided[
+        :,
+        :,
+        layer.stride[0] * indices + strided_pad[0],
+        strided_pad[1] : -strided_pad[1] : layer.stride[1],
+    ] = inp[:, :, indices, :]
+    del inp
+    inp = (
+        inp_strided  # so the rest is just processing for Conv2D with transposed weights
+    )
+
+    # TODO reduce code duplication with Conv2D
+    unfold = nn.Unfold(
+        layer.kernel_size,
+        dilation=layer.dilation,
+        padding=(
+            0,
+            0,
+        ),  # equivalent Conv2D has (0, 0) padding for input_strided as input
+        stride=(1, 1),  # equivalent Conv2D has (1, 1) stride for input_strided as input
+    )
+
+    if layer.groups != 1:
+        inp = inp.reshape(
+            inp.size(0) * layer.groups,
+            inp.size(1) // layer.groups,
+            inp.shape[2],
+            inp.shape[3],
+        )  # inp.shape == (batch*groups, in_channels / groups, H, W) to meet Groupwise-wise Convolution, so that each group is colvolved with its own filter
+
+    inp = unfold(inp).permute([1, 0, 2]).flatten(1)
+    return inp
+
+
 class GPTQ:
     def __init__(self, layer):
         self.layer = layer
@@ -38,6 +168,9 @@ class GPTQ:
         W = layer.weight.data.clone()
         if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+        elif isinstance(self.layer, nn.ConvTranspose2d):
+            W = convtranspose2d_weights_to_conv2d_weights(self.layer, W)
+            W = W.flatten(1)
 
         self.rows = W.shape[0]
         self.columns = W.shape[1]
@@ -113,6 +246,9 @@ class GPTQ:
             inp = inp.permute([1, 0, 2])
             inp = inp.flatten(1)
 
+        if isinstance(self.layer, nn.ConvTranspose2d):
+            inp = get_matmul_input_for_convtranspose2d(self.layer, inp)
+
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp
         inp = math.sqrt(2 / self.nsamples) * inp.float()
@@ -130,6 +266,11 @@ class GPTQ:
         W = self.layer.weight.data.clone()
         if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+        elif isinstance(self.layer, nn.ConvTranspose2d):
+            W = convtranspose2d_weights_to_conv2d_weights(self.layer, W)
+            conv2d_shape = W.shape
+            W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+
         W = W.float()
         tick = time.time()
         if not self.quantizer.ready():
@@ -231,6 +372,16 @@ class GPTQ:
                     self.quantizer.zero,
                     self.quantizer.maxq,
                 )
+        elif isinstance(self.layer, nn.ConvTranspose2d):
+            if groupsize == -1:  # TODO support groupsize != -1
+                Q[:, dead] = quantize(
+                    convtranspose2d_weights_to_conv2d_weights(
+                        self.layer, self.layer.weight.data
+                    ).flatten(1)[:, dead],
+                    self.quantizer.scale,
+                    self.quantizer.zero,
+                    self.quantizer.maxq,
+                )
         else:
             if groupsize == -1:  # TODO support groupsize != -1
                 Q[:, dead] = quantize(
@@ -244,9 +395,15 @@ class GPTQ:
             groupsize == -1 or torch.sum(dead) == 0
         )  # TODO `dead` elements should be RTN quantized for groupwise
 
-        self.layer.weight.data = Q.reshape(self.layer.weight.shape).to(
-            self.layer.weight.data.dtype
-        )
+        if isinstance(self.layer, nn.ConvTranspose2d):
+            Q_conv2d = Q.reshape(conv2d_shape).to(self.layer.weight.data.dtype)
+            self.layer.weight.data = conv2d_weights_to_convtranspose2d_weights(
+                self.layer, Q_conv2d
+            )
+        else:
+            self.layer.weight.data = Q.reshape(self.layer.weight.shape).to(
+                self.layer.weight.data.dtype
+            )
 
     def free(self):
         self.H = None

--- a/tico/quantization/algorithm/rtn/quantizer.py
+++ b/tico/quantization/algorithm/rtn/quantizer.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+from tico.quantization.algorithm.gptq.gptq import (
+    conv2d_weights_to_convtranspose2d_weights,
+    convtranspose2d_weights_to_conv2d_weights,
+)
+from tico.quantization.algorithm.gptq.quant import quantize, Quantizer
+from tico.quantization.algorithm.gptq.utils import (
+    find_layers,
+    gather_single_batch_from_dict,
+    gather_single_batch_from_list,
+)
+from tico.quantization.config.rtn import RTNConfig
+from tico.quantization.quantizer import BaseQuantizer
+from tico.quantization.quantizer_registry import register_quantizer
+from tqdm.auto import tqdm
+
+
+@register_quantizer(RTNConfig)
+class RTNQuantizer(BaseQuantizer):
+    """
+    Quantizer for applying the GPTQ algorithm (typically for weight quantization).
+    This implementation expects:
+        1) prepare(model, ...) to only attach hooks/Catchers and NOT run the model internally.
+        2) The user runs the model with arbitrary number of batches to collect calibration data.
+        3) convert(model) to consume the collected data and apply GPTQ.
+    """
+
+    def __init__(self, config: RTNConfig):
+        super().__init__(config)
+
+    @torch.no_grad()
+    def prepare(
+        self,
+        model: torch.nn.Module,
+        args: Optional[Any] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        return model
+
+    @torch.no_grad()
+    def convert(self, model):
+        rtn_conf = self.config
+        assert isinstance(rtn_conf, RTNConfig)
+
+        # Disable use_cache during calibration
+        if hasattr(model, "config") and hasattr(model.config, "use_cache"):
+            orig_use_cache = model.config.use_cache
+            model.config.use_cache = False
+        else:
+            orig_use_cache = None
+
+        # Identify layers
+        if hasattr(model, "model"):
+            target_layers = model.model.layers
+        else:
+            target_layers = [model]
+
+        quantizers: Dict[str, Any] = {}
+        for l_idx, layer in enumerate(
+            tqdm(
+                target_layers,
+                desc="Quantizing layers",
+                unit="layer",
+                disable=not rtn_conf.show_progress,
+            )
+        ):
+            # 1) Identify quantizable submodules within the layer
+            full = find_layers(
+                layer,
+                layers=[
+                    torch.nn.Linear,
+                    torch.nn.Conv2d,
+                    torch.nn.Conv1d,
+                    torch.nn.ConvTranspose2d,
+                ],
+            )
+            sequential = [list(full.keys())]
+
+            # 2) Set up
+            for names in sequential:
+                subset = {n: full[n] for n in names}
+
+                # 3) Quantize each submodule
+                for name in subset:
+                    layer = subset[name]
+                    quantizer = Quantizer()
+                    quantizer.configure(bits=3, perchannel=True, sym=False, mse=False)
+
+                    W = layer.weight.data.clone()
+                    if isinstance(layer, torch.nn.Conv2d) or isinstance(
+                        layer, torch.nn.Conv1d
+                    ):
+                        W = W.flatten(1)
+                    if isinstance(layer, torch.nn.ConvTranspose2d):
+                        W = convtranspose2d_weights_to_conv2d_weights(layer, W)
+                        conv2d_shape = W.shape
+                        W = W.flatten(1)
+                    W = W.float()
+                    quantizer.find_params(W, weight=True)
+                    Q = quantize(W, quantizer.scale, quantizer.zero, quantizer.maxq)
+
+                    quantizers[f"model.layers.{l_idx}.{name}"] = quantizer
+                    if isinstance(layer, torch.nn.ConvTranspose2d):
+                        Q_conv2d = Q.reshape(conv2d_shape).to(layer.weight.data.dtype)
+                        layer.weight.data = conv2d_weights_to_convtranspose2d_weights(
+                            layer, Q_conv2d
+                        )
+                    else:
+                        layer.weight.data = Q.reshape(layer.weight.shape).to(
+                            layer.weight.data.dtype
+                        )
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        # Restore the original cache configuration.
+        if orig_use_cache is not None:
+            model.config.use_cache = orig_use_cache
+
+        model.quantizers = quantizers
+
+        return model

--- a/tico/quantization/config/rtn.py
+++ b/tico/quantization/config/rtn.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tico.quantization.config.base import BaseConfig
+
+
+class RTNConfig(BaseConfig):
+    """
+    Configuration for RTN. (Round-To-Nearest configuration)
+    """
+
+    def __init__(self, verbose: bool = False, show_progress: bool = True):
+        self.verbose = verbose
+        self.show_progress = show_progress
+
+    @property
+    def name(self) -> str:
+        return "rtn"

--- a/trn_TCONV_to_CONV1d.py
+++ b/trn_TCONV_to_CONV1d.py
@@ -1,0 +1,55 @@
+import torch
+
+batch = 1
+groups = 14
+out_channels = 70
+in_channels = 28
+kernel = 6
+padding = 5  # 0 <= padding < kernel
+dilation = 3
+stride = 5
+
+bias = torch.rand(out_channels)
+inp = torch.randn(batch, in_channels, 25)
+w = torch.randn(in_channels, out_channels // groups, kernel)
+
+e_out = torch.nn.functional.conv_transpose1d(
+    inp, w, bias=bias, groups=groups, stride=stride, padding=padding, dilation=dilation
+)
+
+if groups > 1:
+    w_conv_transposed = torch.zeros(out_channels, in_channels // groups, kernel)
+    for i in range(0, groups):
+        w_conv_transposed[
+            i * out_channels // groups : (i + 1) * out_channels // groups, :, :
+        ] = (
+            w[i * in_channels // groups : (i + 1) * in_channels // groups, :, :]
+            .transpose(1, 0)
+            .flip(-1)
+        )
+else:
+    w_conv_transposed = w.transpose(1, 0).flip(-1)
+
+inp_strided = torch.zeros(
+    inp.shape[0],
+    inp.shape[1],
+    stride * (inp.shape[2] - 1) - 2 * padding + 2 * dilation * (kernel - 1) + 1,
+)
+indices = torch.arange(0, inp.shape[2])
+inp_strided[:, :, stride * indices + dilation * (kernel - 1) - padding] = inp[
+    :, :, indices
+]
+e_out_c = torch.nn.functional.conv1d(
+    inp_strided,
+    w_conv_transposed,
+    bias=bias,
+    groups=groups,
+    dilation=dilation,
+    padding=0,
+)
+
+error_max = torch.max(torch.abs(e_out - e_out_c))
+error_mean = torch.mean(torch.abs(e_out - e_out_c))
+print(
+    f"error_max - {error_max.cpu().item():.4f}, error_mean - {error_mean.cpu().item():.4f}"
+)

--- a/trn_TCONV_to_CONV2d.py
+++ b/trn_TCONV_to_CONV2d.py
@@ -1,0 +1,82 @@
+import torch
+
+batch = 1
+groups = 2
+out_channels = 128
+in_channels = 256
+kernel = (3, 8)
+padding = (1, 2)  # 0 <= padding < kernel
+dilation = (3, 2)
+stride = (2, 3)
+
+bias = torch.rand(out_channels)
+inp = torch.randn(batch, in_channels, 21, 80)
+w = torch.randn(in_channels, out_channels // groups, kernel[0], kernel[1])
+
+e_out = torch.nn.functional.conv_transpose2d(
+    inp, w, bias=bias, groups=groups, stride=stride, padding=padding, dilation=dilation
+)
+
+if groups > 1:
+    w_conv_transposed = torch.zeros(
+        out_channels, in_channels // groups, kernel[0], kernel[1]
+    )
+    for i in range(0, groups):
+        w_conv_transposed[
+            i * out_channels // groups : (i + 1) * out_channels // groups, :, :, :
+        ] = (
+            w[i * in_channels // groups : (i + 1) * in_channels // groups, :, :, :]
+            .transpose(1, 0)
+            .flip((-2, -1))
+        )
+    w_orig = torch.zeros_like(w)
+    for i in range(0, groups):
+        w_orig[i * in_channels // groups : (i + 1) * in_channels // groups, :, :, :] = (
+            w_conv_transposed[
+                i * out_channels // groups : (i + 1) * out_channels // groups, :, :, :
+            ]
+            .transpose(1, 0)
+            .flip((-2, -1))
+        )
+    error_tr = torch.max(torch.abs(w - w_orig))
+
+else:
+    w_conv_transposed = w.transpose(1, 0).flip((-2, -1))
+    w_orig = w_conv_transposed.transpose(1, 0).flip((-2, -1))
+    error_tr = torch.max(torch.abs(w - w_orig))
+
+strided_pad = (
+    dilation[0] * (kernel[0] - 1) - padding[0],
+    dilation[1] * (kernel[1] - 1) - padding[1],
+)
+
+inp_strided = torch.zeros(
+    inp.shape[0],
+    inp.shape[1],
+    stride[0] * (inp.shape[2] - 1) + 2 * strided_pad[0] + 1,
+    stride[1] * (inp.shape[3] - 1) + 2 * strided_pad[1] + 1,
+)
+
+# input will ne interleaved with zero rows and columns
+indices = torch.arange(0, inp.shape[2])
+inp_strided[
+    :,
+    :,
+    stride[0] * indices + strided_pad[0],
+    strided_pad[1] : -strided_pad[1] : stride[1],
+] = inp[:, :, indices, :]
+
+e_out_c = torch.nn.functional.conv2d(
+    inp_strided,
+    w_conv_transposed,
+    bias=bias,
+    groups=groups,
+    dilation=dilation,
+    padding=0,
+)
+
+error_max = torch.max(torch.abs(e_out - e_out_c))
+error_mean = torch.mean(torch.abs(e_out - e_out_c))
+print(
+    f"error_max - {error_max.cpu().item():.4f}, error_mean - {error_mean.cpu().item():.4f}"
+)


### PR DESCRIPTION
This PR enables quantization of ConvTranspose2D in FPIGPTQ/GPTQ and adds tests for it.

<details> 
<summary> ./ccex test --include-internal -k test_gptq</summary>

```
RUN unit tests with -k test_gptq ...
test_groupwise_conv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 9 tests in 52.034s

OK
```

</details>

<details> <summary>./ccex test --include-internal -k test_fpi_gptq </summary>

```
RUN unit tests with -k test_fpi_gptq ...
test_groupwise_conv1d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_net (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok

----------------------------------------------------------------------
Ran 8 tests in 69.054s

OK
```
</details>

Please see some thoughts about processing wieghts of ConvTransposed to get equivalent Conv weights:
[TCONV2NCONV.pdf](https://github.com/user-attachments/files/23899321/TCONV2NCONV.pdf)

Below are results of quantizing weights of `Conv2D`, `Linear`, `ConvTransposed2D` to 4 bits and activations are left in `float32 ` for some models with at least a single `nn.ConvTranspose2D`:

|model| FPI_speedup (%)|time_FPI_GPTQ (s)|time_GPTQ (s)|BOX_MAP|Keypoint/Mask_MAP|BOX_MAP_FPI_GPTQ|Keypoint/Mask_MAP_FPI_GPTQ|BOX_MAP_GPTQ|Keypoint/Mask_MAP_GPTQ|
|-|-|-|-|-|-|-|-|-|-|
|maskrcnn_resnet50_fpn| **25**|65|86|37.9|34.6|37.4|34.3|37.5|34.4|
|maskrcnn_resnet50_fpn_v2| **17.25**|111|134|47.4|41.7|46.6.|41.4|46.6|41.5|
|keypointrcnn_resnet50_legacy| **21.74**|103|132|50.2|60|49.8|59.6|49.8|59.6|

Please see https://docs.pytorch.org/vision/main/models.html for reference.

`FPI_speedup` is below 50 % due to high inference cost.

Below are results of quantizing weights of `Conv2D`, `Linear`, `ConvTransposed2D` to 4 bits and activations are left in `float32 ` for some models with at least a single `nn.ConvTranspose2D` to `RTN` and `GPTQ` for comparison:


|model| BOX_MAP|Keypoint/Mask_MAP|BOX_MAP_RTN|Keypoint/Mask_MAP_RTN|BOX_MAP_GPTQ|Keypoint/Mask_MAP_GPTQ|
|-|-|-|-|-|-|-|
|maskrcnn_resnet50_fpn| 37.9|34.6|29.1|26.7|37.5|34.4|
|maskrcnn_resnet50_fpn_v2| 47.4|41.7|39.1|36.2|46.6|41.5|
|keypointrcnn_resnet50_legacy| 50.2|60|44|51.7|49.8|59.6|

_Please note significant accuracy drop in simple `RTN` method._

`trn_TCONV_ro_CONV2d.py`, `trn_TCONV_ro_CONV1d.py` are the scripts to test numerically correctness of `ConvTranspose=>Conv` transform.
`test_tconv_GPTQ.py` is as script to reproduce the results above, just use ` python test_tconv_GPTQ.py --models='all' --num_of_calibration_images=100`

Quantizing the only `ConvTranspose2D` node to 2 bits we get the following:
|model| BOX_MAP|Keypoint/Mask_MAP|BOX_MAP_RTN|Keypoint/Mask_MAP_RTN|BOX_MAP_GPTQ|Keypoint/Mask_MAP_GPTQ|
|-|-|-|-|-|-|-|
|maskrcnn_resnet50_fpn| 37.9|34.6|37.9|34.5|37.9|34.6|
|maskrcnn_resnet50_fpn_v2| 47.4|41.7|47.4|41.6|47.4|41.7|
|keypointrcnn_resnet50_legacy| 50.2|60|50.2|55.9|50.2|59.6|

_Please note significant accuracy drop for `keypointrcnn_resnet50_legacy` while GPTQ provides almost no accuracy decrease._

Quantizing the only `ConvTranspose2D` node to 1 bits we get the following:
|model| BOX_MAP|Keypoint/Mask_MAP|BOX_MAP_RTN|Keypoint/Mask_MAP_RTN|BOX_MAP_GPTQ|Keypoint/Mask_MAP_GPTQ|
|-|-|-|-|-|-|-|
|maskrcnn_resnet50_fpn| 37.9|34.6|37.9|31.1|37.9|33.6|
|maskrcnn_resnet50_fpn_v2| 47.4|41.7|47.4|38.2|47.4|40.4|
|keypointrcnn_resnet50_legacy| 50.2|60|50.2|0.1|50.2|31.1|

_Please note all accuracy loss for `keypointrcnn_resnet50_legacy` while GPTQ provides only half of accuracy drop._

Related: #397

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>