### PR TITLE
[quantization] Fix for multiple gpu

### DIFF
--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -254,7 +254,7 @@ class GPTQ:
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp
         inp = math.sqrt(2 / self.nsamples) * inp.float()
-        self.H += inp.matmul(inp.t())
+        self.H += inp.matmul(inp.t()).to(self.H.device)
 
     def fasterquant(
         self,


### PR DESCRIPTION
This PR fixes usage of multiple gpus for colleting Hessian statistics.

While running #559 it occured that `inp` and `Hessian` can reside on different GPU's so this PR transfers `inp` statistics to `Hessian`'s device.

Draft: #559
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>