### PR TITLE
[quantization] Rename save options

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -313,7 +313,7 @@ def main():
         "--save",
         nargs="*",
         type=str,
-        choices=["model_circle", "model_layers", "ptq_checkpoint", "sensitivity"],
+        choices=["circle_full", "circle_per_layer", "ptq_checkpoint", "sensitivity"],
         help="which artifacts should be saved to output_dir",
     )
     parser.add_argument(
@@ -512,10 +512,10 @@ def main():
     # after PTQ quantizer only fixed-length input sequences are valid
     evaluate(q_m, tokenizer, dataset_test, args)
 
-    if args.output_dir is not None and "model_layers" in args.save:
+    if args.output_dir is not None and "circle_per_layer" in args.save:
         save_layers_to(q_m, args.max_seq_len, args.output_dir)
 
-    if args.output_dir is not None and "model_circle" in args.save:
+    if args.output_dir is not None and "circle_full" in args.save:
         calib_inputs = list(torch.stack(calib_inputs).reshape(-1, 1, args.max_seq_len))
         save_model_to(q_m, calib_inputs, args.output_dir)
 


### PR DESCRIPTION
This PR renames :
1. `model_circle` to `circle_full`
2. `model_layers` to `circle_per_layer` to make save options more appropriate.

<details> <summary> sample run with options enabled</summary>

```
Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_spinquant=True, no_PTQ=False, output_dir='.', save=['circle_per_layer', 'circle_full', 'ptq_checkpoint', 'sensitivity'], cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse='smse', max_seq_len=2048, calibrate_seq_len=2048, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks=None, sensitivity_path=None)
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
Skipping SpinQuant preprocessing …

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL:  99%|██████████████████████████████████████████████████████████████████████▌| 158/159 [00:06<00:00, 25.57it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  7584.31
└───────────────────────────────────────────
Applying GPTQ …
Computing calibration set
100%|████████████████████████████████████████████████████████████████████████████| 128/128 [00:05<00:00, 24.34it/s]
Calibrating sensitivity
100%|████████████████████████████████████████████████████████████████████████████| 128/128 [00:19<00:00,  6.59it/s]
Saving calibrated_sensitivities to sensitivities_for_Maykeye_TinyLLama-v0_wikitext_128_42.pt
Quantizing layers: 100%|██████████████████████████████████████████████████████████| 8/8 [00:08<00:00,  1.07s/layer]
Wrapping layers with PTQWrapper …                                                                                  
Calibrating PTQ obeservers…
100%|████████████████████████████████████████████████████████████████████████████| 128/128 [00:41<00:00,  3.07it/s]
Saving PTQ model to PTQ_Maykeye_TinyLLama-v0_GPTQ_smse_128_42.pt

Calculating perplexities …
PPL:  99%|██████████████████████████████████████████████████████████████████████▌| 158/159 [00:27<00:00,  5.83it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  7369.64
└───────────────────────────────────────────
Saving model layer_0 to /mnt/storage/slow_repos/TICO/decoder_layer_0.q.circle
Saving model layer_1 to /mnt/storage/slow_repos/TICO/decoder_layer_1.q.circle
Saving model layer_2 to /mnt/storage/slow_repos/TICO/decoder_layer_2.q.circle
Saving model layer_3 to /mnt/storage/slow_repos/TICO/decoder_layer_3.q.circle
Saving model layer_4 to /mnt/storage/slow_repos/TICO/decoder_layer_4.q.circle
Saving model layer_5 to /mnt/storage/slow_repos/TICO/decoder_layer_5.q.circle
Saving model layer_6 to /mnt/storage/slow_repos/TICO/decoder_layer_6.q.circle
Saving model layer_7 to /mnt/storage/slow_repos/TICO/decoder_layer_7.q.circle
saving the whole model to /mnt/storage/slow_repos/TICO/model.q.circle
```

</details>

Origin: https://github.com/Samsung/TICO/pull/625#discussion_r3080360748

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>