### PR TITLE
[quantization] Support PTQ quantization for VLM Qwen3-vl

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_model.py
@@ -245,21 +245,6 @@ class TestQuantQwen3VLVisionModel(unittest.TestCase):
         q_model.freeze_qparams()
         self.assertIs(q_model._mode, Mode.QUANT)
 
-    def test_forward_grid_mismatch_during_calibration(self):
-        """Test forward pass fails with mismatched grid_thw during calibration."""
-        ptq_config = self._make_ptq_config((1, 8, 8))
-        q_model = QuantQwen3VLVisionModel(
-            self.fp_model, qcfg=ptq_config, fp_name="test_model"
-        )
-        q_model.enable_calibration()
-
-        # Try with different grid
-        hidden_states, grid_thw = self._create_test_inputs((1, 4, 4))
-
-        with self.assertRaises(AssertionError) as context:
-            _ = q_model(hidden_states, grid_thw)
-        self.assertIn("grid_thw", str(context.exception))
-
     def test_observer_count(self):
         """Test that the wrapper has the correct number of observers."""
         ptq_config = self._make_ptq_config((1, 8, 8))

--- a/tico/quantization/config/builders.py
+++ b/tico/quantization/config/builders.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import copy
-from typing import Any, Dict, Optional, Tuple, Type
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional, Tuple, Type
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.config.utils import auto_qscheme_for
@@ -438,4 +439,497 @@ def build_llm_ptq_config(
         default_observer=default_observer,
         overrides=overrides,
         strict_wrap=strict_wrap,
+    )
+
+
+def _build_qwen3_vl_norm_override(
+    *,
+    norm_dtype: Optional[DType],
+    norm_weight_dtype: Optional[DType],
+) -> Dict[str, Any]:
+    """
+    Build an override dictionary for Qwen3-VL norm modules (RMSNorm and LayerNorm).
+
+    Parameters
+    ----------
+    norm_dtype : Optional[DType]
+        Explicit module-level dtype override for the norm module.
+    norm_weight_dtype : Optional[DType]
+        Explicit weight dtype override for the norm weight.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Override dictionary for the norm module. Returns an empty dictionary
+        if no explicit override is requested.
+    """
+    override: Dict[str, Any] = {}
+
+    if norm_dtype is not None:
+        norm_qscheme = auto_qscheme_for(norm_dtype)
+        override["dtype"] = norm_dtype
+        override["qscheme"] = norm_qscheme
+
+        # RMSNorm observers (used in text model)
+        for obs_name in ["act_in", "act_out"]:
+            override[obs_name] = {"qscheme": norm_qscheme}
+
+        # LayerNorm observers (used in vision blocks)
+        for obs_name in [
+            "mean",
+            "centered",
+            "square",
+            "var",
+            "eps",
+            "add_eps",
+            "inv_std",
+            "norm",
+            "affine_mul",
+            "affine_add",
+        ]:
+            override[obs_name] = {"qscheme": norm_qscheme}
+
+    if norm_weight_dtype is not None:
+        weight_qscheme = auto_qscheme_for(norm_weight_dtype, "weight")
+        override["weight"] = {
+            "dtype": norm_weight_dtype,
+            "qscheme": weight_qscheme,
+        }
+        # Also handle bias with same dtype/qscheme as weight
+        override["bias"] = {
+            "dtype": norm_weight_dtype,
+            "qscheme": weight_qscheme,
+        }
+
+    return override
+
+
+def _build_qwen3_vl_vision_block_overrides(
+    *,
+    linear_weight_dtype: Optional[DType],
+    norm_dtype: Optional[DType],
+    norm_weight_dtype: Optional[DType],
+) -> Dict[str, Any]:
+    """
+    Build per-block overrides for a Qwen3-VL vision transformer block.
+
+    The generated overrides can cover:
+      - attn.qkv - combined Q/K/V projection
+      - attn.proj - attention output projection
+      - mlp.linear_fc1 - MLP first linear layer
+      - mlp.linear_fc2 - MLP second linear layer
+      - norm1 - first layer norm
+      - norm2 - second layer norm
+
+    Parameters
+    ----------
+    linear_weight_dtype : Optional[DType]
+        Explicit or resolved dtype applied to vision block linear projection
+        weights. If None, no linear override is emitted.
+    norm_dtype : Optional[DType]
+        Explicit module-level dtype override for norm modules.
+    norm_weight_dtype : Optional[DType]
+        Explicit weight dtype override for norm weights.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Nested override dictionary for one vision block.
+    """
+    block_overrides: Dict[str, Any] = {}
+
+    linear_override = _build_weight_override(linear_weight_dtype)
+
+    if linear_override:
+        _set_nested_override(block_overrides, ("attn", "qkv"), linear_override)
+        _set_nested_override(block_overrides, ("attn", "proj"), linear_override)
+        _set_nested_override(block_overrides, ("mlp", "linear_fc1"), linear_override)
+        _set_nested_override(block_overrides, ("mlp", "linear_fc2"), linear_override)
+
+    norm_override = _build_qwen3_vl_norm_override(
+        norm_dtype=norm_dtype,
+        norm_weight_dtype=norm_weight_dtype,
+    )
+    if norm_override:
+        _set_nested_override(block_overrides, ("norm1",), norm_override)
+        _set_nested_override(block_overrides, ("norm2",), norm_override)
+
+    return block_overrides
+
+
+def _build_qwen3_vl_vision_merger_overrides(
+    *,
+    linear_weight_dtype: Optional[DType],
+    norm_dtype: Optional[DType],
+    norm_weight_dtype: Optional[DType],
+) -> Dict[str, Any]:
+    """
+    Build overrides for a Qwen3-VL vision patch merger.
+
+    The generated overrides can cover:
+      - norm - LayerNorm before merging
+      - linear_fc1 - first linear layer
+      - linear_fc2 - second linear layer
+
+    Parameters
+    ----------
+    linear_weight_dtype : Optional[DType]
+        Explicit or resolved dtype applied to merger linear projection
+        weights. If None, no linear override is emitted.
+    norm_dtype : Optional[DType]
+        Explicit module-level dtype override for norm module.
+    norm_weight_dtype : Optional[DType]
+        Explicit weight dtype override for norm weight.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Nested override dictionary for a vision merger.
+    """
+    merger_overrides: Dict[str, Any] = {}
+
+    linear_override = _build_weight_override(linear_weight_dtype)
+    if linear_override:
+        _set_nested_override(merger_overrides, ("linear_fc1",), linear_override)
+        _set_nested_override(merger_overrides, ("linear_fc2",), linear_override)
+
+    norm_override = _build_qwen3_vl_norm_override(
+        norm_dtype=norm_dtype,
+        norm_weight_dtype=norm_weight_dtype,
+    )
+    if norm_override:
+        _set_nested_override(merger_overrides, ("norm",), norm_override)
+
+    return merger_overrides
+
+
+def _build_qwen3_vl_text_layer_overrides(
+    *,
+    linear_weight_dtype: Optional[DType],
+    norm_dtype: Optional[DType],
+    norm_weight_dtype: Optional[DType],
+) -> Dict[str, Any]:
+    """
+    Build per-layer overrides for a Qwen3-VL text decoder block.
+
+    The generated overrides can cover:
+      - self_attn.q_proj
+      - self_attn.k_proj
+      - self_attn.v_proj
+      - self_attn.o_proj
+      - self_attn.q_norm - query RMSNorm
+      - self_attn.k_norm - key RMSNorm
+      - mlp.gate_proj
+      - mlp.up_proj
+      - mlp.down_proj
+      - input_layernorm
+      - post_attention_layernorm
+
+    Parameters
+    ----------
+    linear_weight_dtype : Optional[DType]
+        Explicit or resolved dtype applied to decoder-layer linear projection
+        weights. If None, no linear override is emitted.
+    norm_dtype : Optional[DType]
+        Explicit module-level dtype override for per-layer norm modules.
+    norm_weight_dtype : Optional[DType]
+        Explicit weight dtype override for per-layer norm weights.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Nested override dictionary for one decoder layer.
+    """
+    layer_overrides: Dict[str, Any] = {}
+
+    linear_override = _build_weight_override(linear_weight_dtype)
+    if linear_override:
+        _set_nested_override(layer_overrides, ("self_attn", "q_proj"), linear_override)
+        _set_nested_override(layer_overrides, ("self_attn", "k_proj"), linear_override)
+        _set_nested_override(layer_overrides, ("self_attn", "v_proj"), linear_override)
+        _set_nested_override(layer_overrides, ("self_attn", "o_proj"), linear_override)
+
+        _set_nested_override(layer_overrides, ("mlp", "gate_proj"), linear_override)
+        _set_nested_override(layer_overrides, ("mlp", "up_proj"), linear_override)
+        _set_nested_override(layer_overrides, ("mlp", "down_proj"), linear_override)
+
+    norm_override = _build_qwen3_vl_norm_override(
+        norm_dtype=norm_dtype,
+        norm_weight_dtype=norm_weight_dtype,
+    )
+    if norm_override:
+        _set_nested_override(layer_overrides, ("input_layernorm",), norm_override)
+        _set_nested_override(
+            layer_overrides, ("post_attention_layernorm",), norm_override
+        )
+        # Qwen3-VL specific: attention norms for Q and K
+        _set_nested_override(layer_overrides, ("self_attn", "q_norm"), norm_override)
+        _set_nested_override(layer_overrides, ("self_attn", "k_norm"), norm_override)
+
+    return layer_overrides
+
+
+def _build_qwen3_vl_overrides(
+    *,
+    num_vision_blocks: int,
+    num_text_layers: int,
+    num_deepstack_mergers: int,
+    linear_weight_dtype: Optional[DType],
+    vision_patch_embed_weight_dtype: Optional[DType],
+    embedding_weight_dtype: Optional[DType],
+    lm_head_weight_dtype: Optional[DType],
+    norm_dtype: Optional[DType],
+    norm_weight_dtype: Optional[DType],
+    quantize_vision: bool = True,
+    quantize_text: bool = True,
+    quantize_lm_head: bool = True,
+) -> Dict[str, Any]:
+    """
+    Build PTQ overrides for a Qwen3-VL model.
+
+    This helper generates overrides for:
+      - Vision tower: model.visual.patch_embed, model.visual.blocks.{i},
+                      model.visual.merger, model.visual.deepstack_merger_list.{i}
+      - Text model: model.language_model.embed_tokens, model.language_model.layers.{i},
+                    model.language_model.norm
+      - Output: lm_head
+
+    Parameters
+    ----------
+    num_vision_blocks : int
+        Number of vision transformer blocks.
+    num_text_layers : int
+        Number of text decoder layers.
+    num_deepstack_mergers : int
+        Number of deepstack merger modules in the vision tower.
+    linear_weight_dtype : Optional[DType]
+        Weight dtype override for linear projections.
+    vision_patch_embed_weight_dtype : Optional[DType]
+        Weight dtype override for vision patch embed projection.
+    embedding_weight_dtype : Optional[DType]
+        Weight dtype override for embedding weights.
+    lm_head_weight_dtype : Optional[DType]
+        Weight dtype override for lm_head.weight.
+    norm_dtype : Optional[DType]
+        Module-level dtype override for norm modules.
+    norm_weight_dtype : Optional[DType]
+        Weight dtype override for norm weights.
+    quantize_vision : bool
+        Whether to quantize vision tower.
+    quantize_text : bool
+        Whether to quantize text model.
+    quantize_lm_head : bool
+        Whether to quantize lm_head.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Nested override dictionary consumable by PTQConfig.
+    """
+    overrides: Dict[str, Any] = {"model": {}}
+
+    # Vision tower overrides
+    if quantize_vision:
+        vision_overrides: Dict[str, Any] = {}
+
+        # Patch embedding projection (Conv3d) - uses separate dtype
+        patch_embed_override = _build_weight_override(vision_patch_embed_weight_dtype)
+        if patch_embed_override:
+            _set_nested_override(
+                vision_overrides, ("patch_embed", "proj"), patch_embed_override
+            )
+
+        # Vision blocks
+        vision_overrides["blocks"] = {}
+        for block_idx in range(num_vision_blocks):
+            vision_overrides["blocks"][
+                str(block_idx)
+            ] = _build_qwen3_vl_vision_block_overrides(
+                linear_weight_dtype=linear_weight_dtype,
+                norm_dtype=norm_dtype,
+                norm_weight_dtype=norm_weight_dtype,
+            )
+
+        # Merger (has norm, linear_fc1, linear_fc2)
+        merger_override = _build_qwen3_vl_vision_merger_overrides(
+            linear_weight_dtype=linear_weight_dtype,
+            norm_dtype=norm_dtype,
+            norm_weight_dtype=norm_weight_dtype,
+        )
+        if merger_override:
+            vision_overrides["merger"] = merger_override
+
+        # Deepstack mergers (each has norm, linear_fc1, linear_fc2)
+        if num_deepstack_mergers > 0:
+            vision_overrides["deepstack_merger_list"] = {}
+            deepstack_override = _build_qwen3_vl_vision_merger_overrides(
+                linear_weight_dtype=linear_weight_dtype,
+                norm_dtype=norm_dtype,
+                norm_weight_dtype=norm_weight_dtype,
+            )
+            for merger_idx in range(num_deepstack_mergers):
+                vision_overrides["deepstack_merger_list"][
+                    str(merger_idx)
+                ] = copy.deepcopy(deepstack_override)
+
+        overrides["model"]["visual"] = vision_overrides
+
+    # Text model overrides
+    if quantize_text:
+        text_overrides: Dict[str, Any] = {}
+
+        # Text embedding
+        embedding_override = _build_weight_override(embedding_weight_dtype)
+        if embedding_override:
+            _set_nested_override(text_overrides, ("embed_tokens",), embedding_override)
+
+        # Text layers
+        text_overrides["layers"] = {}
+        for layer_idx in range(num_text_layers):
+            text_overrides["layers"][
+                str(layer_idx)
+            ] = _build_qwen3_vl_text_layer_overrides(
+                linear_weight_dtype=linear_weight_dtype,
+                norm_dtype=norm_dtype,
+                norm_weight_dtype=norm_weight_dtype,
+            )
+
+        # Final norm
+        final_norm_override = _build_qwen3_vl_norm_override(
+            norm_dtype=norm_dtype,
+            norm_weight_dtype=norm_weight_dtype,
+        )
+        if final_norm_override:
+            _set_nested_override(text_overrides, ("norm",), final_norm_override)
+
+        overrides["model"]["language_model"] = text_overrides
+
+    # LM head
+    if quantize_lm_head:
+        lm_head_override = _build_weight_override(lm_head_weight_dtype)
+        if lm_head_override:
+            overrides["lm_head"] = lm_head_override
+
+    return overrides
+
+
+def build_qwen3_vl_ptq_config(
+    *,
+    num_vision_blocks: int,
+    num_text_layers: int,
+    num_deepstack_mergers: int,
+    model_args: Mapping[str, Any],
+    activation_dtype: DType = DType.int(16),
+    default_qscheme: QScheme = QScheme.PER_TENSOR_SYMM,
+    default_observer: Type[ObserverBase] = MinMaxObserver,
+    linear_weight_bits: Optional[int] = None,
+    linear_weight_dtype: Optional[DType] = None,
+    vision_patch_embed_weight_bits: Optional[int] = None,
+    vision_patch_embed_weight_dtype: Optional[DType] = None,
+    embedding_weight_bits: Optional[int] = None,
+    embedding_weight_dtype: Optional[DType] = None,
+    lm_head_weight_bits: Optional[int] = None,
+    lm_head_weight_dtype: Optional[DType] = None,
+    norm_dtype: Optional[DType] = None,
+    norm_weight_bits: Optional[int] = None,
+    norm_weight_dtype: Optional[DType] = None,
+    quantize_vision: bool = True,
+    quantize_text: bool = True,
+    quantize_lm_head: bool = True,
+    strict_wrap: bool = True,
+) -> PTQConfig:
+    """
+    Build a PTQConfig for Qwen3-VL model.
+
+    This helper generates PTQ configuration for the full Qwen3-VL model including:
+      - Vision tower (patch_embed, blocks, merger, deepstack_mergers)
+      - Text decoder (Llama-like layers)
+      - Language modeling head
+
+    Parameters
+    ----------
+    num_vision_blocks : int
+        Number of vision transformer blocks in the vision tower.
+    num_text_layers : int
+        Number of decoder layers in the text model.
+    num_deepstack_mergers : int, default=0
+        Number of deepstack merger modules in the vision tower.
+    activation_dtype : DType, default=DType.int(16)
+    default_observer : Type[ObserverBase], default=MinMaxObserver
+        Observer class to instantiate when no explicit observer is provided.
+    linear_weight_bits : Optional[int], default=None
+        Convenience bit-width for linear projection weights.
+    linear_weight_dtype : Optional[DType], default=None
+        Explicit dtype for linear projection weights.
+    embedding_weight_bits : Optional[int], default=None
+        Convenience bit-width for embedding weights.
+    embedding_weight_dtype : Optional[DType], default=None
+        Explicit dtype for embedding weights.
+    lm_head_weight_bits : Optional[int], default=None
+        Convenience bit-width for LM head weight.
+    lm_head_weight_dtype : Optional[DType], default=None
+        Explicit dtype for LM head weight.
+    norm_dtype : Optional[DType], default=None
+        Module-level dtype override for norm modules.
+    norm_weight_bits : Optional[int], default=None
+        Convenience bit-width for norm weights.
+    norm_weight_dtype : Optional[DType], default=None
+        Explicit dtype for norm weights.
+    quantize_vision : bool, default=True
+        Whether to quantize the vision tower.
+    quantize_text : bool, default=True
+        Whether to quantize the text model.
+    quantize_lm_head : bool, default=True
+        Whether to quantize the language modeling head.
+    strict_wrap : bool, default=True
+        If True, preparing a model will raise when a required module cannot be wrapped.
+
+    Returns
+    -------
+    PTQConfig
+        PTQ configuration object ready to pass into `prepare()`.
+    """
+    resolved_linear_weight_dtype = _resolve_weight_dtype(
+        dtype=linear_weight_dtype,
+        bits=linear_weight_bits,
+    )
+    resolved_vision_patch_embed_weight_dtype = _resolve_weight_dtype(
+        dtype=vision_patch_embed_weight_dtype,
+        bits=vision_patch_embed_weight_bits,
+    )
+    resolved_embedding_weight_dtype = _resolve_weight_dtype(
+        dtype=embedding_weight_dtype,
+        bits=embedding_weight_bits,
+    )
+    resolved_lm_head_weight_dtype = _resolve_weight_dtype(
+        dtype=lm_head_weight_dtype,
+        bits=lm_head_weight_bits,
+    )
+    resolved_norm_weight_dtype = _resolve_weight_dtype(
+        dtype=norm_weight_dtype,
+        bits=norm_weight_bits,
+    )
+
+    overrides = _build_qwen3_vl_overrides(
+        num_vision_blocks=num_vision_blocks,
+        num_text_layers=num_text_layers,
+        num_deepstack_mergers=num_deepstack_mergers,
+        linear_weight_dtype=resolved_linear_weight_dtype,
+        vision_patch_embed_weight_dtype=resolved_vision_patch_embed_weight_dtype,
+        embedding_weight_dtype=resolved_embedding_weight_dtype,
+        lm_head_weight_dtype=resolved_lm_head_weight_dtype,
+        norm_dtype=norm_dtype,
+        norm_weight_dtype=resolved_norm_weight_dtype,
+        quantize_vision=quantize_vision,
+        quantize_text=quantize_text,
+        quantize_lm_head=quantize_lm_head,
+    )
+
+    return PTQConfig(
+        default_dtype=activation_dtype,
+        default_qscheme=default_qscheme,
+        default_observer=default_observer,
+        overrides=overrides,
+        strict_wrap=strict_wrap,
+        model_args=model_args,
     )

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -18,16 +18,23 @@ import io
 from typing import Any, Optional
 
 import torch
