### PR TITLE
[quantization] Introduce wrapper for Qwen3VLTextModel

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_model import (
+    QuantQwen3VLTextModel,
+)
+
+skip_msg = "required transformers not installed — skipping Qwen3VLTextModel tests"
+
+
+@unittest.skipUnless(has_transformers_for("qwen3-vl"), skip_msg)
+class TestQuantQwen3VLTextModel(unittest.TestCase):
+    fp_model: torch.nn.Module
+    vocab_size: int
+    hidden_size: int
+    num_hidden_layers: int
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+            Qwen3VLTextConfig,
+        )
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLTextModel
+
+        # Use smaller sizes for testing
+        cfg = Qwen3VLTextConfig(
+            vocab_size=1000,
+            hidden_size=64,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=16,
+            max_position_embeddings=1024,
+            rope_scaling={"rope_type": "default", "mrope_section": [1, 1, 2]},
+        )
+
+        # Ensure eager attention implementation so outputs are deterministic
+        # and do not require GPU flash attention kernels.
+        # Some versions use `_attn_implementation`, others expose `attn_implementation`.
+        if not hasattr(cfg, "_attn_implementation"):
+            setattr(cfg, "_attn_implementation", "eager")
+        else:
+            cfg._attn_implementation = "eager"
+
+        cls.fp_model = Qwen3VLTextModel(cfg)
+        cls.vocab_size = cfg.vocab_size
+        cls.hidden_size = cfg.hidden_size
+        cls.num_hidden_layers = cfg.num_hidden_layers
+
+    def _create_test_inputs(self, batch_size=2, seq_len=16):
+        """Helper to create test inputs for TextModel."""
+        input_ids = torch.randint(0, self.vocab_size, (batch_size, seq_len))
+        return input_ids
+
+    def test_mode_transitions(self):
+        """Test quantization mode transitions: NO_QUANT → CALIB → QUANT"""
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        self.assertIs(q_model._mode, Mode.NO_QUANT)
+
+        q_model.enable_calibration()
+        self.assertIs(q_model._mode, Mode.CALIB)
+
+        # Run forward pass during calibration
+        input_ids = self._create_test_inputs()
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+        self.assertIs(q_model._mode, Mode.QUANT)
+
+    def test_forward_diff(self):
+        """
+        Test that quantized output is acceptably close to FP32 reference.
+        """
+        torch.manual_seed(42)
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        # Calibrate with multiple inputs
+        for _ in range(4):
+            input_ids = self._create_test_inputs()
+            _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        input_ids = self._create_test_inputs()
+        with torch.no_grad():
+            q_out = q_model(input_ids=input_ids, use_cache=False)
+            fp_out = self.fp_model(input_ids=input_ids, use_cache=False)
+
+        # Extract last_hidden_state
+        q_hidden = q_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+        self.assertEqual(fp_hidden.shape, q_hidden.shape)
+        diff = (fp_hidden - q_hidden).abs().mean().item()
+        self.assertGreater(diff, 0.0)  # not identical
+        self.assertLess(diff, 0.7)  # acceptably close
+
+    def test_registration_in_registry(self):
+        """
+        Test that Qwen3VLTextModel is properly registered.
+        """
+        from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_model import (
+            QuantQwen3VLTextModel,
+        )
+        from tico.quantization.wrapq.wrappers.registry import lookup
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLTextModel
+
+        wrapper_cls = lookup(Qwen3VLTextModel)
+        self.assertIs(wrapper_cls, QuantQwen3VLTextModel)
+
+    def test_output_shape(self):
+        """
+        Test that output shape is preserved.
+        Input: (batch_size, seq_len)
+        Output last_hidden_state: (batch_size, seq_len, hidden_size)
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        batch_size = 2
+        seq_len = 16
+        input_ids = self._create_test_inputs(batch_size, seq_len)
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(input_ids=input_ids, use_cache=False)
+            fp_out = self.fp_model(input_ids=input_ids, use_cache=False)
+
+        q_hidden = q_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+        expected_shape = (batch_size, seq_len, self.hidden_size)
+        self.assertEqual(q_hidden.shape, expected_shape)
+        self.assertEqual(fp_hidden.shape, expected_shape)
+
+    def test_embedding_layer_quantization(self):
+        """
+        Test that embedding layer is properly wrapped and quantized.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs()
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        # Check that embed_tokens is wrapped
+        from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+        self.assertIsInstance(q_model.embed_tokens, PTQWrapper)
+
+    def test_rotary_emb_not_wrapped(self):
+        """
+        Test that rotary_emb is NOT wrapped (saved as-is).
+        """
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLTextRotaryEmbedding,
+        )
+
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+
+        # rotary_emb should be the original module, not a wrapper
+        self.assertIsInstance(q_model.rotary_emb, Qwen3VLTextRotaryEmbedding)
+
+        from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+        self.assertNotIsInstance(q_model.rotary_emb, PTQWrapper)
+
+    def test_layers_wrapped(self):
+        """
+        Test that all decoder layers are properly wrapped with PTQWrapper.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+
+        from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+        self.assertEqual(len(q_model.layers), self.num_hidden_layers)
+        for layer in q_model.layers:
+            self.assertIsInstance(layer, PTQWrapper)
+
+    def test_norm_wrapped(self):
+        """
+        Test that final normalization layer is properly wrapped.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+
+        from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+        self.assertIsInstance(q_model.norm, PTQWrapper)
+
+    def test_different_batch_sizes(self):
+        """
+        Test that quantization works correctly with different batch sizes.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        # Calibrate with one batch size
+        calibrate_input = self._create_test_inputs(batch_size=2)
+        for _ in range(3):
+            _ = q_model(input_ids=calibrate_input, use_cache=False)
+        q_model.freeze_qparams()
+
+        # Test with different batch sizes
+        for batch_size in [1, 2, 4]:
+            input_ids = self._create_test_inputs(batch_size=batch_size)
+            with torch.no_grad():
+                q_out = q_model(input_ids=input_ids, use_cache=False)
+                fp_out = self.fp_model(input_ids=input_ids, use_cache=False)
+
+            q_hidden = q_out.last_hidden_state
+            fp_hidden = fp_out.last_hidden_state
+
+            self.assertEqual(q_hidden.shape[0], batch_size)
+            self.assertEqual(fp_hidden.shape[0], batch_size)
+            diff = (fp_hidden - q_hidden).abs().mean().item()
+            self.assertLess(diff, 0.8)
+
+    def test_different_sequence_lengths(self):
+        """
+        Test that quantization works correctly with different sequence lengths.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        # Calibrate with one sequence length
+        calibrate_input = self._create_test_inputs(seq_len=16)
+        for _ in range(3):
+            _ = q_model(input_ids=calibrate_input, use_cache=False)
+        q_model.freeze_qparams()
+
+        # Test with different sequence lengths
+        for seq_len in [8, 16, 32]:
+            input_ids = self._create_test_inputs(seq_len=seq_len)
+            with torch.no_grad():
+                q_out = q_model(input_ids=input_ids, use_cache=False)
+                fp_out = self.fp_model(input_ids=input_ids, use_cache=False)
+
+            q_hidden = q_out.last_hidden_state
+            fp_hidden = fp_out.last_hidden_state
+
+            self.assertEqual(q_hidden.shape[1], seq_len)
+            self.assertEqual(fp_hidden.shape[1], seq_len)
+            diff = (fp_hidden - q_hidden).abs().mean().item()
+            self.assertLess(diff, 0.8)
+
+    def test_observer_count(self):
+        """
+        Test that the wrapper has the correct number of observers.
+        - 5 local observers (embeds, cos, sin, hidden_states, visual_embeds)
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        observers = list(q_model._all_observers())
+        # Should have 6 local observers
+        self.assertEqual(len(observers), 5 + len(q_model.layers))
+
+    def test_per_module_override(self):
+        """
+        Test that PTQConfig overrides propagate correctly to submodules.
+        """
+        cfg = PTQConfig(
+            default_dtype=DType.uint(8),
+            overrides={"inputs_embeds": {"dtype": DType.uint(4)}},
+        )
+        q_model = QuantQwen3VLTextModel(self.fp_model, qcfg=cfg)
+
+        # Check that override is applied
+        # The embed_tokens weight should have the override
+        self.assertEqual(q_model.obs_inputs_embeds.dtype, DType.uint(4))
+
+    def test_deepstack_injection(self):
+        """
+        Test that DeepStack visual feature injection works correctly.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        batch_size = 2
+        seq_len = 16
+        input_ids = self._create_test_inputs(batch_size, seq_len)
+
+        # Calibrate without DeepStack
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        # Test with DeepStack features
+        visual_pos_masks = torch.zeros(batch_size, seq_len, dtype=torch.bool)
+        visual_pos_masks[:, :4] = True  # First 4 positions get visual features
+
+        # Create visual embeddings for first layer only
+        visual_embeds = [
+            torch.randn(
+                8, self.hidden_size
+            )  # 8 visual tokens (batch_size * 4 positions)
+        ]
+
+        with torch.no_grad():
+            q_out = q_model(
+                input_ids=input_ids,
+                visual_pos_masks=visual_pos_masks,
+                deepstack_visual_embeds=visual_embeds,
+                use_cache=False,
+            )
+            fp_out = self.fp_model(
+                input_ids=input_ids,
+                visual_pos_masks=visual_pos_masks,
+                deepstack_visual_embeds=visual_embeds,
+                use_cache=False,
+            )
+
+        q_hidden = q_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+        self.assertEqual(q_hidden.shape, fp_hidden.shape)
+        # Visual positions should have different values due to DeepStack injection
+        self.assertFalse(
+            torch.equal(
+                q_hidden[visual_pos_masks],
+                fp_hidden[visual_pos_masks],
+            )
+        )
+
+    def test_inputs_embeds_path(self):
+        """
+        Test that the model works correctly when inputs_embeds are provided instead of input_ids.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        # Calibrate with input_ids
+        input_ids = self._create_test_inputs()
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        # Test with inputs_embeds
+        batch_size = 2
+        seq_len = 16
+        inputs_embeds = torch.randn(batch_size, seq_len, self.hidden_size)
+
+        with torch.no_grad():
+            q_out = q_model(inputs_embeds=inputs_embeds, use_cache=False)
+            fp_out = self.fp_model(inputs_embeds=inputs_embeds, use_cache=False)
+
+        q_hidden = q_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+        self.assertEqual(q_hidden.shape, fp_hidden.shape)
+        diff = (fp_hidden - q_hidden).abs().mean().item()
+        self.assertLess(diff, 1.0)
+
+    def test_no_cache_mode(self):
+        """
+        Test that the model works correctly with use_cache=False.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs()
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(input_ids=input_ids, use_cache=False)
+            fp_out = self.fp_model(input_ids=input_ids, use_cache=False)
+
+        q_hidden = q_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+        self.assertEqual(q_hidden.shape, fp_hidden.shape)
+        diff = (fp_hidden - q_hidden).abs().mean().item()
+        self.assertLess(diff, 0.7)
+
+        # past_key_values should be None when use_cache=False
+        self.assertIsNone(q_out.past_key_values)
+        self.assertIsNone(fp_out.past_key_values)

