### PR TITLE
[quantization] Introduce fixed visual data start index in the input prompt for Qwen3VL

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py
@@ -97,6 +97,7 @@ class TestQuantQwen3VLForConditionalGeneration(unittest.TestCase):
             model_args={
                 "vision": {
                     "grid_thw": grid_thw,
+                    "visual_start_idx": 0,
                 }
             }
         )

--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py
@@ -93,6 +93,7 @@ class TestQuantQwen3VLModel(unittest.TestCase):
             model_args={
                 "vision": {
                     "grid_thw": grid_thw,
+                    "visual_start_idx": 0,
                 }
             }
         )

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
@@ -53,6 +53,10 @@ class QuantQwen3VLModel(QuantModuleBase):
         super().__init__(qcfg, fp_name=fp_name)
         self.module = fp_model
 
+        # Extract visual_start_idx from config for the insertion
+        # of visual embddings into the embedded input prompt
+        self.visual_start_idx = self._get_visual_start_idx(qcfg)
+
         self.image_token_id = fp_model.config.image_token_id
         self.video_token_id = fp_model.config.video_token_id
 
@@ -158,9 +162,11 @@ class QuantQwen3VLModel(QuantModuleBase):
             # Replace image placeholders with actual visual features
             if torch.compiler.is_compiling() or self.force_export:
                 # If we are exporting the model as a static graph.
-                # This assumes visual tokens are placed strictly in the beginning of the prompt
+                # This assumes visual tokens are starting at visual_start_idx in the prompt
                 # Violating this requirement will lead to a corrupted prompt
