### PR TITLE
[quantization] Add `calibrate_seq_len`

### DIFF
--- a/tico/quantization/evaluation/script/llm_tasks_eval.py
+++ b/tico/quantization/evaluation/script/llm_tasks_eval.py
@@ -23,11 +23,20 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
 def evaluate_llm_on_tasks(
-    model, tokenizer: AutoTokenizer, tasks: str
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    tasks: str,
+    max_length: int | None = None,
 ) -> dict[str, Any]:
     if hasattr(model, "wrapped"):
         model = model.wrapped
-    model_to_evaluate = HFLM(model, "causal", tokenizer=tokenizer)
+    model_to_evaluate = HFLM(
+        model,
+        "causal",
+        tokenizer=tokenizer,
+        max_length=max_length,
+        truncation=True,
+    )
     tasks_list: list[str] = tasks.split(",")
     return evaluator.simple_evaluate(model_to_evaluate, tasks=tasks_list)
 

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -107,7 +107,7 @@ def save_circles_to(q_m, calib_inputs, save_circle_to_folder):
     print(f"saving the whole model to {save_path.resolve()}")
     with torch.no_grad():
         with SuppressWarning(UserWarning, ".*"):
-            cm = tico.convert(q_m.wrapped, (calib_inputs[0],), strict=False)
+            cm = tico.convert(q_m, (calib_inputs[0],), strict=False)
 
             cm.save(save_path)
 
@@ -238,14 +238,18 @@ def evaluate(q_m, tokenizer, dataset_test, args):
     # -------------------------------------------------------------------------
     print("\nCalculating perplexities …")
     enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
-    ppl_uint8 = perplexity(q_m, enc, args.device, stride=args.max_seq_len)
+    ppl_uint8 = perplexity(
+        q_m, enc, args.device, max_length=args.max_seq_len, stride=args.max_seq_len
+    )
 
     print("\n┌── Wikitext-2 test perplexity ─────────────")
     print(f"│ int16 : {ppl_uint8:8.2f}")
     print("└───────────────────────────────────────────")
 
     if args.eval_tasks is not None:
-        results = evaluate_llm_on_tasks(q_m, tokenizer, args.eval_tasks)
+        results = evaluate_llm_on_tasks(
+            q_m, tokenizer, args.eval_tasks, max_length=args.max_seq_len
+        )
         print("Quantized RESULTS ARE:")
         print(make_table(results))
 
@@ -330,7 +334,13 @@ def main():
         "--max_seq_len",
         type=int,
         default=None,
-        help="constraint for max_position_embeddings",
+        help="seq_len to use in model evaluation and conversion to circle",
+    )
+    parser.add_argument(
+        "--calibrate_seq_len",
+        type=int,
+        default=2048,
+        help="seq_len to use in quantized model calibration. More the better",
     )
     parser.add_argument(
         "--embedding_weight_bits",
@@ -387,9 +397,9 @@ def main():
     )
 
     model.config.use_cache = False  # TODO use args for it
-    if args.max_seq_len is not None:
+    if args.calibrate_seq_len is not None:
         model.config.max_position_embeddings = min(
-            model.config.max_position_embeddings, args.max_seq_len
+            model.config.max_position_embeddings, args.calibrate_seq_len
         )
 
     dataset_test = load_dataset(
@@ -399,7 +409,7 @@ def main():
     print("\nCalculating original perplexities …")
     enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
     ppl_fp32 = perplexity(
-        model, enc, device, stride=model.config.max_position_embeddings
+        model, enc, device, max_length=args.max_seq_len, stride=args.max_seq_len
     )
 
     print("\n┌── Wikitext-2 test perplexity ─────────────")
@@ -407,7 +417,9 @@ def main():
     print("└───────────────────────────────────────────")
 
     if args.eval_tasks is not None:
-        results = evaluate_llm_on_tasks(model, tokenizer, args.eval_tasks)
+        results = evaluate_llm_on_tasks(
+            model, tokenizer, args.eval_tasks, max_length=args.max_seq_len
+        )
         print("Original RESULTS ARE:")
         print(make_table(results))
 
@@ -456,6 +468,7 @@ def main():
     evaluate(q_m, tokenizer, dataset_test, args)
 
     if args.save_circle_to_folder is not None:
+        calib_inputs = list(torch.stack(calib_inputs).reshape(-1, 1, args.max_seq_len))
         save_circles_to(q_m, calib_inputs, args.save_circle_to_folder)
 
 

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -209,8 +209,8 @@ class QuantLlamaModel(QuantModuleBase):
         position_embeddings = self.get_position_embeddings_for(hidden_states)
         cos, sin = position_embeddings
         position_embeddings = (
-            self._fq(cos, self.obs_cos),
-            self._fq(sin, self.obs_sin),
+            self._fq(cos[:, : hidden_states.size(1), :], self.obs_cos),
+            self._fq(sin[:, : hidden_states.size(1), :], self.obs_sin),
         )
 
         # decoder layers

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -26,19 +26,6 @@ from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
 
 
-def fix_inputs(config, pad_token_id, input_ids):
-    pads = torch.full(
-        (
-            input_ids.shape[0],
-            config.max_position_embeddings - input_ids.shape[1],
-        ),
-        fill_value=pad_token_id,
-        device=input_ids.device,
-    )
-
-    return torch.cat((input_ids, pads), dim=1)
-
-
 @try_register("transformers.models.llama.modeling_llama.LlamaForCausalLM")
 class QuantLlamaForCausalLM(QuantModuleBase):
     def __init__(
@@ -90,16 +77,6 @@ class QuantLlamaForCausalLM(QuantModuleBase):
         logits_to_keep: int | torch.Tensor = 0,
         **kwargs,
     ) -> CausalLMOutputWithPast:
-        orig_len = input_ids.shape[-1]  # type: ignore[union-attr]
-        pad_id = (
-            self.config.pad_token_id
-            if getattr(self.config, "pad_token_id", None) is not None
-            else self.config.eos_token_id
-        )
-
-        input_ids = fix_inputs(self.config, pad_id, input_ids)
-        if labels is not None:
-            labels = fix_inputs(self.config, pad_id, labels)
 
         output_attentions = self.config.output_attentions
         output_hidden_states = self.config.output_hidden_states
@@ -128,9 +105,6 @@ class QuantLlamaForCausalLM(QuantModuleBase):
             else logits_to_keep
         )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
