### PR TITLE
[quantization] Tidy `SensitivityCalibrator`

### DIFF
--- a/tico/quantization/algorithm/gptq/utils.py
+++ b/tico/quantization/algorithm/gptq/utils.py
@@ -152,13 +152,11 @@ class SensitivityCalibrator:
 
         sensitivity = {}
         modules_to_process = {}
-        name_of_module: dict[torch.nn.Module, str] = {}
 
         for name, module in model.named_modules():
             for type in self.calibrated_types:
                 if isinstance(module, type):
                     modules_to_process[name] = module
-                    name_of_module[module] = name
                     sensitivity[name] = torch.zeros_like(module.weight).cpu()
                     break
 


### PR DESCRIPTION
This commit removes unused `name_of_module` used for debugging previously.

Original note: https://github.com/Samsung/TICO/pull/581#discussion_r2986972439

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>