### PR TITLE
[quantization] Save gpu memory

### DIFF
--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -28,6 +28,11 @@ from tico.quantization.algorithm.gptq.utils import (
 from tico.quantization.config.gptq import GPTQConfig
 from tico.quantization.quantizer import BaseQuantizer
 from tico.quantization.quantizer_registry import register_quantizer
+from tico.utils.utils import move_to_device
+
+
+def move_to_cpu(obj):
+    return move_to_device(obj, "cpu")
 
 
 class StopForward(Exception):
@@ -118,12 +123,12 @@ class GPTQQuantizer(BaseQuantizer):
             for idx, item in enumerate(args):
                 if (idx + 1) > len(self.cache_args):
                     self.cache_args.append([])
-                self.cache_args[idx].append(item)
+                self.cache_args[idx].append(move_to_cpu(item))
             # Store keyword args
             for k, v in kwargs.items():
                 if self.cache_kwargs.get(k, None) is None:
                     self.cache_kwargs[k] = []
-                self.cache_kwargs[k].append(v)
+                self.cache_kwargs[k].append(move_to_cpu(v))
 
             self.num_batches += 1
             raise StopForward  # stop after the first layer
@@ -280,6 +285,7 @@ class GPTQQuantizer(BaseQuantizer):
 
                 # Run layer forward over all cached batches to build Hessian/statistics
                 batch_num = self.num_batches
+                device = next(model.parameters()).device
                 for batch_idx in tqdm(
                     range(batch_num),
                     desc=f"[L{l_idx}] collecting",
@@ -290,9 +296,13 @@ class GPTQQuantizer(BaseQuantizer):
                     cache_args_batch = gather_single_batch_from_list(
                         self.cache_args, batch_idx
                     )
+                    cache_args_batch = move_to_device(cache_args_batch, device)
+
                     cache_kwargs_batch = gather_single_batch_from_dict(
                         self.cache_kwargs, batch_idx
                     )
+                    cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+
                     layer(*cache_args_batch, **cache_kwargs_batch)
 
                 # Remove handles
@@ -314,6 +324,7 @@ class GPTQQuantizer(BaseQuantizer):
                     gptq[name].free()
 
             # 4) After quantization, re-run the layer to produce outputs for the next layer
+            device = next(model.parameters()).device
             for batch_idx in tqdm(
                 range(batch_num),
                 desc=f"[L{l_idx}] re-forward",
@@ -324,9 +335,13 @@ class GPTQQuantizer(BaseQuantizer):
                 cache_args_batch = gather_single_batch_from_list(
                     self.cache_args, batch_idx
                 )
+                cache_args_batch = move_to_device(cache_args_batch, device)
+
                 cache_kwargs_batch = gather_single_batch_from_dict(
                     self.cache_kwargs, batch_idx
                 )
+                cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+
                 outs = layer(*cache_args_batch, **cache_kwargs_batch)
                 # LLaMA's decoder layer return type differs across Transformers versions:
                 # some return a tuple (hidden_states, ...), others return just a tensor.
@@ -334,7 +349,14 @@ class GPTQQuantizer(BaseQuantizer):
                 outs = outs[0] if isinstance(outs, tuple) else outs
                 # Update inputs for next iteration.
                 if len(self.cache_args) > 0:
-                    self.cache_args[0][batch_idx] = outs
+                    if hasattr(outs, "to") and hasattr(
+                        self.cache_args[0][batch_idx], "device"
+                    ):
+                        self.cache_args[0][batch_idx] = outs.to(
+                            self.cache_args[0][batch_idx].device
+                        )
+                    else:
+                        self.cache_args[0][batch_idx] = outs
 
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -396,3 +396,24 @@ def is_target_node(
         return False
 
     return True
+
+
+def move_to_device(obj, device):
+    """
+    Recursively move tensors inside a nested structure to the given device.
+    Non-tensor objects are preserved as-is.
+    """
+    if isinstance(obj, torch.Tensor):
+        return obj.to(device)
+
+    elif isinstance(obj, tuple):
+        return tuple(move_to_device(x, device) for x in obj)
+
+    elif isinstance(obj, list):
+        return [move_to_device(x, device) for x in obj]
+
+    elif isinstance(obj, dict):
+        return {k: move_to_device(v, device) for k, v in obj.items()}
+
+    # preserve everything else (bool, int, None, custom objects, etc.)
+    return obj


### PR DESCRIPTION
This PR uses gpu memory in GPTQ algorithm only for inference to reduce gpu memory usage.

It will make it possible to use large number of samples on a gpu with constrained memory.

<details> <summary> Sample run on 256 samples for TinyLlama/TinyLlama-1.1B-Chat-v1.0' on 8Gb GPU </summary>

```
Namespace(model='TinyLlama/TinyLlama-1.1B-Chat-v1.0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_spinquant=True, no_PTQ=False, save_circle_to_folder=None, save_layers_to_folder=None, cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=256, linear_weight_bits=4, gptq_mse='mse', max_seq_len=2048, calibrate_seq_len=2048, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks=None, sensitivity_path=None)
=== Config ===
Model            : TinyLlama/TinyLlama-1.1B-Chat-v1.0
Device           : cuda
DType            : float32

Loading FP model …
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 201/201 [00:01<00:00, 109.01it/s]
Skipping SpinQuant preprocessing …

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (341469 > 2048). Running this sequence through the model will result in indexing errors
PPL:  99%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉ | 166/167 [02:26<00:00,  1.13it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :     7.97
└───────────────────────────────────────────
Applying GPTQ …
Quantizing layers: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 22/22 [16:18<00:00, 44.47s/layer]
Wrapping layers with PTQWrapper …                                                                                                                                                                                          
Calibrating PTQ obeservers…
  0%|                                                                                                                                                                                              | 0/256 [00:00<?, ?it/s]`use_return_dict` is deprecated! Use `return_dict` instead!
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 256/256 [06:54<00:00,  1.62s/it]

Calculating perplexities …
PPL:  99%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉ | 166/167 [04:01<00:01,  1.45s/it]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :     8.66
└───────────────────────────────────────────
```

</details>

<details> <summary> ./ccex test --include-internal -k quantization.algorithm.test_gptq </summary>

```
RUN unit tests with -k quantization.algorithm.test_gptq ...
test_gptq_config_validate_rejects_non_positive_weight_bits_override (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_gptq_config_validate_weight_bits_overrides (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 7095.52it/s]
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... No specialized wrapper found for ModuleList; applying recursive wrapping.
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_resolve_weight_bits_priority (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_weight_bits_overrides_are_applied_per_module (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 21 tests in 72.134s

OK
```

</details>

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>