### PR TITLE
[quantization] Add missing observer calls

### DIFF
--- a/tico/quantization/wrapq/wrappers/llama/quant_attn_prefill.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attn_prefill.py
@@ -192,6 +192,8 @@ class QuantLlamaAttentionPrefill(QuantModuleBase):
 
         # Rope tables
         cos, sin = position_embeddings
+        cos = self._fq(cos, self.obs_cos)
+        sin = self._fq(sin, self.obs_sin)
 
         # --- KV for attention & present_key_value -------------
         present_key_value: Tuple[torch.Tensor, torch.Tensor]


### PR DESCRIPTION
This commit applies missing observer calls.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>