### PR TITLE
[quantization] Add `eval_tasks` option

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -36,6 +36,7 @@ from typing import Any, List, Optional, Tuple, Union
 import torch
 import tqdm
 from datasets import load_dataset
+from lm_eval.utils import make_table
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from transformers.cache_utils import Cache
@@ -48,6 +49,7 @@ import tico
 from tico.quantization import convert, prepare
 from tico.quantization.config.gptq import GPTQConfig
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.evaluation.script.llm_tasks_eval import evaluate_llm_on_tasks
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
 from tico.quantization.wrapq.qscheme import QScheme
@@ -364,6 +366,11 @@ def evaluate(q_m, tokenizer, dataset_test, args):
     print(f"│ int16 : {ppl_uint8:8.2f}")
     print("└───────────────────────────────────────────")
 
+    if args.eval_tasks is not None:
+        results = evaluate_llm_on_tasks(q_m, tokenizer, args.eval_tasks)
+        print("Quantized RESULTS ARE:")
+        print(make_table(results))
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -520,6 +527,11 @@ def main():
     print("\n┌── Wikitext-2 test perplexity ─────────────")
     print(f"│ FP32 : {ppl_fp32:8.2f}")
     print("└───────────────────────────────────────────")
+
+    if args.eval_tasks is not None:
+        results = evaluate_llm_on_tasks(model, tokenizer, args.eval_tasks)
+        print("Original RESULTS ARE:")
+        print(make_table(results))
 
     # -------------------------------------------------------------------------
     # Prepare calibration dataset


### PR DESCRIPTION
This PR adds `eval_tasks` option to the full model quantization script. It will allow users to estimate accuracy of quantization.

<details> <summary> Run `python  --model Maykeye/TinyLLama-v0 --eval_tasks "arc_easy,arc_challenge" `</summary>

```

Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_PTQ=False, save_circle_to_folder='.', cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse=False, max_seq_len=256, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks='arc_easy,arc_challenge')
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊| 1267/1268 [00:23<00:00, 54.62it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  6848.98
└───────────────────────────────────────────
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1172/1172 [00:12<00:00, 95.52it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2376/2376 [00:24<00:00, 98.19it/s]
Running loglikelihood requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14188/14188 [03:31<00:00, 67.11it/s]
Original RESULTS ARE:
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.1937|±  |0.0115|
|             |       |none  |     0|acc_norm|↑  |0.2253|±  |0.0122|
|arc_easy     |      1|none  |     0|acc     |↑  |0.2572|±  |0.0090|
|             |       |none  |     0|acc_norm|↑  |0.2563|±  |0.0090|

Applying GPTQ …
Quantizing layers: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:06<00:00,  1.15layer/s]
Wrapping layers with PTQWrapper …                                                                                                                                                                                                                                                       
Calibrating PTQ obeservers…
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:58<00:00,  2.17it/s]

Calculating perplexities …
PPL: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊| 1267/1268 [05:19<00:00,  3.96it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  6690.81
└───────────────────────────────────────────
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1172/1172 [00:10<00:00, 111.59it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2376/2376 [00:19<00:00, 123.86it/s]
Running loglikelihood requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14188/14188 [49:28<00:00,  4.78it/s]
Quantized RESULTS ARE:
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.1971|±  |0.0116|
|             |       |none  |     0|acc_norm|↑  |0.2235|±  |0.0122|
|arc_easy     |      1|none  |     0|acc     |↑  |0.2614|±  |0.0090|
|             |       |none  |     0|acc_norm|↑  |0.2580|±  |0.0090|

```

</details>

Draft: #436 
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>