### PR TITLE
[quantization] Use `balanced` device_map

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -352,23 +352,21 @@ def main():
     # 2. Load the FP backbone and tokenizer
     # -------------------------------------------------------------------------
     print("Loading FP model …")
+    dev_map = "balanced" if args.device != "cpu" else "cpu"
     tokenizer = AutoTokenizer.from_pretrained(
         args.model,
         trust_remote_code=args.trust_remote_code,
         token=args.hf_token,
         cache_dir=args.cache_dir,
     )
-    model = (
-        AutoModelForCausalLM.from_pretrained(
-            args.model,
-            dtype=dtype,
-            trust_remote_code=args.trust_remote_code,
-            token=args.hf_token,
-            cache_dir=args.cache_dir,
-        )
-        .to(device)
-        .eval()
-    )
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model,
+        dtype=dtype,
+        trust_remote_code=args.trust_remote_code,
+        token=args.hf_token,
+        cache_dir=args.cache_dir,
+        device_map=dev_map,
+    ).eval()
 
     model.config.use_cache = False  # TODO use args for it
     if args.calibrate_seq_len is not None:


### PR DESCRIPTION
This PR uses `balanced` device_map to spread the model across all available GPUs. It should increase amount of available memory.

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>