### PR TITLE
[quantization] Evaluate fk llama model

### DIFF
--- a/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
+++ b/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
@@ -69,19 +69,25 @@ def main():
     parser.add_argument(
         "--fk_model_path", type=str, required=True, help="Path to fake_quantized model"
     )
-
     parser.add_argument(
         "--eval_tasks",
         type=str,
         default=None,
+        required=True,  # TODO revisit this option as this script can also be used for sample generation
         help="tasks to be evaluated using lm_eval, e.g. `winogrande,arc_easy,arc_challenge,openbookqa,mmlu_pro,ifeval,bbh`",
+    )
+    parser.add_argument(
+        "--skip_fp_eval",
+        action="store_true",
+        help="Enable only if you trust the model repo code.",
     )
 
     args = parser.parse_args()
     print(args)
 
+    # -------------------------------------------------------------------------
     # Basic setup
-
+    # -------------------------------------------------------------------------
     device = torch.device(args.device)
     dtype = DTYPE_MAP[args.dtype]
 
@@ -92,50 +98,54 @@ def main():
     print(f"fk_model_path    : {args.fk_model_path}")
     print()
 
-    # -------------------------------------------------------------------------
-    # 2. Load the FP backbone and tokenizer
-    # -------------------------------------------------------------------------
-    print("Loading FP model …")
     tokenizer = AutoTokenizer.from_pretrained(
         args.model,
         trust_remote_code=args.trust_remote_code,
         token=args.hf_token,
         cache_dir=args.cache_dir,
     )
