### PR TITLE
[quantization] Remove unused tokenizer

### DIFF
--- a/tico/quantization/algorithm/gptq/utils.py
+++ b/tico/quantization/algorithm/gptq/utils.py
@@ -113,9 +113,8 @@ class SensitivityCalibrator:
     Please see https://arxiv.org/abs/1905.12558?ref=inference.vc for a discussion.
     """
 
-    def __init__(self, model, tokenizer, dataset):
+    def __init__(self, model, dataset):
         self.model = model
-        self.tokenizer = tokenizer
         self.dataset = dataset
 
     def compute_sensitivity_info(self):

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -425,7 +425,7 @@ def main():
             if args.sensitivity_path is not None:
                 sens = torch.load(args.sensitivity_path)
             else:
-                calibrator = SensitivityCalibrator(model, tokenizer, calib_inputs)
+                calibrator = SensitivityCalibrator(model, calib_inputs)
                 sens = calibrator.compute_sensitivity_info()
 
         gptq_config = GPTQConfig(


### PR DESCRIPTION
This PR removes unused tokenizer from SensitivityCalibrator.

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>