### PR TITLE
[quantization] Introduce wrapper for Qwen3VLTextDecoderLayer

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import tempfile
+import unittest
+import warnings
+
+import tico
+
+import torch
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.nn.quant_layernorm import QuantLayerNorm
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer import (
+    QuantQwen3VLTextDecoderLayer,
+)
+
+
+skip_msg = (
+    "required transformers not installed — skipping Qwen3VLTextDecoderLayer tests"
+)
+
+
+@unittest.skipUnless(has_transformers_for("qwen3-vl"), skip_msg)
+class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
+    fp_model: torch.nn.Module
+    hidden_size: int
+    num_attention_heads: int
+    head_dim: int
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+            Qwen3VLTextConfig,
+        )
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLTextDecoderLayer,
+        )
+
+        # Use smaller sizes for testing
+        cfg = Qwen3VLTextConfig(
+            hidden_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=32,
+            max_position_embeddings=2048,
+            intermediate_size=1024,
+        )
+
+        # Ensure eager attention implementation so outputs are deterministic
+        # and do not require GPU flash attention kernels.
+        # Some versions use `_attn_implementation`, others expose `attn_implementation`.
+        if not hasattr(cfg, "_attn_implementation"):
+            setattr(cfg, "_attn_implementation", "eager")
+        else:
+            cfg._attn_implementation = "eager"
+
+        cls.fp_model = Qwen3VLTextDecoderLayer(cfg, layer_idx=0)
+        cls.hidden_size = cfg.hidden_size
+        cls.num_attention_heads = cfg.num_attention_heads
+        cls.head_dim = cls.hidden_size // cls.num_attention_heads
+
+    def _rand_position_embeddings(self, batch_size, seq_len):
+        """Helper to create dummy rotary position embeddings"""
+        cos = torch.randn(batch_size, seq_len, self.head_dim)
+        sin = torch.randn(batch_size, seq_len, self.head_dim)
+        return cos, sin
+
+    def _create_test_inputs(self, batch_size=2, seq_len=16):
+        """Helper to create test inputs for TextDecoderLayer."""
+        hidden_states = torch.randn(batch_size, seq_len, self.hidden_size)
+        position_embeddings = self._rand_position_embeddings(batch_size, seq_len)
+        attention_mask = torch.ones(batch_size, 1, seq_len, seq_len)
+        position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
+        return hidden_states, position_embeddings, attention_mask, position_ids
+
+    def test_mode_transitions(self):
+        """Test quantization mode transitions: NO_QUANT → CALIB → QUANT"""
+
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        self.assertIs(q_model._mode, Mode.NO_QUANT)
+
+        q_model.enable_calibration()
+        self.assertIs(q_model._mode, Mode.CALIB)
+
+        # Run forward pass during calibration
+        hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
+        _ = q_model(
+            hidden_states=hidden_states,
+            position_embeddings=pos_emb,
+            attention_mask=attn_mask,
+            position_ids=pos_ids,
+        )
+
+        q_model.freeze_qparams()
+        self.assertIs(q_model._mode, Mode.QUANT)
+
+    def test_forward_diff(self):
+        """
+        Test that quantized output is acceptably close to FP32 reference.
+        """
+        torch.manual_seed(42)
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        q_model.enable_calibration()
+
+        # Calibrate with multiple inputs
+        for _ in range(4):
+            hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
+            _ = q_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+
+        q_model.freeze_qparams()
+
+        hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
+        with torch.no_grad():
+            q_out = q_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+            fp_out = self.fp_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+
+        self.assertEqual(fp_out.shape, q_out.shape)
+        diff = (fp_out - q_out).abs().mean().item()
+        self.assertGreater(diff, 0.0)  # not identical
+        self.assertLess(diff, 0.7)  # acceptably close
+
+    def test_registration_in_registry(self):
+        """
+        Test that Qwen3VLTextDecoderLayer is properly registered.
+        """
+        from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer import (
+            QuantQwen3VLTextDecoderLayer,
+        )
+        from tico.quantization.wrapq.wrappers.registry import lookup
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLTextDecoderLayer,
+        )
+
+        wrapper_cls = lookup(Qwen3VLTextDecoderLayer)
+        self.assertIs(wrapper_cls, QuantQwen3VLTextDecoderLayer)
+
+    def test_output_shape(self):
+        """
+        Test that output shape is preserved.
+        Input: (batch_size, seq_len, hidden_size)
+        Output: (batch_size, seq_len, hidden_size)
+        """
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        q_model.enable_calibration()
+
+        batch_size = 2
+        seq_len = 16
+        hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs(
+            batch_size, seq_len
+        )
+        _ = q_model(
+            hidden_states=hidden_states,
+            position_embeddings=pos_emb,
+            attention_mask=attn_mask,
+            position_ids=pos_ids,
+        )
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+            fp_out = self.fp_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+
+        expected_shape = (batch_size, seq_len, self.hidden_size)
+        self.assertEqual(q_out.shape, expected_shape)
+        self.assertEqual(fp_out.shape, expected_shape)
+
+    def test_residual_connection_preservation(self):
+        """
+        Test that residual connections are preserved (output close to input + transformation).
+        """
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        q_model.enable_calibration()
+
+        hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
+        _ = q_model(
+            hidden_states=hidden_states,
+            position_embeddings=pos_emb,
+            attention_mask=attn_mask,
+            position_ids=pos_ids,
+        )
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            # Save input
+            input_copy = hidden_states.clone()
+
+            # Run forward pass
+            output = q_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+
+        # Output should be different from input (transformation applied)
+        self.assertFalse(torch.equal(output, input_copy))
+
+        # But shape should be preserved
+        self.assertEqual(output.shape, input_copy.shape)
+
+    def test_observer_count(self):
+        """
+        Test that the wrapper has the correct number of observers.
+        - 3 local observers (input, post_attn, output)
+        """
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        observers = list(q_model._all_observers())
+        # Should have 3 local observers
+        self.assertEqual(len(observers), 3)
+
+    def test_per_module_override(self):
+        """
+        Test that PTQConfig overrides propagate correctly to submodules.
+        """
+        cfg = PTQConfig(
+            default_dtype=DType.uint(8),
+            overrides={
+                "self_attn": {
+                    "act_in": {"dtype": DType.uint(4)},
+                }
+            },
+        )
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model, qcfg=cfg)
+
+        # Check that override is applied to local observer
+        self.assertEqual(q_model.obs_act_in.dtype, DType.uint(8))
+
+    def test_different_batch_sizes(self):
+        """
+        Test that quantization works correctly with different batch sizes.
+        """
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        q_model.enable_calibration()
+
+        # Calibrate with one batch size
+        calibrate_hidden, pos_emb, attn_mask, pos_ids = self._create_test_inputs(
+            batch_size=2
+        )
+        for _ in range(3):
+            _ = q_model(
+                hidden_states=calibrate_hidden,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+            )
+        q_model.freeze_qparams()
+
+        # Test with different batch sizes
+        for batch_size in [1, 2, 4]:
+            hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs(
+                batch_size=batch_size
+            )
+            with torch.no_grad():
+                q_out = q_model(
+                    hidden_states=hidden_states,
+                    position_embeddings=pos_emb,
+                    attention_mask=attn_mask,
+                    position_ids=pos_ids,
+                )
+                fp_out = self.fp_model(
+                    hidden_states=hidden_states,
+                    position_embeddings=pos_emb,
+                    attention_mask=attn_mask,
+                    position_ids=pos_ids,
+                )
+
+            self.assertEqual(q_out.shape, fp_out.shape)
+            diff = (fp_out - q_out).abs().mean().item()
+            self.assertLess(diff, 0.8)

