### PR TITLE
[quantization] Propagate qparam for `expand`

### DIFF
--- a/test/quantization/pass/test_propagate_quant_param.py
+++ b/test/quantization/pass/test_propagate_quant_param.py
@@ -260,3 +260,21 @@ class CatTest(SingleOpPropagateQParamForwardTest):
 
         # The test will check cat's scale is 1.0, the larger one
         self.run_test()
+
+
+class ExpandModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x.expand(5, 3)
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 3),), {}
+
+
+class ExpandTest(SingleOpPropagateQParamForwardTest):
+    # TODO Support u8
+    def test_s16(self):
+        self.setup(ExpandModule(), torch.ops.aten.expand.default, dtype="int16")
+        self.run_test()

--- a/tico/quantization/passes/propagate_qparam_forward.py
+++ b/tico/quantization/passes/propagate_qparam_forward.py
@@ -27,6 +27,7 @@ from tico.utils.passes import PassBase, PassResult
 from tico.utils.trace_decorators import trace_graph_diff_on_pass
 from tico.utils.validate_args_kwargs import (
     CatArgs,
+    ExpandArgs,
     NegArgs,
     PermuteArgs,
     ReshapeArgs,
@@ -130,7 +131,9 @@ class PropagateQParamForward(PassBase):
 
                 assert max_scale_node is not None
                 _propagate_qparam_if_possible(max_scale_node, node)
-
+            elif node.target == torch.ops.aten.expand.default:
+                expand_args = ExpandArgs(*node.args, **node.kwargs)
+                _propagate_qparam_if_possible(expand_args.input, node)
             # TODO Support more ops.
 
         graph.eliminate_dead_code()


### PR DESCRIPTION
This PR propagates `qparam` forward for `torch.ops.aten.expand.default` .

It occurs that `q_i @ k_i.transpose(-2, -1)` expands `k_i` to match `q_i` shape. The `expand` operation is not quantized, so that its output is `float32`. Although `o1 optimizer` from `ONE`  from handle such cases, let's try to support it here.

To find `unquantized` nodes just look for `expand_1` in `Netron` and check its output.

<details> <summary> ./ccex test -k quantization.pass.test_propagate_quant_param.ExpandTest </summary>

```

RUN unit tests with -k quantization.pass.test_propagate_quant_param.ExpandTest ...
test_s16 (quantization.pass.test_propagate_quant_param.ExpandTest) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.011s

OK

```

</details>

Draft: #436
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>