### PR TITLE
Import a module for _decomposed

### DIFF
--- a/tico/serialize/operators/op_dequantize_per_channel.py
+++ b/tico/serialize/operators/op_dequantize_per_channel.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     import torch.fx
 import numpy as np
 import torch
+import torch.ao.quantization.fx._decomposed  # register `dequantize_per_channel`
 from circle_schema import circle
 
 from tico.serialize.circle_graph import CircleSubgraph

--- a/tico/serialize/operators/op_dequantize_per_tensor.py
+++ b/tico/serialize/operators/op_dequantize_per_tensor.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import torch._ops
     import torch.fx
 import torch
-import torch.ao.quantization.fx._decomposed  # register `dequantize_per_tensor``
+import torch.ao.quantization.fx._decomposed  # register `dequantize_per_tensor`
 from circle_schema import circle
 
 from tico.serialize.circle_graph import CircleSubgraph


### PR DESCRIPTION
This commit imports a module for registering _decomposed attributes.

This will resolve the internal CI errors.
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>