### PR TITLE
[quantization] Fix quant_vision_patch_merger

### DIFF
--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py
@@ -100,7 +100,7 @@ class QuantQwen3VLVisionPatchMerger(QuantModuleBase):
             # Reshape to (N, hidden_size) before norm
             x = self.norm(x.view(-1, self.hidden_size)).view(-1, self.hidden_size)
         else:
-            x = x.view(-1, self.hidden_size)
+            x = self.norm(x).view(-1, self.hidden_size)
 
         # Apply first linear layer
         x = self.linear_fc1(x)


### PR DESCRIPTION
This commit fixes wrapper `quant_vision_patch_merger`

From original `Qwen3VLVisionPatchMerger`:
```
x = self.norm(x.view(-1, self.hidden_size) if self.use_postshuffle_norm else x).view(-1, self.hidden_size)
```

TICO-DCO-1.0-Signed-off-by: Evgenii Maltsev <e.maltsev@samsung.com>