+import tqdm
 from transformers import AutoProcessor
 
 from tico.quantization import convert, prepare
 from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
+from tico.quantization.config.builders import build_qwen3_vl_ptq_config
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
 from tico.quantization.evaluation.vlm_eval_utils import (
     get_accuracy_on_dataset,
     get_calib_inputs,
     get_dataset,
 )
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+
 
 DTYPE_MAP = {
     "float32": torch.float32,
@@ -195,9 +202,204 @@ def print_markdown_comparison(
     print(quantized_row)
 
 
+# -------------------------------------------------------------------------
+# Helper — copy GPTQ (scale, zp) into PTQ observers
+# -------------------------------------------------------------------------
+def inject_gptq_qparams(
+    root: torch.nn.Module,
+    gptq_quantizers: dict[str, Any],  # {fp_name: quantizer}
+    weight_obs_name: str = "weight",
+):
+    """
+    For every `QuantModuleBase` whose `fp_name` matches a GPTQ key,
+    locate the observer called `weight_obs_name` and overwrite its
+    (scale, zero-point), then lock them against further updates.
+    """
+    for m in root.modules():
+        if not isinstance(m, QuantModuleBase):
+            continue
+        if m.fp_name is None:
+            continue
+
+        gptq_key = m.fp_name
+        if gptq_key.startswith("model."):
+            gptq_key = gptq_key[
+                len("model.") :
+            ]  # Remove "model." prefix which comes from `QuantQwen3VLForConditionalGeneration` wrapper
+
+        quantizer = gptq_quantizers.get(gptq_key)
+        if quantizer is None:
+            continue
+        obs = m.get_observer(weight_obs_name)
+        if obs is None:
+            continue
+        assert isinstance(obs, AffineObserverBase)
+        # GPTQ quantizer attributes
+        obs.load_qparams(quantizer.scale, quantizer.zero, lock=True)
+
+
+def quantize_using_PTQ(
+    q_m,
+    calib_inputs,
+    args,
+    grid_thw,
+    num_vision_blocks: int,
+    num_text_layers: int,
+    num_deepstack_mergers: int,
+):
+    """
+    Wrap model with PTQWrapper and calibrate activation observers.
+
+    Args:
+        q_m: Model after GPTQ quantization.
+        calib_inputs: Calibration inputs for PTQ calibration.
+        args: Command-line arguments.
+        num_vision_blocks: Number of vision transformer blocks.
+        num_text_layers: Number of text decoder layers.
+        num_deepstack_mergers: Number of deepstack merger modules.
+
+    Returns:
+        PTQ-quantized model.
+    """
+    print("Wrapping model with PTQWrapper …")
+    qcfg = build_qwen3_vl_ptq_config(
+        num_vision_blocks=num_vision_blocks,
+        num_text_layers=num_text_layers,
+        num_deepstack_mergers=num_deepstack_mergers,
+        activation_dtype=DType.int(16),
+        default_qscheme=QScheme.PER_TENSOR_SYMM,
+        linear_weight_bits=args.linear_weight_bits,
+        vision_patch_embed_weight_bits=args.vision_patch_embed_weight_bits,
+        embedding_weight_bits=args.embedding_weight_bits,
+        lm_head_weight_bits=args.lm_head_weight_bits,
+        norm_dtype=DType.int(16),
+        norm_weight_dtype=DType.int(16),
+        quantize_vision=args.quantize_vision,
+        quantize_text=args.quantize_text,
+        quantize_lm_head=args.quantize_lm_head,
+        strict_wrap=True,
+        model_args={
+            "vision": {
+                "grid_thw": grid_thw,
+                "visual_start_idx": args.visual_start_idx,
+                "spatial_merge_size": args.spatial_merge_size,
+            }
+        },
+    )
+
+    q_m = prepare(q_m, qcfg)
+
+    # -------------------------------------------------------------------------
+    # Single-pass activation calibration
+    # -------------------------------------------------------------------------
+    print("Calibrating PTQ observers…")
+
+    # Overwrite weight observers with GPTQ statistics
+    if hasattr(q_m, "quantizers") and isinstance(q_m.quantizers, dict):
+        inject_gptq_qparams(q_m, q_m.quantizers)
+    elif (
+        hasattr(q_m, "wrapped")
+        and hasattr(q_m.wrapped, "module")
+        and hasattr(q_m.wrapped.module, "quantizers")
+        and isinstance(q_m.wrapped.module.quantizers, dict)
+    ):
+        inject_gptq_qparams(q_m.wrapped, q_m.wrapped.module.quantizers)
+    else:
+        print(
+            "[Warn] q_m.quantizers not found or not a dict; skipping GPTQ qparam injection."
+        )
+
+    device = torch.device(args.device)
+    with torch.no_grad():
+        for inp in tqdm.tqdm(calib_inputs):
+            dev_inp = move_batch_to_device(inp, args.device)
+            q_m(**dev_inp)
+
+    # Freeze all Q-params (scale, zero-point)
+    q_m = convert(q_m)
+
+    return q_m
+
+
+def get_num_vision_blocks(q_m) -> int:
+    """
+    Get the number of vision transformer blocks from model config.
+
+    Args:
+        q_m: Model with config attribute containing vision_config.
+
+    Returns:
+        Number of vision blocks.
+
+    Raises:
+        ValueError: If vision config or layer count cannot be determined.
+    """
+    if hasattr(q_m, "config") and hasattr(q_m.config, "vision_config"):
+        vision_config = q_m.config.vision_config
+        if hasattr(vision_config, "num_hidden_layers"):
+            return vision_config.num_hidden_layers
+        elif hasattr(vision_config, "num_layers"):
+            return vision_config.num_layers
+        elif hasattr(vision_config, "depth"):
+            return vision_config.depth
+        else:
+            raise ValueError(
+                "Cannot determine num_vision_blocks from vision_config. "
+                "Expected vision_config.num_hidden_layers, num_layers, or depth."
+            )
+    else:
+        raise ValueError(
+            "Cannot determine num_vision_blocks from model config. "
+            "Please ensure the model has config.vision_config."
+        )
+
+
+def get_num_text_layers(q_m) -> int:
+    """
+    Get the number of text decoder layers from model config.
+
+    Args:
+        q_m: Model with config attribute containing text_config.
+
+    Returns:
+        Number of text layers.
+
+    Raises:
+        ValueError: If text config or layer count cannot be determined.
+    """
+    if hasattr(q_m, "config") and hasattr(q_m.config, "text_config"):
+        return q_m.config.text_config.num_hidden_layers
+    elif hasattr(q_m, "config") and hasattr(q_m.config, "num_hidden_layers"):
+        return q_m.config.num_hidden_layers
+    else:
+        raise ValueError(
+            "Cannot determine num_text_layers from model config. "
+            "Please ensure the model has config.text_config.num_hidden_layers "
+            "or config.num_hidden_layers."
+        )
+
+
+def get_num_deepstack_mergers(q_m) -> int:
+    """
+    Get the number of deepstack merger modules from model config.
+
+    Args:
+        q_m: Model with config attribute containing vision_config.
+
+    Returns:
+        Number of deepstack mergers (0 if not present).
+    """
+    num_deepstack_mergers = 0
+    if hasattr(q_m, "config") and hasattr(q_m.config, "vision_config"):
+        vision_config = q_m.config.vision_config
+        if hasattr(vision_config, "deepstack_visual_indexes"):
+            num_deepstack_mergers = len(vision_config.deepstack_visual_indexes)
+    return num_deepstack_mergers
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Qwen3-VL GPTQ pipeline (architecture-aware, stagewise)"
+        description="Qwen3-VL GPTQ+PTQ pipeline (architecture-aware, stagewise)"
     )
     parser.add_argument(
         "--model",
@@ -241,6 +443,12 @@ def main() -> None:
         help="Skip GPTQ and keep the model in floating-point.",
     )
     parser.add_argument(
+        "--no_PTQ",
+        action="store_true",
+        default=False,
+        help="Skip PTQ activation quantization.",
+    )
+    parser.add_argument(
         "--cache_dir",
         type=str,
         default=None,
@@ -281,6 +489,24 @@ def main() -> None:
         type=int,
         default=4,
         help="Weight bit-width for GPTQ quantization.",
+    )
+    parser.add_argument(
+        "--vision_patch_embed_weight_bits",
+        type=int,
+        default=8,
+        help="Number of bits for vision patch embedding (Conv3d) quantization.",
+    )
+    parser.add_argument(
+        "--embedding_weight_bits",
+        type=int,
+        default=8,
+        help="Number of bits for input Embedding quantization.",
+    )
+    parser.add_argument(
+        "--lm_head_weight_bits",
+        type=int,
+        default=4,
+        help="Number of bits for lm_head quantization.",
     )
     parser.add_argument(
         "--gptq_mse",
@@ -363,6 +589,25 @@ def main() -> None:
         default=False,
         help="Disable tqdm progress bars.",
     )
+    parser.add_argument(
+        "--grid_thw",
+        type=int,
+        nargs=3,
+        default=[8, 24, 24],
+        help="Grid temporal-height-width for vision model (e.g. 8 24 24).",
+    )
+    parser.add_argument(
+        "--visual_start_idx",
+        type=int,
+        default=0,
+        help="Starting index for visual tokens in the input sequence.",
+    )
+    parser.add_argument(
+        "--spatial_merge_size",
+        type=int,
+        default=2,
+        help="Spatial merge size for vision tokens.",
+    )
 
     args = parser.parse_args()
     print(args)
@@ -375,6 +620,8 @@ def main() -> None:
     quantize_text = args.quantize_text
     quantize_lm_head = args.quantize_lm_head
 
+    grid_thw = tuple(args.grid_thw)
+
     print("=== Config ===")
     print(f"Model            : {args.model}")
     print(f"Device           : {device.type}")
@@ -384,6 +631,12 @@ def main() -> None:
     print(f"Quantize vision  : {quantize_vision}")
     print(f"Quantize text    : {quantize_text}")
     print(f"Quantize lm_head : {quantize_lm_head}")
+    print(f"Use GPTQ         : {not args.no_GPTQ}")
+    print(f"Use PTQ          : {not args.no_PTQ}")
+    print(f"grid_thw         : {grid_thw}")
+    print(f"spatial_merge_size: {args.spatial_merge_size}")
+    print(f"visual_start_idx : {args.visual_start_idx}")
+
     print()
 
     print("Loading FP model …")
@@ -421,6 +674,11 @@ def main() -> None:
         )
 
     model.eval()
