### PR TITLE
[quantization] Fix `quantize_decoder_layer_prefill.py`

### DIFF
--- a/tico/quantization/wrapq/examples/llama/quantize_decoder_layer_prefill.py
+++ b/tico/quantization/wrapq/examples/llama/quantize_decoder_layer_prefill.py
@@ -58,7 +58,7 @@ model.eval()  # disable dropout, etc.
 # 1. Swap in the quant wrapper
 # -------------------------------------------------------------------------
 fp32_layer = model.model.layers[0]  # keep a reference for diff check
-model.model.layers[0] = prepare(fp32_layer, PTQConfig())
+model.model.layers[0] = prepare(fp32_layer, PTQConfig(wrapper_variant="prefill"))
 model.eval()
 
 qlayer = model.model.layers[0]  # alias for brevity


### PR DESCRIPTION
This PR fixes `quantize_decoder_layer_prefill.py` to save `decoder_layer` in `prefill` mode.

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>