### PR TITLE
[quantization] Enable `nn.ConvTranspose2D` in GPTQs

### DIFF
--- a/test/quantization/algorithm/test_fpi_gptq.py
+++ b/test/quantization/algorithm/test_fpi_gptq.py
@@ -119,6 +119,24 @@ class GroupwiseConv1D(torch.nn.Module):
         return (torch.randn(1, 32, 16),), {}
 
 
+class TransposedConv2DGeneral(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.tconv = torch.nn.ConvTranspose2d(16, 32, (2, 2), stride=2, groups=1)
+        self.tconv2 = torch.nn.ConvTranspose2d(
+            32, 16, (3, 3), stride=4, groups=2
+        )  # general groupwise
+
+    def forward(self, x):
+        z = self.tconv(x)
+        z = self.tconv2(z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 16, 7, 7),), {}
+
+
 class FPIGPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -321,3 +339,29 @@ class FPIGPTQTest(unittest.TestCase):
         ), "second conv node is not quantized"
 
         # TODO add PT2E quantization (right now it can't be evaluated on backend)
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_transposed_conv2d(self):
+        q_m = TransposedConv2DGeneral()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, FPIGPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.tconv" in q_m.quantizers
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.tconv2" in q_m.quantizers
+        ), "second conv node is not quantized"
+
+        # TODO add PT2E quantization

