### PR TITLE
Import a module for _decomposed

### DIFF
--- a/tico/serialize/operators/op_quantize_per_tensor.py
+++ b/tico/serialize/operators/op_quantize_per_tensor.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     import torch._ops
     import torch.fx
 import torch
+import torch.ao.quantization.fx._decomposed  # register `quantize_per_tensor`
 from circle_schema import circle
 
 from tico.serialize.circle_graph import CircleSubgraph


### PR DESCRIPTION
This commit imports a module for registering _decomposed attributes.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>