### PR TITLE
[quantization] Add quantization coverage check

### DIFF
--- a/test/quantization/wrapq/utils/test_check_missing_qparam.py
+++ b/test/quantization/wrapq/utils/test_check_missing_qparam.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from tico.quantization.wrapq.utils.check_missing_qparam import check_missing_qparam
+from tico.serialize.quant_param import QPARAM_KEY
+
+
+class _FakeTarget:
+    def __init__(self, name: str):
+        self.__name__ = name
+
+
+class _FakeNode:
+    def __init__(
+        self,
+        *,
+        op: str = "call_function",
+        target=None,
+        meta=None,
+        users=None,
+        name: str = "node",
+    ):
+        self.op = op
+        self.target = target if target is not None else _FakeTarget("fake_op")
+        self.meta = meta if meta is not None else {}
+        self.users = users if users is not None else {}
+        self.name = name
+
+
+def _make_exported_program(nodes):
+    graph = types.SimpleNamespace(nodes=nodes)
+    graph_module = types.SimpleNamespace(graph=graph)
+    exported_program = types.SimpleNamespace(graph_module=graph_module)
+    return exported_program
+
+
+class CheckMissingQParamTest(unittest.TestCase):
+    def test_no_missing_qparam(self):
+        node_quantized = _FakeNode(
+            name="linear_0",
+            target=_FakeTarget("linear"),
+            meta={
+                "val": torch.randn(1, 4),
+                QPARAM_KEY: object(),
+            },
+            users={"user0": object()},
+        )
+        node_non_tensor = _FakeNode(
+            name="shape_0",
+            target=_FakeTarget("sym_size"),
+            meta={"val": 16},
+            users={},
+        )
+        node_non_call = _FakeNode(
+            op="placeholder",
+            name="input_0",
+            meta={"val": torch.randn(1, 4)},
+        )
+
+        exported_program = _make_exported_program(
+            [node_quantized, node_non_tensor, node_non_call]
+        )
+
+        mock_logger = MagicMock()
+
+        with patch(
+            "tico.quantization.wrapq.utils.check_missing_qparam.logging.getLogger",
+            return_value=mock_logger,
+        ), patch("builtins.print") as mock_print:
+            check_missing_qparam(exported_program, strict=False)
+
+        mock_logger.debug.assert_any_call("[QuantCheck] quantized nodes : 1")
+        mock_logger.debug.assert_any_call("[QuantCheck] fp nodes        : 0")
+        mock_logger.warning.assert_not_called()
+        mock_print.assert_not_called()
+
+    def test_missing_qparam_prints_warning_and_logs_details(self):
+        node_quantized = _FakeNode(
+            name="linear_0",
+            target=_FakeTarget("linear"),
+            meta={
+                "val": torch.randn(1, 4),
+                QPARAM_KEY: object(),
+                "stack_trace": "model.py:10",
+            },
+            users={"user0": object()},
+        )
+        node_missing = _FakeNode(
+            name="add_0",
+            target=_FakeTarget("add"),
+            meta={
+                "val": torch.randn(1, 4),
+                "stack_trace": "model.py:20",
+            },
+            users={"user0": object(), "user1": object()},
+        )
+
+        exported_program = _make_exported_program([node_quantized, node_missing])
+
+        mock_logger = MagicMock()
+
+        with patch(
+            "tico.quantization.wrapq.utils.check_missing_qparam.logging.getLogger",
+            return_value=mock_logger,
+        ), patch("builtins.print") as mock_print:
+            check_missing_qparam(exported_program, strict=False)
+
+        mock_logger.debug.assert_any_call("[QuantCheck] quantized nodes : 1")
+        mock_logger.debug.assert_any_call("[QuantCheck] fp nodes        : 1")
+
+        mock_print.assert_called_once_with(
+            "[QuantCheck] WARNING: 1 nodes without qparam detected " "(see logs)."
+        )
+
+        dummy_name = "add_0"
+        dummy_target = "add"
+        dummy_users = 2
+        dummy_trace = "model.py:20"
+        mock_logger.debug.assert_any_call(
+            f"[QuantCheck] Missing qparam:\n"
+            f"  name   : {dummy_name}\n"
+            f"  target : {dummy_target}\n"
+            f"  users  : {dummy_users}\n"
+            f"  trace  : {dummy_trace}",
+        )
+
+    def test_strict_mode_raises_runtime_error(self):
+        node_missing = _FakeNode(
+            name="matmul_0",
+            target=_FakeTarget("matmul"),
+            meta={
+                "val": torch.randn(2, 2),
+                "stack_trace": "model.py:30",
+            },
+            users={"user0": object()},
+        )
+
+        exported_program = _make_exported_program([node_missing])
+
+        mock_logger = MagicMock()
+
+        with patch(
+            "tico.quantization.wrapq.utils.check_missing_qparam.logging.getLogger",
+            return_value=mock_logger,
+        ), patch("builtins.print") as mock_print:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"\[QuantCheck\] 1 nodes without qparam detected\.",
+            ):
+                check_missing_qparam(exported_program, strict=True)
+
+        mock_logger.debug.assert_any_call("[QuantCheck] quantized nodes : 0")
+        mock_logger.debug.assert_any_call("[QuantCheck] fp nodes        : 1")
+        mock_print.assert_called_once_with(
+            "[QuantCheck] WARNING: 1 nodes without qparam detected " "(see logs)."
+        )
+
+    def test_ignore_targets_skips_nodes_from_check_and_counts(self):
+        ignored_target = _FakeTarget("getitem")
+        checked_target = _FakeTarget("linear")
+
+        node_ignored_missing = _FakeNode(
+            name="getitem_0",
+            target=ignored_target,
+            meta={
+                "val": torch.randn(1, 4),
+                "stack_trace": "model.py:40",
+            },
+            users={"user0": object()},
+        )
+        node_checked_quantized = _FakeNode(
+            name="linear_0",
+            target=checked_target,
+            meta={
+                "val": torch.randn(1, 4),
+                QPARAM_KEY: object(),
+                "stack_trace": "model.py:41",
+            },
+            users={"user0": object()},
+        )
+
+        exported_program = _make_exported_program(
+            [node_ignored_missing, node_checked_quantized]
+        )
+
+        mock_logger = MagicMock()
+
+        with patch(
+            "tico.quantization.wrapq.utils.check_missing_qparam.logging.getLogger",
+            return_value=mock_logger,
+        ), patch("builtins.print") as mock_print:
+            check_missing_qparam(
+                exported_program,
+                strict=False,
+                ignore_targets={ignored_target},
+            )
+
+        mock_logger.debug.assert_any_call("[QuantCheck] quantized nodes : 1")
+        mock_logger.debug.assert_any_call("[QuantCheck] fp nodes        : 0")
+        mock_logger.warning.assert_not_called()
+        mock_print.assert_not_called()
+
+    def test_tensor_meta_without_val_is_still_checked(self):
+        node_missing = _FakeNode(
+            name="reshape_0",
+            target=_FakeTarget("reshape"),
+            meta={
+                "tensor_meta": object(),
+                "stack_trace": "model.py:50",
+            },
+            users={"user0": object()},
+        )
+
+        exported_program = _make_exported_program([node_missing])
+
+        mock_logger = MagicMock()
+
+        with patch(
+            "tico.quantization.wrapq.utils.check_missing_qparam.logging.getLogger",
+            return_value=mock_logger,
+        ), patch("builtins.print") as mock_print:
+            check_missing_qparam(exported_program, strict=False)
+
+        mock_logger.debug.assert_any_call("[QuantCheck] quantized nodes : 0")
+        mock_logger.debug.assert_any_call("[QuantCheck] fp nodes        : 1")
+        mock_print.assert_called_once()

