### PR TITLE
[quantization] Fix evaluation of quantized model

### DIFF
--- a/tico/quantization/evaluation/script/llm_tasks_eval.py
+++ b/tico/quantization/evaluation/script/llm_tasks_eval.py
@@ -23,8 +23,10 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
 def evaluate_llm_on_tasks(
-    model: AutoModelForCausalLM, tokenizer: AutoTokenizer, tasks: str
+    model, tokenizer: AutoTokenizer, tasks: str
 ) -> dict[str, Any]:
+    if hasattr(model, "wrapped"):
+        model = model.wrapped
     model_to_evaluate = HFLM(model, "causal", tokenizer=tokenizer)
     tasks_list: list[str] = tasks.split(",")
     return evaluator.simple_evaluate(model_to_evaluate, tasks=tasks_list)

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -238,9 +238,7 @@ def evaluate(q_m, tokenizer, dataset_test, args):
     # -------------------------------------------------------------------------
     print("\nCalculating perplexities …")
     enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
-    ppl_uint8 = perplexity(
-        q_m, enc, args.device, stride=q_m.wrapped.config.max_position_embeddings
-    )
+    ppl_uint8 = perplexity(q_m, enc, args.device, stride=args.max_seq_len)
 
     print("\n┌── Wikitext-2 test perplexity ─────────────")
     print(f"│ int16 : {ppl_uint8:8.2f}")

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -72,6 +72,10 @@ class QuantLlamaForCausalLM(QuantModuleBase):
         )
         self.config = model_fp.config
         self.loss_function = model_fp.loss_function
+        self.device = model_fp.device
+
+    def tie_weights(self):
+        pass
 
     def forward(
         self,


### PR DESCRIPTION
This PR fixes lm_eval usage for quantized model.

<details> <summary> sample run `python tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py --model "Maykeye/TinyLLama-v0" --gptq_mse --max_seq_len 256 --save_circle_to_folder "~"  --eval_tasks "arc_challenge,arc_easy" `</summary>

```

Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_PTQ=False, save_circle_to_folder='/home/stanislav', cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse=True, max_seq_len=256, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks='arc_challenge,arc_easy')
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
`torch_dtype` is deprecated! Use `dtype` instead!
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Loading weights: 100%|██████████████| 75/75 [00:00<00:00, 562.92it/s, Materializing param=model.norm.weight]

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL: 100%|████████████████████████████████████████████████████████████▉| 1267/1268 [00:10<00:00, 126.67it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  6848.98
└───────────────────────────────────────────
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
100%|██████████████████████████████████████████████████████████████████| 2376/2376 [00:11<00:00, 203.07it/s]
100%|██████████████████████████████████████████████████████████████████| 1172/1172 [00:05<00:00, 202.79it/s]
Running loglikelihood requests: 100%|████████████████████████████████| 14188/14188 [01:36<00:00, 147.10it/s]
Original RESULTS ARE:
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.1937|±  |0.0115|
|             |       |none  |     0|acc_norm|↑  |0.2253|±  |0.0122|
|arc_easy     |      1|none  |     0|acc     |↑  |0.2572|±  |0.0090|
|             |       |none  |     0|acc_norm|↑  |0.2563|±  |0.0090|

Applying GPTQ …
Quantizing layers: 100%|███████████████████████████████████████████████████| 8/8 [00:04<00:00,  1.66layer/s]
Wrapping layers with PTQWrapper …                                                                           
Calibrating PTQ obeservers…
100%|█████████████████████████████████████████████████████████████████████| 128/128 [00:32<00:00,  3.89it/s]

Calculating perplexities …
PPL: 100%|█████████████████████████████████████████████████████████████▉| 1267/1268 [02:33<00:00,  8.26it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  6625.49
└───────────────────────────────────────────
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
100%|██████████████████████████████████████████████████████████████████| 2376/2376 [00:11<00:00, 203.38it/s]
100%|██████████████████████████████████████████████████████████████████| 1172/1172 [00:05<00:00, 203.65it/s]
Running loglikelihood requests: 100%|█████████████████████████████████| 14188/14188 [25:52<00:00,  9.14it/s]
Quantized RESULTS ARE:
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.1971|±  |0.0116|
|             |       |none  |     0|acc_norm|↑  |0.2218|±  |0.0121|
|arc_easy     |      1|none  |     0|acc     |↑  |0.2546|±  |0.0089|
|             |       |none  |     0|acc_norm|↑  |0.2555|±  |0.0089|

saving the whole model to /home/stanislav/model.q.circle

```

</details>

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>