### PR TITLE
[quantization] Fix `truthfulqa`

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -184,7 +184,6 @@ def save_layers_to(q_m, max_seq_len, save_layers_to_folder):
 
 def quantize_using_PTQ(q_m, calib_inputs, args):
     print("Wrapping layers with PTQWrapper …")
-
     qcfg = build_llm_ptq_config(
         model_type="llama",
         num_hidden_layers=len(q_m.model.layers),
@@ -220,7 +219,16 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
     device = torch.device(args.device)
     with torch.no_grad():
         for inp in tqdm.tqdm(calib_inputs):
-            q_m(inp.to(device))
+            if args.calibrate_use_cache:
+                outputs = q_m(inp[..., :-1].to(device), use_cache=True)
+                # TODO add padding?
+                q_m(
+                    inp[..., -1:].to(device),
+                    past_key_values=outputs.past_key_values,
+                    use_cache=True,
+                )
+            else:
+                q_m(inp.to(device))
 
     # Freeze all Q-params (scale, zero-point)
     q_m = convert(q_m)
@@ -414,6 +422,12 @@ def main():
         action="store_true",
         help="Verbose logging for debugging (e.g., GPTQ injection coverage)",
     )
+    parser.add_argument(
+        "--calibrate_use_cache",
+        action="store_true",
+        default=False,
+        help="Calibrate using cache (e.g. for PTQ-model evaluation on `truthfulqa` benchmark)",
+    )
     args = parser.parse_args()
     print(args)
 
@@ -456,7 +470,7 @@ def main():
     else:
         print("Skipping SpinQuant preprocessing …")
 