--- a/tico/quantization/wrapq/utils/check_missing_qparam.py
+++ b/tico/quantization/wrapq/utils/check_missing_qparam.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Set
+
+import torch
+from torch.export import ExportedProgram
+
+from tico.serialize.quant_param import QPARAM_KEY
+from tico.utils import logging
+
+
+def _is_tensor_like_node(node: torch.fx.Node) -> bool:
+    """
+    Return True if the node appears to produce a tensor or a container of tensors.
+
+    We rely on FX/export metadata because the graph may contain non-tensor nodes
+    such as shape/index bookkeeping ops that should not be checked for qparam.
+    """
+    val = node.meta.get("val", None)
+
+    if isinstance(val, torch.Tensor):
+        return True
+
+    if isinstance(val, (tuple, list)) and val:
+        return any(isinstance(x, torch.Tensor) for x in val)
+
+    if "tensor_meta" in node.meta:
+        return True
+
+    return False
+
+
+def check_missing_qparam(
+    exported_program: ExportedProgram,
+    *,
+    strict: bool = False,
+    ignore_targets: Optional[Set[object]] = None,
+) -> None:
+    """
+    Inspect the final graph once after all quantization-related passes complete.
+
+    This checker warns or raises if tensor-producing call_function nodes still do
+    not have QPARAM metadata. It is intentionally not implemented as a pass
+    because PassManager may restart and rerun passes multiple times, while this
+    check should run exactly once on the final graph.
+
+    Args:
+        exported_program:
+            The exported program to inspect.
+        strict:
+            If True, raise RuntimeError when any missing-qparam node is found.
+            If False, only emit warnings.
+        ignore_targets:
+            A set of call targets to exclude from the check.
+    """
+    logger = logging.getLogger(__name__)
+
+    ignore_targets = ignore_targets or set()
+    graph = exported_program.graph_module.graph
+
+    missing: list[torch.fx.Node] = []
+    quantized_nodes = 0
+    fp_nodes = 0
+
+    for node in graph.nodes:
+        if node.op != "call_function":
+            continue
+
+        if node.target in ignore_targets:
+            continue
+
+        if not _is_tensor_like_node(node):
+            continue
+
+        if QPARAM_KEY in node.meta:
+            quantized_nodes += 1
+        else:
+            fp_nodes += 1
+            missing.append(node)
+
+    # Summary statistics
+    logger.debug(f"[QuantCheck] quantized nodes : {quantized_nodes}")
+    logger.debug(f"[QuantCheck] fp nodes        : {fp_nodes}")
+
+    if not missing:
+        return
+
+    # Short message for user-facing output
+    print(
+        f"[QuantCheck] WARNING: {len(missing)} nodes without qparam detected "
+        "(see logs)."
+    )
+
+    # Detailed logs for debugging
+    for node in missing:
+        target_name = getattr(node.target, "__name__", str(node.target))
+
+        logger.debug(
+            f"[QuantCheck] Missing qparam:\n"
+            f"  name   : {node.name}\n"
+            f"  target : {target_name}\n"
+            f"  users  : {len(node.users)}\n"
+            f"  trace  : {node.meta.get('stack_trace')}",
+        )
+
+    if strict:
+        raise RuntimeError(
+            f"[QuantCheck] {len(missing)} nodes without qparam detected."
+        )

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -71,6 +71,7 @@ from tico.quantization.passes.propagate_qparam_backward import PropagateQParamBa
 from tico.quantization.passes.propagate_qparam_forward import PropagateQParamForward
 from tico.quantization.passes.quantize_bias import QuantizeBias
 from tico.quantization.passes.remove_weight_dequant_op import RemoveWeightDequantOp
