### PR TITLE
[quantization] Increase the test threshold

### DIFF
--- a/test/quantization/wrapq/utils/test_introspection.py
+++ b/test/quantization/wrapq/utils/test_introspection.py
@@ -179,7 +179,7 @@ class TestSmoothQuantPTQDiff(unittest.TestCase):
             self.assertLessEqual(
                 metric_dict["diff"],
                 3.0,
-                msg=f"{name}: diff={metric_dict['diff']:.3e} > 1.0",
+                msg=f"{name}: diff={metric_dict['diff']:.3e} > 3.0",
             )
 
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
This commit increases the test threshold according to the RMSNorm wrapper.

The quantization of RMSNorm causes some differences. `test_layerwise_diff` test failure will be resolved with this PR.
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>