### PR TITLE
[quantization] Quantize` lm_head`

### DIFF
--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -361,6 +361,13 @@ class GPTQQuantizer(BaseQuantizer):
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
+        if (
+            hasattr(model, "model")
+            and hasattr(model.model, "norm")
+            and hasattr(model, "lm_head")
+        ):  # quantize lm_head
+            self._quantize_lm_head(model, quantizers)
+
         # Restore the original cache configuration.
         if orig_use_cache is not None:
             model.config.use_cache = orig_use_cache
@@ -373,3 +380,89 @@ class GPTQQuantizer(BaseQuantizer):
         model.quantizers = quantizers
 
         return model
+
+    def _quantize_lm_head(self, model, quantizers):
+        gptq_conf = self.config
+        assert isinstance(gptq_conf, GPTQConfig)
+        # TODO reduce code duplication with layer-wise quantization
+
+        # prepare data for lm_head
+        batch_num = self.num_batches
+        device = next(model.parameters()).device
+        for batch_idx in tqdm(
+            range(batch_num),
+            desc=f"[model.norm] re-forward",
+            leave=False,
+            unit="batch",
+            disable=not gptq_conf.show_progress,
+        ):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+
+            hidden_states = model.model.norm(hidden_states)
+            if len(self.cache_args) > 0:
+                self.cache_args[0][batch_idx] = move_to_cpu(hidden_states)
+
+        layer = model.lm_head
+        gptq = GPTQ(layer)
+        full_module_name = "lm_head"
+        weight_bits = self._resolve_weight_bits(
+            gptq_conf,
+            full_module_name=full_module_name,
+            local_module_name="lm_head",
+        )
+        if (
+            gptq_conf.sensitivity is not None
+            and isinstance(gptq_conf.sensitivity, dict)
+            and full_module_name in gptq_conf.sensitivity
+        ):
+            cur_sensitivity = gptq_conf.sensitivity[full_module_name]
+        else:
+            cur_sensitivity = None
+        gptq.quantizer.configure(
+            bits=weight_bits,
+            perchannel=gptq_conf.perchannel,
+            sym=gptq_conf.symmetric,
+            mse=gptq_conf.mse,
+            sensitivity=cur_sensitivity,
+        )
+
+        # Hook to collect (inp, out) for GPTQ
+        def add_batch():
+            def _hook(_, inp, out):
+                gptq.add_batch(inp[0].data, out.data)
+
+            return _hook
+
+        handles = [layer.register_forward_hook(add_batch())]
+
+        # Run layer forward over all cached batches to build Hessian/statistics
+        device = next(layer.parameters()).device  # in case lm_head is located on cpu
+        for batch_idx in tqdm(
+            range(batch_num),
+            desc=f"[lm_head] collecting",
+            leave=False,
+            unit="batch",
+            disable=not gptq_conf.show_progress,
+        ):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+
+            layer(hidden_states)
+
+        # Remove handles
+        for h in handles:
+            h.remove()
+
+        # Quantize
+        if gptq_conf.verbose:
+            print(f"[lm_head] -> Quantizing ...")
+        gptq.fasterquant(
+            percdamp=gptq_conf.percdamp,
+            groupsize=gptq_conf.groupsize,
+            actorder=gptq_conf.actorder,
+            static_groups=gptq_conf.static_groups,
+            verbose=gptq_conf.verbose,
+        )
+        quantizers[f"model.lm_head"] = gptq.quantizer
+        gptq.free()

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -464,5 +464,5 @@ class GPTQQuantizer(BaseQuantizer):
             static_groups=gptq_conf.static_groups,
             verbose=gptq_conf.verbose,
         )
-        quantizers[f"model.lm_head"] = gptq.quantizer
+        quantizers[f"lm_head"] = gptq.quantizer
         gptq.free()


### PR DESCRIPTION
This PR quantizes `lm_head` in GPTQ to imorove accuracy.

<details> <summary>  ./ccex test --include-internal -k quantization.algorithm.test_gptq </summary>

```

RUN unit tests with -k quantization.algorithm.test_gptq ...
test_gptq_config_validate_rejects_non_positive_weight_bits_override (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_gptq_config_validate_weight_bits_overrides (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_groupwise_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_model (quantization.algorithm.test_gptq.GPTQTest) ... <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
<frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
ok
test_net (quantization.algorithm.test_gptq.GPTQTest) ... No specialized wrapper found for ModuleList; applying recursive wrapping.
ok
test_net_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv1d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv2d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_on_zero_inputs (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_normconv3d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_paddednormconv3d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_resolve_weight_bits_priority (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_transposed_conv2d_with_logits (quantization.algorithm.test_gptq.GPTQTest) ... ok
test_weight_bits_overrides_are_applied_per_module (quantization.algorithm.test_gptq.GPTQTest) ... ok

----------------------------------------------------------------------
Ran 21 tests in 119.973s

OK
```
</details>

Value tests: 

HuggingFaceTB/SmolLM2-135M-Instruct
| Config ID | PPL  |
|-----------|------|
| FP32 | 17.40 |
| GPTQ_MSE_w4A16_head4| 27.83|
| GPTQ_MSE_w4A16_head_GPTQ_4| **25.09**|
| GPTQ_SMSE_w4A16_head4| 26.89|
| GPTQ_SMSE_w4A16_head_GPTQ_4| **23.97**|


TinyLlama/TinyLlama-1.1B-Chat-v1.0:
| Config ID | PPL  |
|-----------|------|
| FP32 | 7.97 |
| GPTQ_MSE_w4A16_head4| 8.66|
| GPTQ_MSE_w4A16_head_GPTQ_4|**8.54**|
| GPTQ_SMSE_w4A16_head4| 8.52|
| GPTQ_SMSE_w4A16_head_GPTQ_4|**8.42**|

unsloth/Llama-3.2-1B-Instruct:
| Config ID | PPL  |
|-----------|------|
| FP32 | 13.17 |
| GPTQ_MSE_w4A16_head4| 18.59|
| GPTQ_MSE_w4A16_head_GPTQ_4|**18.30**|
| GPTQ_SMSE_w4A16_head4| 15.26|
| GPTQ_SMSE_w4A16_head_GPTQ_4|**15.01**|

unsloth/Llama-3.2-3B-Instruct:
| Config ID | PPL  |
|-----------|------|
| FP32 | 11.05 |
| GPTQ_MSE_w4A16_head4| 12.96|
| GPTQ_MSE_w4A16_head_GPTQ_4|**12.68**|
| GPTQ_SMSE_w4A16_head4| 12.43|
| GPTQ_SMSE_w4A16_head_GPTQ_4|**12.28**|

Related: as a fallback  to #624 
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>