### PR TITLE
[quantization] Introduce wrapper for Qwen3VLForConditionalGeneration

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py
@@ -1,0 +1,525 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import unittest
+from typing import Tuple
+
+import torch
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_for_conditional_generation import (
+    QuantQwen3VLForConditionalGeneration,
+)
+
+
+skip_msg = "transformers not installed — skipping Qwen3VLForConditionalGeneration tests"
+
+
+@unittest.skipUnless(has_transformers_for("qwen3-vl"), skip_msg)
+class TestQuantQwen3VLForConditionalGeneration(unittest.TestCase):
+    fp_model: torch.nn.Module
+    hidden_size: int
+    vocab_size: int
+    patch_size: int
+    temporal_patch_size: int
+    video_token_id: int
+    image_token_id: int
+    spatial_merge_size: int
+    ptq_config: PTQConfig
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLForConditionalGeneration,
+        )
+
+        # Use smaller sizes for testing
+        cfg = Qwen3VLConfig(
+            vision_config={
+                "hidden_size": 64,
+                "num_heads": 4,
+                "depth": 2,  # Smaller depth for faster testing
+                "temporal_patch_size": 2,
+                "patch_size": 16,
+                "out_hidden_size": 64,
+                "deepstack_visual_indexes": [0, 1],
+            },
+            text_config={
+                "hidden_size": 64,
+                "intermediate_size": 256,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "head_dim": 32,
+                "num_hidden_layers": 2,
+                "attention_bias": False,
+                "attention_dropout": 0.0,
+                "max_position_embeddings": 1024,
+                "vocab_size": 1000,
+                "use_cache": False,
+                "rope_scaling": {"rope_type": "default", "mrope_section": [1, 1, 2]},
+            },
+            image_token_id=998,
+            video_token_id=999,
+        )
+
+        assert cfg.image_token_id < cfg.text_config.vocab_size
+        assert cfg.video_token_id < cfg.text_config.vocab_size
+        assert cfg.vision_config.out_hidden_size == cfg.text_config.hidden_size
+
+        cls.fp_model = Qwen3VLForConditionalGeneration(cfg)
+        cls.patch_size = cfg.vision_config.patch_size
+        cls.temporal_patch_size = cfg.vision_config.temporal_patch_size
+        cls.hidden_size = cfg.text_config.hidden_size
+        cls.vocab_size = cfg.text_config.vocab_size
+        cls.video_token_id = cfg.video_token_id
+        cls.image_token_id = cfg.image_token_id
+        cls.spatial_merge_size = cfg.vision_config.spatial_merge_size
+
+    @staticmethod
+    def _make_ptq_config(grid_thw: Tuple[int, int, int]) -> PTQConfig:
+        return PTQConfig(
+            model_args={
+                "vision": {
+                    "grid_thw": grid_thw,
+                }
+            }
+        )
+
+    @staticmethod
+    def _compute_3d_position_ids(
+        input_ids: torch.Tensor,
+        thw: Tuple[int, int, int],
+        spatial_merge_size: int,
+        image_token_id: int,
+    ) -> torch.Tensor:
+        """
+        Compute 3D position IDs for multimodal RoPE.
+        This function pre-computes position_ids to avoid tracing issues during model export.
+        """
+        batch_size, seq_len = input_ids.shape
+        device = input_ids.device
+
+        position_ids = torch.ones(
+            3, batch_size, seq_len, dtype=input_ids.dtype, device=device
+        )
+
+        for i in range(batch_size):
+            # Find positions of image tokens
+            image_mask = input_ids[i] == image_token_id
+            image_positions = torch.nonzero(image_mask, as_tuple=True)[0]
+
+            llm_pos_ids_list: list[torch.tensor] = []
+            st = 0
+
+            # Process visual tokens
+            if len(image_positions) > 0:
+                # Group consecutive placeholder tokens into a single visual object
+                # All consecutive image tokens represent ONE image/video
+                start_pos = image_positions[0].item()
+
+                # Text position IDs (before first visual token)
+                text_len = start_pos - st
+                if text_len > 0:
+                    st_idx = (
+                        llm_pos_ids_list[-1].max() + 1
+                        if len(llm_pos_ids_list) > 0
+                        else 0
+                    )
+                    llm_pos_ids_list.append(
+                        torch.arange(text_len, device=device).view(1, -1).expand(3, -1)
+                        + st_idx
+                    )
+
+                # Vision position IDs (3D)
+                llm_grid_t = 1  # Always 1 for images
+                llm_grid_h = thw[1] // spatial_merge_size
+                llm_grid_w = thw[2] // spatial_merge_size
+
+                t_index = (
+                    torch.arange(llm_grid_t, device=device)
+                    .view(-1, 1)
+                    .expand(-1, llm_grid_h * llm_grid_w)
+                    .flatten()
+                )
+                h_index = (
+                    torch.arange(llm_grid_h, device=device)
+                    .view(1, -1, 1)
+                    .expand(llm_grid_t, -1, llm_grid_w)
+                    .flatten()
+                )
+                w_index = (
+                    torch.arange(llm_grid_w, device=device)
+                    .view(1, 1, -1)
+                    .expand(llm_grid_t, llm_grid_h, -1)
+                    .flatten()
+                )
+                st_idx = (
+                    llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+                )
+                llm_pos_ids_list.append(
+                    torch.stack([t_index, h_index, w_index]) + st_idx
+                )
+
+                # Update st to after all visual placeholder tokens
+                # The number of visual tokens is (thw[1] // spatial_merge_size) * (thw[2] // spatial_merge_size)
+                num_visual_tokens = (thw[1] // spatial_merge_size) * (
+                    thw[2] // spatial_merge_size
+                )
+                st = start_pos + num_visual_tokens
+
+            # Trailing text
+            if st < seq_len:
+                st_idx = (
+                    llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+                )
+                text_len = seq_len - st
+                llm_pos_ids_list.append(
+                    torch.arange(text_len, device=device).view(1, -1).expand(3, -1)
+                    + st_idx
+                )
+
+            llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+            position_ids[..., i, :] = llm_positions
+
+        return position_ids
+
+    def _create_text_only_input(self, batch_size=1, seq_len=10):
+        """Helper to create text-only input without images/videos."""
+        input_ids = torch.randint(
+            low=0, high=self.vocab_size, size=(batch_size, seq_len), dtype=torch.long
+        )
+        attention_mask = torch.ones_like(input_ids)
+        return input_ids, attention_mask
+
+    def _create_visual_input(
+        self,
+        visual_token_id: int,
+        batch_size: int,
+        seq_len: int,
+        thw: Tuple[int, int, int],
+    ):
+        """Helper to create input with videos or images."""
+        assert visual_token_id in (self.video_token_id, self.image_token_id)
+
+        # Calculate number of visual placeholder tokens needed
+        # Each video is represented by multiple tokens after spatial merge
+        # Spatial merge reduces the grid size by spatial_merge_size in each dimension
+        num_video_tokens = (thw[1] // self.spatial_merge_size) * (
+            thw[2] // self.spatial_merge_size
+        )
+        assert (
+            num_video_tokens <= seq_len
+        ), f"{num_video_tokens} video tokens can't fit into input sequence of length {seq_len}"
+
+        # Create input_ids with random text tokens
+        input_ids = torch.randint(
+            low=0,
+            high=self.vocab_size - 2,
+            size=(batch_size, seq_len),
+            dtype=torch.long,
+        )
+        attention_mask = torch.ones_like(input_ids)
+
+        # Replace first tokens with video placeholder tokens
+        # This marks where the video features should be inserted
+        for i in range(batch_size):
+            input_ids[i, :num_video_tokens] = visual_token_id
+
+        num_temporal_patches, num_spatial_patches_h, num_spatial_patches_w = thw
+
+        # Create pixel values for videos
+        pixel_values = torch.randn(
+            batch_size,
+            3,
+            num_temporal_patches * self.temporal_patch_size,
+            num_spatial_patches_h * self.patch_size,
+            num_spatial_patches_w * self.patch_size,
+        )
+        video_grid_thw = torch.tensor([thw])
+
+        position_ids = self._compute_3d_position_ids(
+            input_ids=input_ids,
+            thw=thw,
+            spatial_merge_size=self.spatial_merge_size,
+            image_token_id=visual_token_id,
+        )
+
+        return input_ids, attention_mask, pixel_values, video_grid_thw, position_ids
+
+    def _create_video_input(
+        self,
+        batch_size: int = 1,
+        seq_len: int = 64,
+        thw: Tuple[int, int, int] = (1, 8, 8),
+    ):
+        return self._create_visual_input(self.video_token_id, batch_size, seq_len, thw)
+
+    def _create_image_input(
+        self,
+        batch_size: int = 1,
+        seq_len: int = 64,
+        thw: Tuple[int, int, int] = (1, 8, 8),
+    ):
+        return self._create_visual_input(self.image_token_id, batch_size, seq_len, thw)
+
+    # -------------------------------------------------------------------------
+    # Initialization tests
+    # -------------------------------------------------------------------------
+
+    def test_wraps_submodules(self):
+        """Test that __init__ wraps all submodules with PTQWrapper."""
+        ptq_config = self._make_ptq_config(grid_thw=(1, 8, 8))
+        q_model = QuantQwen3VLForConditionalGeneration(self.fp_model, qcfg=ptq_config)
+
+        # Check that submodules are wrapped
+        self.assertTrue(hasattr(q_model, "model"))
+        self.assertIsInstance(q_model.model, PTQWrapper)
+
+        self.assertTrue(hasattr(q_model, "lm_head"))
+        self.assertIsInstance(q_model.lm_head, PTQWrapper)
+
+    def test_mode_transitions(self):
+        """Test quantization mode transitions: NO_QUANT → CALIB → QUANT"""
+        ptq_config = self._make_ptq_config(grid_thw=(1, 8, 8))
+        q_model = QuantQwen3VLForConditionalGeneration(self.fp_model, qcfg=ptq_config)
+        self.assertIs(q_model._mode, Mode.NO_QUANT)
+
+        q_model.enable_calibration()
+        self.assertIs(q_model._mode, Mode.CALIB)
+
+        # Run forward pass during calibration (text-only)
+        input_ids, attention_mask = self._create_text_only_input()
+        _ = q_model(input_ids=input_ids, attention_mask=attention_mask)
+
+        q_model.freeze_qparams()
+        self.assertIs(q_model._mode, Mode.QUANT)
+
+    # -------------------------------------------------------------------------
+    # Forward pass tests
+    # -------------------------------------------------------------------------
+
+    def test_forward_text_only(self):
+        """Test forward pass with text-only input."""
+        ptq_config = self._make_ptq_config(grid_thw=(1, 8, 8))
+        q_model = QuantQwen3VLForConditionalGeneration(self.fp_model, qcfg=ptq_config)
+        q_model.enable_calibration()
+
+        input_ids, attention_mask = self._create_text_only_input()
+        _ = q_model(input_ids=input_ids, attention_mask=attention_mask)
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            output = q_model(input_ids=input_ids, attention_mask=attention_mask)
+
+        # Check output structure
+        self.assertTrue(hasattr(output, "logits"))
+        self.assertTrue(hasattr(output, "past_key_values"))
+        self.assertTrue(hasattr(output, "rope_deltas"))
+
+        # Check output shape
+        batch_size, seq_len = input_ids.shape
+        self.assertEqual(output.logits.shape, (batch_size, seq_len, self.vocab_size))
+
+    def test_forward_with_images(self):
+        """Test forward pass with image input."""
+        thw = (1, 8, 8)
+        ptq_config = self._make_ptq_config(grid_thw=thw)
+        q_model = QuantQwen3VLForConditionalGeneration(self.fp_model, qcfg=ptq_config)
+        q_model.enable_calibration()
+
+        (
+            input_ids,
+            attention_mask,
+            pixel_values,
+            image_grid_thw,
+            position_ids,
+        ) = self._create_image_input(thw=thw)
+
+        _ = q_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            position_ids=position_ids,
+        )
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            output = q_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                position_ids=position_ids,
+            )
+
+        # Check output structure
+        self.assertTrue(hasattr(output, "logits"))
+        self.assertTrue(hasattr(output, "past_key_values"))
+        self.assertTrue(hasattr(output, "rope_deltas"))
+
+        # Check output shape
+        batch_size, seq_len = input_ids.shape
+        self.assertEqual(output.logits.shape, (batch_size, seq_len, self.vocab_size))
+
+    def test_forward_with_videos(self):
+        """Test forward pass with video input."""
+        thw = (1, 8, 8)
+        ptq_config = self._make_ptq_config(grid_thw=thw)
+        q_model = QuantQwen3VLForConditionalGeneration(self.fp_model, qcfg=ptq_config)
+        q_model.enable_calibration()
+
+        (
+            input_ids,
+            attention_mask,
+            pixel_values_videos,
+            video_grid_thw,
+            position_ids,
+        ) = self._create_video_input(thw=thw)
+
+        _ = q_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+            position_ids=position_ids,
+        )
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            output = q_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+                position_ids=position_ids,
+            )
+
+        # Check output structure
+        self.assertTrue(hasattr(output, "logits"))
+        self.assertTrue(hasattr(output, "past_key_values"))
+        self.assertTrue(hasattr(output, "rope_deltas"))
+
+        # Check output shape
+        batch_size, seq_len = input_ids.shape
+        self.assertEqual(output.logits.shape, (batch_size, seq_len, self.vocab_size))
+
+    def test_forward_with_both_images_and_videos(self):
+        """Test forward pass with both image and video inputs (tests deepstack feature combination)."""
+        thw = (1, 8, 8)
+        ptq_config = self._make_ptq_config(grid_thw=thw)
+        q_model = QuantQwen3VLForConditionalGeneration(self.fp_model, qcfg=ptq_config)
+        q_model.enable_calibration()
+
+        # Calculate visual token count
+        num_visual_tokens = (thw[1] // self.spatial_merge_size) * (
+            thw[2] // self.spatial_merge_size
+        )  # 16 tokens
+
+        # Create input with both images and videos
+        batch_size = 1
+        seq_len = 64
+
+        # Start with image tokens
+        input_ids = torch.randint(
+            low=0,
+            high=self.vocab_size - 2,
+            size=(batch_size, seq_len),
+            dtype=torch.long,
+        )
+        input_ids[0, 0:num_visual_tokens] = self.image_token_id
+
+        # Add video tokens later in the sequence (with some text in between)
+        video_start = num_visual_tokens + 10
+        input_ids[
+            0, video_start : video_start + num_visual_tokens
+        ] = self.video_token_id
+
+        # Create pixel values for images
+        pixel_values = torch.randn(
+            batch_size,
+            3,
+            thw[0] * self.temporal_patch_size,
+            thw[1] * self.patch_size,
+            thw[2] * self.patch_size,
+        )
+        image_grid_thw = torch.tensor([thw])
+
+        # Create pixel values for videos
+        pixel_values_videos = torch.randn(
+            batch_size,
+            3,
+            thw[0] * self.temporal_patch_size,
+            thw[1] * self.patch_size,
+            thw[2] * self.patch_size,
+        )
+        video_grid_thw = torch.tensor([thw])
+
+        # Run forward pass with both images and videos
+        _ = q_model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+        )
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            output = q_model(
+                input_ids=input_ids,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+            )
+
+        # Check output structure
+        self.assertTrue(hasattr(output, "logits"))
+        self.assertTrue(hasattr(output, "past_key_values"))
+        self.assertTrue(hasattr(output, "rope_deltas"))
+
+        # Check output shape
+        batch_size, seq_len = input_ids.shape
+        self.assertEqual(output.logits.shape, (batch_size, seq_len, self.vocab_size))
+
+    # -------------------------------------------------------------------------
+    # Registration tests
+    # -------------------------------------------------------------------------
+
+    def test_registration_in_registry(self):
+        """Test that Qwen3VLForConditionalGeneration is properly registered."""
+        from tico.quantization.wrapq.wrappers.qwen_vl.quant_for_conditional_generation import (
+            QuantQwen3VLForConditionalGeneration,
+        )
+        from tico.quantization.wrapq.wrappers.registry import lookup
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLForConditionalGeneration,
+        )
+
+        wrapper_cls = lookup(Qwen3VLForConditionalGeneration)
+        self.assertIs(wrapper_cls, QuantQwen3VLForConditionalGeneration)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example script for quantizing and converting Qwen3VLForConditionalGeneration to Circle format.
+
+This script demonstrates:
+1. Loading a Qwen3VL vision-language model (with lm_head for generation)
+2. Preparing calibration data with text, images, and videos
+3. Configuring PTQ (Post-Training Quantization)
+4. Calibrating the model to collect statistics
+5. Converting to quantized model
+6. Evaluating quantization accuracy
+7. Converting to Circle format for deployment
+
+Usage:
+    python quantize_for_conditional_generation.py
+"""
+
+import copy
+import sys
+from collections import namedtuple
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+import tico
+import tico.quantization
+import tico.quantization.config.ptq
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.evaluation.utils import plot_two_outputs
+from tico.quantization.wrapq.utils.version import has_transformers_for
+
+torch.manual_seed(123)
+
+
+# Check if transformers is available
+if not has_transformers_for("qwen3-vl"):
+    print(
+        "Error: Required transformers package not installed. Cannot test Qwen3VLForConditionalGeneration."
+    )
+    sys.exit(1)
+
+from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+    Qwen3VLForConditionalGeneration,
+)
+
+ModelInput = namedtuple(
+    "ModelInput",
+    [
+        "input_ids",
+        "attention_mask",
+        "position_ids",
+        "past_key_values",
+        "inputs_embeds",
+        "labels",
+        "pixel_values",
+        "pixel_values_videos",
+        "image_grid_thw",
+        "video_grid_thw",
+        "cache_position",
+        "logits_to_keep",
+    ],
+)
+
+
+def create_visual_input(
+    seq_len: int,
+    thw: Tuple[int, int, int],
+    spatial_merge_size: int,
+    temporal_patch_size: int,
+    spatial_patch_size: int,
+    vocab_size: int,
+    image_token_id: int,
+):
+    """Helper to create input with videos or images."""
+    assert (
+        image_token_id >= vocab_size - 2
+    ), f"Visual token Id {image_token_id} must be outside text vocabulary range 0...{vocab_size-2}."
+
+    batch_size = 1
+
+    # Calculate number of visual placeholder tokens needed
+    # Each video is represented by multiple tokens after spatial merge
+    # Spatial merge reduces the grid size by spatial_merge_size in each dimension
+    num_video_tokens = (thw[1] // spatial_merge_size) * (thw[2] // spatial_merge_size)
+    assert (
+        num_video_tokens <= seq_len
+    ), f"{num_video_tokens} video tokens can't fit into input sequence of length {seq_len}"
+
+    # Create input_ids with random text tokens
+    input_ids = torch.randint(
+        low=0,
+        high=vocab_size - 2,
+        size=(batch_size, seq_len),
+        dtype=torch.long,
+    )
+
+    # Replace first tokens with video placeholder tokens
+    # This marks where the video features should be inserted
+    for i in range(batch_size):
+        input_ids[i, :num_video_tokens] = image_token_id
+
+    num_temporal_patches, num_spatial_patches_h, num_spatial_patches_w = thw
+
+    # Create pixel values for videos
+    pixel_values = torch.randn(
+        batch_size,
+        3,
+        num_temporal_patches * temporal_patch_size,
+        num_spatial_patches_h * spatial_patch_size,
+        num_spatial_patches_w * spatial_patch_size,
+    )
+    grid_thw = torch.tensor([thw])
+
+    # Compute position_ids for 3D RoPE
+    # This replicates the logic from _get_rope_index but pre-computes it
+    position_ids = compute_3d_position_ids(
+        input_ids=input_ids,
+        thw=thw,
+        spatial_merge_size=spatial_merge_size,
+        image_token_id=image_token_id,
+    )
+
+    return ModelInput(
+        input_ids=input_ids,
+        attention_mask=None,
+        position_ids=position_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        pixel_values=pixel_values,
+        pixel_values_videos=None,
+        image_grid_thw=grid_thw,
+        video_grid_thw=None,
+        cache_position=None,
+        logits_to_keep=0,
+    )
+
+
+def compute_3d_position_ids(
+    input_ids: torch.Tensor,
+    thw: Tuple[int, int, int],
+    spatial_merge_size: int,
+    image_token_id: int,
+) -> torch.Tensor:
+    """
+    Compute 3D position IDs for multimodal RoPE.
+    This function pre-computes position_ids to avoid tracing issues during model export.
+    """
+    batch_size, seq_len = input_ids.shape
+    device = input_ids.device
+
+    position_ids = torch.ones(
+        3, batch_size, seq_len, dtype=input_ids.dtype, device=device
+    )
+
+    for i in range(batch_size):
+        # Find positions of image tokens
+        image_mask = input_ids[i] == image_token_id
+        image_positions = torch.nonzero(image_mask, as_tuple=True)[0]
+
+        llm_pos_ids_list: list[torch.tensor] = []
+        st = 0
+
+        # Process visual tokens
+        if len(image_positions) > 0:
+            # Group consecutive placeholder tokens into a single visual object
+            # All consecutive image tokens represent ONE image/video
+            start_pos = image_positions[0].item()
+
+            # Text position IDs (before first visual token)
+            text_len = start_pos - st
+            if text_len > 0:
+                st_idx = (
+                    llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+                )
+                llm_pos_ids_list.append(
+                    torch.arange(text_len, device=device).view(1, -1).expand(3, -1)
+                    + st_idx
+                )
+
+            # Vision position IDs (3D)
+            llm_grid_t = 1  # Always 1 for images
+            llm_grid_h = thw[1] // spatial_merge_size
+            llm_grid_w = thw[2] // spatial_merge_size
+
+            t_index = (
+                torch.arange(llm_grid_t, device=device)
+                .view(-1, 1)
+                .expand(-1, llm_grid_h * llm_grid_w)
+                .flatten()
+            )
+            h_index = (
+                torch.arange(llm_grid_h, device=device)
+                .view(1, -1, 1)
+                .expand(llm_grid_t, -1, llm_grid_w)
+                .flatten()
+            )
+            w_index = (
+                torch.arange(llm_grid_w, device=device)
+                .view(1, 1, -1)
+                .expand(llm_grid_t, llm_grid_h, -1)
+                .flatten()
+            )
+            st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+            llm_pos_ids_list.append(torch.stack([t_index, h_index, w_index]) + st_idx)
+
+            # Update st to after all visual placeholder tokens
+            # The number of visual tokens is (thw[1] // spatial_merge_size) * (thw[2] // spatial_merge_size)
+            num_visual_tokens = (thw[1] // spatial_merge_size) * (
+                thw[2] // spatial_merge_size
+            )
+            st = start_pos + num_visual_tokens
+
+        # Trailing text
+        if st < seq_len:
+            st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+            text_len = seq_len - st
+            llm_pos_ids_list.append(
+                torch.arange(text_len, device=device).view(1, -1).expand(3, -1) + st_idx
+            )
+
+        llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+        position_ids[..., i, :] = llm_positions
+
+    return position_ids
+
+
+def generate_calibration_data(
+    batch_size: int,
+    seq_len: int,
+    thw: Tuple[int, int, int],
+    spatial_merge_size: int,
+    temporal_patch_size: int,
+    spatial_patch_size: int,
+    vocab_size: int,
+    image_token_id: int,
+):
+    calibration_data = []
+    for i in range(batch_size):
+        x = create_visual_input(
+            seq_len,
+            thw,
+            spatial_merge_size,
+            temporal_patch_size,
+            spatial_patch_size,
+            vocab_size,
+            image_token_id,
+        )
+        calibration_data.append(x)
+    return calibration_data
+
+
+def main():
+    # Create Qwen3VL configuration
+    cfg = Qwen3VLConfig(
+        vision_config={
+            "hidden_size": 64,
+            "num_heads": 4,
+            "depth": 2,  # Smaller depth for faster testing
+            "temporal_patch_size": 2,
+            "patch_size": 16,
+            "out_hidden_size": 64,
+        },
+        text_config={
+            "hidden_size": 64,
+            "intermediate_size": 256,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "head_dim": 32,
+            "num_hidden_layers": 2,
+            "attention_bias": False,
+            "attention_dropout": 0.0,
+            "max_position_embeddings": 1024,
+            "vocab_size": 1000,
+            "use_cache": False,
+            "rope_scaling": {"rope_type": "default", "mrope_section": [1, 1, 2]},
+        },
+        image_token_id=998,
+        video_token_id=999,
+    )
+    thw = (1, 8, 8)
+
+    # Configure PTQ
+    ptq_config = tico.quantization.config.ptq.PTQConfig(
+        model_args={
+            "vision": {
+                "grid_thw": thw,
+            }
+        }
+    )
+
+    # Load the model
+    model = Qwen3VLForConditionalGeneration(cfg)
+    orig_model = copy.deepcopy(model)
+    model.eval()
+
+    # Prepare the model for quantization
+    prepared_model = tico.quantization.prepare(
+        model, ptq_config, inplace=True  # Transform the model in place
+    )
+
+    # Generate calibration data
+    calibration_data = generate_calibration_data(
+        batch_size=10,
+        seq_len=50,
+        thw=thw,
+        spatial_merge_size=cfg.vision_config.spatial_merge_size,
+        temporal_patch_size=cfg.vision_config.temporal_patch_size,
+        spatial_patch_size=cfg.vision_config.patch_size,
+        vocab_size=cfg.text_config.vocab_size,
+        image_token_id=cfg.image_token_id,
+    )
+
+    # Calibrate the model (collect statistics)
+    with torch.no_grad():
+        for calibration_input in calibration_data:
+            prepared_model(**calibration_input._asdict())
+
+    # Convert to quantized model
+    quantized_model = tico.quantization.convert(prepared_model, inplace=True)
+
+    # Compute quantization error metrics
+    with torch.no_grad():
+        test_input = calibration_data[0]._asdict()
+        test_input["position_ids"] = None
+        quant_out = quantized_model(**test_input).logits
+        fp_out = orig_model(**test_input).logits
+
+    print(f"┌───────────── Quantization Error Summary ─────────────")
+    print(f"│ Mean |diff|: {(quant_out - fp_out).abs().mean().item():.6f}")
+    print(f"│ PEIR       : {compute_peir(fp_out, quant_out) * 100:.6f} %")
+    print(f"└──────────────────────────────────────────────────────")
+    print(plot_two_outputs(fp_out, quant_out))
+
+    # Convert to Circle format
+
+    example_input = calibration_data[0]
+    circle_model = tico.convert(quantized_model.eval(), example_input)
+
+    # Save the Circle model
+    filename = "qwen3vl_for_conditional_generation.q.circle"
+    circle_model.save(filename)
+    print(f"Circle model saved as '{filename}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, Optional, Union
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+@try_register(
+    "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLForConditionalGeneration",
+)
+class QuantQwen3VLForConditionalGeneration(QuantModuleBase):
+    """
+    Quantization wrapper for Qwen3VLForConditionalGeneration module.
+
+    This is the full multimodal generation model that includes:
+    - Vision and language model (Qwen3VLModel): Processes inputs and generates hidden states
+    - Language modeling head (lm_head): Projects hidden states to vocabulary logits for generation
+
+    The forward pass simply delegates to the wrapped model and lm_head,
+    with no additional quantization operations needed at this level.
+    """
+
+    def __init__(
+        self,
+        fp_model: nn.Module,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ):
+        super().__init__(qcfg, fp_name=fp_name)
+        self.module = fp_model
+
+        # Wrap the vision-language model
+        self.model = PTQWrapper(
+            fp_model.model,
+            qcfg=qcfg.child("model") if qcfg else None,
+            fp_name=f"{fp_name}.model",
+        )
+
+        # Wrap the language modeling head
+        self.lm_head = PTQWrapper(
+            fp_model.lm_head,
+            qcfg=qcfg.child("lm_head") if qcfg else None,
+            fp_name=f"{fp_name}.lm_head",
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        past_key_values=None,
+        inputs_embeds: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        **kwargs,
+    ) -> Union[torch.Tensor, tuple]:
+        """
+        Forward pass with fake quantization.
+
+        Args:
+            input_ids: Input token IDs of shape (batch_size, sequence_length)
+            attention_mask: Attention mask of shape (batch_size, sequence_length)
+            position_ids: Position IDs for RoPE
+            past_key_values: Past key-value caches for autoregressive generation
+            inputs_embeds: Input embeddings of shape (batch_size, sequence_length, hidden_size)
+            labels: Labels for computing masked language modeling loss
+            pixel_values: Image pixel values of shape (batch_size, C, H, W)
+            pixel_values_videos: Video pixel values
+            image_grid_thw: Grid dimensions for images of shape (num_images, 3)
+            video_grid_thw: Grid dimensions for videos
+            cache_position: Cache positions for generation
+            logits_to_keep: Number of logits to keep from the end
+            **kwargs: Additional keyword arguments
+
+        Returns:
+            Model output containing logits, past key values, etc.
+        """
+        # Get hidden states from the vision-language model
+        outputs = self.model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs[0]
+
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        slice_indices = (
+            slice(-logits_to_keep, None)
+            if isinstance(logits_to_keep, int)
+            else logits_to_keep
+        )
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        # Return output with proper structure
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLCausalLMOutputWithPast,
+        )
+
+        return Qwen3VLCausalLMOutputWithPast(
+            loss=None,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=outputs.rope_deltas,
+        )
+
+    def _all_observers(self) -> Iterable:
+        """Yield all observers from this module and wrapped submodules."""
+        # No local observers - all observers are in wrapped submodules
+        # This method is required by QuantModuleBase but yields nothing
+        return iter([])

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -78,6 +78,7 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_block",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_vision_model",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_model",
+    "tico.quantization.wrapq.wrappers.qwen_vl.quant_for_conditional_generation",
     # add future core wrappers here
 )
 


### PR DESCRIPTION
This change introduces `QuantQwen3VLForConditionalGeneration` wrapper to support post-training quantization of `Qwen3VLForConditionalGeneration` module.

# Why?

`Qwen3VLForConditionalGeneration` is an essential part of Qwen model.
Trying to quantize `Qwen3VLForConditionalGeneration` via PTQ generates exception `PTQQuantizer: no quantization wrapper for Qwen3VLForConditionalGeneration`.

# What

This change introduces:

- Class `QuantQwen3VLForConditionalGeneration` (`tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py`).
- Unit tests: `class TestQuantQwen3VLForConditionalGeneration` (`test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py`).
- New entry in `_CORE_MODULES` (`tico/quantization/wrapq/wrappers/registry.py`).
- Example of `Qwen3VLForConditionalGeneration` quantization and conversion to Circle (`tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py`).

# Unit Tests

Unit tests results with coverage information:

```bash
$ coverage run -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py -v
================================================================== test session starts ==================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 7 items                                                                                                                                       

test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_text_only                   PASSED [ 14%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_both_images_and_videos PASSED [ 28%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_images                 PASSED [ 42%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_videos                 PASSED [ 57%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_mode_transitions                    PASSED [ 71%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_registration_in_registry            PASSED [ 85%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_wraps_submodules                    PASSED [100%]

============================================================= 7 passed, 2 warnings in 8.48s =============================================================
```

Coverage info (irrelevant files skipped):
```bash
$ coverage report -m
Name                                                                           Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------------------------
...
tico/quantization/wrapq/wrappers/nn/quant_linear.py                               29      0   100%
...
tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py      23      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py                          215     52    76%   114, 120, 163, 199, 277-281, 348-363, 427-436, 499-576, 620-625
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py                      136      5    96%   196-197, 201-203
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py              42      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py                        43      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py                     130      8    94%   248, 254-256, 260, 278, 282, 285-286
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attn.py                    105      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py                    42      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_mlp.py                      33      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_model.py                   173      6    97%   166, 173, 180, 195, 279, 452
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_embed.py              25      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py             36      0   100%
tico/quantization/wrapq/wrappers/registry.py                                      36      1    97%   260
...
------------------------------------------------------------------------------------------------------------
TOTAL                                                                          11720   6838    42%
```

# Script for testing quantization and conversion to Circle

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.022036
│ PEIR       : 16.040346 %
└──────────────────────────────────────────────────────
     ┌───────────────────────────────────────────┐
 0.72┤                                           │
     │                                    •••••  │
 0.48┤                                 •••••••   │
     │                              •••••••      │
     │                          •••••••••        │
 0.24┤                     • ••••••••••          │
     │                     ••••••••••            │
-0.00┤                  •••••••••••              │
     │             •••••••••••• •                │
     │            ••••••••••  •                  │
-0.24┤          •••••••••••                      │
     │      • ••••••••                           │
-0.48┤      ••••••••                             │
     │    ••••••                                 │
     │  ••••                                     │
-0.72┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -0.72      -0.36     -0.00      0.36     0.72 

[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).
Circle model saved as 'qwen3vl_for_conditional_generation.q.circle'
```