### PR TITLE
[quantization] Introduce wrapper for Qwen3VLVisionBlock

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+import warnings
+
+import tico
+
+import torch
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.nn.quant_layernorm import QuantLayerNorm
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_block import (
+    QuantQwen3VLVisionBlock,
+)
+
+
+skip_msg = "transformers not installed — skipping Qwen3VLVisionBlock tests"
+
+
+@unittest.skipUnless(has_transformers_for("qwen3-vl"), skip_msg)
+class TestQuantQwen3VLVisionBlock(unittest.TestCase):
+    fp_block: torch.nn.Module
+    hidden_size: int
+    num_heads: int
+    head_dim: int
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+            Qwen3VLVisionConfig,
+        )
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionBlock
+
+        # Use smaller sizes for testing
+        cfg = Qwen3VLVisionConfig(
+            hidden_size=64,
+            num_heads=4,
+        )
+
+        # Ensure eager attention implementation so outputs are deterministic
+        # and do not require GPU flash attention kernels.
+        # Some versions use `_attn_implementation`, others expose `attn_implementation`.
+        if not hasattr(cfg, "_attn_implementation"):
+            setattr(cfg, "_attn_implementation", "eager")
+        else:
+            cfg._attn_implementation = "eager"
+
+        cls.fp_block = Qwen3VLVisionBlock(cfg)
+        cls.hidden_size = cfg.hidden_size
+        cls.num_heads = cfg.num_heads
+        cls.head_dim = cls.hidden_size // cls.num_heads
+
+    def _rand_rope(self, seq_len):
+        """Helper to create dummy rotary position embeddings"""
+        emb = torch.randn(seq_len, self.head_dim)
+        return emb.cos(), emb.sin()
+
+    def _create_test_inputs(self, num_patches=32):
+        """Helper to create test inputs for VisionBlock."""
+        hidden_states = torch.randn(num_patches, self.hidden_size)
+        # For testing, use a single chunk (no splitting) to avoid position embedding mismatch
+        cu_seqlens = torch.tensor([0, num_patches])
+        position_embeddings = self._rand_rope(num_patches)
+        return hidden_states, cu_seqlens, position_embeddings
+
+    def test_mode_transitions(self):
+        """Test quantization mode transitions: NO_QUANT → CALIB → QUANT"""
+        q_block = QuantQwen3VLVisionBlock(self.fp_block)
+        self.assertIs(q_block._mode, Mode.NO_QUANT)
+
+        q_block.enable_calibration()
+        self.assertIs(q_block._mode, Mode.CALIB)
+
+        # Run forward pass during calibration
+        hidden_states, cu_seqlens, pos_emb = self._create_test_inputs()
+        _ = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+        q_block.freeze_qparams()
+        self.assertIs(q_block._mode, Mode.QUANT)
+
+    def test_forward_diff(self):
+        """
+        Test that quantized output is acceptably close to FP32 reference.
+        """
+        torch.manual_seed(42)
+        q_block = QuantQwen3VLVisionBlock(self.fp_block)
+        q_block.enable_calibration()
+
+        # Calibrate with multiple inputs
+        for _ in range(4):
+            hidden_states, cu_seqlens, pos_emb = self._create_test_inputs()
+            _ = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+        q_block.freeze_qparams()
+
+        hidden_states, cu_seqlens, pos_emb = self._create_test_inputs()
+        with torch.no_grad():
+            q_out = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+            fp_out = self.fp_block(
+                hidden_states, cu_seqlens, position_embeddings=pos_emb
+            )
+
+        self.assertEqual(fp_out.shape, q_out.shape)
+        diff = (fp_out - q_out).abs().mean().item()
+        self.assertGreater(diff, 0.0)  # not identical
+        self.assertLess(diff, 0.7)  # acceptably close
+
+    def test_registration_in_registry(self):
+        """
+        Test that Qwen3VLVisionBlock is properly registered.
+        """
+        from tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_block import (
+            QuantQwen3VLVisionBlock,
+        )
+        from tico.quantization.wrapq.wrappers.registry import lookup
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionBlock
+
+        wrapper_cls = lookup(Qwen3VLVisionBlock)
+        self.assertIs(wrapper_cls, QuantQwen3VLVisionBlock)
+
+    def test_output_shape(self):
+        """
+        Test that output shape is preserved.
+        Input: (num_patches, hidden_size)
+        Output: (num_patches, hidden_size)
+        """
+        q_block = QuantQwen3VLVisionBlock(self.fp_block)
+        q_block.enable_calibration()
+
+        num_patches = 32
+        hidden_states, cu_seqlens, pos_emb = self._create_test_inputs(num_patches)
+        _ = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+        q_block.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+            fp_out = self.fp_block(
+                hidden_states, cu_seqlens, position_embeddings=pos_emb
+            )
+
+        expected_shape = (num_patches, self.hidden_size)
+        self.assertEqual(q_out.shape, expected_shape)
+        self.assertEqual(fp_out.shape, expected_shape)
+
+    def test_residual_connection_preservation(self):
+        """
+        Test that residual connections are preserved (output close to input + transformation).
+        """
+        q_block = QuantQwen3VLVisionBlock(self.fp_block)
+        q_block.enable_calibration()
+
+        hidden_states, cu_seqlens, pos_emb = self._create_test_inputs()
+        _ = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+        q_block.freeze_qparams()
+
+        with torch.no_grad():
+            # Save input
+            input_copy = hidden_states.clone()
+
+            # Run forward pass
+            output = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+        # Output should be different from input (transformation applied)
+        self.assertFalse(torch.equal(output, input_copy))
+
+        # But shape should be preserved
+        self.assertEqual(output.shape, input_copy.shape)
+
+    def test_different_num_patches(self):
+        """
+        Test that quantization works correctly with different numbers of patches.
+        """
+        q_block = QuantQwen3VLVisionBlock(self.fp_block)
+        q_block.enable_calibration()
+
+        # Calibrate with one size
+        calibrate_hidden, calibrate_cu, pos_emb = self._create_test_inputs(32)
+        for _ in range(3):
+            _ = q_block(calibrate_hidden, calibrate_cu, position_embeddings=pos_emb)
+        q_block.freeze_qparams()
+
+        # Test with different sizes
+        for num_patches in [16, 32, 64]:
+            hidden_states, cu_seqlens, pos_emb = self._create_test_inputs(num_patches)
+            with torch.no_grad():
+                q_out = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+                fp_out = self.fp_block(
+                    hidden_states, cu_seqlens, position_embeddings=pos_emb
+                )
+
+            self.assertEqual(q_out.shape[0], num_patches)
+            self.assertEqual(q_out.shape[1], self.hidden_size)
+            diff = (fp_out - q_out).abs().mean().item()
+            self.assertLess(diff, 0.7)
+
+    def test_observer_count(self):
+        """
+        Test that the wrapper has the correct number of observers.
+        - 3 local observers (input, post_attn, output)
+        """
+        q_block = QuantQwen3VLVisionBlock(self.fp_block)
+        q_block.enable_calibration()
+
+        # Calibrate to ensure observers are initialized
+        hidden_states, cu_seqlens, pos_emb = self._create_test_inputs()
+        _ = q_block(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+        q_block.freeze_qparams()
+
+        observers = list(q_block._all_observers())
+        # Should have 3 local + submodules' observers
+        self.assertEqual(len(observers), 3)

--- a/tico/quantization/wrapq/examples/qwen/quantize_vision_block.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_vision_block.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import importlib.util
+import sys
+
+import torch
+import torch.nn as nn
+
+import tico
+import tico.quantization
+import tico.quantization.config.ptq
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.evaluation.utils import plot_two_outputs
+
+# Check if transformers is available
+trans_spec = importlib.util.find_spec("transformers")
+if trans_spec is None:
+    print("Error: transformers package not installed. Cannot test Qwen3VLVisionBlock.")
+    sys.exit(1)
+
+from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLVisionConfig
+from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionBlock
+
+
+def generate_calibration_data(
+    batch_size: int, num_patches: int, hidden_size: int
+) -> list:
+    """Generate calibration data for PTQ"""
+    calibration_data = []
+    for i in range(batch_size):
+        hidden_states = torch.randn(num_patches, hidden_size)
+        calibration_data.append(hidden_states)
+    return calibration_data
+
+
+def rand_rope(seq_len, head_dim):
+    """Helper to create dummy rotary position embeddings"""
+    emb = torch.randn(seq_len, head_dim)
+    return emb.cos(), emb.sin()
+
+
+def main():
+    # Create the vision block model
+    cfg = Qwen3VLVisionConfig(
+        hidden_size=1024,
+        num_heads=16,
+    )
+    # Ensure eager attention implementation so outputs are deterministic
+    # and do not require GPU flash attention kernels.
+    # Some versions use `_attn_implementation`, others expose `attn_implementation`.
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+
+    model = Qwen3VLVisionBlock(cfg)
+    orig_model = copy.deepcopy(model)
+    model.eval()
+
+    # Generate calibration data
+    # Input shape: (num_patches, hidden_size)
+    # Example: (256, 1024) - 256 patches from 2 videos (2*8*16=256)
+    # cu_seqlens: Cumulative sequence lengths for handling variable-length sequences
+    num_patches = 256
+    hidden_size = cfg.hidden_size
+    head_dim = hidden_size // cfg.num_heads
+    cu_seqlens = torch.tensor([0, num_patches])
+    calibration_data = generate_calibration_data(
+        batch_size=20, num_patches=num_patches, hidden_size=hidden_size
+    )
+    pos_emb = rand_rope(num_patches, head_dim)
+
+    # Configure PTQ
+    ptq_config = tico.quantization.config.ptq.PTQConfig()
+
+    # Prepare the model for quantization
+    prepared_model = tico.quantization.prepare(
+        model, ptq_config, inplace=True  # Transform the model in place
+    )
+
+    # Calibrate the model (collect statistics)
+    with torch.no_grad():
+        for i, hidden_states in enumerate(calibration_data):
+            prepared_model(hidden_states, cu_seqlens, position_embeddings=pos_emb)
+
+    # Convert to quantized model
+    quantized_model = tico.quantization.convert(prepared_model, inplace=True)
+
+    # Compute PEIR (Peak Error-to-Input Ratio) between quantized model and original model
+    with torch.no_grad():
+        test_hidden = calibration_data[0]
+        quant_out = quantized_model(
+            test_hidden, cu_seqlens, position_embeddings=pos_emb
+        )
+        fp_out = orig_model(test_hidden, cu_seqlens, position_embeddings=pos_emb)
+
+    print(f"┌───────────── Quantization Error Summary ─────────────")
+    print(f"│ Mean |diff|: {(quant_out - fp_out).abs().mean().item():.6f}")
+    print(f"│ PEIR       : {compute_peir(fp_out, quant_out) * 100:.6f} %")
+    print(f"└──────────────────────────────────────────────────────")
+    print(plot_two_outputs(fp_out, quant_out))
+
+    # Convert to Circle format
+    # example_inputs: tuple containing (hidden_states, cu_seqlens)
+    example_input = (calibration_data[0], cu_seqlens, None, pos_emb)
+    circle_model = tico.convert(quantized_model, example_input)
+
+    # Save the Circle model
+    filename = "quantized_vision_block.circle"
+    circle_model.save(filename)
+    print(f"Circle model saved as '{filename}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+@try_register(
+    "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLVisionBlock",
+)
+class QuantQwen3VLVisionBlock(QuantModuleBase):
+    """
+    Quantization wrapper for Qwen3VLVisionBlock module.
+
+    This is a Transformer encoder block for vision processing, containing:
+    - 2 LayerNorm layers (pre-norm architecture)
+    - 1 Self-Attention module
+    - 1 MLP (Feed-Forward Network)
+    - 2 Residual connections
+    """
+
+    def __init__(
+        self,
+        fp_block: nn.Module,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ):
+        super().__init__(qcfg, fp_name=fp_name)
+
+        assert hasattr(fp_block, "norm1") and isinstance(fp_block.norm1, nn.LayerNorm)
+        assert hasattr(fp_block, "norm2") and isinstance(fp_block.norm2, nn.LayerNorm)
+        assert hasattr(fp_block, "attn")
+        assert hasattr(fp_block, "mlp")
+
+        # --- Wrap submodules via PTQWrapper ----------------------------------
+        norm1_cfg = qcfg.child("norm1") if qcfg else None
+        norm2_cfg = qcfg.child("norm2") if qcfg else None
+        attn_cfg = qcfg.child("attn") if qcfg else None
+        mlp_cfg = qcfg.child("mlp") if qcfg else None
+
+        self.norm1 = PTQWrapper(
+            fp_block.norm1,
+            qcfg=norm1_cfg,
+            fp_name=f"{fp_name}.norm1",
+        )
+
+        self.norm2 = PTQWrapper(
+            fp_block.norm2,
+            qcfg=norm2_cfg,
+            fp_name=f"{fp_name}.norm2",
+        )
+
+        self.attn = PTQWrapper(
+            fp_block.attn,
+            qcfg=attn_cfg,
+            fp_name=f"{fp_name}.attn",
+        )
+
+        self.mlp = PTQWrapper(
+            fp_block.mlp,
+            qcfg=mlp_cfg,
+            fp_name=f"{fp_name}.mlp",
+        )
+
+        # --- Observers for residual additions ----------------------------------
+        mk = self._make_obs
+        self.obs_act_in = mk("act_in")
+        self.obs_post_attn = mk("post_attn")
+        self.obs_act_out = mk("act_out")
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Forward pass with fake quantization.
+
+        Args:
+            hidden_states: Input tensor of shape (num_patches, hidden_size)
+            cu_seqlens: Cumulative sequence lengths
+            rotary_pos_emb: rotary position embeddings (optional)
+            position_embeddings: (cos, sin) position embeddings (optional)
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            Transformed features of shape (num_patches, hidden_size)
+        """
+        # Quantize input activation
+        hidden_states = self._fq(hidden_states, self.obs_act_in)
+
+        # Save input for residual connection
+        residual = hidden_states
+
+        # Pre-attention normalization
+        hidden_states = self.norm1(hidden_states)
+
+        # Self-attention
+        hidden_states = self.attn(
+            hidden_states,
+            cu_seqlens=cu_seqlens,
+            rotary_pos_emb=rotary_pos_emb,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+
+        # Post-attention residual connection
+        hidden_states = hidden_states + residual
+        hidden_states = self._fq(hidden_states, self.obs_post_attn)
+
+        # Save for MLP residual connection
+        residual = hidden_states
+
+        # Pre-MLP normalization
+        hidden_states = self.norm2(hidden_states)
+
+        # Feed-Forward Network (MLP)
+        hidden_states = self.mlp(hidden_states)
+
+        # Post-MLP residual connection
+        hidden_states = hidden_states + residual
+
+        # Quantize output activation
+        hidden_states = self._fq(hidden_states, self.obs_act_out)
+
+        return hidden_states
+
+    def _all_observers(self) -> Iterable:
+        """Yield all observers from this module and wrapped submodules."""
+        # Local observers for residual connections
+        yield from (
+            self.obs_act_in,
+            self.obs_post_attn,
+            self.obs_act_out,
+        )

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -51,6 +51,7 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_mlp",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_patch_embed",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_patch_merger",
+    "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_block",
     # add future core wrappers here
 )
 


### PR DESCRIPTION
This change introduces `QuantQwen3VLVisionBlock` wrapper to support post-training quantization of `Qwen3VLVisionBlock` module.

# Why?

`Qwen3VLVisionBlock` module is used in the image encoder part of Qwen model.
Trying to quantize `Qwen3VLVisionBlock` via PTQ generates exception `PTQQuantizer: no quantization wrapper for Qwen3VLVisionBlock`.

# What

This change introduces:

- Class `QuantQwen3VLVisionBlock` (`tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py`).
- Unit tests: `class TestQuantQwen3VLVisionBlock` (`test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py`) - skipped if `transformers` package is not installed.
- New entry in `_CORE_MODULES` (`tico/quantization/wrapq/wrappers/registry.py`).
- Example of `Qwen3VLVisionBlock` quantization and conversion to Circle (`tico/quantization/wrapq/examples/qwen/quantize_vision_block.py`).

# Unit Tests

Below unit tests run is presented along with coverage information (irrelevant files replaced with ellipsis ...):
```sh
$ coverage run -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py -v
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 7 items                                                                                                                                                                                  

test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_different_num_patches            PASSED                                               [ 14%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_forward_diff                     PASSED                                               [ 28%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_mode_transitions                 PASSED                                               [ 42%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_observer_count                   PASSED                                               [ 57%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_output_shape                     PASSED                                               [ 71%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_registration_in_registry         PASSED                                               [ 85%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_block.py::TestQuantQwen3VLVisionBlock::test_residual_connection_preservation PASSED                                               [100%]

================================================================================== 7 passed, 2 warnings in 7.21s ===================================================================================
```

```sh
$ coverage report -m
Name                                                                    Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------
...
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py             42      0   100%
...
-----------------------------------------------------------------------------------------------------
TOTAL                                                                   10670   6671    37%
```

# Example Script

```sh
$ python3 tico/quantization/wrapq/examples/qwen/quantize_vision_block.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.139611
│ PEIR       : 8.666391 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 5.4┤                                            │
    │                                        ••  │
    │                                     •• •   │
 3.6┤                                  ••••••    │
    │                                 ••••••     │
    │                              ••••••        │
    │                           ••••••••         │
 1.9┤                          •••••••           │
    │                       ••••••••             │
    │                     ••••••••               │
 0.1┤                   ••••••••                 │
    │                 ••••••••                   │
    │              •••••••••                     │
    │             ••••••••                       │
-1.6┤           ••••••••                         │
    │          ••••••                            │
    │       ••••••••                             │
-3.4┤      ••••••                                │
    │    •••••                                   │
    │  •••••                                     │
    │                                            │
-5.1┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -5.1       -2.5        0.1       2.8       5.4 


Circle model saved as 'quantized_vision_block.circle'
```