### PR TITLE
[quantization] [draft] GPTQ for VLM

### DIFF
--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -259,6 +259,41 @@ class GPTQ:
             )  # depthwise/groupwise are not supported currently
             assert all(dilation == 1 for dilation in self.layer.dilation)
 
+            # test
+            #  input_dim = [22, 59, 114]
+            #  in_channels = 10
+            #  out_channels = 5
+            #  kernel_size = (4, 2, 3)
+            #  padding = (1, 4, 3)
+            #  stride = (1, 1, 1)
+            #  N = 51
+            #  input_tensor = torch.zeros(N, in_channels, input_dim[0], input_dim[1], input_dim[2]).uniform_(-1, 1)
+            #  conv = nn.Conv3d(in_channels=in_channels, out_channels=out_channels, kernel_size=kernel_size, padding=padding, stride=stride, bias=False)
+            #  output_tensor = conv(input_tensor)
+            #  output_dim = [0, 0, 0]
+            #  output_dim[0] = int((input_tensor.shape[2] - kernel_size[0] + 2 * padding[0]) / stride[0]) + 1
+            #  output_dim[1] = int((input_tensor.shape[3] - kernel_size[1] + 2 * padding[1]) / stride[1]) + 1
+            #  output_dim[2] = int((input_tensor.shape[4] - kernel_size[2] + 2 * padding[2]) / stride[2]) + 1
+            #  if not all(item == 0 for item in padding):
+            #      input_tensor = F.pad(input_tensor, pad=(padding[2], padding[2], padding[1], padding[1], padding[0], padding[0]), mode="constant", value=0)
+            #
+            #  unfolded_input_tensor = input_tensor.unfold(2, kernel_size[0], stride[0]).unfold(3, kernel_size[1], stride[1]).unfold(4, kernel_size[2], stride[2])
+            #  unfolded_input_tensor = unfolded_input_tensor.reshape(N, in_channels, -1, kernel_size[0] * kernel_size[1] * kernel_size[2])
+            #  unfolded_input_tensor = unfolded_input_tensor.permute([0, 2, 1, 3])
+            #  #unfolded_input_tensor = unfolded_input_tensor.reshape(-1, unfolded_input_tensor.shape[2] *  unfolded_input_tensor.shape[3])
+            #  #unfolded_input_tensor = unfolded_input_tensor.reshape( unfolded_input_tensor.shape[0],  unfolded_input_tensor.shape[1], unfolded_input_tensor.shape[2] *  unfolded_input_tensor.shape[3])
+            #  #unfolded_input_tensor = unfolded_input_tensor.permute([2, 0, 1])
+            #  #unfolded_input_tensor = unfolded_input_tensor.flatten(1).T #(N * NPatches, inner_dim)
+            #  unfolded_input_tensor = unfolded_input_tensor.reshape(unfolded_input_tensor.shape[0] *  unfolded_input_tensor.shape[1], unfolded_input_tensor.shape[2] *  unfolded_input_tensor.shape[3])
+            #
+            #  kernels_flat = conv.weight.detach().clone().flatten(1)#view(out_channels, -1)
+            #  alt_output_tensor = torch.matmul(kernels_flat, unfolded_input_tensor.T) #(out_channels, N * NPatches)
+            #  alt_output_tensor = alt_output_tensor.view(out_channels, N, output_dim[0], output_dim[1], output_dim[2])
+            #  alt_output_tensor = alt_output_tensor.permute([1, 0, 2, 3, 4])
+            #  eps_max = torch.max(torch.abs(output_tensor - alt_output_tensor))
+            #  eps_mean = torch.mean(torch.abs(output_tensor - alt_output_tensor))
+            #  assert( eps_max < 1.e-04 or eps_mean < 1.e-06)
+
             # inp is assumed to be (N, C_in, H, W, D)
             padding = get_numerical_padding(self.layer)
             if isinstance(padding, int):
@@ -363,49 +398,58 @@ class GPTQ:
         Hinv = H
 
         assert isinstance(Hinv, torch.Tensor)
-        for i1 in range(0, self.columns, blocksize):
-            i2 = min(i1 + blocksize, self.columns)
-            count = i2 - i1
+        just_quantize = False
+        if just_quantize:
+            Q = quantize(
+                W,
+                self.quantizer.scale,
+                self.quantizer.zero,
+                self.quantizer.maxq,
+            )
+        else:
+            for i1 in range(0, self.columns, blocksize):
+                i2 = min(i1 + blocksize, self.columns)
+                count = i2 - i1
 