-        logits = logits[..., :orig_len, :]
-        if labels is not None:
-            labels = labels[..., :orig_len]
 
         loss = None
         if labels is not None:


### PR DESCRIPTION
This PR adds `calibrate_seq_len` to get better results on accuracy.

please see results  [here](https://github.com/Samsung/TICO/pull/533#issuecomment-3990447438)

<details>
<summary>log of `python tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py --model "HuggingFaceTB/SmolLM2-135M-Instruct"  --max_seq_len 256 --gptq_mse "--eval_tasks" "winogrande,arc_easy,arc_challenge,openbookqa" ...`</summary>

```

Namespace(model='HuggingFaceTB/SmolLM2-135M-Instruct', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_PTQ=False, save_circle_to_folder='/home/stanislav', cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse=True, max_seq_len=256, calibrate_seq_len=2048, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks='winogrande,arc_easy,arc_challenge,openbookqa')
=== Config ===
Model            : HuggingFaceTB/SmolLM2-135M-Instruct
Device           : cuda
DType            : float32

Loading FP model …
`torch_dtype` is deprecated! Use `dtype` instead!
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 272/272 [00:01<00:00, 170.72it/s, Materializing param=model.norm.weight]

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (304978 > 8192). Running this sequence through the model will result in indexing errors
PPL: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊| 1191/1192 [01:38<00:00, 12.15it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :    30.32
└───────────────────────────────────────────
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:03<00:00, 141.97it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1172/1172 [00:12<00:00, 96.22it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2376/2376 [00:21<00:00, 108.32it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1267/1267 [00:00<00:00, 11541.23it/s]
Running loglikelihood requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18722/18722 [21:08<00:00, 14.76it/s]
Original RESULTS ARE:
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.2594|±  |0.0128|
|             |       |none  |     0|acc_norm|↑  |0.2773|±  |0.0131|
|arc_easy     |      1|none  |     0|acc     |↑  |0.5400|±  |0.0102|
|             |       |none  |     0|acc_norm|↑  |0.4882|±  |0.0103|
|openbookqa   |      1|none  |     0|acc     |↑  |0.2240|±  |0.0187|
|             |       |none  |     0|acc_norm|↑  |0.3320|±  |0.0211|
|winogrande   |      1|none  |     0|acc     |↑  |0.5107|±  |0.0140|

Applying GPTQ …
Quantizing layers: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [02:50<00:00,  5.67s/layer]
Wrapping layers with PTQWrapper …                                                                                                                                                                                                                         
Calibrating PTQ obeservers…
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [02:24<00:00,  1.13s/it]

Calculating perplexities …
PPL: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊| 1191/1192 [10:56<00:00,  1.81it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :    52.08
└───────────────────────────────────────────
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:05<00:00, 87.04it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1172/1172 [00:12<00:00, 91.11it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2376/2376 [00:24<00:00, 96.53it/s]
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1267/1267 [00:00<00:00, 9694.34it/s]
Running loglikelihood requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18722/18722 [1:29:06<00:00,  3.50it/s]
Quantized RESULTS ARE:
|    Tasks    |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-------------|------:|------|-----:|--------|---|-----:|---|-----:|
|arc_challenge|      1|none  |     0|acc     |↑  |0.2560|±  |0.0128|
|             |       |none  |     0|acc_norm|↑  |0.2790|±  |0.0131|
|arc_easy     |      1|none  |     0|acc     |↑  |0.4617|±  |0.0102|
|             |       |none  |     0|acc_norm|↑  |0.4470|±  |0.0102|
|openbookqa   |      1|none  |     0|acc     |↑  |0.1960|±  |0.0178|
|             |       |none  |     0|acc_norm|↑  |0.2980|±  |0.0205|
|winogrande   |      1|none  |     0|acc     |↑  |0.5328|±  |0.0140|

saving the whole model to /home/stanislav/model.q.circle

```

</details>

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>