-    model = (
-        AutoModelForCausalLM.from_pretrained(
-            args.model,
-            dtype=dtype,
-            trust_remote_code=args.trust_remote_code,
-            token=args.hf_token,
-            cache_dir=args.cache_dir,
+
+    if not args.skip_fp_eval:
+
+        # -------------------------------------------------------------------------
+        # FP model evaluation
+        # -------------------------------------------------------------------------
+        print("Loading FP model …")
+        model = (
+            AutoModelForCausalLM.from_pretrained(
+                args.model,
+                dtype=dtype,
+                trust_remote_code=args.trust_remote_code,
+                token=args.hf_token,
+                cache_dir=args.cache_dir,
+            )
+            .cpu()
+            .eval()
         )
-        .cpu()
-        .eval()
-    )
 
-    fk_model = torch.load(args.fk_model_path, weights_only=False)
+        if args.eval_tasks is not None:
+            config = model.config
+            max_seq_len = config.max_position_embeddings
+            results = evaluate_llm_on_tasks(
+                model, tokenizer, args.eval_tasks, max_length=max_seq_len
+            )
+            print("Original RESULTS ARE:")
+            print(make_table(results))
 
-    fk_model.eval()
-    fk_model = fk_model.cpu()
-    config = fk_model.wrapped.config
-    max_seq_len = config.max_position_embeddings
-    if device.type == "cuda" and torch.cuda.is_available():
-        torch.cuda.empty_cache()
+        model = model.cpu()
+        if device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    # -------------------------------------------------------------------------
+    # FK model evaluation
+    # -------------------------------------------------------------------------
+    print("Loading fake quantized model …")
+    fk_model = torch.load(args.fk_model_path, weights_only=False).eval().to(args.device)
 
     if args.eval_tasks is not None:
-        results = evaluate_llm_on_tasks(
-            model, tokenizer, args.eval_tasks, max_length=max_seq_len
-        )
-        print("Original RESULTS ARE:")
-        print(make_table(results))
+        config = fk_model.wrapped.config
+        max_seq_len = config.max_position_embeddings
 
-    model = model.cpu()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-
-    fk_model = fk_model.to(args.device)
-    if args.eval_tasks is not None:
         results = evaluate_llm_on_tasks(
             fk_model, tokenizer, args.eval_tasks, max_length=max_seq_len
         )

--- a/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
+++ b/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
@@ -120,7 +120,7 @@ def main():
     fk_model = fk_model.cpu()
     config = fk_model.wrapped.config
     max_seq_len = config.max_position_embeddings
-    if torch.cuda.is_available():
+    if device.type == "cuda" and torch.cuda.is_available():
         torch.cuda.empty_cache()
 
     if args.eval_tasks is not None:

--- a/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
+++ b/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+import torch
+
+from lm_eval.utils import make_table
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from tico.quantization.evaluation.script.llm_tasks_eval import evaluate_llm_on_tasks
+
+DTYPE_MAP = {
+    "float32": torch.float32,
+    # TODO Support more dtypes
+    # "bfloat16": torch.bfloat16,
+    # "float16": torch.float16,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Evaluate a fake-quantized Llama model"
+    )
+    parser.add_argument(
+        "--model", type=str, required=True, help="HF repo name or local path."
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Device to run on (cuda|cpu|mps).",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=list(DTYPE_MAP.keys()),
+        default="float32",
+        help="Model dtype for load.",
+    )
+    parser.add_argument(
+        "--hf-token",
+        type=str,
+        default=None,
+        help="Optional HF token for gated/private repos.",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Enable only if you trust the model repo code.",
+    )
+    parser.add_argument(
+        "--cache_dir",
+        type=str,
+        default=None,
+        help="cache_dir for using model/datasets loading",
+    )
+    parser.add_argument(
+        "--fk_model_path", type=str, required=True, help="Path to fake_quantized model"
+    )
+
+    parser.add_argument(
+        "--eval_tasks",
+        type=str,
+        default=None,
+        help="tasks to be evaluated using lm_eval, e.g. `winogrande,arc_easy,arc_challenge,openbookqa,mmlu_pro,ifeval,bbh`",
+    )
+
+    args = parser.parse_args()
+    print(args)
+
+    # Basic setup
+
+    device = torch.device(args.device)
+    dtype = DTYPE_MAP[args.dtype]
+
+    print("=== Config ===")
+    print(f"Model            : {args.model}")
+    print(f"Device           : {device.type}")
+    print(f"DType            : {args.dtype}")
+    print(f"fk_model_path    : {args.fk_model_path}")
+    print()
+
+    # -------------------------------------------------------------------------
+    # 2. Load the FP backbone and tokenizer
+    # -------------------------------------------------------------------------
+    print("Loading FP model …")
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model,
+        trust_remote_code=args.trust_remote_code,
+        token=args.hf_token,
+        cache_dir=args.cache_dir,
+    )
+    model = (
+        AutoModelForCausalLM.from_pretrained(
+            args.model,
+            dtype=dtype,
+            trust_remote_code=args.trust_remote_code,
+            token=args.hf_token,
+            cache_dir=args.cache_dir,
+        )
+        .cpu()
+        .eval()
+    )
+
+    fk_model = torch.load(args.fk_model_path, weights_only=False)
+
+    fk_model.eval()
+    fk_model = fk_model.cpu()
+    config = fk_model.wrapped.config
+    max_seq_len = config.max_position_embeddings
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    if args.eval_tasks is not None:
+        results = evaluate_llm_on_tasks(
+            model, tokenizer, args.eval_tasks, max_length=max_seq_len
+        )
+        print("Original RESULTS ARE:")
+        print(make_table(results))
+
+    model = model.cpu()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    fk_model = fk_model.to(args.device)
+    if args.eval_tasks is not None:
+        results = evaluate_llm_on_tasks(
+            fk_model, tokenizer, args.eval_tasks, max_length=max_seq_len
+        )
+        print("Quantized RESULTS ARE:")
+        print(make_table(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
+++ b/tico/quantization/wrapq/examples/evaluate_fk_llama_model.py
@@ -73,13 +73,12 @@ def main():
         "--eval_tasks",
         type=str,
         default=None,
-        required=True,  # TODO revisit this option as this script can also be used for sample generation
         help="tasks to be evaluated using lm_eval, e.g. `winogrande,arc_easy,arc_challenge,openbookqa,mmlu_pro,ifeval,bbh`",
     )
     parser.add_argument(
         "--skip_fp_eval",
         action="store_true",
-        help="Enable only if you trust the model repo code.",
+        help="Skip original model evaluation.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR adds script to evaluate fake-quantized Llama-based model.

<details> <summary> sample run on the model produced by #625 </summary>

```
Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', hf_token=None, trust_remote_code=False, cache_dir='/mnt/storage/transformers_cache', fk_model_path='./PTQ_Maykeye_TinyLLama-v0_SpinQuant_GPTQ_smse_32_42.pt', eval_tasks='openbookqa')
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32
fk_model_path    : ./PTQ_Maykeye_TinyLLama-v0_SpinQuant_GPTQ_smse_32_42.pt

Loading FP model …
Loading weights: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 1893.81it/s]
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
Generating train split: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4957/4957 [00:00<00:00, 18822.43 examples/s]
Generating validation split: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:00<00:00, 67593.37 examples/s]
Generating test split: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:00<00:00, 118946.85 examples/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:04<00:00, 106.94it/s]
Running loglikelihood requests: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2000/2000 [00:32<00:00, 61.30it/s]
Original RESULTS ARE:
|  Tasks   |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|----------|------:|------|-----:|--------|---|----:|---|-----:|
|openbookqa|      1|none  |     0|acc     |↑  |0.114|±  |0.0142|
|          |       |none  |     0|acc_norm|↑  |0.210|±  |0.0182|

`pretrained` model kwarg is not of type `str`. Many other model arguments may be ignored. Please do not launch via accelerate or use `parallelize=True` if passing an existing model this way.
Passed an already-initialized model through `pretrained`, assuming single-process call to evaluate() or custom distributed integration
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [00:04<00:00, 109.21it/s]
Running loglikelihood requests:   0%|                                                                                                                                                                                           | 0/2000 [00:00<?, ?it/s]`use_return_dict` is deprecated! Use `return_dict` instead!
Running loglikelihood requests: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2000/2000 [09:06<00:00,  3.66it/s]
Quantized RESULTS ARE:
|  Tasks   |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|----------|------:|------|-----:|--------|---|----:|---|-----:|
|openbookqa|      1|none  |     0|acc     |↑  |0.118|±  |0.0144|
|          |       |none  |     0|acc_norm|↑  |0.210|±  |0.0182|
```

</details>

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>