--- a/tico/quantization/wrapq/examples/qwen/quantize_text_model.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_text_model.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import sys
+
+import torch
+
+import tico
+import tico.quantization
+import tico.quantization.config.ptq
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.evaluation.utils import plot_two_outputs
+from tico.quantization.wrapq.utils.version import has_transformers_for
+
+torch.manual_seed(123)
+
+
+# Check if transformers is available
+
+if not has_transformers_for("qwen3-vl"):
+    print("Error: transformers package not installed. Cannot test Qwen3VLTextModel.")
+    sys.exit(1)
+
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+    Qwen3VLTextConfig,
+    Qwen3VLTextModel,
+)
+
+
+def generate_calibration_data(
+    batch_size: int, vocab_size: int, seq_len: int
+) -> list[torch.Tensor]:
+    """Generate calibration data for PTQ"""
+    calibration_data = []
+    for _ in range(batch_size):
+        # Generate random input IDs
+        input_ids = torch.randint(0, vocab_size, (1, seq_len))
+        calibration_data.append(input_ids)
+    return calibration_data
+
+
+def main():
+    # Create a sample config (small model for faster testing)
+    cfg = Qwen3VLTextConfig(
+        vocab_size=10000,  # Smaller vocab for testing
+        hidden_size=256,  # Smaller hidden size
+        intermediate_size=1024,  # Smaller intermediate size
+        num_hidden_layers=2,  # Only 2 layers for testing
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=128,
+        max_position_embeddings=2048,
+        use_cache=False,
+    )
+
+    # Ensure eager attention implementation so outputs are deterministic
+    # and do not require GPU flash attention kernels.
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+
+    # Create the text model
+    model = Qwen3VLTextModel(cfg)
+    orig_model = copy.deepcopy(model)
+    model.eval()
+
+    # Prepare for quantization
+    qcfg = tico.quantization.config.ptq.PTQConfig()
+    prepared_model = tico.quantization.prepare(model, qcfg)
+
+    # Calibrate the model (collect statistics)
+    batch_size = 10
+    seq_len = 128
+    vocab_size = cfg.vocab_size
+
+    calibration_data = generate_calibration_data(
+        batch_size=batch_size,
+        vocab_size=vocab_size,
+        seq_len=seq_len,
+    )
+
+    for input_ids in calibration_data:
+        prepared_model(
+            input_ids=input_ids,
+            use_cache=False,  # Disable caching for calibration
+        )
+
+    # Convert to quantized version
+    quantized_model = tico.quantization.convert(prepared_model, inplace=True)
+
+    # Compute PEIR (Peak Error-to-Interval Ratio) between quantized model and original model
+    with torch.no_grad():
+        test_input_ids = calibration_data[0]
+        quant_out = quantized_model(
+            input_ids=test_input_ids,
+            use_cache=False,
+        )
+        fp_out = orig_model(
+            input_ids=test_input_ids,
+            use_cache=False,
+        )
+
+        # Extract last_hidden_state for comparison
+        quant_hidden = quant_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+    print(f"┌───────────── Quantization Error Summary ─────────────")
+    print(f"│ Mean |diff|: {(quant_hidden - fp_hidden).abs().mean().item():.6f}")
+    print(f"│ PEIR       : {compute_peir(fp_hidden, quant_hidden) * 100:.6f} %")
+    print(f"└──────────────────────────────────────────────────────")
+    print(plot_two_outputs(fp_hidden, quant_hidden))
+
+    # Convert to Circle format
+    example_input = (calibration_data[0],)
+    circle_model = tico.convert(
+        quantized_model.eval(), example_input, kwargs={"use_cache": False}
+    )
+
+    # Save the Circle model
+    filename = "qwen3vl_text_model.q.circle"
+    circle_model.save(filename)
+    print(f"Circle model saved as '{filename}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -1,0 +1,382 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+from typing import Iterable, Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import try_register
+from transformers.cache_utils import Cache
+
+
+def apply_interleaved_mrope(self, freqs, mrope_section):
+    """
+    Apply interleaved MRoPE to 3D rotary embeddings.
+    Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
+    interleaved [THWTHWTHW...TT], preserving frequency continuity.
+
+    Args:
+        freqs: (3, bs, seq_len, head_dim // 2)
+        mrope_section: (3,)
+
+    Returns:
+        freqs_t: (bs, seq_len, head_dim // 2)
+
+    Design Note:
+        This implementation is using slice_copy, index_select, and cat
+        to avoid yet unsupported slice_scatter with step=3 operation and
+        to avoid unsupported in-place operator index_put.default.
+    """
+    # Start with T dimension (will keep some, replace some)
+    freqs_t_base = freqs[0]
+
+    # For each dimension (H, W), extract frequency bands to be interleaved
+    h_w_bands = []
+
+    for dim, offset in enumerate((1, 2), start=1):  # H, W dimensions
+        length = mrope_section[dim] * 3
+        indices = torch.arange(offset, length, 3, device=freqs.device)
+
+        # Select frequency bands from H/W dimensions
+        # freqs[dim] has shape (bs, seq_len, head_dim//2)
+        # index_select on last dim: (bs, seq_len, num_selected)
+        freqs_bands = freqs[dim].index_select(dim=-1, index=indices)
+        h_w_bands.append(freqs_bands)
+
+    # Now we need to build the interleaved output
+    # Original T dimension indices range from 0 to (head_dim // 2 - 1)
+    # We want to replace specific indices with H/W bands
+
+    # The interleaving pattern: T0, H1, W2, T3, H4, W5, T6, H7, W8, ...
+    # - Positions where i % 3 == 0: T dimension (unchanged from freqs[0])
+    # - Positions where i % 3 == 1: H dimension (overwritten from freqs[1])
+    # - Positions where i % 3 == 2: W dimension (overwritten from freqs[2])
+    # After mrope_section[dim] * 3 positions, H/W bands are exhausted and
+    # fallback to T values for all remaining mod 1 and mod 2 positions.
+
+    # Build the output by slicing and concatenating
+    # Strategy: Slice T dimension into chunks, insert H/W bands, concatenate
+
+    chunks = []
+    pos = 0
+
+    # Total length in the last dimension
+    total_len = freqs_t_base.shape[-1]
+
+    for i in range(total_len):
+        # Determine which dimension this position belongs to
+        # Pattern: T, H, W, T, H, W, T, H, W, ... (repeating cycle)
+        mod = i % 3
+
+        if mod == 0:
+            # T dimension position - take from T
+            # Slice just this index from T
+            chunk = freqs_t_base[..., i : i + 1]
+            chunks.append(chunk)
+        elif mod == 1:
+            # H dimension position - take from H
+            # Calculate which band this is
+            band_idx = (i - 1) // 3
+            if band_idx < h_w_bands[0].shape[-1]:
+                chunk = h_w_bands[0][..., band_idx : band_idx + 1]
+                chunks.append(chunk)
+            else:
+                # Fallback to T if out of bounds
+                chunk = freqs_t_base[..., i : i + 1]
+                chunks.append(chunk)
+        else:  # mod == 2
+            # W dimension position - take from W
+            band_idx = (i - 2) // 3
+            if band_idx < h_w_bands[1].shape[-1]:
+                chunk = h_w_bands[1][..., band_idx : band_idx + 1]
+                chunks.append(chunk)
+            else:
+                # Fallback to T if out of bounds
+                chunk = freqs_t_base[..., i : i + 1]
+                chunks.append(chunk)
+
+    # Concatenate all chunks
+    freqs_t = torch.cat(chunks, dim=-1)
+
+    return freqs_t
+
+
+@try_register(
+    "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLTextModel",
+)
+class QuantQwen3VLTextModel(QuantModuleBase):
+    """
+    Quantization wrapper for Qwen3VLTextModel module.
+
+    This is the text model for Qwen3VL, containing:
+    - Embedding layer (embed_tokens)
+    - Multiple decoder layers (layers)
+    - Final normalization layer (norm)
+    - Rotary position embedding (rotary_emb) - NOT wrapped
+    """
+
+    def __init__(
+        self,
+        fp_model: nn.Module,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ):
+        super().__init__(qcfg, fp_name=fp_name)
+
+        self.module = fp_model
+        self.config = fp_model.config
+
+        assert hasattr(fp_model, "embed_tokens")
+        assert hasattr(fp_model, "layers")
+        assert hasattr(fp_model, "norm")
+        assert hasattr(fp_model, "rotary_emb")
+
+        # --- Wrap submodules via PTQWrapper ----------------------------------
+        embed_tokens_cfg = qcfg.child("embed_tokens") if qcfg else None
+        layers_cfg = qcfg.child("layers") if qcfg else None
+        norm_cfg = qcfg.child("norm") if qcfg else None
+
+        self.embed_tokens = PTQWrapper(
+            fp_model.embed_tokens,
+            qcfg=embed_tokens_cfg,
+            fp_name=f"{fp_name}.embed_tokens",
+        )
+
+        # Wrap each decoder layer
+        self.layers = nn.ModuleList()
+        for idx, layer in enumerate(fp_model.layers):
+            layer_cfg = layers_cfg.child(str(idx)) if layers_cfg else None
+            wrapped_layer = PTQWrapper(
+                layer,
+                qcfg=layer_cfg,
+                fp_name=f"{fp_name}.layers.{idx}",
+            )
+            self.layers.append(wrapped_layer)
+
+        self.norm = PTQWrapper(
+            fp_model.norm,
+            qcfg=norm_cfg,
+            fp_name=f"{fp_name}.norm",
+        )
+
+        # rotary_emb
+        self.rotary_emb = fp_model.rotary_emb
+        # The original Qwen3VLTextRotaryEmbedding.apply_interleaved_mrope emits `slice_scatter with step > 1`.
+        # Replace it with pure functional implementation using basic tensor slicing, index_select, and cat.
+        self.rotary_emb.apply_interleaved_mrope = types.MethodType(
+            apply_interleaved_mrope, self.rotary_emb
+        )
+
+        # ----- static buffers: causal mask template ---------------------------
+        assert isinstance(self.config.max_position_embeddings, int)
+        max_seq = self.config.max_position_embeddings
+        mask = torch.full((1, 1, max_seq, max_seq), float("-120"))
+        mask.triu_(1)
+        self.register_buffer("causal_mask_template", mask, persistent=False)
+
+        # --- Observers for floating-point tensors -----------------------------
+        mk = self._make_obs
+        self.obs_inputs_embeds = mk("inputs_embeds")
+        self.obs_attention_mask = mk("attention_mask")
+        self.obs_local_this = mk("local_this")
+        self.obs_cos = mk("cos")
+        self.obs_sin = mk("sin")
+
+        self.obs_deepstack_visual_embeds = []
+        for layer_idx in range(len(self.layers)):
+            obs_name = f"deepstack_visual_embeds_{layer_idx}"
+            obs = mk(obs_name)
+            self.obs_deepstack_visual_embeds.append(obs)
+            self.add_module(obs_name, obs)
+
+    def _slice_causal(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        assert isinstance(self.causal_mask_template, torch.Tensor)
+        return self.causal_mask_template[..., :seq_len, :seq_len].to(device)
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        # args for deepstack
+        visual_pos_masks: torch.Tensor | None = None,
+        deepstack_visual_embeds: list[torch.Tensor] | None = None,
+        **kwargs,
+    ):
+        """
+        Forward pass with fake quantization.
+
+        Args:
+            input_ids: Token indices (LongTensor, not quantized)
+            attention_mask: Attention mask (may be int, not quantized)
+            position_ids: Position indices (LongTensor, not quantized)
+            past_key_values: Cached key-value pairs for attention (optional)
+            inputs_embeds: Pre-computed input embeddings (optional)
+            use_cache: Whether to use key-value caching (optional)
+            cache_position: Cache position indices (LongTensor, not quantized)
+            visual_pos_masks: Mask indicating visual positions (may be int/bool, not quantized)
+            deepstack_visual_embeds: Visual feature embeddings to inject (list of float tensors)
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            BaseModelOutputWithPast with last_hidden_state and past_key_values
+        """
+        from transformers.modeling_outputs import BaseModelOutputWithPast
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
+
+        # torch.jit.trace() doesn't support cache objects in the output
+        if use_cache and past_key_values is None and not torch.jit.is_tracing():
+            from transformers.cache_utils import DynamicCache
+
+            past_key_values = DynamicCache(config=self.config)
+
+        # Get input embeddings
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        else:
+            inputs_embeds = self._fq(inputs_embeds, self.obs_inputs_embeds)
+
+        # Handle cache_position (integer tensor, not quantized)
+        if cache_position is None:
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        # Handle position_ids (integer tensor, not quantized)
+        # the hard coded `3` is for temporal, height and width.
+        if position_ids is None:
+            position_ids = cache_position.view(1, 1, -1).expand(
+                3, inputs_embeds.shape[0], -1
+            )
+        elif position_ids.ndim == 2:
+            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+
+        if position_ids.ndim == 3 and position_ids.shape[0] == 4:
+            text_position_ids = position_ids[0]
+            position_ids = position_ids[1:]
+        else:
+            text_position_ids = position_ids[0]
+
+        # Build causal mask if not provided (or provided as bool)
+        if attention_mask is None or attention_mask.dtype == torch.bool:
+            attention_mask = self._slice_causal(
+                inputs_embeds.shape[1], inputs_embeds.device
+            )
+            # from transformers.masking_utils import create_causal_mask
+            # attention_mask = create_causal_mask(
+            #    config=self.config,
+            #    input_embeds=inputs_embeds,
+            #    attention_mask=attention_mask,
+            #    cache_position=cache_position,
+            #    past_key_values=past_key_values,
+            #    position_ids=text_position_ids,
+            # )
+        attention_mask = self._fq(attention_mask, self.obs_attention_mask)
+
+        hidden_states = inputs_embeds
+
+        # create position embeddings to be shared across the decoder layers
+        # rotary_emb returns (cos, sin) which are float tensors and need quantization
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        cos, sin = position_embeddings
+        position_embeddings = (
+            self._fq(cos, self.obs_cos),
+            self._fq(sin, self.obs_sin),
+        )
+
+        # decoder layers
+        for layer_idx, decoder_layer in enumerate(self.layers):
+            layer_outputs = decoder_layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_ids=text_position_ids,
+                past_key_values=past_key_values,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+            hidden_states = layer_outputs
+
+            # add visual features to the hidden states of first several layers
+            # deepstack_visual_embeds are float tensors and need quantization
+            if deepstack_visual_embeds is not None and layer_idx in range(
+                len(deepstack_visual_embeds)
+            ):
+                deepstack_visual_embeds[layer_idx] = self._fq(
+                    deepstack_visual_embeds[layer_idx],  # type: ignore[index]
+                    self.obs_deepstack_visual_embeds[layer_idx],
+                )
+                hidden_states = self._deepstack_process(
+                    hidden_states,
+                    visual_pos_masks,
+                    deepstack_visual_embeds[layer_idx],  # type: ignore[index]
+                )
+
+        # Final normalization
+        hidden_states = self.norm(hidden_states)
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+        )
+
+    def _deepstack_process(
+        self,
+        hidden_states: torch.Tensor,
+        visual_pos_masks: torch.Tensor,
+        visual_embeds: torch.Tensor,
+    ):
+        """
+        Process and inject visual features via DeepStack.
+
+        visual_pos_masks: May be int/bool (not quantized)
+        visual_embeds: Float tensor (needs quantization)
+        """
+        # Move tensors to correct device/dtype
+        visual_pos_masks = visual_pos_masks.to(hidden_states.device)
+        visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
+        hidden_states = hidden_states.clone()
+        local_this = hidden_states[visual_pos_masks, :] + visual_embeds
+        local_this = self._fq(local_this, self.obs_local_this)
+        hidden_states[visual_pos_masks, :] = local_this
+        return hidden_states
+
+    def _all_observers(self) -> Iterable:
+        """Yield all observers from this module."""
+        yield from (
+            self.obs_inputs_embeds,
+            self.obs_attention_mask,
+            self.obs_local_this,
+            self.obs_cos,
+            self.obs_sin,
+        )
+        yield from self.obs_deepstack_visual_embeds

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -70,6 +70,7 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_attn",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_mlp",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer",
+    "tico.quantization.wrapq.wrappers.qwen_vl.quant_text_model",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_attn",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_mlp",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_patch_embed",