--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -77,7 +77,13 @@ class FPIGPTQQuantizer(GPTQQuantizer):
         ):
             # 1) Identify quantizable submodules within the layer
             full = find_layers(
-                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
+                layer,
+                layers=[
+                    torch.nn.Linear,
+                    torch.nn.Conv2d,
+                    torch.nn.Conv1d,
+                    torch.nn.ConvTranspose2d,
+                ],
             )
             sequential = [list(full.keys())]
 

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -31,6 +31,136 @@ torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False
 
 
+def convtranspose2d_weights_to_conv2d_weights(layer, w) -> torch.Tensor:
+    if layer.groups == 1:
+        # the last two dimensions of w is (k_h, k_w) to get equivalent Conv2D we need to flip them to get `w_conv2D_equivalent_to_w[i, j] = w_conv[k_h - i - 1, k_w - j - 1]`
+        # the first two dimensions of w is (input_channels, output_channels), so we need to transpose them as Conv2D weights should be in the (output_channels, input_channels) form
+        # please see https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L1059-L1061 for additional info
+        w_conv_transposed = w.transpose(1, 0).flip((-2, -1))
+    else:
+        # basically it's the same as for `layer.groups == 1` but groupwise
+        in_channels, out_channels, kernel_h, kernel_w = layer.weight.shape
+        out_channels *= layer.groups
+        w_conv_transposed = torch.zeros(
+            out_channels, in_channels // layer.groups, kernel_h, kernel_w
+        )
+        for i in range(0, layer.groups):
+            w_conv_transposed[
+                i
+                * out_channels
+                // layer.groups : (i + 1)
+                * out_channels
+                // layer.groups,
+                :,
+                :,
+                :,
+            ] = (
+                w[
+                    i
+                    * in_channels
+                    // layer.groups : (i + 1)
+                    * in_channels
+                    // layer.groups,
+                    :,
+                    :,
+                    :,
+                ]
+                .transpose(1, 0)
+                .flip((-2, -1))
+            )
+
+    return w_conv_transposed
+
+
+def conv2d_weights_to_convtranspose2d_weights(orig_layer, w) -> torch.Tensor:
+    # this is just an inverse of convtranspose2d_weights_to_conv2d_weights
+    if orig_layer.groups > 1:
+        in_channels, out_channels, _, _ = orig_layer.weight.shape
+        out_channels *= orig_layer.groups
+        w_conv_transposed = torch.zeros_like(orig_layer.weight)
+        for i in range(0, orig_layer.groups):
+            w_conv_transposed[
+                i
+                * in_channels
+                // orig_layer.groups : (i + 1)
+                * in_channels
+                // orig_layer.groups,
+                :,
+                :,
+                :,
+            ] = (
+                w[
+                    i
+                    * out_channels
+                    // orig_layer.groups : (i + 1)
+                    * out_channels
+                    // orig_layer.groups,
+                    :,
+                    :,
+                    :,
+                ]
+                .transpose(1, 0)
+                .flip((-2, -1))
+            )
+    else:
+        w_conv_transposed = w.transpose(1, 0).flip((-2, -1))
+
+    return w_conv_transposed
+
+
+def get_matmul_input_for_convtranspose2d(layer, inp):
+    # Please see https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L996-L998 for padding
+    strided_pad = (
+        layer.dilation[0] * (layer.kernel_size[0] - 1) - layer.padding[0],
+        layer.dilation[1] * (layer.kernel_size[1] - 1) - layer.padding[1],
+    )
+
+    # interleave input with zero rows and columns according to stride
+    # Please see https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L991-L994 for more info
+    inp_strided = torch.zeros(
+        inp.shape[0],
+        inp.shape[1],
+        layer.stride[0] * (inp.shape[2] - 1) + 2 * strided_pad[0] + 1,
+        layer.stride[1] * (inp.shape[3] - 1) + 2 * strided_pad[1] + 1,
+        device=inp.device,
+    )
+
+    indices = torch.arange(0, inp.shape[2], device=inp.device)
+    # insert original input values according to stride to meet https://github.com/pytorch/pytorch/blob/d38164a545b4a4e4e0cf73ce67173f70574890b6/torch/nn/modules/conv.py#L991-L994
+    inp_strided[
+        :,
+        :,
+        layer.stride[0] * indices + strided_pad[0],
+        strided_pad[1] : -strided_pad[1] : layer.stride[1],
+    ] = inp[:, :, indices, :]
+    del inp
+    inp = (
+        inp_strided  # so the rest is just processing for Conv2D with transposed weights
+    )
+
+    # TODO reduce code duplication with Conv2D
+    unfold = nn.Unfold(
+        layer.kernel_size,
+        dilation=layer.dilation,
+        padding=(
+            0,
+            0,
+        ),  # equivalent Conv2D has (0, 0) padding for input_strided as input
+        stride=(1, 1),  # equivalent Conv2D has (1, 1) stride for input_strided as input
+    )
+
+    if layer.groups != 1:
+        inp = inp.reshape(
+            inp.size(0) * layer.groups,
+            inp.size(1) // layer.groups,
+            inp.shape[2],
+            inp.shape[3],
+        )  # inp.shape == (batch*groups, in_channels / groups, H, W) to meet Groupwise-wise Convolution, so that each group is colvolved with its own filter
+
+    inp = unfold(inp).permute([1, 0, 2]).flatten(1)
+    return inp
+
+
 class GPTQ:
     def __init__(self, layer):
         self.layer = layer
@@ -38,6 +168,9 @@ class GPTQ:
         W = layer.weight.data.clone()
         if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+        elif isinstance(self.layer, nn.ConvTranspose2d):
+            W = convtranspose2d_weights_to_conv2d_weights(self.layer, W)
+            W = W.flatten(1)
 
         self.rows = W.shape[0]
         self.columns = W.shape[1]
@@ -113,6 +246,9 @@ class GPTQ:
             inp = inp.permute([1, 0, 2])
             inp = inp.flatten(1)
 
+        if isinstance(self.layer, nn.ConvTranspose2d):
+            inp = get_matmul_input_for_convtranspose2d(self.layer, inp)
+
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp
         inp = math.sqrt(2 / self.nsamples) * inp.float()
@@ -130,6 +266,11 @@ class GPTQ:
         W = self.layer.weight.data.clone()
         if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+        elif isinstance(self.layer, nn.ConvTranspose2d):
