### PR TITLE
[quantization] Revisit the way observers manage attributes

### DIFF
--- a/test/quantization/wrapq/test_quant_config.py
+++ b/test/quantization/wrapq/test_quant_config.py
@@ -136,7 +136,7 @@ class TestObserverAndDTypePrecedence(unittest.TestCase):
         """
         qcfg = PTQConfig(
             default_dtype=DType.uint(8),
-            default_observer=MinMaxObserver,
+            default_observer=MinMaxObserver,  # type: ignore[type-abstract]
             overrides={
                 "act_in": {
                     "dtype": DType.uint(4),
@@ -169,7 +169,7 @@ class TestObserverAndDTypePrecedence(unittest.TestCase):
         """
         qcfg = PTQConfig(
             default_dtype=DType.uint(8),
-            default_observer=MinMaxObserver,
+            default_observer=MinMaxObserver,  # type: ignore[type-abstract]
             overrides={
                 # nothing for 'act_out'
             },
@@ -195,7 +195,7 @@ class TestObserverAndDTypePrecedence(unittest.TestCase):
         """
         qcfg = PTQConfig(
             default_dtype=DType.uint(8),
-            default_observer=MinMaxObserver,
+            default_observer=MinMaxObserver,  # type: ignore[type-abstract]
             overrides={
                 "act_in": {
                     "qscheme": QScheme.PER_TENSOR_ASYMM,
@@ -235,7 +235,7 @@ class TestObserverAndDTypePrecedence(unittest.TestCase):
         qcfg = PTQConfig(
             default_dtype=DType.uint(8),
             default_qscheme=QScheme.PER_TENSOR_ASYMM,
-            default_observer=MinMaxObserver,
+            default_observer=MinMaxObserver,  # type: ignore[type-abstract]
             overrides={},
         )
 

--- a/tico/quantization/config/ptq.py
+++ b/tico/quantization/config/ptq.py
@@ -72,7 +72,7 @@ class PTQConfig(BaseConfig):
     """
 
     default_dtype: DType = DType.uint(8)
-    default_observer: Type[ObserverBase] = MinMaxObserver
+    default_observer: Type[ObserverBase] = MinMaxObserver  # type: ignore[type-abstract]
     default_qscheme: QScheme = QScheme.PER_TENSOR_ASYMM
     overrides: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
     # If True, any module that cannot be wrapped will raise.

--- a/tico/quantization/wrapq/observers/base.py
+++ b/tico/quantization/wrapq/observers/base.py
@@ -16,12 +16,13 @@ from abc import ABC, abstractmethod
 from typing import Optional, Tuple
 
 import torch
+import torch.nn as nn
 
 from tico.quantization.wrapq.dtypes import DType, UINT8
 from tico.quantization.wrapq.qscheme import QScheme
 
 
-class ObserverBase(ABC):
+class ObserverBase(nn.Module, ABC):
     """
     Minimal abstract base for all observers/quantizers.
 
@@ -41,12 +42,12 @@ class ObserverBase(ABC):
         qscheme: QScheme = QScheme.PER_TENSOR_ASYMM,
         channel_axis: Optional[int] = None,  # None → per-tensor
     ):
+        super().__init__()
         self.name = name
         self.dtype = dtype
         self.qscheme = qscheme
         self.channel_axis = channel_axis if qscheme.is_per_channel() else None
         self.enabled = True
-        self.reset()
 
     @abstractmethod
     def reset(self) -> None:


### PR DESCRIPTION
This commit makes attributes of observers buffers.

Related: #443 
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>