### PR DESCRIPTION
This change introduces `QuantQwen3VLTextModel` wrapper to support post-training quantization of `Qwen3VLTextModel` module.

# Why?

`Qwen3VLTextModel` is an essential part of Qwen model.
Trying to quantize `Qwen3VLTextModel` via PTQ generates exception `PTQQuantizer: no quantization wrapper for Qwen3VLTextModel`.

# What

This change introduces:

- Class `QuantQwen3VLTextModel` (`tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py`).
- Unit tests: `class TestQuantQwen3VLTextModel` (`test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py`) - skipped if `transformers` package is not installed.
- New entry in `_CORE_MODULES` (`tico/quantization/wrapq/wrappers/registry.py`).
- Example of `Qwen3VLTextModel` quantization and conversion to Circle (`tico/quantization/wrapq/examples/qwen/quantize_text_model.py`).

# Unit Tests

Unit tests results with coverage information:

```bash
$ coverage run -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py -v
================================================================================================================ test session starts ===========
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 15 items                                                                                                                                                                                                                                  

test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_deepstack_injection             PASSED [  6%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_different_batch_sizes           PASSED [ 13%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_different_sequence_lengths      PASSED [ 20%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_embedding_layer_quantization    PASSED [ 26%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_forward_diff                    PASSED [ 33%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_inputs_embeds_path              PASSED [ 40%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_layers_wrapped                  PASSED [ 46%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_mode_transitions                PASSED [ 53%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_no_cache_mode                   PASSED [ 60%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_norm_wrapped                    PASSED [ 66%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_observer_count                  PASSED [ 73%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_output_shape                    PASSED [ 80%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_per_module_override             PASSED [ 86%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_registration_in_registry        PASSED [ 93%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_rotary_emb_not_wrapped          PASSED [100%]

========================================================= 15 passed, 2 warnings in 8.35s =======================================================
```

Coverage info (irrelevant files skipped):

```bash
$ coverage report -m
Name                                                                    Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------
...
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py               135      5    96%   196-197, 201-203
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py       42      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py                 43      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py               96      7    93%   150, 156-158, 183-184, 187-188
...
-----------------------------------------------------------------------------------------------------
TOTAL                                                                   11374   7195    37%
```

# Script for testing quantization and conversion to Circle

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_text_model.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.132488
│ PEIR       : 8.692164 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 4.0┤                                            │
    │                                    ••••••  │
 2.5┤                                ••••••••    │
    │                            •••••••••       │
 1.0┤                        ••••••••••          │
    │                     •••••••••              │
-0.6┤                 ••••••••••                 │
    │              •••••••••                     │
-2.1┤           ••••••••                         │
    │        •••••••                             │
-3.6┤     •••••                                  │
    │  •                                         │
-5.1┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -5.1       -2.9       -0.6       1.7       4.0 

Circle model saved as 'qwen3vl_text_model.q.circle'
```