### PR TITLE
[quantization] Introduce wrapper for GELUTanh

### DIFF
--- a/tico/quantization/wrapq/wrappers/quant_elementwise.py
+++ b/tico/quantization/wrapq/wrappers/quant_elementwise.py
@@ -19,7 +19,7 @@ import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
-from tico.quantization.wrapq.wrappers.registry import register
+from tico.quantization.wrapq.wrappers.registry import register, try_register
 
 
 class QuantElementwise(QuantModuleBase):
@@ -119,8 +119,8 @@ def _sigmoid(x: torch.Tensor) -> torch.Tensor:
     return torch.sigmoid(x)
 
 
-def _gelu(x: torch.Tensor) -> torch.Tensor:
-    return torch.nn.functional.gelu(x)
+def _gelu(x: torch.Tensor, approximate="none") -> torch.Tensor:
+    return torch.nn.functional.gelu(x, approximate=approximate)
 
 
 @register(nn.Sigmoid)
@@ -149,3 +149,10 @@ class QuantGELU(QuantElementwise):
     @staticmethod
     def FUNC(x: torch.Tensor) -> torch.Tensor:
         return _gelu(x)
+
+
+@try_register("transformers.activations.GELUTanh")
+class QuantGELUTanh(QuantElementwise):
+    @staticmethod
+    def FUNC(x: torch.Tensor) -> torch.Tensor:
+        return _gelu(x, approximate="tanh")


### PR DESCRIPTION
This change introduces `QuantGELUTanh` wrapper to support post-training quantization of `GELUTanh` operation.

# Why?

`GELUTanh` operation is used in the image encoder part of Qwen model.
Trying to quantize `GELUTanh` via PTQ generates exception `PTQQuantizer: no quantization wrapper for GELUTanh`.

# What

This change introduces:

- Class `QuantGELUTanh` (`tico/quantization/wrapq/wrappers/quant_elementwise.py`) inheriting from `QuantElementwise`.
- Unit tests: add a `GELUTanh` entry to `ACTIVATIONS` list (`test/quantization/wrapq/wrappers/test_quant_elementwise.py`) conditionally (only if `transformers` installed).

# Unit Tests

Unit tests results with coverage information:

```sh
$ coverage run -m pytest test/quantization/wrapq/wrappers/test_quant_elementwise.py -v
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 4 items                                                                                                                                                                                  

test/quantization/wrapq/wrappers/test_quant_elementwise.py::TestElementwiseWrappers::test_dtype_override        PASSED                                                                       [ 25%]
test/quantization/wrapq/wrappers/test_quant_elementwise.py::TestElementwiseWrappers::test_missing_FUNC_raises   PASSED                                                                       [ 50%]
test/quantization/wrapq/wrappers/test_quant_elementwise.py::TestElementwiseWrappers::test_mode_and_forward_diff PASSED                                                                       [ 75%]
test/quantization/wrapq/wrappers/test_quant_elementwise.py::TestElementwiseWrappers::test_registry_and_factory  PASSED                                                                       [100%]

================================================================================== 4 passed, 2 warnings in 6.33s ===================================================================================
```

Coverage info (irrelevant files skipped):
```sh
$ coverage report -m
Name                                                              Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------
...
tico/quantization/wrapq/wrappers/quant_elementwise.py                62      1    98%   39
...
-----------------------------------------------------------------------------------------------
TOTAL                                                             10140   6524    36%
```

# Script for testing quantization and conversion to Circle

```python
#!/usr/bin/env python3

import tico
import torch
import torch.nn as nn
from transformers.activations import GELUTanh
import tico.quantization
import tico.quantization.config.ptq

def generate_calibration_data(batch_size: int, sample_shape) -> list:
    """Generate calibration data for PTQ"""
    calibration_data = []
    for i in range(batch_size):
        x = torch.randn(sample_shape) * 3  # Wider distribution for better tanh coverage
        calibration_data.append(x)
    return calibration_data

def main():
    # Create the custom model
    model = GELUTanh()
    model.eval()

    # Generate calibration data
    # sample_shape for GELUTanh activation (e.g., hidden_size)
    calibration_data = generate_calibration_data(batch_size=20, sample_shape=(128,))

    # Configure PTQ
    ptq_config = tico.quantization.config.ptq.PTQConfig()

    # Prepare the model for quantization
    prepared_model = tico.quantization.prepare(
        model,
        ptq_config,
        inplace=True  # Transform the model in place
    )

    # Calibrate the model (collect statistics)
    with torch.no_grad():
        for i, batch in enumerate(calibration_data):
            prepared_model(batch)

    # Convert to quantized model
    quantized_model = tico.quantization.convert(prepared_model, inplace=True)

    # Convert to Circle format
    # example_inputs shape for GELUTanh activation
    example_inputs = (torch.randn(10, 128) * 3,)  # Batch of 10 samples
    circle_model = tico.convert(quantized_model, example_inputs)

    # Save the Circle model
    filename = 'quantized_gelutanh.circle'
    circle_model.save(filename)
    print(f"Circle model saved as '{filename}'")

if __name__ == "__main__":
    main()
```