### PR TITLE
[quantization] Revise artifacts saving

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -217,9 +217,43 @@ def evaluate(q_m, tokenizer, dataset_test, args):
         print(make_table(results))
 
 
+def get_sensitivities_info_name(model, dataset, seed, n_samples):
+    model_name = model.config.name_or_path.replace("/", "_")
+
+    name = (
+        "."
+        + "/sensitivities_for_"
+        + model_name
+        + "_"
+        + dataset
+        + "_"
+        + str(n_samples)
+        + "_"
+        + str(seed)
+        + ".pt"
+    )
+    return name
+
+
+def get_ptq_model_name(model, args):
+    model_name = model.config.name_or_path.replace("/", "_")
+
+    name = (
+        f"PTQ_{model_name}_"
+        + ("SpinQuant_" if args.no_spinquant is False else "")
+        + ("GPTQ_" if args.no_GPTQ is False else "")
+        + (f"{args.gptq_mse}_" if args.no_GPTQ is False else "")
+        + str(args.nsamples_for_qcalibration)
+        + "_"
+        + str(args.seed)
+        + ".pt"
+    )
+    return name
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="GPTQ+PTQ pipeline (weight-only + activation)"
+        description="GPTQ+PTQ pipeline (weight-only + activation)",
     )
     parser.add_argument(
         "--model", type=str, required=True, help="HF repo name or local path."
@@ -270,16 +304,17 @@ def main():
         help="Leave model float",
     )
     parser.add_argument(
-        "--save_circle_to_folder",
+        "--output_dir",
         type=str,
         default=None,
-        help="Save the whole model to the folder specified",
+        help="Save specified artifacts to output_dir",
     )
     parser.add_argument(
-        "--save_layers_to_folder",
+        "--save",
+        nargs="*",
         type=str,
-        default=None,
-        help="Save all layers to the folder specified",
+        choices=["model_circle", "model_layers", "ptq_checkpoint", "sensitivity"],
+        help="which artifacts should be saved to output_dir",
     )
     parser.add_argument(
         "--cache_dir",
@@ -439,6 +474,13 @@ def main():
             else:
                 calibrator = SensitivityCalibrator(model, calib_inputs)
                 sens = calibrator.compute_sensitivity_info()
+                if args.output_dir is not None and "sensitivity" in args.save:
+                    save_name = get_sensitivities_info_name(
+                        model, "wikitext", args.seed, len(calib_inputs)
+                    )
+                    save_path = pathlib.Path(args.output_dir, save_name)
+                    print(f"Saving calibrated_sensitivities to {save_path}")
+                    torch.save(sens, save_path)
 
         gptq_config = GPTQConfig(
             weight_bits=args.linear_weight_bits,
@@ -461,15 +503,21 @@ def main():
     if not args.no_PTQ:
         q_m = quantize_using_PTQ(q_m, calib_inputs, args)
 
+        if args.output_dir is not None and "ptq_checkpoint" in args.save:
+            save_name = get_ptq_model_name(model, args)
+            save_path = pathlib.Path(args.output_dir, save_name)
+            print(f"Saving PTQ model to {save_path}")
+            torch.save(q_m, save_path)
+
     # after PTQ quantizer only fixed-length input sequences are valid
     evaluate(q_m, tokenizer, dataset_test, args)
 
-    if args.save_layers_to_folder is not None:
-        save_layers_to(q_m, args.max_seq_len, args.save_layers_to_folder)
+    if args.output_dir is not None and "model_layers" in args.save:
+        save_layers_to(q_m, args.max_seq_len, args.output_dir)
 
-    if args.save_circle_to_folder is not None:
+    if args.output_dir is not None and "model_circle" in args.save:
         calib_inputs = list(torch.stack(calib_inputs).reshape(-1, 1, args.max_seq_len))
-        save_model_to(q_m, calib_inputs, args.save_circle_to_folder)
+        save_model_to(q_m, calib_inputs, args.output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR revises saving facilities of the script to make them more transparent and adds an option to save ptq_checkpoint and sensitivity.


<details> <summary> sample output for  `Maykeye/TinyLLama-v0` </summary>

```
Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_spinquant=False, no_PTQ=False, output_dir='./outs_temp', save=['model_circle', 'sensitivity', 'model_layers', 'ptq_checkpoint'], cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse='smse', max_seq_len=2048, calibrate_seq_len=2048, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks=None, sensitivity_path=None)
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Loading weights: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 4225.40it/s]
Applying SpinQuant preprocessing …
Applying SpinQuant rotations: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 677.18it/s]

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL:   0%|                                                                                                                                                                                                                       | 0/159 [00:00<?, ?it/s]/mnt/storage/slow_repos/TICO_1/TICO/tico/quantization/algorithm/spinquant/spin_llama.py:150: FutureWarning: `input_embeds` is deprecated and will be removed in version 5.6.0 for `create_causal_mask`. Use `inputs_embeds` instead.
  causal_mask = create_causal_mask(
PPL:  99%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋ | 158/159 [00:04<00:00, 37.10it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  7584.31
└───────────────────────────────────────────
Applying GPTQ …
Computing calibration set
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:02<00:00, 47.68it/s]
Calibrating sensitivity
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:19<00:00,  6.73it/s]
Saving calibrated_sensitivities to outs_temp/sensitivities_for_Maykeye_TinyLLama-v0_wikitext_128_42.pt
Quantizing layers: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:15<00:00,  1.90s/layer]
Wrapping layers with PTQWrapper …                                                                                                                                                                                                                        
Calibrating PTQ obeservers…
  0%|                                                                                                                                                                                                                            | 0/128 [00:00<?, ?it/s]`use_return_dict` is deprecated! Use `return_dict` instead!
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:56<00:00,  2.26it/s]
Saving PTQ model to outs_temp/PTQ_Maykeye_TinyLLama-v0_SpinQuant_GPTQ_smse_128_42.pt

Calculating perplexities …
PPL:  99%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋ | 158/159 [00:44<00:00,  3.52it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  7206.84
└───────────────────────────────────────────
Saving model layer_0 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_0.q.circle
Saving model layer_1 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_1.q.circle
Saving model layer_2 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_2.q.circle
Saving model layer_3 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_3.q.circle
Saving model layer_4 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_4.q.circle
Saving model layer_5 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_5.q.circle
Saving model layer_6 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_6.q.circle
Saving model layer_7 to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/decoder_layer_7.q.circle
saving the whole model to /mnt/storage/slow_repos/TICO_1/TICO/outs_temp/model.q.circle
```

</details>

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>