+            W = convtranspose2d_weights_to_conv2d_weights(self.layer, W)
+            conv2d_shape = W.shape
+            W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+
         W = W.float()
         tick = time.time()
         if not self.quantizer.ready():
@@ -231,6 +372,16 @@ class GPTQ:
                     self.quantizer.zero,
                     self.quantizer.maxq,
                 )
+        elif isinstance(self.layer, nn.ConvTranspose2d):
+            if groupsize == -1:  # TODO support groupsize != -1
+                Q[:, dead] = quantize(
+                    convtranspose2d_weights_to_conv2d_weights(
+                        self.layer, self.layer.weight.data
+                    ).flatten(1)[:, dead],
+                    self.quantizer.scale,
+                    self.quantizer.zero,
+                    self.quantizer.maxq,
+                )
         else:
             if groupsize == -1:  # TODO support groupsize != -1
                 Q[:, dead] = quantize(
@@ -244,9 +395,15 @@ class GPTQ:
             groupsize == -1 or torch.sum(dead) == 0
         )  # TODO `dead` elements should be RTN quantized for groupwise
 
-        self.layer.weight.data = Q.reshape(self.layer.weight.shape).to(
-            self.layer.weight.data.dtype
-        )
+        if isinstance(self.layer, nn.ConvTranspose2d):
+            Q_conv2d = Q.reshape(conv2d_shape).to(self.layer.weight.data.dtype)
+            self.layer.weight.data = conv2d_weights_to_convtranspose2d_weights(
+                self.layer, Q_conv2d
+            )
+        else:
+            self.layer.weight.data = Q.reshape(self.layer.weight.shape).to(
+                self.layer.weight.data.dtype
+            )
 
     def free(self):
         self.H = None

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -194,7 +194,13 @@ class GPTQQuantizer(BaseQuantizer):
         ):
             # 1) Identify quantizable submodules within the layer
             full = find_layers(
-                layer, layers=[torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv1d]
+                layer,
+                layers=[
+                    torch.nn.Linear,
+                    torch.nn.Conv2d,
+                    torch.nn.Conv1d,
+                    torch.nn.ConvTranspose2d,
+                ],
             )
             sequential = [list(full.keys())]
 


### PR DESCRIPTION
This PR enables quantization of `nn.ConvTranspose2D` in FPIGPTQ/GPTQ and adds tests for it.


<details>
<summary>./ccex test --include-internal -k test_gptq</summary>

```
RUN unit tests with -k test_gptq ...
test_groupwise_conv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 9 tests in 42.699s

OK
```

</details>

<details><summary>./ccex test --include-internal -k test_fpi_gptq</summary>

```
RUN unit tests with -k test_fpi_gptq ...
test_groupwise_conv1d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_net (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_net_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... /mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:57: FutureWarning: `torch.export.export_for_training` is deprecated and will be removed in PyTorch 2.10. Please use `torch.export.export` instead, which is functionally equivalent.
  model = torch.export.export_for_training(
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:65: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  model = prepare_pt2e(model, quantizer)
/mnt/storage/slow_repos/TICO/tico/quantization/algorithm/pt2e/quantizer.py:81: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10. 
For migrations of users: 
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead 
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx, please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e) 
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e) 
see https://github.com/pytorch/ao/issues/2259 for more details
  return convert_pt2e(model)
ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_fpi_gptq.FPIGPTQTest) ... ok

----------------------------------------------------------------------
Ran 8 tests in 59.155s

OK
```

</details>

In short:
`ConvTranspose2D` can be converted to `Conv2D` and `Conv2D` is already processed in GPTQs.
Please see idea of conversion justification in TCONV2NCONV.pdf.
[TCONV2NCONV.pdf](https://github.com/user-attachments/files/23923578/TCONV2NCONV.pdf)
Please see #427 for more details.


Please see results in https://github.com/Samsung/TICO/pull/427#issuecomment-3610757064.

Draft: #427
Related: #397

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>