### PR TITLE
[quantization] Introduce wrapper for Qwen3VLTextMLP

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_mlp.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_mlp.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import tempfile
+import unittest
+import warnings
+
+import tico
+
+import torch
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_mlp import QuantQwen3VLTextMLP
+
+
+skip_msg = "required transformers not installed — skipping Qwen3VLTextMLP tests"
+
+
+class DummyTextMLP(torch.nn.Module):
+    """Tiny stand-in for Qwen3VLTextMLP (hidden=4, inter=8)."""
+
+    def __init__(self):
+        super().__init__()
+        self.hidden_size = 4
+        self.intermediate_size = 8
+        self.gate_proj = torch.nn.Linear(4, 8, bias=False)
+        self.up_proj = torch.nn.Linear(4, 8, bias=False)
+        self.down_proj = torch.nn.Linear(8, 4, bias=False)
+        self.act_fn = torch.nn.SiLU()
+
+    def forward(self, x):
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+@unittest.skipUnless(has_transformers_for("qwen3-vl"), skip_msg)
+class TestQuantQwen3VLTextMLP(unittest.TestCase):
+    mlp_fp: torch.nn.Module
+    hidden_size: int
+    intermediate_size: int
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+            Qwen3VLTextConfig,
+        )
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLTextMLP
+
+        cfg = Qwen3VLTextConfig(
+            hidden_size=4,
+            intermediate_size=8,
+            hidden_act="silu",
+        )
+
+        cls.mlp_fp = Qwen3VLTextMLP(cfg)
+        cls.hidden_size = cfg.hidden_size
+        cls.intermediate_size = cfg.intermediate_size
+
+    def test_mode_transitions(self):
+        qmlp = QuantQwen3VLTextMLP(self.mlp_fp)
+        self.assertIs(qmlp._mode, Mode.NO_QUANT)
+
+        qmlp.enable_calibration()
+        self.assertIs(qmlp._mode, Mode.CALIB)
+
+        x = torch.randn(2, 5, self.hidden_size)
+        _ = qmlp(x)
+
+        qmlp.freeze_qparams()
+        self.assertIs(qmlp._mode, Mode.QUANT)
+
+    def test_forward_diff(self):
+        qmlp = QuantQwen3VLTextMLP(self.mlp_fp)
+        qmlp.enable_calibration()
+        for _ in range(4):
+            inp = torch.randn(2, 6, self.hidden_size)
+            _ = qmlp(inp)
+        qmlp.freeze_qparams()
+
+        x = torch.randn(2, 6, self.hidden_size)
+        with torch.no_grad():
+            q_out = qmlp(x)
+            fp_out = self.mlp_fp(x)
+
+        diff = (fp_out - q_out).abs().mean().item()
+        self.assertGreater(diff, 0.0)
+        self.assertLess(diff, 0.4)
+        self.assertEqual(fp_out.shape, q_out.shape)
+
+    def test_per_projection_override(self):
+        cfg = PTQConfig(
+            default_dtype=DType.uint(8),
+            overrides={
+                "gate_proj": {
+                    "act_in": {"dtype": DType.uint(4)},
+                    "act_out": {"dtype": DType.uint(4)},
+                }
+            },
+        )
+        qmlp = QuantQwen3VLTextMLP(self.mlp_fp, qcfg=cfg)
+        q_lin = qmlp.gate_proj.wrapped
+
+        self.assertIsInstance(q_lin, QuantLinear)
+        self.assertEqual(q_lin.obs_act_in.dtype, DType.uint(4))
+        self.assertEqual(q_lin.obs_act_out.dtype, DType.uint(4))
+
+
+class TestSubgraphExport(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.mlp_int8 = QuantQwen3VLTextMLP(DummyTextMLP()).eval()
+        self.x = torch.randn(16, 4)
+
+    def test_calib_quant_export(self):
+        # calib
+        self.mlp_int8.enable_calibration()
+        _ = self.mlp_int8(self.x)
+        self.mlp_int8.freeze_qparams()
+
+        self.assertIs(self.mlp_int8._mode, Mode.QUANT)
+
+        # export
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "mlp.circle"
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning)
+                exported = tico.convert(self.mlp_int8, (self.x[:1],))
+            exported.save(path)
+            self.assertTrue(path.exists())

