### PR TITLE
[github] Use Python 3.12

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: "Run configure"
         run: |


### PR DESCRIPTION
This commit uses Python 3.12 for linter.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>