### PR TITLE
[quantization]  Support `torch.nn.Conv3d` in GPTQ

### DIFF
--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -151,6 +151,39 @@ class TransposedConv2DGeneral(torch.nn.Module):
         return (torch.randn(1, 16, 7, 7),), {}
 
 
+class NormConv3D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.m = torch.nn.ModuleList()
+        self.m.append(torch.nn.Conv3d(16, 8, (2, 3, 5), stride=1))
+        self.m.append(torch.nn.Conv3d(8, 32, (3, 5, 2), stride=2))
+
+    def forward(self, x):
+        z = self.m[0](x)
+        z = self.m[1](z)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(5, 16, 17, 19, 35),), {}
+
+    def get_zero_inputs(self):
+        return (torch.zeros(5, 16, 17, 19, 35),), {}
+
+
+class PaddedNormConv3D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.m = torch.nn.ModuleList()
+        self.m.append(torch.nn.Conv3d(16, 8, (2, 3, 5), stride=1, padding="valid"))
+
+    def forward(self, x):
+        z = self.m[0](x)
+        return z
+
+    def get_example_inputs(self):
+        return (torch.randn(5, 16, 17, 19, 35),), {}
+
+
 class GPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -430,3 +463,64 @@ class GPTQTest(unittest.TestCase):
         ), "second conv node is not quantized"
 
         # TODO add quantization
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv3d(self):
+        q_m = NormConv3D()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, GPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+        ), "second conv node is not quantized"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv3d_on_zero_inputs(self):
+        q_m = NormConv3D()
+        q_m.eval()
+        ori_m = q_m
+
+        # Apply GPTQ
+        q_m = prepare(q_m, GPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_zero_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        assert torch.sum(q_m.m[0].weight != 0) > 0, "weights should not be all zeros"  # type: ignore[arg-type]
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_paddednormconv3d(self):
+        q_m = PaddedNormConv3D()
+        q_m.eval()
+        ori_m = q_m
+        args, kwargs = ori_m.get_example_inputs()
+
+        # Apply GPTQ
+        q_m = prepare(q_m, GPTQConfig(show_progress=False))
+        for _ in range(30):
+            args, kwargs = ori_m.get_example_inputs()
+            q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+        ), "first conv node is not quantized"

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -24,6 +24,7 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from tico.quantization.algorithm.gptq.quant import quantize, Quantizer
 from tico.quantization.algorithm.gptq.utils import get_numerical_padding
@@ -167,7 +168,7 @@ class GPTQ:
         self.layer = layer
         self.dev = self.layer.weight.device
         W = layer.weight.data.clone()
-        if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
+        if isinstance(self.layer, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
         elif isinstance(self.layer, nn.ConvTranspose2d):
             W = convtranspose2d_weights_to_conv2d_weights(self.layer, W)
@@ -251,6 +252,48 @@ class GPTQ:
         if isinstance(self.layer, nn.ConvTranspose2d):
             inp = get_matmul_input_for_convtranspose2d(self.layer, inp)
 
+        if isinstance(self.layer, nn.Conv3d):
+            # adapted from https://discuss.pytorch.org/t/manual-implementation-of-unrolled-3d-convolutions/91021
+            assert (
+                self.layer.groups == 1
+            )  # depthwise/groupwise are not supported currently
+            assert all(dilation == 1 for dilation in self.layer.dilation)
+
+            # inp is assumed to be (N, C_in, H, W, D)
+            padding = get_numerical_padding(self.layer)
+            if isinstance(padding, int):
+                padding = (padding, padding, padding)
+            if not all(item == 0 for item in padding):
+                inp = F.pad(
+                    inp,
+                    pad=(
+                        padding[2],
+                        padding[2],
+                        padding[1],
+                        padding[1],
+                        padding[0],
+                        padding[0],
+                    ),
+                    mode="constant",
+                    value=0,
+                )
+            krn_size = self.layer.kernel_size
+            stride = self.layer.stride
+            inp = (
+                inp.unfold(2, krn_size[0], stride[0])
+                .unfold(3, krn_size[1], stride[1])
+                .unfold(4, krn_size[2], stride[2])
+            )  # inp.shape = (N, C_in, ..patches... , krn_size[0], krn_size[1], krn_size[2])
+            inp = inp.reshape(
+                inp.shape[0], inp.shape[1], -1, krn_size[0] * krn_size[1] * krn_size[2]
+            )  # inp.shape = (N, C_in, num_patches, krn_size[0] * krn_size[1] * krn_size[2])
+            inp = inp.permute(
+                [0, 2, 1, 3]
+            )  # inp.shape = (N, num_patches, C_in, krn_size[0] * krn_size[1] * krn_size[2])
+            inp = inp.reshape(
+                inp.shape[0] * inp.shape[1], inp.shape[2] * inp.shape[3]
+            ).T  # inp.shape =(C_in * krn_size[0] * krn_size[1] * krn_size[2], N * num_patches)
+
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp
         inp = math.sqrt(2 / self.nsamples) * inp.float()
@@ -266,12 +309,19 @@ class GPTQ:
         verbose=False,
     ):
         W = self.layer.weight.data.clone()
-        if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
+        if isinstance(self.layer, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+            if self.quantizer.sensitivity is not None:
+                self.quantizer.sensitivity = self.quantizer.sensitivity.flatten(1)
         elif isinstance(self.layer, nn.ConvTranspose2d):
             W = convtranspose2d_weights_to_conv2d_weights(self.layer, W)
             conv2d_shape = W.shape
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
+            if self.quantizer.sensitivity is not None:
+                self.quantizer.sensitivity = convtranspose2d_weights_to_conv2d_weights(
+                    self.layer, self.quantizer.sensitivity
+                )
+                self.quantizer.sensitivity = self.quantizer.sensitivity.flatten(1)
 
         W = W.float()
         tick = time.time()
@@ -366,7 +416,7 @@ class GPTQ:
         if actorder:
             Q = Q[:, invperm]
 
-        if isinstance(self.layer, nn.Conv2d) or isinstance(self.layer, nn.Conv1d):
+        if isinstance(self.layer, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
             if groupsize == -1:  # TODO support groupsize != -1
                 Q[:, dead] = quantize(
                     self.layer.weight.flatten(1)[:, dead],

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -204,6 +204,7 @@ class GPTQQuantizer(BaseQuantizer):
                     torch.nn.Linear,
                     torch.nn.Conv2d,
                     torch.nn.Conv1d,
+                    torch.nn.Conv3d,
                     torch.nn.ConvTranspose2d,
                 ],
             )


### PR DESCRIPTION
This PR adds support for `torch.nn.Conv3d` in GPTQ.

<details> <summary> ./ccex test --include-internal -k quantization.algorithm.test_gptq.GPTQTest </summary>


```

RUN unit tests with -k quantization.algorithm.test_gptq.GPTQTest ...
test_groupwise_conv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
<frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... No specialized wrapper found for ModuleList; applying recursive wrapping.
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 13 tests in 52.871s

OK

```

</details>


Draft: #559 

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>