### PR TITLE
[quantization] Add `save_layers_to_folder` option

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -114,6 +114,39 @@ def save_circles_to(q_m, calib_inputs, save_circle_to_folder):
             cm.save(save_path)
 
 
+def save_layers_to(q_m, max_seq_len, save_layers_to_folder):
+    q_m.eval()
+    q_m.cpu()
+
+    if not hasattr(q_m, "wrapped"):
+        print("Saving layers currently is supported only for PTQ quantized model")
+        return
+
+    layers = q_m.wrapped.model.wrapped.layers
+    config = q_m.wrapped.config
+    for i, qlayer in enumerate(layers):
+        save_path = pathlib.Path(save_layers_to_folder, f"decoder_layer_{i}.q.circle")
+        B, S, D = 1, max_seq_len, config.hidden_size
+        example_hidden = torch.randn(B, S, D)
+
+        attention_mask = qlayer.wrapped._slice_causal(S, "cpu").squeeze(0)
+        dtype = example_hidden.dtype
+        pos_embeds = qlayer.wrapped._slice_rope(S, "cpu", dtype)
+
+        print(f"Saving model layer_{i} to {save_path.resolve()}")
+        with torch.no_grad():
+            with SuppressWarning(UserWarning, ".*"):
+                cm = tico.convert(
+                    qlayer,
+                    (example_hidden,),
+                    kwargs={
+                        "attention_mask": attention_mask,
+                        "position_embeddings": pos_embeds,
+                    },
+                )
+        cm.save(save_path)
+
+
 def quantize_using_PTQ(q_m, calib_inputs, args):
     print("Wrapping layers with PTQWrapper …")
 
@@ -234,6 +267,12 @@ def main():
         type=str,
         default=None,
         help="Save embedding/lm_head/all_layers/model.model/the_whole_model to the folder specified",
+    )
+    parser.add_argument(
+        "--save_layers_to_folder",
+        type=str,
+        default=None,
+        help="Save all layers to the folder specified",
     )
     parser.add_argument(
         "--cache_dir",
@@ -412,6 +451,9 @@ def main():
 
     # after PTQ quantizer only fixed-length input sequences are valid
     evaluate(q_m, tokenizer, dataset_test, args)
+
+    if args.save_layers_to_folder is not None:
+        save_layers_to(q_m, args.max_seq_len, args.save_layers_to_folder)
 
     if args.save_circle_to_folder is not None:
         calib_inputs = list(torch.stack(calib_inputs).reshape(-1, 1, args.max_seq_len))

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer_prefill.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer_prefill.py
@@ -170,6 +170,15 @@ class QuantLlamaDecoderLayerPrefill(QuantModuleBase):
         assert isinstance(self.causal_mask_template, torch.Tensor)
         return self.causal_mask_template[..., :seq_len, :seq_len].to(device)
 
+    def _slice_rope(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert isinstance(self.rope_cos_template, torch.Tensor)
+        assert isinstance(self.rope_sin_template, torch.Tensor)
+        cos = self.rope_cos_template[:, :seq_len, :].to(device=device, dtype=dtype)
+        sin = self.rope_sin_template[:, :seq_len, :].to(device=device, dtype=dtype)
+        return cos, sin
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -198,13 +207,8 @@ class QuantLlamaDecoderLayerPrefill(QuantModuleBase):
         )  # let it be quantized immediately
 
         if position_embeddings is None:
-            position_embeddings = (
-                self.rope_cos_template.to(
-                    dtype=hidden_states.dtype, device=hidden_states.device
-                ),
-                self.rope_sin_template.to(
-                    dtype=hidden_states.dtype, device=hidden_states.device
-                ),
+            position_embeddings = self._slice_rope(
+                hidden_states.size(1), hidden_states.device, hidden_states.dtype
             )
         cos, sin = position_embeddings
         position_embeddings = (


### PR DESCRIPTION
This PR adds `save_layers_to_folder` option to make it possible to save all layers of quantized model to separate files.

Log of `python tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py --model Maykeye/TinyLLama-v0 --gptq_mse=mse save_layers_to_folder='.'  `:
```
Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_PTQ=False, save_circle_to_folder='.', save_layers_to_folder='.', cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse='mse', max_seq_len=2048, calibrate_seq_len=2048, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks=None, sensitivity_path=None)
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL:  99%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌ | 158/159 [00:06<00:00, 22.90it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  7584.31
└───────────────────────────────────────────
Applying GPTQ …
Quantizing layers: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:08<00:00,  1.04s/layer]
Wrapping layers with PTQWrapper …                                                                                                                                                                                                                                              
Calibrating PTQ obeservers…
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:39<00:00,  3.20it/s]

Calculating perplexities …
PPL:  99%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌ | 158/159 [00:28<00:00,  5.59it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  7297.10
└───────────────────────────────────────────
Saving model layer_0 to /mnt/storage/slow_repos/TICO/decoder_layer_0.q.circle
Saving model layer_1 to /mnt/storage/slow_repos/TICO/decoder_layer_1.q.circle
Saving model layer_2 to /mnt/storage/slow_repos/TICO/decoder_layer_2.q.circle
Saving model layer_3 to /mnt/storage/slow_repos/TICO/decoder_layer_3.q.circle
Saving model layer_4 to /mnt/storage/slow_repos/TICO/decoder_layer_4.q.circle
Saving model layer_5 to /mnt/storage/slow_repos/TICO/decoder_layer_5.q.circle
Saving model layer_6 to /mnt/storage/slow_repos/TICO/decoder_layer_6.q.circle
Saving model layer_7 to /mnt/storage/slow_repos/TICO/decoder_layer_7.q.circle
```

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>