### PR TITLE
[quantization] Remove `copy`

### DIFF
--- a/tico/quantization/wrapq/wrappers/llama/quant_attn_decode.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attn_decode.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 from typing import List, Optional, Tuple
 
 import torch
@@ -103,7 +102,7 @@ class QuantLlamaAttentionDecode(QuantModuleBase):
             fp_attn.q_proj, qcfg=q_cfg, fp_name=f"{fp_name}.q_proj"
         )
         self.k_proj = PTQWrapper(
-            copy.deepcopy(fp_attn.k_proj), qcfg=k_cfg, fp_name=f"{fp_name}.k_proj"
+            fp_attn.k_proj, qcfg=k_cfg, fp_name=f"{fp_name}.k_proj"
         )
         self.v_proj = PTQWrapper(
             fp_attn.v_proj, qcfg=v_cfg, fp_name=f"{fp_name}.v_proj"

--- a/tico/quantization/wrapq/wrappers/llama/quant_attn_prefill.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attn_prefill.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 from typing import List, Optional, Tuple
 
 import torch
@@ -78,7 +77,7 @@ class QuantLlamaAttentionPrefill(QuantModuleBase):
             fp_attn.q_proj, qcfg=q_cfg, fp_name=f"{fp_name}.q_proj"
         )
         self.k_proj = PTQWrapper(
-            copy.deepcopy(fp_attn.k_proj), qcfg=k_cfg, fp_name=f"{fp_name}.k_proj"
+            fp_attn.k_proj, qcfg=k_cfg, fp_name=f"{fp_name}.k_proj"
         )
         self.v_proj = PTQWrapper(
             fp_attn.v_proj, qcfg=v_cfg, fp_name=f"{fp_name}.v_proj"


### PR DESCRIPTION
This commit removes redundant copy of key modules.
Copy was used for debugging, so we don't need it any more.

Draft: #570
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>