### PR TITLE
[quantization] Suppport `convolutions` in `SensitivityCalibrator`

### DIFF
--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -19,6 +19,7 @@ import tico
 import torch
 
 from tico.quantization import convert, prepare
+from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
 from tico.quantization.config.gptq import GPTQConfig
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.evaluation.evaluate import BACKEND, evaluate
@@ -100,6 +101,29 @@ class GroupwiseConv2D(torch.nn.Module):
         return (torch.randn(1, 32, 16, 16),), {}
 
 
+class NormConv2DWithLogits(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.m = torch.nn.ModuleList()
+        self.m.append(torch.nn.Conv2d(128, 256, (3, 3), stride=1))
+        self.m.append(torch.nn.Conv2d(256, 512, (5, 5), stride=2))
+
+    def forward(self, x):
+        class OutputWithLogits:
+            def __init__(self, logits):
+                self.logits = logits
+
+        z = self.m[0](x)
+        z = self.m[1](z)
+        z = z.reshape((-1, 64)).unsqueeze(0)
+        return OutputWithLogits(z)
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 128, 32, 32),), {}
+
+
 class NormConv1D(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -133,6 +157,28 @@ class GroupwiseConv1D(torch.nn.Module):
         return (torch.randn(1, 32, 16),), {}
 
 
+class NormConv1DWithLogits(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.conv = torch.nn.Conv1d(128, 256, 3, stride=1)
+        self.conv2 = torch.nn.Conv1d(256, 512, 5, stride=2)
+
+    def forward(self, x):
+        class OutputWithLogits:
+            def __init__(self, logits):
+                self.logits = logits
+
+        z = self.conv(x)
+        z = self.conv2(z)
+        z = z.reshape((-1, 64)).unsqueeze(0)
+        return OutputWithLogits(z)
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 128, 32),), {}
+
+
 class TransposedConv2DGeneral(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -146,6 +192,30 @@ class TransposedConv2DGeneral(torch.nn.Module):
         z = self.tconv(x)
         z = self.tconv2(z)
         return z
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 16, 7, 7),), {}
+
+
+class TransposedConv2DGeneralWithLogits(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.tconv = torch.nn.ConvTranspose2d(16, 32, (2, 2), stride=2, groups=1)
+        self.tconv2 = torch.nn.ConvTranspose2d(
+            32, 16, (3, 3), stride=4, groups=2
+        )  # general groupwise
+
+    def forward(self, x):
+        class OutputWithLogits:
+            def __init__(self, logits):
+                self.logits = logits
+
+        z = self.tconv(x)
+        z = self.tconv2(z)
+        z = z.reshape((-1, 8)).unsqueeze(0)
+        return OutputWithLogits(z)
 
     def get_example_inputs(self):
         return (torch.randn(1, 16, 7, 7),), {}
@@ -179,6 +249,29 @@ class PaddedNormConv3D(torch.nn.Module):
     def forward(self, x):
         z = self.m[0](x)
         return z
+
+    def get_example_inputs(self):
+        return (torch.randn(5, 16, 17, 19, 35),), {}
+
+
+class NormConv3DWithLogits(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.m = torch.nn.ModuleList()
+        self.m.append(torch.nn.Conv3d(16, 8, (2, 3, 5), stride=1))
+        self.m.append(torch.nn.Conv3d(8, 32, (3, 5, 2), stride=2))
+
+    def forward(self, x):
+        class OutputWithLogits:
+            def __init__(self, logits):
+                self.logits = logits
+
+        z = self.m[0](x)
+        z = self.m[1](z)
+        z = z.reshape((-1, 8)).unsqueeze(0)
+        return OutputWithLogits(z)
 
     def get_example_inputs(self):
         return (torch.randn(5, 16, 17, 19, 35),), {}
@@ -305,6 +398,44 @@ class GPTQTest(unittest.TestCase):
             assert (
                 results["peir"][0] < tolerance
             ), f"PEIR exceeds tolerance. PEIR:{results['peir'][0]}%, tolerance: {tolerance}%"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv2d_with_logits(self):
+        q_m = NormConv2DWithLogits()
+        q_m.eval()
+        ori_m = q_m
+
+        dataset = []  # type: ignore[var-annotated]
+        for _ in range(30):
+            args, _ = ori_m.get_example_inputs()
+            dataset.append(*args)
+
+        calibrator = SensitivityCalibrator(q_m, dataset, show_progress=False)
+        sens = calibrator.compute_sensitivity_info()
+
+        # Apply GPTQ
+        q_m = prepare(
+            q_m,
+            GPTQConfig(
+                show_progress=False,
+                mse="smse",
+                perchannel=True,
+                sensitivity=sens,
+            ),
+        )
+        for input in dataset:
+            q_m(input)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+        ), "second conv node is not quantized"
 
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -441,6 +572,46 @@ class GPTQTest(unittest.TestCase):
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
     )
