### PR TITLE
[quantization] Remove outdated test

### DIFF
--- a/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
@@ -94,13 +94,3 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         self.assertGreater(diff, 0.0)
         self.assertLess(diff, 0.5)
         self.assertEqual(fp_out.shape, q_out.shape)
-
-    def test_layernorm_preserved(self):
-        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
-        self.assertIsInstance(
-            qlayer.input_layernorm, type(self.fp_layer.input_layernorm)
-        )
-        self.assertIsInstance(
-            qlayer.post_attention_layernorm,
-            type(self.fp_layer.post_attention_layernorm),
-        )


### PR DESCRIPTION
This commit removes outdated test.
Because `input_layernorm`/`post_attention_layernorm` are quantized.

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>