-            W1 = W[:, i1:i2].clone()
-            Q1 = torch.zeros_like(W1)
-            Err1 = torch.zeros_like(W1)
-            Losses1 = torch.zeros_like(W1)
-            Hinv1 = Hinv[i1:i2, i1:i2]
+                W1 = W[:, i1:i2].clone()
+                Q1 = torch.zeros_like(W1)
+                Err1 = torch.zeros_like(W1)
+                Losses1 = torch.zeros_like(W1)
+                Hinv1 = Hinv[i1:i2, i1:i2]
 
-            for i in range(count):
-                w = W1[:, i]
-                d = Hinv1[i, i]
+                for i in range(count):
+                    w = W1[:, i]
+                    d = Hinv1[i, i]
 
-                if groupsize != -1:
-                    if not static_groups:
-                        if (i1 + i) % groupsize == 0:
-                            self.quantizer.find_params(
-                                W[:, (i1 + i) : (i1 + i + groupsize)], weight=True
-                            )
-                    else:
-                        idx: torch.Tensor | int = i1 + i
-                        if actorder:
-                            idx = perm[idx]
-                        self.quantizer = groups[idx // groupsize]
+                    if groupsize != -1:
+                        if not static_groups:
+                            if (i1 + i) % groupsize == 0:
+                                self.quantizer.find_params(
+                                    W[:, (i1 + i) : (i1 + i + groupsize)], weight=True
+                                )
+                        else:
+                            idx: torch.Tensor | int = i1 + i
+                            if actorder:
+                                idx = perm[idx]
+                            self.quantizer = groups[idx // groupsize]
 
-                q = quantize(
-                    w.unsqueeze(1),
-                    self.quantizer.scale,
-                    self.quantizer.zero,
-                    self.quantizer.maxq,
-                ).flatten()
-                Q1[:, i] = q
-                Losses1[:, i] = (w - q) ** 2 / d**2
+                    q = quantize(
+                        w.unsqueeze(1),
+                        self.quantizer.scale,
+                        self.quantizer.zero,
+                        self.quantizer.maxq,
+                    ).flatten()
+                    Q1[:, i] = q
+                    Losses1[:, i] = (w - q) ** 2 / d**2
 
-                err1 = (w - q) / d
-                W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
-                Err1[:, i] = err1
+                    err1 = (w - q) / d
+                    W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+                    Err1[:, i] = err1
 
-            Q[:, i1:i2] = Q1
-            Losses[:, i1:i2] = Losses1 / 2
+                Q[:, i1:i2] = Q1
+                Losses[:, i1:i2] = Losses1 / 2
 
-            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+                W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -110,9 +110,7 @@ class GPTQQuantizer(BaseQuantizer):
             ):
                 self._first_layer_ref = model.model.layers[0]
             else:
-                raise RuntimeError(
-                    "GPTQ Quantizer assumes the model has a nested structure like `model.model.layers`, commonly found in LLaMA and other Hugging Face transformer models."
-                )
+                self._first_layer_ref = model  # let's treat it as a single layer (fallback)
         else:
             # fallback if the model is not LLaMA-like; treat whole model as single layer
             self._first_layer_ref = model
@@ -180,7 +178,10 @@ class GPTQQuantizer(BaseQuantizer):
 
         # Identify layers
         if hasattr(model, "model"):
-            target_layers = model.model.layers
+            if hasattr(model.model, "layers"):
+                target_layers = model.model.layers
+            else:
+                target_layers = [model]
         else:
             target_layers = [model]
 
@@ -301,7 +302,8 @@ class GPTQQuantizer(BaseQuantizer):
                 # This line ensures we always take the first element when it's a tuple.
                 outs = outs[0] if isinstance(outs, tuple) else outs
                 # Update inputs for next iteration.
-                self.cache_args[0][batch_idx] = outs
+                if len(self.cache_args) > 0:
+                    self.cache_args[0][batch_idx] = outs
 
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()

--- a/tico/quantization/wrapq/examples/quantize_full_vlm_model_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_vlm_model_with_gptq.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+import torch
+from transformers import AutoProcessor
+
+from tico.quantization import convert, prepare
+
+from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
+from tico.quantization.config.gptq import GPTQConfig
+from tico.quantization.evaluation.vlm_eval_utils import get_calib_inputs
+from tico.quantization.wrapq.examples.quantize_qwen3_vl_with_gptq import (
+    evaluate_model,
+    print_eval_results,
+    print_markdown_comparison,
+)
+
+DTYPE_MAP = {
+    "float32": torch.float32,
+    # TODO Support more dtypes
+    # "bfloat16": torch.bfloat16,
+    # "float16": torch.float16,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="GPTQ+PTQ pipeline (weight-only + activation)"
+    )
+    parser.add_argument(
+        "--model", type=str, required=True, help="HF repo name or local path."
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Device to run on (cuda|cpu|mps).",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=list(DTYPE_MAP.keys()),
+        default="float32",
+        help="Model dtype for load.",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable only if you trust the model repo code.",
+    )
+    parser.add_argument(
+        "--hf-token",
+        type=str,
+        default=None,
+        help="Optional HF token for gated/private repos.",
+    )
+    parser.add_argument(
+        "--cache_dir",
+        type=str,
+        default=None,
+        help="cache_dir for using model/datasets loading",
+    )
+    parser.add_argument(
+        "--nsamples_for_qcalibration",
+        type=int,
+        default="128",  # almost standard
+        help="number of samples to be used in GPTQ/PTQ calibration",
+    )
+    parser.add_argument(
+        "--nsamples_for_evaluation",
+        type=int,
+        default="50",
+        help="number of samples to be used in equantized model valuation. -1 stands for the whole dataset",
+    )
+    parser.add_argument(
+        "--calib_seq_len",
+        type=int,
+        default=2048,
+        help=(
+            "Maximum text sequence length for calibration inputs. "
+            "If not set, processor default behavior is used."
+        ),
+    )
+    parser.add_argument(
+        "--max_seq_len",
+        type=int,
+        default=2048,
+        help=(
+            "Maximum text sequence length for evaluation and export. "
+            "If not set, processor default behavior is used."
+        ),
+    )
+    parser.add_argument(
+        "--linear_weight_bits",
+        type=int,
+        default=4,
+        help="Weight bit-width for GPTQ quantization.",
+    )
+    parser.add_argument(
+        "--gptq_mse",
+        type=str,
+        default=None,
+        choices=["mse", "smse"],
+        help="Whether and how to use mse in GPTQ.",
+    )
+    parser.add_argument(
+        "--eval_tasks",
+        type=str,
+        default=None,
+        help="Tasks to evaluate, e.g. `vqav2,textvqa`.",
+    )
+    parser.add_argument(
+        "--sensitivity_path",
+        type=str,
+        default=None,
+    )
+
+    args = parser.parse_args()
+    print(args)
+
+    # Basic setup
+    torch.manual_seed(args.seed)
+    device = torch.device(args.device)
+    dtype = DTYPE_MAP[args.dtype]
+
+    print("=== Config ===")
+    print(f"Model            : {args.model}")
+    print(f"Device           : {device.type}")
+    print(f"DType            : {args.dtype}")
+    print(f"Calib seq len    : {args.calib_seq_len}")
+    print(f"Max seq len      : {args.max_seq_len}")
+    print()
+
+    # -------------------------------------------------------------------------
+    # Load model and processor
+    # -------------------------------------------------------------------------
+    print("Loading FP model …")
+
+    processor = AutoProcessor.from_pretrained(
+        args.model, trust_remote_code=True, cache_dir=args.cache_dir
+    )
+    dev_map = "balanced" if args.device != "cpu" else "cpu"
+    try:
+        from transformers import AutoModelForImageTextToText
+
+        model = AutoModelForImageTextToText.from_pretrained(
+            args.model,
+            dtype=dtype,
+            trust_remote_code=True,
+            cache_dir=args.cache_dir,
+            device_map=dev_map,
+        )
+    except:
+        from transformers import AutoModelForVision2Seq
+
+        model = AutoModelForVision2Seq.from_pretrained(
+            args.model,
+            torch_dtype=dtype,
+            trust_remote_code=True,
+            cache_dir=args.cache_dir,
+            device_map=dev_map,
+        )
+
+    model.eval()
+    if hasattr(model, "config") and hasattr(model.config, "use_cache"):
+        model.config.use_cache = False
+    if hasattr(model, "config") and hasattr(model.config, "text_config"):
+        if hasattr(model.config.text_config, "use_cache"):
+            model.config.text_config.use_cache = False
+
+    if args.calib_seq_len is not None:
+        model.config.text_config.max_position_embeddings = min(
+            model.config.text_config.max_position_embeddings, args.calib_seq_len
+        )
+
+    if args.eval_tasks is not None:
+        print("Evaluating original model")
+        original_results = evaluate_model(
+            model,
+            processor,
+            args.eval_tasks,
+            args.device,
+            args.nsamples_for_evaluation,
+            max_seq_len=args.max_seq_len,
+        )
+        print_eval_results("Evaluating original model", original_results)
+        for key in original_results:
+            result = original_results[key]
+            print(
+                f"Original EM: {result[0]/result[1]:.4f}  (dataset={key}, n={result[1]})"
+            )
+
+    calib_inputs = get_calib_inputs(
+        "vqav2", processor, n_samples=args.nsamples_for_qcalibration
+    )
+
+    # -------------------------------------------------------------------------
+    # Run GPTQ (weight-only) pass
+    # -------------------------------------------------------------------------
+    print("Applying GPTQ …")
+
+    sens = None
+    if args.gptq_mse is not None and args.gptq_mse == "smse":
+        if args.sensitivity_path is not None:
+            sens = torch.load(args.sensitivity_path)
+        else:
+            calibrator = SensitivityCalibrator(model, calib_inputs)
+            sens = calibrator.compute_sensitivity_info()
+
+    gptq_config = GPTQConfig(
+        weight_bits=args.linear_weight_bits,
+        perchannel=True,
+        mse=args.gptq_mse,
+        sensitivity=sens,
+    )
+    q_m = prepare(model, gptq_config, inplace=True)
+
+    with torch.no_grad():
+        for inp in calib_inputs:
+            for item in inp:
+                inp[item] = inp[item].to(args.device)
+            q_m(**inp)
+
+    q_m = convert(q_m, inplace=True)
+
+    # -------------------------------------------------------------------------
+    # evaluate quantized model
+    # -------------------------------------------------------------------------
+    if args.eval_tasks is not None:
+        quantized_results = evaluate_model(
+            q_m,
+            processor,
+            args.eval_tasks,
+            args.device,
+            args.nsamples_for_evaluation,
+            max_seq_len=args.max_seq_len,
+        )
+        print_eval_results("Evaluating quantized model", quantized_results)
+        print_markdown_comparison(original_results, quantized_results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR is the first try out for full quantization of VLM model by GPTQ+PTQ.

TODO:

1. m.b. make it less resource intensive (right now it makes inference for the whole model, not in layerwise fashion)
2. support `PTQ` quantization
3. synchronize GPTQ/PTQ Conv3d quantization
4. support convert to `circle`


| model| orig_accuracy_vqav2  |minmax_quantize_accuracy_vqav2|GPTQ_mse_accuracy_vqav2|GPTQ_smse_accuracy_vqav2|
|-----------|------|--|-|-|
| [Qwen2_2B](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct)|0.8900|0.8260 |0.8450|**0.8740**|
| [Qwen3_2B](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct)|0.8570|0.7970 |**0.8470**|0.8390|
| [Qwen3_4B](https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct)|0.8950|0.8450 |**0.8910**|0.8820|

<details> <summary> some_details</summary>

all models above were quantized using GPTQ+mse/GPTQ+smse: 
1. weights of `torch.nn.Linear`, `torch.nn.Conv2D`, `torch.nn.Conv1D`, `nn.ConvTranspose2d`  to 4 bits, 
2. activations were left at `float32`
3. accuracy was computed on the first 1000 samples on `vqav2`


</details>

for 256:
|model|vqav2_on_1000_samples|
|--|--|
| [Qwen2_2B](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct)_original|0.8900|
| [Qwen2_2B](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct)_GPTQ_mse_256_qsamples|0.8630|
| [Qwen2_2B](https://huggingface.co/Qwen/Qwen2-VL-2B-Instruct)_GPTQ_smse_256_qsamples|**0.8780**|
|[Qwen3_2B](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct)_original|0.8570|
|[Qwen3_2B](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct)_GPTQ_mse_256_qsamples|0.8430|
|[Qwen3_2B](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct)_GPTQ_smse_256_qsamples|**0.8520**|


- [x] Support `Conv3d` (#577)
- [x] Support all Convs in `SensitivityCalibrator` (#581)
- [x] Add example script (#583)

Related: #548

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>