### PR TITLE
[quantization] Load models with float32 dtype in examples

### DIFF
--- a/tico/quantization/wrapq/examples/debug_quant_outputs.py
+++ b/tico/quantization/wrapq/examples/debug_quant_outputs.py
@@ -59,8 +59,9 @@ TOKENS: dict[str, int] = {
 
 DTYPE_MAP = {
     "float32": torch.float32,
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
+    # TODO Support more dtypes
+    # "bfloat16": torch.bfloat16,
+    # "float16": torch.float16,
 }
 
 # Hardcoded dataset settings

--- a/tico/quantization/wrapq/examples/llama/quantize_llama_attn.py
+++ b/tico/quantization/wrapq/examples/llama/quantize_llama_attn.py
@@ -26,7 +26,7 @@ from tico.quantization.wrapq.wrappers.llama.quant_attn import QuantLlamaAttentio
 from tico.utils.utils import SuppressWarning
 
 name = "Maykeye/TinyLLama-v0"
-model = AutoModelForCausalLM.from_pretrained(name)
+model = AutoModelForCausalLM.from_pretrained(name, dtype=torch.float32)
 tokenizer = AutoTokenizer.from_pretrained(name)
 
 # -------------------------------------------------------------------------

--- a/tico/quantization/wrapq/examples/llama/quantize_llama_mlp.py
+++ b/tico/quantization/wrapq/examples/llama/quantize_llama_mlp.py
@@ -29,7 +29,7 @@ from tico.quantization.wrapq.wrappers.llama.quant_mlp import QuantLlamaMLP
 from tico.utils.utils import SuppressWarning
 
 name = "Maykeye/TinyLLama-v0"
-model = AutoModelForCausalLM.from_pretrained(name)
+model = AutoModelForCausalLM.from_pretrained(name, dtype=torch.float32)
 tokenizer = AutoTokenizer.from_pretrained(name)
 model.eval()
 

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -60,8 +60,9 @@ from tico.utils.utils import SuppressWarning
 
 DTYPE_MAP = {
     "float32": torch.float32,
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
+    # TODO Support more dtypes
+    # "bfloat16": torch.bfloat16,
+    # "float16": torch.float16,
 }
 
 # Hardcoded dataset settings

--- a/tico/quantization/wrapq/examples/quantize_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_with_gptq.py
@@ -55,8 +55,9 @@ TOKENS: dict[str, int] = {
 
 DTYPE_MAP = {
     "float32": torch.float32,
-    "bfloat16": torch.bfloat16,
-    "float16": torch.float16,
+    # TODO Support more dtypes
+    # "bfloat16": torch.bfloat16,
+    # "float16": torch.float16,
 }
 
 # Hardcoded dataset settings

--- a/tico/quantization/wrapq/examples/qwen/quantize_qwen_text_attn.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_qwen_text_attn.py
@@ -35,6 +35,7 @@ model = AutoModelForVision2Seq.from_pretrained(
     name,
     device_map="cpu",
     trust_remote_code=True,
+    dtype=torch.float32,
 )
 tokenizer = AutoTokenizer.from_pretrained(name, trust_remote_code=True)
 


### PR DESCRIPTION
This commit loads models with float32 dtype in examples.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>