+from tico.quantization.wrapq.utils.check_missing_qparam import check_missing_qparam
 from tico.serialize.circle_serializer import build_circle
 from tico.serialize.operators.node_visitor import get_support_targets
 from tico.utils import logging
@@ -308,6 +309,13 @@ def convert_exported_module_to_circle(
             ]
         )
         quantize_graph.run(exported_program)
+
+        # For `torch.ops.aten.split_with_sizes`, the qparam is attached to the corresponding `getitem` nodes.
+        check_missing_qparam(
+            exported_program,
+            strict=False,
+            ignore_targets={torch.ops.aten.split_with_sizes.default},
+        )
 
     if os.environ.get("TICO_GRAPH_DUMP"):
         save_fx_graph_as_png(exported_program, file_name="3_after_quantfold")


### PR DESCRIPTION
This commit checks if missing qparams exist after quant passes.

### Example

```
[QuantCheck] WARNING: 2 nodes without qparam detected (see logs).
```

```
# in the log file
DEBUG:tico.quantization.wrapq.utils.check_missing_qparams:[QuantCheck] quantized nodes : 487
DEBUG:tico.quantization.wrapq.utils.check_missing_qparams:[QuantCheck] fp nodes        : 2
DEBUG:tico.quantization.wrapq.utils.check_missing_qparams:[QuantCheck] Missing qparam:
  name   : cat_65
  target : cat.default
  users  : 1
  trace  :   File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/ptq_wrapper.py", line 68, in forward
    return self.wrapped(*args, **kwargs)
  File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer_decode.py", line 219, in forward
    attn_out = self.self_attn(
  File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/ptq_wrapper.py", line 68, in forward
    return self.wrapped(*args, **kwargs)
  File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/llama/quant_attn_decode.py", line 312, in forward
    new_k = torch.stack(new_k_parts, dim=1)

DEBUG:tico.quantization.wrapq.utils.check_missing_qparams:[QuantCheck] Missing qparam:
  name   : reshape_default_101
  target : reshape.default
  users  : 1
  trace  :   File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/ptq_wrapper.py", line 68, in forward
    return self.wrapped(*args, **kwargs)
  File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer_decode.py", line 219, in forward
    attn_out = self.self_attn(
  File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/ptq_wrapper.py", line 68, in forward
    return self.wrapped(*args, **kwargs)
  File "/home/seongwoo/TICO/tico/quantization/wrapq/wrappers/llama/quant_attn_decode.py", line 312, in forward
    new_k = torch.stack(new_k_parts, dim=1)
```

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>