--- a/tico/quantization/wrapq/examples/qwen/quantize_text_decoder_layer.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_text_decoder_layer.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import importlib.util
+import sys
+
+import torch
+
+import tico
+import tico.quantization
+import tico.quantization.config.ptq
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.evaluation.utils import plot_two_outputs
+from tico.quantization.wrapq.utils.version import has_transformers_for
+
+torch.manual_seed(123)
+
+
+# Check if transformers is available
+
+if not has_transformers_for("qwen3-vl"):
+    print(
+        "Error: transformers package not installed. Cannot test Qwen3VLTextDecoderLayer."
+    )
+    sys.exit(1)
+
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+    Qwen3VLTextConfig,
+    Qwen3VLTextDecoderLayer,
+)
+
+
+def generate_calibration_data(
+    batch_size: int, hidden_size: int, seq_len: int, head_dim: int
+) -> tuple:
+    """Generate calibration data for PTQ"""
+    calibration_data = []
+    for i in range(batch_size):
+        hidden_states = torch.randn(1, seq_len, hidden_size)
+        calibration_data.append(hidden_states)
+
+    position_embeddings = (
+        torch.randn(1, seq_len, head_dim),
+        torch.randn(1, seq_len, head_dim),
+    )
+    attention_mask = torch.ones(1, 1, seq_len, seq_len)
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+    return calibration_data, position_embeddings, attention_mask, position_ids
+
+
+def main():
+    # Create a sample config
+    cfg = Qwen3VLTextConfig(
+        hidden_size=256,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=128,
+        max_position_embeddings=2048,
+        intermediate_size=1024,
+    )
+
+    # Ensure eager attention implementation so outputs are deterministic
+    # and do not require GPU flash attention kernels.
+    # Some versions use `_attn_implementation`, others expose `attn_implementation`.
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+
+    # Create a decoder layer
+    model = Qwen3VLTextDecoderLayer(cfg, layer_idx=0)
+    orig_model = copy.deepcopy(model)
+    model.eval()
+
+    # Prepare for quantization
+    qcfg = tico.quantization.config.ptq.PTQConfig()
+    prepared_model = tico.quantization.prepare(model, qcfg)
+
+    # Calibrate the model (collect statistics)
+    batch_size = 10
+    seq_len = 128
+    hidden_size = cfg.hidden_size
+    head_dim = hidden_size // cfg.num_attention_heads
+
+    (
+        calibration_data,
+        position_embeddings,
+        attention_mask,
+        position_ids,
+    ) = generate_calibration_data(
+        batch_size=batch_size,
+        hidden_size=hidden_size,
+        seq_len=seq_len,
+        head_dim=head_dim,
+    )
+    for hidden_states in calibration_data:
+        prepared_model(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+    # Convert to quantized version
+    quantized_model = tico.quantization.convert(prepared_model, inplace=True)
+
+    # Compute PEIR (Peak Error-to-Input Ratio) between quantized model and original model
+    with torch.no_grad():
+        test_input = calibration_data[0]
+        quant_out = quantized_model(
+            hidden_states=test_input,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+        fp_out = orig_model(
+            hidden_states=test_input,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+    print(f"┌───────────── Quantization Error Summary ─────────────")
+    print(f"│ Mean |diff|: {(quant_out - fp_out).abs().mean().item():.6f}")
+    print(f"│ PEIR       : {compute_peir(fp_out, quant_out) * 100:.6f} %")
+    print(f"└──────────────────────────────────────────────────────")
+    print(plot_two_outputs(fp_out, quant_out))
+
+    # Convert to Circle format
+    example_input = (
+        calibration_data[0],
+        position_embeddings,
+        attention_mask,
+        position_ids,
+    )
+    circle_model = tico.convert(quantized_model.eval(), example_input)
+
+    # Save the Circle model
+    filename = "qwen3vl_text_decoder_layer.q.circle"
+    circle_model.save(filename)
+    print(f"Circle model saved as '{filename}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+@try_register(
+    "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLTextDecoderLayer",
+)
+class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
+    """
+    Quantization wrapper for Qwen3VLTextDecoderLayer module.
+
+    This is a Transformer decoder layer for text processing, containing:
+    - 2 RMSNorm layers (pre-norm architecture)
+    - 1 Self-Attention module
+    - 1 MLP (Feed-Forward Network)
+    - 2 Residual connections
+    """
+
+    def __init__(
+        self,
+        fp_layer: nn.Module,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ):
+        super().__init__(qcfg, fp_name=fp_name)
+
+        assert hasattr(fp_layer, "self_attn")
+        assert hasattr(fp_layer, "mlp")
+        assert hasattr(fp_layer, "input_layernorm")
+        assert hasattr(fp_layer, "post_attention_layernorm")
+
+        # --- Wrap submodules via PTQWrapper ----------------------------------
+        self_attn_cfg = qcfg.child("self_attn") if qcfg else None
+        mlp_cfg = qcfg.child("mlp") if qcfg else None
+        input_layernorm_cfg = qcfg.child("input_layernorm") if qcfg else None
+        post_attention_layernorm_cfg = (
+            qcfg.child("post_attention_layernorm") if qcfg else None
+        )
+
+        self.self_attn = PTQWrapper(
+            fp_layer.self_attn,
+            qcfg=self_attn_cfg,
+            fp_name=f"{fp_name}.self_attn",
+        )
+
+        self.mlp = PTQWrapper(
+            fp_layer.mlp,
+            qcfg=mlp_cfg,
+            fp_name=f"{fp_name}.mlp",
+        )
+
+        self.input_layernorm = PTQWrapper(
+            fp_layer.input_layernorm,
+            qcfg=input_layernorm_cfg,
+            fp_name=f"{fp_name}.input_layernorm",
+        )
+
+        self.post_attention_layernorm = PTQWrapper(
+            fp_layer.post_attention_layernorm,
+            qcfg=post_attention_layernorm_cfg,
+            fp_name=f"{fp_name}.post_attention_layernorm",
+        )
+
+        # --- Observers for residual additions ----------------------------------
+        mk = self._make_obs
+        self.obs_act_in = mk("act_in")
+        self.obs_post_attn = mk("post_attn")
+        self.obs_act_out = mk("act_out")
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: torch.Tensor | None = None,
+        use_cache: bool | None = False,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Forward pass with fake quantization.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_len, hidden_size)
+            position_embeddings: (cos, sin) position embeddings tuple
+            attention_mask: Attention mask tensor (optional)
+            position_ids: Position indices tensor (optional)
+            past_key_values: Cached key-value pairs for attention (optional)
+            use_cache: Whether to use key-value caching (optional)
+            cache_position: Cache position indices (optional)
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            Transformed hidden states of shape (batch_size, seq_len, hidden_size)
+        """
+        # Quantize input activation
+        hidden_states = self._fq(hidden_states, self.obs_act_in)
+
+        # Save input for residual connection
+        residual = hidden_states
+
+        # Pre-attention normalization
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self-attention
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+
+        # Post-attention residual connection
+        hidden_states = hidden_states + residual
+        hidden_states = self._fq(hidden_states, self.obs_post_attn)
+
+        # Save for MLP residual connection
+        residual = hidden_states
+
+        # Pre-MLP normalization
+        hidden_states = self.post_attention_layernorm(hidden_states)
+
+        # Feed-Forward Network (MLP)
+        hidden_states = self.mlp(hidden_states)
+
+        # Post-MLP residual connection
+        hidden_states = hidden_states + residual
+
+        # Quantize output activation
+        hidden_states = self._fq(hidden_states, self.obs_act_out)
+
+        return hidden_states
+
+    def _all_observers(self) -> Iterable:
+        """Yield all observers from this module."""
+        # Local observers for residual connections
+        yield from (
+            self.obs_act_in,
+            self.obs_post_attn,
+            self.obs_act_out,
+        )

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -69,6 +69,7 @@ _CORE_MODULES = (
     ## qwen_vl ##
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_attn",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_mlp",
+    "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_attn",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_mlp",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_patch_embed",


### PR DESCRIPTION
This change introduces `QuantQwen3VLTextDecoderLayer` wrapper to support post-training quantization of `Qwen3VLTextDecoderLayer` module.

# Why?

`Qwen3VLTextDecoderLayer` is an essential part of Qwen model.
Trying to quantize `Qwen3VLTextDecoderLayer` via PTQ generates exception `PTQQuantizer: no quantization wrapper for Qwen3VLTextDecoderLayer`.

# What

This change introduces:

- Class `QuantQwen3VLTextDecoderLayer` (`tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py`).
- Unit tests: `class TestQuantQwen3VLTextDecoderLayer` (`test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py`) - skipped if `transformers` package is not installed.
- New entry in `_CORE_MODULES` (`tico/quantization/wrapq/wrappers/registry.py`).
- Example of `Qwen3VLTextDecoderLayer` quantization and conversion to Circle (`tico/quantization/wrapq/examples/qwen/quantize_text_decoder_layer.py`).

# Unit Tests

Unit tests results with coverage information:

```bash
$ coverage run -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py -v
================================================================== test session starts ===================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 8 items

test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_different_batch_sizes            PASSED [ 12%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_forward_diff                     PASSED [ 25%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_mode_transitions                 PASSED [ 37%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_observer_count                   PASSED [ 50%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_output_shape                     PASSED [ 62%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_per_module_override              PASSED [ 75%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_registration_in_registry         PASSED [ 87%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py::TestQuantQwen3VLTextDecoderLayer::test_residual_connection_preservation PASSED [100%]

======================================================== 8 passed, 2 warnings in 80.06s (0:01:20) ========================================================
```

Coverage info (irrelevant files skipped):

```bash
$ coverage report -m

Name                                                                    Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------
...
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py       42      0   100%
...
-----------------------------------------------------------------------------------------------------
TOTAL                                                                   11272   7196    36%
```

# Script for testing quantization and conversion to Circle

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_text_decoder_layer.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.018236
│ PEIR       : 1.069503 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 4.5┤                                            │
    │                                         •  │
    │                                      •••   │
 3.0┤                                    •••     │
    │                                  •••       │
    │                                •••         │
    │                             ••••           │
 1.5┤                           ••••             │
    │                         ••••               │
    │                       ••••                 │
 0.0┤                     ••••                   │
    │                   ••••                     │
    │                 ••••                       │
    │               ••••                         │
-1.5┤             ••••                           │
    │           ••••                             │
    │         •••                                │
-3.0┤       •••                                  │
    │     •••                                    │
    │   •••                                      │
    │  •                                         │
-4.5┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -4.5       -2.3        0.0       2.3       4.5 

Circle model saved as 'qwen3vl_text_decoder_layer.q.circle'
```