+
+    if args.calib_seq_len is not None:
+        model.config.text_config.max_position_embeddings = min(
+            model.config.text_config.max_position_embeddings, args.calib_seq_len
+        )
 
     if hasattr(model, "config") and hasattr(model.config, "use_cache"):
         model.config.use_cache = False
@@ -490,6 +748,30 @@ def main() -> None:
         q_m = convert(q_m, inplace=True)
     else:
         q_m = model
+
+    # -------------------------------------------------------------------------
+    # Wrap with PTQ for activation quantization
+    # -------------------------------------------------------------------------
+    if not args.no_PTQ:
+        # Get architecture parameters from model config
+        num_vision_blocks = get_num_vision_blocks(q_m)
+        num_text_layers = get_num_text_layers(q_m)
+        num_deepstack_mergers = get_num_deepstack_mergers(q_m)
+
+        print(
+            f"Vision blocks: {num_vision_blocks}, "
+            f"Text layers: {num_text_layers}, "
+            f"Deepstack mergers: {num_deepstack_mergers}"
+        )
+        q_m = quantize_using_PTQ(
+            q_m=q_m,
+            calib_inputs=calib_inputs,
+            args=args,
+            grid_thw=grid_thw,
+            num_vision_blocks=num_vision_blocks,
+            num_text_layers=num_text_layers,
+            num_deepstack_mergers=num_deepstack_mergers,
+        )
 
     if args.eval_tasks is not None:
         quantized_results = evaluate_model(

--- a/tico/quantization/wrapq/wrappers/ptq_wrapper.py
+++ b/tico/quantization/wrapq/wrappers/ptq_wrapper.py
@@ -74,3 +74,13 @@ class PTQWrapper(QuantModuleBase):
 
     def extra_repr(self) -> str:
         return self.wrapped.extra_repr()
+
+    def generate(self, *args, **kwargs):
+        """
+        Delegate generate calls to the wrapped module.
+
+        This method allows the quantized wrapper to support the same generation
+        interface as the original Hugging Face model, which is required for
+        evaluation and inference workflows.
+        """
+        return self.wrapped.generate(*args, **kwargs)

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -22,11 +22,13 @@ from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
 
+from transformers.generation.utils import GenerationMixin
+
 
 @try_register(
     "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLForConditionalGeneration",
 )
-class QuantQwen3VLForConditionalGeneration(QuantModuleBase):
+class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
     """
     Quantization wrapper for Qwen3VLForConditionalGeneration module.
 
@@ -37,6 +39,10 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase):
     The forward pass simply delegates to the wrapped model and lm_head,
     with no additional quantization operations needed at this level.
     """
+
+    main_input_name = "input_ids"
+    _is_stateful = True
+    _supports_cache_class = True
 
     def __init__(
         self,
@@ -154,3 +160,44 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase):
         # No local observers - all observers are in wrapped submodules
         # This method is required by QuantModuleBase but yields nothing
         return iter([])
+
+    @property
+    def device(self):
+        """Return the device for generation."""
+        return self.module.device
+
+    @property
+    def generation_config(self):
+        """Return the generation config."""
+        return self.module.generation_config
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        cache_position=None,
+        position_ids=None,
+        use_cache=True,
+        pixel_values=None,
+        pixel_values_videos=None,
+        image_grid_thw=None,
+        video_grid_thw=None,
+        **kwargs,
+    ):
+        """Prepare inputs for generation step."""
+        return self.module.prepare_inputs_for_generation(
+            input_ids=input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            cache_position=cache_position,
+            position_ids=position_ids,
+            use_cache=use_cache,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            **kwargs,
+        )

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_model.py
@@ -76,17 +76,17 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
         self.register_buffer("pos_embed_template", pos_embeds, persistent=False)
 
         # Precompute rotary frequency table for RoPE