-                inputs_embeds = self._fuse_text_n_image(inputs_embeds, image_embeds)
+                inputs_embeds = self._fuse_text_n_image(
+                    inputs_embeds, image_embeds, visual_start_idx=self.visual_start_idx
+                )
             else:
                 # This operation cannot be converted to Circle because it produces data-dependent dynamic shapes
                 inputs_embeds = self._masked_scatter(
@@ -194,9 +200,11 @@ class QuantQwen3VLModel(QuantModuleBase):
             # Replace video placeholders with actual visual features
             if torch.compiler.is_compiling() or self.force_export:
                 # If we are exporting the model as a static graph
-                # This assumes visual tokens are placed strictly in the beginning of the prompt
+                # This assumes visual tokens are starting at visual_start_idx in the prompt
                 # Violating this requirement will lead to a corrupted prompt
-                inputs_embeds = self._fuse_text_n_image(inputs_embeds, video_embeds)
+                inputs_embeds = self._fuse_text_n_image(
+                    inputs_embeds, video_embeds, visual_start_idx=self.visual_start_idx
+                )
             else:
                 # This operation cannot be converted to Circle because it produces data-dependent dynamic shapes
                 inputs_embeds = self._masked_scatter(
@@ -273,10 +281,62 @@ class QuantQwen3VLModel(QuantModuleBase):
         )
 
     @staticmethod
-    def _fuse_text_n_image(inputs_embeds, visual_embeds):
+    def _get_visual_start_idx(qcfg: Optional[PTQConfig]) -> int:
+        """
+        Extract vision tokens starting index in the input prompt
+        from PTQConfig.model_args.
+
+        Expected format:
+            PTQConfig(
+                model_args={
+                    "vision": {
+                        "visual_start_idx": img_start_idx,
+                    }
+                }
+            )
+        """
+        if qcfg is None:
+            raise ValueError(
+                "PTQConfig is required for QuantQwen3VLModel because "
+                "vision.visual_start_idx must be provided via PTQConfig.model_args."
+            )
+
+        vision_args = qcfg.get_model_arg("vision", {})
+        if not isinstance(vision_args, dict):
+            raise ValueError(
+                "PTQConfig.model_args['vision'] must be a mapping containing "
+                "'visual_start_idx'."
+            )
+
+        visual_start_idx = vision_args.get("visual_start_idx")
+        if visual_start_idx is None:
+            raise ValueError(
+                "vision.visual_start_idx must be specified in PTQConfig.model_args for "
+                "QuantQwen3VLVisionModel.\n"
+                "Example:\n"
+                "PTQConfig(\n"
+                "    model_args={\n"
+                "        'vision': {\n"
+                "            'visual_start_idx': 4,\n"
+                "        }\n"
+                "    }\n"
+                ")"
+            )
+
+        visual_start_idx = int(visual_start_idx)
+        if visual_start_idx < 0:
+            raise ValueError(
+                f"vision.visual_start_idx must be greater than zero, but got {visual_start_idx}."
+            )
+        return visual_start_idx
+
+    @staticmethod
+    def _fuse_text_n_image(inputs_embeds, visual_embeds, visual_start_idx):
         num_visual_tokens = visual_embeds.shape[0]
         flat_inputs = inputs_embeds.view(-1, inputs_embeds.shape[-1])
-        flat_inputs[:num_visual_tokens] = visual_embeds
+        flat_inputs[
+            visual_start_idx : visual_start_idx + num_visual_tokens
+        ] = visual_embeds
         inputs_embeds = flat_inputs.view_as(inputs_embeds)
         return inputs_embeds
 


### PR DESCRIPTION
# What

This PR introduces a fixed visual data start index as `PTQConfig.vision.visual_start_idx` for Quant wrappers of Qwen3VL model.

# Why

The motivation for this change is described in detail in [Qwen3VL: Fixed Input Data Format At Inference Time](https://github.com/Samsung/TICO/issues/614) issue. Long story short: we need to fix the exact index at which visual data (image/video) begins in the model's input prompt at export time in order to be able to convert the model to Circle format.

# What has changed exactly

- `tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py`:  `QuantQwen3VLModel.__init__` now calls a new function `_get_visual_start_idx` to read the starting index of visual data in the prompt, stores the index in `self` and uses it to fuse visual and textual embedding vectors.

# Unit Tests

## QuantQwen3VLForConditionalGeneration
```bash
$ python -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py -v
=============================================================== test session starts ===============================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 7 items                                                                                                                                 

test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_text_only PASSED [ 14%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_both_images_and_videos PASSED [ 28%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_images PASSED [ 42%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_videos PASSED [ 57%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_mode_transitions PASSED [ 71%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_registration_in_registry PASSED [ 85%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_wraps_submodules PASSED [100%]
========================================================== 7 passed, 2 warnings in 6.20s ==========================================================
```

## QuantQwen3VLModel
```bash
$ python -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py -v
=============================================================== test session starts ===============================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 22 items                                                                                                                                

test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_activation_stats_collected_text_only PASSED       [  4%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_activation_stats_collected_with_images PASSED     [  9%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_compute_3d_position_ids_reuses_cached_rope_deltas PASSED [ 13%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_different_batch_sizes_text_only PASSED            [ 18%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_dtype_override PASSED                             [ 22%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_diff_text_only PASSED                     [ 27%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_input_validation PASSED                   [ 31%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_text_only PASSED                          [ 36%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_both_images_and_videos PASSED        [ 40%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_images PASSED                        [ 45%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_inputs_embeds PASSED                 [ 50%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_inputs_embeds_and_images PASSED      [ 54%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_videos PASSED                        [ 59%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_get_rope_index_with_images_and_videos PASSED      [ 63%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_graph_tracing_behavior_with_images PASSED         [ 68%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_graph_tracing_behavior_with_videos PASSED         [ 72%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_mode_transitions PASSED                           [ 77%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_multiple_calibration_steps_text_only PASSED       [ 81%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_observer_count PASSED                             [ 86%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_registration_in_registry PASSED                   [ 90%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_rope_deltas_computed_after_forward PASSED         [ 95%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_wraps_submodules PASSED                           [100%]
========================================================= 22 passed, 2 warnings in 11.28s =========================================================
```