### PR TITLE
[quantization] Use QuantRMSNorm

### DIFF
--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -29,6 +29,8 @@ _CORE_MODULES = (
     # This includes not only `nn.SiLU` but also `SiLUActivation` from transformers
     # as they are same operation.
     "tico.quantization.wrapq.wrappers.nn.quant_silu",
+    ## ops ##
+    "tico.quantization.wrapq.wrappers.ops.quant_rmsnorm",
     ## llama ##
     "tico.quantization.wrapq.wrappers.llama.quant_attn",
     "tico.quantization.wrapq.wrappers.llama.quant_decoder_layer",

--- a/tico/utils/register_custom_op.py
+++ b/tico/utils/register_custom_op.py
@@ -710,7 +710,7 @@ def CircleRMSNorm():
     def rms_norm(
         hidden_states: torch.Tensor,
         weight: torch.Tensor,
-        eps: float = 1e-05,
+        eps: float = 1e-06,
     ) -> torch.Tensor:
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
@@ -722,7 +722,7 @@ def CircleRMSNorm():
     def _(
         hidden_states: torch.Tensor,
         weight: torch.Tensor,
-        eps: float = 1e-05,
+        eps: float = 1e-06,
     ) -> torch.Tensor:
         return hidden_states.new_empty(hidden_states.size())
 

--- a/tico/utils/validate_args_kwargs.py
+++ b/tico/utils/validate_args_kwargs.py
@@ -200,7 +200,7 @@ class CircleRMSNormArgs:
 
     input: torch.fx.Node
     weight: torch.fx.Node
-    eps: float
+    eps: float = 1e-6
 
 
 @enforce_type


### PR DESCRIPTION
This commit uses QuantRMSNorm in the decoder layer.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>