-        dim = (
+        self.dim = (
             fp_model.rotary_pos_emb.dim
             if hasattr(fp_model.rotary_pos_emb, "dim")
             else (cfg.hidden_size // cfg.num_heads) // 2
         )
-        theta = (
+        self.theta = (
             fp_model.rotary_pos_emb.theta
             if hasattr(fp_model.rotary_pos_emb, "theta")
             else 10000.0
         )
-        inv_freq = self._precompute_rope_inv_freq(dim=dim, theta=theta)
+        inv_freq = self._precompute_rope_inv_freq(dim=self.dim, theta=self.theta)
         self.register_buffer("rope_inv_freq", inv_freq, persistent=False)
 
         # Precompute RoPE position embeddings for fixed vision_grid_thw
@@ -358,20 +358,27 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
         Returns:
             BaseModelOutputWithDeepstackFeatures or similar
         """
-        # Assert that grid_thw matches the precomputed vision_grid_thw
-        if self._mode is Mode.CALIB:
-            assert torch.equal(grid_thw, self.vision_grid_thw.to(grid_thw.device)), (
-                f"grid_thw {grid_thw.tolist()} does not match the precomputed "
-                f"vision_grid_thw {self.vision_grid_thw.tolist()}"
-            )
-
         # Patch embedding (already quantized by wrapper)
         hidden_states = self.patch_embed(hidden_states)
 
+        # Model export mode (torch.export.export) requires the use of fixed `grid_thw` and precomputed values (`position_embeddings`,`cu_seqlens').
+        # `torch.compiler.is_compiling()` controls the conditional behavior of the model:
+        # - precomputed values are used in export mode
+        # - otherwise, the calculation is performed dynamically(e.g. benchmarks evaluation)
+
         # Position embedding
-        pos_embeds = self.pos_embed_template.to(
-            dtype=hidden_states.dtype, device=hidden_states.device
-        )
+        if torch.compiler.is_compiling():
+            # Use precomputed position embedding
+            pos_embeds = self.pos_embed_template.to(
+                dtype=hidden_states.dtype, device=hidden_states.device
+            )
+        else:
+            pos_embeds = QuantQwen3VLVisionModel._fast_pos_embed_interpolate(
+                merge_size=self.spatial_merge_size,
+                num_grid_per_side=self.num_grid_per_side,
+                pos_embedder=self.module.pos_embed,
+                grid_thw=grid_thw,
+            )
         pos_embeds = self._fq(pos_embeds, self.obs_pos_embeds)
         hidden_states = hidden_states + pos_embeds
         hidden_states = self._fq(hidden_states, self.obs_pos_add)
@@ -380,19 +387,32 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
         seq_len, _ = hidden_states.size()
         hidden_states = hidden_states.reshape(seq_len, -1)
 
-        # Use precomputed RoPE position embeddings (cos, sin) and quantize
-        cos = self.rope_cos_template.to(
-            dtype=hidden_states.dtype, device=hidden_states.device
-        )
-        sin = self.rope_sin_template.to(
-            dtype=hidden_states.dtype, device=hidden_states.device
-        )
+        # RoPE position embeddings (cos, sin)
+        if torch.compiler.is_compiling():
+            # Use precomputed RoPE position embeddings (cos, sin) and quantize
+            cos = self.rope_cos_template.to(
+                dtype=hidden_states.dtype, device=hidden_states.device
+            )
+            sin = self.rope_sin_template.to(
+                dtype=hidden_states.dtype, device=hidden_states.device
+            )
+        else:
+            inv_freq = self.rope_inv_freq.to(hidden_states.device)
+            cos, sin = QuantQwen3VLVisionModel._precompute_rope_position_embeddings(
+                merge_size=self.spatial_merge_size,
+                rope_inv_freq=inv_freq,
+                grid_thw=grid_thw,
+            )
+
         position_embeddings = (
             self._fq(cos, self.obs_rope_cos),
             self._fq(sin, self.obs_rope_sin),
         )
 
-        cu_seqlens = self.cu_seqlens_template
+        if torch.compiler.is_compiling():
+            cu_seqlens = self.cu_seqlens_template
+        else:
+            cu_seqlens = QuantQwen3VLVisionModel._precompute_cu_seqlens(grid_thw)
 
         # Process through transformer blocks
         deepstack_feature_lists = []


### PR DESCRIPTION
This PR introduces PTQ quantization for VLM Qwen3-vl.

For benchmarks evaluation `Qwen3VLForConditionalGeneration` has been inherited from the `GenerationMixin`.
In addition, `quant_vision_model.py` was changed by introducing logic for dynamically computing `position_embeddings`,`cu_seqlens`, or using precomputed values with a fixed `grid_thw` to export a static graph.

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>