--- a/tico/quantization/wrapq/examples/qwen/quantize_qwen_text_mlp.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_qwen_text_mlp.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+import torch
+from transformers import AutoModelForVision2Seq, AutoTokenizer
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.evaluation.utils import plot_two_outputs
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_mlp import QuantQwen3VLTextMLP
+from tico.utils.utils import SuppressWarning
+
+# -------------------------------------------------------------------------
+# 0. Load a Qwen3-VL model (text tower) + tokenizer
+# -------------------------------------------------------------------------
+name = "Qwen/Qwen3-VL-2B-Instruct"
+model = AutoModelForVision2Seq.from_pretrained(
+    name,
+    device_map="cpu",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(name, trust_remote_code=True)
+
+# Make sure pad token exists (Llama often uses eos as pad)
+if tokenizer.pad_token_id is None:
+    tokenizer.pad_token = tokenizer.eos_token
+
+"""
+As max_seq increases, the proportion of padded tokens grows, 
+ which directly affects calibration statistics and tends to increase PEIR.
+
+This is not a modeling issue but a calibration artifact: 
+ observers see a distribution dominated by padding rather than real tokens.
+
+For a more representative and realistic accuracy evaluation, 
+the calibration dataset should be adjusted (e.g., longer or more diverse 
+ sequence lengths, or padding-aware calibration) so that activation 
+statistics better reflect actual inference workloads.
+"""
+MAX_SEQ = 128
+text_cfg = model.config.text_config
+text_cfg.max_position_embeddings = MAX_SEQ
+
+# -------------------------------------------------------------------------
+# 1. Replace layer-0's MLP with QuantQwen3VLTextMLP
+# -------------------------------------------------------------------------
+orig_mlp = model.model.language_model.layers[0].mlp
+mlp_q = prepare(orig_mlp, PTQConfig())
+mlp_q.eval()
+
+assert isinstance(mlp_q.wrapped, QuantQwen3VLTextMLP)
+
+# -------------------------------------------------------------------------
+# 2. Single-pass calibration
+# -------------------------------------------------------------------------
+CALIB_TENSORS = []
+for _ in range(10):
+    ct = torch.randn(5, MAX_SEQ, text_cfg.hidden_size)
+    CALIB_TENSORS.append(ct)
+
+with torch.no_grad():
+    for ct in CALIB_TENSORS:
+        _ = mlp_q(ct)
+
+convert(mlp_q)
+assert mlp_q._mode is Mode.QUANT, "Quantization mode should be active now."
+
+# -------------------------------------------------------------------------
+# 3. Quick diff check (INT-sim vs FP32)
+# -------------------------------------------------------------------------
+hidden = CALIB_TENSORS[3]
+
+with torch.no_grad():
+    quant_out = mlp_q(hidden)
+    fp_out = orig_mlp(hidden)
+
+print("┌───────────── Quantization Error Summary ─────────────")
+print(f"│ Mean |diff|: {(quant_out - fp_out).abs().mean().item():.6f}")
+print(f"│ PEIR       : {compute_peir(fp_out, quant_out) * 100:.6f} %")
+print("└──────────────────────────────────────────────────────")
+print(plot_two_outputs(fp_out, quant_out))
+
+# -------------------------------------------------------------------------
+# 4. Export the quantized block
+# -------------------------------------------------------------------------
+import tico
+
+save_path = pathlib.Path("qwen3vl_text_mlp.q.circle")
+B, S, D = 1, MAX_SEQ, text_cfg.hidden_size
+example = torch.randn(B, S, D)
+
+with SuppressWarning(UserWarning, ".*"):
+    cm = tico.convert(mlp_q, (example,))
+cm.save(save_path)
+
+print(f"Quantized Circle model saved to {save_path.resolve()}")

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+@try_register(
+    "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLTextMLP",
+)
+class QuantQwen3VLTextMLP(QuantModuleBase):
+    def __init__(
+        self,
+        mlp_fp: nn.Module,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ):
+        super().__init__(qcfg, fp_name=fp_name)
+
+        # Configure child modules with specific quantization configs if provided
+        gate_proj_cfg = qcfg.child("gate_proj") if qcfg else None
+        up_proj_cfg = qcfg.child("up_proj") if qcfg else None
+        down_proj_cfg = qcfg.child("down_proj") if qcfg else None
+        act_fn_cfg = qcfg.child("act_fn") if qcfg else None
+
+        # ----- wrap Linear layers -------------------------------
+        assert hasattr(mlp_fp, "gate_proj") and isinstance(mlp_fp.gate_proj, nn.Module)
+        assert hasattr(mlp_fp, "up_proj") and isinstance(mlp_fp.up_proj, nn.Module)
+        assert hasattr(mlp_fp, "down_proj") and isinstance(mlp_fp.down_proj, nn.Module)
+
+        self.gate_proj = PTQWrapper(
+            mlp_fp.gate_proj, qcfg=gate_proj_cfg, fp_name=f"{fp_name}.gate_proj"
+        )
+        self.up_proj = PTQWrapper(
+            mlp_fp.up_proj, qcfg=up_proj_cfg, fp_name=f"{fp_name}.up_proj"
+        )
+        self.down_proj = PTQWrapper(
+            mlp_fp.down_proj, qcfg=down_proj_cfg, fp_name=f"{fp_name}.down_proj"
+        )
+
+        # ----- activation function ---------------------------------------------
+        assert hasattr(mlp_fp, "act_fn") and isinstance(mlp_fp.act_fn, nn.Module)
+        self.act_fn = PTQWrapper(
+            mlp_fp.act_fn, qcfg=act_fn_cfg, fp_name=f"{fp_name}.act_fn"
+        )
+
+        # ----- local observers for intermediate activations --------------------
+        # Observer for input activations
+        mk = self._make_obs
+        self.obs_act_in = mk("act_in")
+
+        # Observer for intermediate values in the gating mechanism
+        self.obs_gated_out = mk("gated_out")
+
+        # Observer for final output
+        self.obs_act_out = mk("act_out")
+
+    def forward(self, hidden_state):
+        # Quantize input once
+        x_q = self._fq(hidden_state, self.obs_act_in)
+
+        # Apply gate projection
+        gate_proj_out = self.gate_proj(x_q)
+
+        # Apply up projection
+        up_proj_out = self.up_proj(x_q)
+
+        # Apply activation function to gate projection
+        act_fn_out = self.act_fn(gate_proj_out)
+
+        # Gating mechanism: multiply activated gate with up projection
+        gated_out = act_fn_out * up_proj_out
+        gated_out = self._fq(gated_out, self.obs_gated_out)
+
+        # Apply down projection
+        h = self.down_proj(gated_out)
+        h = self._fq(h, self.obs_act_out)
+
+        return h
+
+    def _all_observers(self) -> Iterable:
+        # Yield local observers
+        yield self.obs_act_in
+        yield self.obs_gated_out
+        yield self.obs_act_out
+
+        # Recurse into children that are QuantModuleBase
+        for m in (self.gate_proj, self.up_proj, self.down_proj, self.act_fn):
+            yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -44,6 +44,7 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.fairseq.quant_mha",
     ## qwen_vl ##
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_attn",
+    "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_mlp",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_attn",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_mlp",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_patch_embed",


### PR DESCRIPTION
This change introduces QuantQwen3VLTextMLP wrapper to support post-training quantization of Qwen3VLTextMLP module.

TICO-DCO-1.0-Signed-off-by: f.zakharov <f.zakharov@partner.samsung.com>