-    model.config.use_cache = False  # TODO use args for it
+    model.config.use_cache = False
     if args.calibrate_seq_len is not None:
         model.config.max_position_embeddings = min(
             model.config.max_position_embeddings, args.calibrate_seq_len

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -205,10 +205,16 @@ class QuantLlamaAttention(QuantModuleBase):
         if past is None:
             return k_new, v_new
         past_k, past_v = past
-        past_k = self._fq(past_k, self.obs_past_key)
-        past_v = self._fq(past_v, self.obs_past_value)
-        k = torch.cat([past_k[:, kv_idx, :, :], k_new], dim=1)
-        v = torch.cat([past_v[:, kv_idx, :, :], v_new], dim=1)
+        if past_k is not None:
+            past_k = self._fq(past_k, self.obs_past_key)
+            k = torch.cat([past_k[:, kv_idx, :, :], k_new], dim=1)
+        else:
+            k = k_new
+        if past_v is not None:
+            past_v = self._fq(past_v, self.obs_past_value)
+            v = torch.cat([past_v[:, kv_idx, :, :], v_new], dim=1)
+        else:
+            v = v_new
         return k, v
 
     def _build_attention_mask(
@@ -228,7 +234,11 @@ class QuantLlamaAttention(QuantModuleBase):
         - additive mask: use as-is.
         """
         q_len = hidden_states.size(1)
-        past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+        past_len = (
+            0
+            if (past_key_value is None or past_key_value[0] is None)
+            else int(past_key_value[0].shape[2])
+        )
         k_len = past_len + q_len
 
         if attention_mask is None:
@@ -267,7 +277,11 @@ class QuantLlamaAttention(QuantModuleBase):
         cos = self._fq(cos, self.obs_cos)
         sin = self._fq(sin, self.obs_sin)
 
-        past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+        past_len = (
+            0
+            if (past_key_value is None or past_key_value[0] is None)
+            else int(past_key_value[0].shape[2])
+        )
         key_len = past_len + S
 
         attn_mask = self._build_attention_mask(

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -204,7 +204,11 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         - additive mask: use as-is.
         """
         q_len = hidden_states.size(1)
-        past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+        past_len = (
+            0
+            if (past_key_value is None or past_key_value[0] is None)
+            else int(past_key_value[0].shape[2])
+        )
         k_len = past_len + q_len
 
         if attention_mask is None:
@@ -305,7 +309,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         if use_cache:
             outputs += (present_key_value,)  # type: ignore[assignment]
 
-        if self.return_type == "tuple":
+        if self.return_type == "tuple" or use_cache:
             return outputs
         if self.return_type == "tensor":
             return hidden_states

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -143,25 +143,88 @@ class QuantLlamaModel(QuantModuleBase):
         self.register_buffer("rope_cos_template", cos_t, persistent=False)
         self.register_buffer("rope_sin_template", sin_t, persistent=False)
 
-    def _slice_causal(self, seq_len: int, device: torch.device) -> torch.Tensor:
-        """Return `[1,1,L,L]` causal mask slice on *device*."""
-        assert isinstance(self.causal_mask_template, torch.Tensor)
-        return self.causal_mask_template[..., :seq_len, :seq_len].to(device)
+    def _slice_rope(
+        self,
+        *,
+        start: int,
+        seq_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert isinstance(self.rope_cos_template, torch.Tensor)
+        assert isinstance(self.rope_sin_template, torch.Tensor)
+        end = start + seq_len
+        cos = self.rope_cos_template[:, start:end, :].to(device=device, dtype=dtype)
+        sin = self.rope_sin_template[:, start:end, :].to(device=device, dtype=dtype)
+        return cos, sin
 
-    def get_attention_mask_for(self, x):
-        L = x.size(1)
-        attention_mask = self._slice_causal(L, x.device)
-        return attention_mask
+    def _normalize_position_embeddings(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]],
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if position_embeddings is None:
+            q_len = hidden_states.size(1)
+            past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+            cos, sin = self._slice_rope(
+                start=past_len,
+                seq_len=q_len,
+                device=hidden_states.device,
+                dtype=hidden_states.dtype,
+            )
+        else:
+            cos, sin = position_embeddings
+        return self._fq(cos, self.obs_cos), self._fq(sin, self.obs_sin)
 
-    def get_position_embeddings_for(self, hidden_states):
-        return (
-            self.rope_cos_template.to(
-                dtype=hidden_states.dtype, device=hidden_states.device
-            ),
-            self.rope_sin_template.to(
-                dtype=hidden_states.dtype, device=hidden_states.device
-            ),
+    def _normalize_attention_mask(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        device: torch.device,
+    ) -> torch.Tensor:
+        """
+        Return an additive attention mask usable with per-head logits.
+
+        Supported cases:
+        - None: build a causal mask slice.
+        - bool mask: convert to additive mask using 0 / -120.
+        - additive mask: use as-is.
+        """
+        seq_len = hidden_states.size(1)
+        past_len = (
+            0
+            if (past_key_value is None or past_key_value[0] is None)
+            else int(past_key_value[0].shape[2])
         )
+
+        if attention_mask is None:
+            assert isinstance(self.causal_mask_template, torch.Tensor)
+            mask = self.causal_mask_template[
+                ..., past_len : past_len + seq_len, : past_len + seq_len
+            ].to(device)
+            return mask.squeeze(0)
+
+        if attention_mask.dtype == torch.bool or attention_mask.dtype == torch.int64:
+            if attention_mask.dtype == torch.int64:
+                attention_mask = attention_mask == 1  # convert to bool
+            mask = self.causal_mask_template[
+                ..., past_len : past_len + seq_len, : past_len + seq_len
+            ].to(
+                device
+            )  # so for q_len == 1 mask will be the last row of causal_mask_template
+            # only padding which is assumed to change causal_mask
+            additive = torch.zeros_like(attention_mask, dtype=torch.float32)
+            additive = additive.masked_fill(~attention_mask, float("-120"))
+            mask = torch.max(
+                torch.tensor(float("-120")).to(device), additive + mask
+            )  # so -120-120->-120, -120+0->-120, 0-120->-120, 0+0->0
+            return mask.squeeze(0)
+
+        return attention_mask
 
     def forward(
         self,
@@ -202,52 +265,68 @@ class QuantLlamaModel(QuantModuleBase):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if use_cache and past_key_values is None:
-            past_key_values = DynamicCache()
+            past_key_values = []
 
-        if cache_position is None:
-            past_seen_tokens = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
-            cache_position = torch.arange(
-                past_seen_tokens,
-                past_seen_tokens + inputs_embeds.shape[1],
-                device=inputs_embeds.device,
-            )
-
-        if position_ids is None:
-            position_ids = cache_position.unsqueeze(0)
-
+        present_key_values = []
         hidden_states = inputs_embeds
 
         # Apply the SpinQuant rotation only when the source model provides it.
         if self.rotate_embedding is not None:
             hidden_states = self.rotate_embedding(hidden_states)
 
+        past_key_value = None  # sample kv-cache to infer past_seq_len
+        if past_key_values is not None:
+            if isinstance(past_key_values, DynamicCache):
+                if past_key_values.layers[0].keys is not None:
+                    past_key_value = (
+                        past_key_values.layers[0].keys,
+                        past_key_values.layers[0].values,
+                    )
+            elif len(past_key_values) > 0:
+                past_key_value = past_key_values[0]
+
         # create position_embeddings and causal_mask to be shared across all the decoder layers
-        causal_mask = self.get_attention_mask_for(hidden_states)
-        causal_mask = causal_mask.squeeze(0)
+        causal_mask = self._normalize_attention_mask(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_value=past_key_value,
+            device=hidden_states.device,
+        )
         causal_mask = self._fq(causal_mask, self.obs_causal_mask)
 
-        position_embeddings = self.get_position_embeddings_for(hidden_states)
-        cos, sin = position_embeddings
-        position_embeddings = (
-            self._fq(cos[:, : hidden_states.size(1), :], self.obs_cos),
-            self._fq(sin[:, : hidden_states.size(1), :], self.obs_sin),
+        position_embeddings = self._normalize_position_embeddings(
+            hidden_states=hidden_states,
+            position_embeddings=None,
+            past_key_value=past_key_value,
         )
-
         # decoder layers
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx, decoder_layer in enumerate(
+            self.layers[: self.config.num_hidden_layers]
+        ):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)  # type: ignore[operator]
+
+            if use_cache is True:
+                if isinstance(past_key_values, DynamicCache):
+                    past_key_value = (
+                        past_key_values.layers[idx].keys,
+                        past_key_values.layers[idx].values,
+                    )
+                else:
+                    past_key_value = (
+                        past_key_values[idx] if idx < len(past_key_values) else None
+                    )
+            else:
+                past_key_value = None
 
             layer_outputs = decoder_layer(
                 hidden_states,
                 attention_mask=causal_mask,
                 position_ids=position_ids,
-                past_key_value=past_key_values,
+                past_key_value=past_key_value,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
                 cache_position=cache_position,
@@ -257,6 +336,16 @@ class QuantLlamaModel(QuantModuleBase):
 
             if decoder_layer.wrapped.return_type == "tuple":
                 hidden_states = layer_outputs[0]
+            elif use_cache is True:
+                hidden_states = layer_outputs[0]
+                if isinstance(past_key_values, DynamicCache):
+                    past_key_values.update(
+                        layer_outputs[1][0], layer_outputs[1][1], layer_idx=idx
+                    )
+                else:
+                    present_key_values.append(
+                        (layer_outputs[1][0], layer_outputs[1][1])
+                    )
             else:
                 hidden_states = layer_outputs
 
@@ -271,7 +360,11 @@ class QuantLlamaModel(QuantModuleBase):
 
         output = BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=past_key_values if use_cache else None,
+            past_key_values=(
+                past_key_values
+                if use_cache and isinstance(past_key_values, DynamicCache)
+                else present_key_values
+            ),
             hidden_states=all_hidden_states,
             attentions=all_self_attns,
         )

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from tico.quantization.config.ptq import PTQConfig
@@ -30,7 +31,9 @@ from tico.quantization.wrapq.wrappers.registry import try_register
     "transformers.models.llama.modeling_llama.LlamaForCausalLM",
     "tico.quantization.algorithm.spinquant.spin_llama.SpinLlamaForCausalLM",
 )
-class QuantLlamaForCausalLM(QuantModuleBase):
+class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
+    _is_stateful = False
+
     def __init__(
         self,
         model_fp: nn.Module,
@@ -76,9 +79,14 @@ class QuantLlamaForCausalLM(QuantModuleBase):
         self.config = model_fp.config
         self.loss_function = model_fp.loss_function
         self.device = model_fp.device
+        self.generation_config = model_fp.generation_config
+        self.main_input_name = model_fp.main_input_name
 
     def tie_weights(self):
         pass
+
+    def is_remote_code(self):
+        return False
 
     def forward(
         self,
@@ -97,6 +105,9 @@ class QuantLlamaForCausalLM(QuantModuleBase):
         output_attentions = self.config.output_attentions
         output_hidden_states = self.config.output_hidden_states
         return_dict = self.config.use_return_dict
+        if "return_dict" in kwargs:
+            # lm_eval set return_dict explicitely in kwargs
+            return_dict = kwargs.pop("return_dict")
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs = self.model(

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -99,15 +99,15 @@ class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
         use_cache: bool | None = None,
         cache_position: torch.LongTensor | None = None,
         logits_to_keep: int | torch.Tensor = 0,
+        return_dict: bool | None = None,
         **kwargs,
     ) -> CausalLMOutputWithPast:
 
         output_attentions = self.config.output_attentions
         output_hidden_states = self.config.output_hidden_states
-        return_dict = self.config.use_return_dict
-        if "return_dict" in kwargs:
-            # lm_eval set return_dict explicitely in kwargs
-            return_dict = kwargs.pop("return_dict")
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs = self.model(


### PR DESCRIPTION
This PR fixes `truthfulqa` evaluation.

<details> <summary> 16-bit run of HuggingFaceTB/SmolLM2-135M-Instruct </summary>

```
Original RESULTS ARE:
|    Tasks     |Version|Filter|n-shot|  Metric   |   | Value |   |Stderr|
|--------------|------:|------|-----:|-----------|---|------:|---|-----:|
|truthfulqa_gen|      3|none  |     0|bleu_acc   |↑  | 0.2913|±  |0.0159|
|              |       |none  |     0|bleu_diff  |↑  |-5.2094|±  |0.6062|
|              |       |none  |     0|bleu_max   |↑  |21.3007|±  |0.7145|
|              |       |none  |     0|rouge1_acc |↑  | 0.2938|±  |0.0159|
|              |       |none  |     0|rouge1_diff|↑  |-7.5999|±  |0.6972|
|              |       |none  |     0|rouge1_max |↑  |46.2006|±  |0.8337|
|              |       |none  |     0|rouge2_acc |↑  | 0.2362|±  |0.0149|
|              |       |none  |     0|rouge2_diff|↑  |-8.3506|±  |0.7790|
|              |       |none  |     0|rouge2_max |↑  |29.6729|±  |0.9197|
|              |       |none  |     0|rougeL_acc |↑  | 0.2827|±  |0.0158|
|              |       |none  |     0|rougeL_diff|↑  |-7.4784|±  |0.6796|
|              |       |none  |     0|rougeL_max |↑  |43.0500|±  |0.8333|
|truthfulqa_mc1|      2|none  |     0|acc        |↑  | 0.2399|±  |0.0149|
|truthfulqa_mc2|      3|none  |     0|acc        |↑  | 0.4178|±  |0.0148|
```

```
Quantized RESULTS ARE:
|    Tasks     |Version|Filter|n-shot|  Metric   |   | Value |   |Stderr|
|--------------|------:|------|-----:|-----------|---|------:|---|-----:|
|truthfulqa_gen|      3|none  |     0|bleu_acc   |↑  | 0.3121|±  |0.0162|
|              |       |none  |     0|bleu_diff  |↑  |-3.3805|±  |0.5129|
|              |       |none  |     0|bleu_max   |↑  |16.8512|±  |0.6326|
|              |       |none  |     0|rouge1_acc |↑  | 0.3305|±  |0.0165|
|              |       |none  |     0|rouge1_diff|↑  |-5.3833|±  |0.6805|
|              |       |none  |     0|rouge1_max |↑  |40.3370|±  |0.8086|
|              |       |none  |     0|rouge2_acc |↑  | 0.2277|±  |0.0147|
|              |       |none  |     0|rouge2_diff|↑  |-5.7747|±  |0.7057|
|              |       |none  |     0|rouge2_max |↑  |23.0924|±  |0.8486|
|              |       |none  |     0|rougeL_acc |↑  | 0.3121|±  |0.0162|
|              |       |none  |     0|rougeL_diff|↑  |-5.3809|±  |0.6535|
|              |       |none  |     0|rougeL_max |↑  |37.0933|±  |0.7974|
|truthfulqa_mc1|      2|none  |     0|acc        |↑  | 0.2485|±  |0.0151|
|truthfulqa_mc2|      3|none  |     0|acc        |↑  | 0.4126|±  |0.0148|
```
which are pretty similar

log: 
[log_SMOLLM_eval_9.txt](https://github.com/user-attachments/files/26704282/log_SMOLLM_eval_9.txt)

</details>

<details> <summary>Run on 4-bit `smse` on unsloth/Llama-3.2-3B-Instruct </summary>

```
Original RESULTS ARE:
|    Tasks     |Version|Filter|n-shot|  Metric   |   | Value |   |Stderr|
|--------------|------:|------|-----:|-----------|---|------:|---|-----:|
|truthfulqa_gen|      3|none  |     0|bleu_acc   |↑  | 0.6193|±  |0.0170|
|              |       |none  |     0|bleu_diff  |↑  |16.4238|±  |1.1327|
|              |       |none  |     0|bleu_max   |↑  |35.2506|±  |0.8846|
|              |       |none  |     0|rouge1_acc |↑  | 0.5998|±  |0.0172|
|              |       |none  |     0|rouge1_diff|↑  |23.1605|±  |1.6231|
|              |       |none  |     0|rouge1_max |↑  |59.2485|±  |1.0459|
|              |       |none  |     0|rouge2_acc |↑  | 0.5349|±  |0.0175|
|              |       |none  |     0|rouge2_diff|↑  |24.4049|±  |1.6812|
|              |       |none  |     0|rouge2_max |↑  |47.2195|±  |1.2588|
|              |       |none  |     0|rougeL_acc |↑  | 0.5887|±  |0.0172|
|              |       |none  |     0|rougeL_diff|↑  |22.9323|±  |1.6371|
|              |       |none  |     0|rougeL_max |↑  |57.5084|±  |1.0770|
|truthfulqa_mc1|      2|none  |     0|acc        |↑  | 0.3366|±  |0.0165|
|truthfulqa_mc2|      3|none  |     0|acc        |↑  | 0.5147|±  |0.0150|

Quantized RESULTS ARE:
|    Tasks     |Version|Filter|n-shot|  Metric   |   | Value |   |Stderr|
|--------------|------:|------|-----:|-----------|---|------:|---|-----:|
|truthfulqa_gen|      3|none  |     0|bleu_acc   |↑  | 0.5508|±  |0.0174|
|              |       |none  |     0|bleu_diff  |↑  |12.0819|±  |1.0953|
|              |       |none  |     0|bleu_max   |↑  |33.8811|±  |0.8637|
|              |       |none  |     0|rouge1_acc |↑  | 0.5177|±  |0.0175|
|              |       |none  |     0|rouge1_diff|↑  |17.0869|±  |1.5387|
|              |       |none  |     0|rouge1_max |↑  |58.7352|±  |0.9873|
|              |       |none  |     0|rouge2_acc |↑  | 0.4835|±  |0.0175|
|              |       |none  |     0|rouge2_diff|↑  |17.0286|±  |1.6394|
|              |       |none  |     0|rouge2_max |↑  |45.4835|±  |1.1998|
|              |       |none  |     0|rougeL_acc |↑  | 0.5080|±  |0.0175|
|              |       |none  |     0|rougeL_diff|↑  |16.9061|±  |1.5483|
|              |       |none  |     0|rougeL_max |↑  |56.7794|±  |1.0144|
|truthfulqa_mc1|      2|none  |     0|acc        |↑  | 0.3097|±  |0.0162|
|truthfulqa_mc2|      3|none  |     0|acc        |↑  | 0.4869|±  |0.0148|
```



</details>

<details> <summary> Run 4-bit mse on unsloth/Llama-3.2-3B-Instruct </summary>


```
Original RESULTS ARE:
|    Tasks     |Version|Filter|n-shot|  Metric   |   | Value |   |Stderr|
|--------------|------:|------|-----:|-----------|---|------:|---|-----:|
|truthfulqa_gen|      3|none  |     0|bleu_acc   |↑  | 0.6193|±  |0.0170|
|              |       |none  |     0|bleu_diff  |↑  |16.4238|±  |1.1327|
|              |       |none  |     0|bleu_max   |↑  |35.2506|±  |0.8846|
|              |       |none  |     0|rouge1_acc |↑  | 0.5998|±  |0.0172|
|              |       |none  |     0|rouge1_diff|↑  |23.1605|±  |1.6231|
|              |       |none  |     0|rouge1_max |↑  |59.2485|±  |1.0459|
|              |       |none  |     0|rouge2_acc |↑  | 0.5349|±  |0.0175|
|              |       |none  |     0|rouge2_diff|↑  |24.4049|±  |1.6812|
|              |       |none  |     0|rouge2_max |↑  |47.2195|±  |1.2588|
|              |       |none  |     0|rougeL_acc |↑  | 0.5887|±  |0.0172|
|              |       |none  |     0|rougeL_diff|↑  |22.9323|±  |1.6371|
|              |       |none  |     0|rougeL_max |↑  |57.5084|±  |1.0770|
|truthfulqa_mc1|      2|none  |     0|acc        |↑  | 0.3366|±  |0.0165|
|truthfulqa_mc2|      3|none  |     0|acc        |↑  | 0.5147|±  |0.0150|

Quantized RESULTS ARE:
|    Tasks     |Version|Filter|n-shot|  Metric   |   | Value |   |Stderr|
|--------------|------:|------|-----:|-----------|---|------:|---|-----:|
|truthfulqa_gen|      3|none  |     0|bleu_acc   |↑  | 0.4835|±  |0.0175|
|              |       |none  |     0|bleu_diff  |↑  | 7.0149|±  |1.0841|
|              |       |none  |     0|bleu_max   |↑  |30.4182|±  |0.8508|
|              |       |none  |     0|rouge1_acc |↑  | 0.4749|±  |0.0175|
|              |       |none  |     0|rouge1_diff|↑  |10.5110|±  |1.4802|
|              |       |none  |     0|rouge1_max |↑  |55.5551|±  |0.9786|
|              |       |none  |     0|rouge2_acc |↑  | 0.4113|±  |0.0172|
|              |       |none  |     0|rouge2_diff|↑  | 9.6823|±  |1.5941|
|              |       |none  |     0|rouge2_max |↑  |40.8478|±  |1.1862|
|              |       |none  |     0|rougeL_acc |↑  | 0.4614|±  |0.0175|
|              |       |none  |     0|rougeL_diff|↑  |10.1191|±  |1.4909|
|              |       |none  |     0|rougeL_max |↑  |53.2202|±  |1.0071|
|truthfulqa_mc1|      2|none  |     0|acc        |↑  | 0.2815|±  |0.0157|
|truthfulqa_mc2|      3|none  |     0|acc        |↑  | 0.4652|±  |0.0148|

```


</details>

<details> <summary>./ccex test --include-internal</summary>

```
...
----------------------------------------------------------------------
Ran 1099 tests in 532.613s

OK (skipped=20)
```
[test_log.txt](https://github.com/user-attachments/files/26667845/test_log.txt)

</details>


Related: #617 
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>