+    def test_normconv1d_with_logits(self):
+        q_m = NormConv1DWithLogits()
+        q_m.eval()
+        ori_m = q_m
+
+        dataset = []  # type: ignore[var-annotated]
+        for _ in range(30):
+            args, _ = ori_m.get_example_inputs()
+            dataset.append(*args)
+
+        calibrator = SensitivityCalibrator(q_m, dataset, show_progress=False)
+        sens = calibrator.compute_sensitivity_info()
+
+        # Apply GPTQ
+        q_m = prepare(
+            q_m,
+            GPTQConfig(
+                show_progress=False,
+                mse="smse",
+                perchannel=True,
+                sensitivity=sens,
+            ),
+        )
+        for input in dataset:
+            q_m(input)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+        ), "second conv node is not quantized"
+
+        # TODO add quantization
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
     def test_transposed_conv2d(self):
         q_m = TransposedConv2DGeneral()
         q_m.eval()
@@ -452,6 +623,46 @@ class GPTQTest(unittest.TestCase):
         for _ in range(30):
             args, kwargs = ori_m.get_example_inputs()
             q_m(*args, **kwargs)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.tconv" in q_m.quantizers  # type: ignore[operator]
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.tconv2" in q_m.quantizers  # type: ignore[operator]
+        ), "second conv node is not quantized"
+
+        # TODO add quantization
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_transposed_conv2d_with_logits(self):
+        q_m = TransposedConv2DGeneralWithLogits()
+        q_m.eval()
+        ori_m = q_m
+
+        dataset = []  # type: ignore[var-annotated]
+        for _ in range(30):
+            args, _ = ori_m.get_example_inputs()
+            dataset.append(*args)
+
+        calibrator = SensitivityCalibrator(q_m, dataset, show_progress=False)
+        sens = calibrator.compute_sensitivity_info()
+
+        # Apply GPTQ
+        q_m = prepare(
+            q_m,
+            GPTQConfig(
+                show_progress=False,
+                mse="smse",
+                perchannel=True,
+                sensitivity=sens,
+            ),
+        )
+        for input in dataset:
+            q_m(input)
         convert(q_m, inplace=True)
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
@@ -524,3 +735,41 @@ class GPTQTest(unittest.TestCase):
         assert (
             "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
+
+    @unittest.skipIf(
+        not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
+    )
+    def test_normconv3d_with_logits(self):
+        q_m = NormConv3DWithLogits()
+        q_m.eval()
+        ori_m = q_m
+
+        dataset = []  # type: ignore[var-annotated]
+        for _ in range(30):
+            args, _ = ori_m.get_example_inputs()
+            dataset.append(*args)
+
+        calibrator = SensitivityCalibrator(q_m, dataset, show_progress=False)
+        sens = calibrator.compute_sensitivity_info()
+
+        # Apply GPTQ
+        q_m = prepare(
+            q_m,
+            GPTQConfig(
+                show_progress=False,
+                mse="smse",
+                perchannel=True,
+                sensitivity=sens,
+            ),
+        )
+        for input in dataset:
+            q_m(input)
+        convert(q_m, inplace=True)
+        # check that all convolution nodes are quantized
+        assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
+        assert (
+            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+        ), "first conv node is not quantized"
+        assert (
+            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+        ), "second conv node is not quantized"

--- a/tico/quantization/algorithm/gptq/utils.py
+++ b/tico/quantization/algorithm/gptq/utils.py
@@ -75,7 +75,7 @@ def get_numerical_padding(layer: torch.nn.Module):
     return padding
 
 
-def get_dataset_for_calibration(model, dataset):
+def get_dataset_for_calibration(model, dataset, show_progress=True):
     """Enrich dataset with model ouputs to be used as targets"""
 
     class DataSetWithLabels(torch.utils.data.Dataset):
@@ -100,9 +100,16 @@ def get_dataset_for_calibration(model, dataset):
     targets = []
 
     with torch.no_grad():
-        print("Computing calibration set")
-        for prompt in tqdm.tqdm(dataset):
-            results = model(prompt.to(model.device)).logits.detach()
+        if show_progress is True:
+            print("Computing calibration set")
+        for prompt in tqdm.tqdm(dataset, disable=not show_progress):
+            if isinstance(prompt, torch.Tensor):
+                results = model(prompt.to(model.device)).logits.detach()
+            else:
+                for item in prompt:
+                    prompt[item] = prompt[item].to(model.device)
+                results = model(**prompt).logits.detach()
+
             results = torch.argmax(results.detach(), dim=-1).cpu()
 
             targets.append(results)
@@ -122,32 +129,51 @@ class SensitivityCalibrator:
     Please see https://arxiv.org/abs/1905.12558?ref=inference.vc for a discussion.
     """
 
-    def __init__(self, model, dataset):
+    def __init__(self, model, dataset, show_progress: bool = True):
         self.model = model
         self.dataset = dataset
+        self.show_progress = show_progress
+        self.calibrated_types = [
+            torch.nn.Linear,
+            torch.nn.Conv2d,
+            torch.nn.Conv1d,
+            torch.nn.Conv3d,
+            torch.nn.ConvTranspose2d,
+        ]
 
     def compute_sensitivity_info(self):
 
-        data_loader = get_dataset_for_calibration(self.model, self.dataset)
+        data_loader = get_dataset_for_calibration(
+            self.model, self.dataset, self.show_progress
+        )
 
         dtype = self.model.dtype
         model = self.model.float()
 
         sensitivity = {}
         modules_to_process = {}
-        name_of_module: dict[torch.nn.Linear, str] = {}
+        name_of_module: dict[torch.nn.Module, str] = {}
 
         for name, module in model.named_modules():
-            if isinstance(module, torch.nn.Linear):
-                modules_to_process[name] = module
-                name_of_module[module] = name
-                sensitivity[name] = torch.zeros_like(module.weight).cpu()
+            for type in self.calibrated_types:
+                if isinstance(module, type):
+                    modules_to_process[name] = module
+                    name_of_module[module] = name
+                    sensitivity[name] = torch.zeros_like(module.weight).cpu()
+                    break
 
-        print("Calibrating sensitivity")
-        for inputs, targets in tqdm.tqdm(data_loader):
+        if self.show_progress is True:
+            print("Calibrating sensitivity")
+        for inputs, targets in tqdm.tqdm(data_loader, disable=not self.show_progress):
             model.zero_grad()
-            inp_ids = inputs.view(-1, inputs.shape[-1])
-            logits = model(inp_ids.to(model.device)).logits
+            if isinstance(inputs, torch.Tensor):
+                inp_ids = inputs.squeeze(0)  # remove redundant batch dimension
+                logits = model(inp_ids.to(model.device)).logits
+            else:
+                for item in inputs:
+                    inputs[item] = inputs[item].to(model.device).squeeze(0)
+
+                logits = model(**inputs).logits
 
             outputs = logits.squeeze()
             targets = targets.squeeze()


### PR DESCRIPTION
This PR:
1. adds support for convolutions  with related tests
2. brings support for multiple inputs
3. adds the option to hide progress to SensitivityCalibrator.

<details> <summary> ./ccex test --include-internal -k quantization.algorithm.test_gptq.GPTQTest </summary>

```

RUN unit tests with -k quantization.algorithm.test_gptq.GPTQTest ...
test_groupwise_conv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
<frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... No specialized wrapper found for ModuleList; applying recursive wrapping.
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 17 tests in 61.068s

OK
```

</details>

Draft: #559 
Related: #548

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>