### PR TITLE
[quantization] Pass static data as inputs

### DIFF
--- a/tico/quantization/wrapq/examples/llama/quantize_decoder_layer_prefill.py
+++ b/tico/quantization/wrapq/examples/llama/quantize_decoder_layer_prefill.py
@@ -43,6 +43,7 @@ from tico.utils.utils import SuppressWarning
 
 MODEL_NAME = "Maykeye/TinyLLama-v0"
 MAX_SEQ = 256
+static_data_inside_the_layer = True
 
 model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype="float32")
 tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, legacy=False)
@@ -139,10 +140,26 @@ B, S, D = 1, MAX_SEQ, model.config.hidden_size
 example_hidden = torch.randn(B, S, D)
 
 with SuppressWarning(UserWarning, ".*"):
-    cm = tico.convert(
-        qlayer,
-        (example_hidden,),
-    )
+    if static_data_inside_the_layer is True:
+        cm = tico.convert(
+            qlayer,
+            (example_hidden,),
+        )
+    else:
+        qattn = qlayer.wrapped
+        attn_mask = qattn._slice_causal(S, "cpu").squeeze(0)
+        dtype = example_hidden.dtype
+        pos_embeds = (
+            qattn.rope_cos_template.cpu().to(dtype),
+            qattn.rope_sin_template.cpu().to(dtype),
+        )
+
+        cm = tico.convert(
+            qlayer,
+            (example_hidden,),
+            kwargs={"attention_mask": attn_mask, "position_embeddings": pos_embeds},
+        )
+
 # Note that the model is not fully quantized.
 cm.save(save_path)
 

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer_prefill.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer_prefill.py
@@ -193,9 +193,9 @@ class QuantLlamaDecoderLayerPrefill(QuantModuleBase):
             L = hidden_states.size(1)
             attention_mask = self._slice_causal(L, hidden_states.device)
             attention_mask = attention_mask.squeeze(0)
-            attention_mask = self._fq(
-                attention_mask, self.obs_causal_mask
-            )  # let it be quantized immediately
+        attention_mask = self._fq(
+            attention_mask, self.obs_causal_mask
+        )  # let it be quantized immediately
 
         if position_embeddings is None:
             position_embeddings = (
@@ -206,11 +206,11 @@ class QuantLlamaDecoderLayerPrefill(QuantModuleBase):
                     dtype=hidden_states.dtype, device=hidden_states.device
                 ),
             )
-            cos, sin = position_embeddings
-            position_embeddings = (
-                self._fq(cos, self.obs_cos),
-                self._fq(sin, self.obs_sin),
-            )
+        cos, sin = position_embeddings
+        position_embeddings = (
+            self._fq(cos, self.obs_cos),
+            self._fq(sin, self.obs_sin),
+        )
 
         attn_out = self.self_attn(
             hidden_states=hidden_states,


### PR DESCRIPTION
This PR adds `static_data_inside_the_layer` option to the scipt to have `attention_mask` and `position_embeddings` as inputs.

Quantized model uses  defined globally `attention_mask` and `position_embeddings` and then passes them to the layers to avoid their population. So this PR tries to keep decoder_layer in sync with the whole quantized model.

So parameters of the saved model look like this for [Maykeye/TinyLLama-v0](https://huggingface.co/Maykeye/TinyLLama-v0):
<img width="666" height="995" alt="image" src="https://github.com/user-attachments/assets/ba7b38e2-7ccc-44ef-8588-a58572409068" />


TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>