### PR TITLE
[quantization] Precompute RoPE position embeddings in QuantQwen3VLTextModel

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
@@ -67,6 +67,41 @@ class TestQuantQwen3VLTextModel(unittest.TestCase):
         cls.hidden_size = cfg.hidden_size
         cls.num_hidden_layers = cfg.num_hidden_layers
 
+    @staticmethod
+    def _create_visual_inputs(
+        vocab_size: int,
+        visual_start_idx: int,
+        grid_thw: tuple[int, int, int],
+        image_token_id: int,
+        vision_start_token_id: int,
+        batch_size: int = 1,
+        patch_size: int = 16,
+        image_width: int = 128,
+        image_height: int = 96,
+    ):
+        num_visual_tokens = image_width * image_height // (patch_size**2)
+        num_tokens = visual_start_idx + num_visual_tokens + 10
+
+        input_ids = torch.randint(
+            low=0, high=vocab_size - 3, size=(batch_size, num_tokens)
+        )
+        input_ids[:, visual_start_idx - 1] = vision_start_token_id
+        input_ids[
+            :, visual_start_idx : visual_start_idx + num_visual_tokens
+        ] = image_token_id
+        attention_mask = torch.ones(batch_size, num_tokens, dtype=torch.int64)
+        pixel_values = torch.full(
+            size=(batch_size, 3, image_height, image_width), fill_value=-1.0
+        )
+        image_grid_thw = torch.tensor(grid_thw)
+
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        }
+
     def _create_test_inputs(self, batch_size=2, seq_len=16):
         """Helper to create test inputs for TextModel."""
         input_ids = torch.randint(0, self.vocab_size, (batch_size, seq_len))
@@ -826,3 +861,51 @@ class TestQuantQwen3VLTextModel(unittest.TestCase):
         self.assertIsInstance(q_out, tuple)
         self.assertEqual(len(q_out), 1)
         self.assertEqual(q_out[0].shape, (1, 8, self.hidden_size))
+
+    def test_forward_diff_export_time(self):
+        """
+        Test that quantized output is acceptably close to FP32 reference at export time.
+        """
+        torch.manual_seed(42)
+        grid_thw = (1, 8, 8)
+        visual_start_idx = 4
+        vocab_size = self.fp_model.config.vocab_size
+
+        ptq_config = PTQConfig(
+            model_args={
+                "vision": {
+                    "grid_thw": grid_thw,
+                    "visual_start_idx": visual_start_idx,
+                }
+            }
+        )
+        q_model = QuantQwen3VLTextModel(self.fp_model, qcfg=ptq_config)
+        q_model.enable_calibration()
+
+        model_inputs: dict = self._create_visual_inputs(
+            vocab_size=vocab_size,
+            visual_start_idx=visual_start_idx,
+            image_token_id=vocab_size - 2,
+            vision_start_token_id=vocab_size - 3,
+            grid_thw=grid_thw,
+            batch_size=1,
+        )
+
+        # Calibrate the model
+        _ = q_model(**model_inputs)
+
+        q_model.freeze_qparams()
+        q_model.force_export = True
+
+        with torch.no_grad():
+            q_out = q_model(**model_inputs)
+            fp_out = self.fp_model(**model_inputs)
+
+        # Extract last_hidden_state
+        q_hidden = q_out.last_hidden_state
+        fp_hidden = fp_out.last_hidden_state
+
+        self.assertEqual(fp_hidden.shape, q_hidden.shape)
+        diff = (fp_hidden - q_hidden).abs().mean().item()
+        self.assertGreater(diff, 0.0)  # not identical
+        self.assertLess(diff, 0.7)  # acceptably close

--- a/tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py
@@ -301,6 +301,7 @@ def main():
         model_args={
             "vision": {
                 "grid_thw": thw,
+                "visual_start_idx": 0,
             }
         }
     )

--- a/tico/quantization/wrapq/examples/qwen/quantize_model.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_model.py
@@ -82,6 +82,7 @@ def create_visual_input(
     spatial_patch_size: int,
     vocab_size: int,
     image_token_id: int,
+    visual_start_idx: int,
 ):
     """Helper to create input with videos or images."""
     assert (
@@ -109,7 +110,9 @@ def create_visual_input(
     # Replace first tokens with video placeholder tokens
     # This marks where the video features should be inserted
     for i in range(batch_size):
-        input_ids[i, :num_video_tokens] = image_token_id
+        input_ids[
+            i, visual_start_idx : visual_start_idx + num_video_tokens
+        ] = image_token_id
 
     num_temporal_patches, num_spatial_patches_h, num_spatial_patches_w = thw
 
@@ -244,6 +247,7 @@ def generate_calibration_data(
     spatial_patch_size: int,
     vocab_size: int,
     image_token_id: int,
+    visual_start_idx: int,
 ):
     calibration_data = []
     for i in range(batch_size):
@@ -255,6 +259,7 @@ def generate_calibration_data(
             spatial_patch_size,
             vocab_size,
             image_token_id,
+            visual_start_idx=visual_start_idx,
         )
         calibration_data.append(x)
     return calibration_data
@@ -289,12 +294,14 @@ def main():
         video_token_id=999,
     )
     thw = (1, 8, 8)
+    visual_start_idx = 0
 
     # Configure PTQ
     ptq_config = tico.quantization.config.ptq.PTQConfig(
         model_args={
             "vision": {
                 "grid_thw": thw,
+                "visual_start_idx": visual_start_idx,
             }
         }
     )
@@ -319,6 +326,7 @@ def main():
         spatial_patch_size=cfg.vision_config.patch_size,
         vocab_size=cfg.text_config.vocab_size,
         image_token_id=cfg.image_token_id,
+        visual_start_idx=visual_start_idx,
     )
 
     # Calibrate the model (collect statistics)

--- a/tico/quantization/wrapq/examples/qwen/trace_qwen.py
+++ b/tico/quantization/wrapq/examples/qwen/trace_qwen.py
@@ -228,6 +228,7 @@ def build_vlm_inputs(
 
 def prepare_inputs(
     image_token_id: int,
+    vision_start_token_id: int,
     vocab_size: int,
     model_name: ModelNameOrPath,
     cache_dir: DirPath | None = None,
@@ -278,9 +279,11 @@ def prepare_inputs(
     )
 
     # Normalize input_ids to be consistent with our image_token_id
-    image_pad_token_id = 151655
+    old_image_pad_token_id = 151655
+    old_vision_start_token_id = 151652
     input_ids: torch.Tensor = model_inputs["input_ids"]
-    input_ids[input_ids == image_pad_token_id] = image_token_id
+    input_ids[input_ids == old_image_pad_token_id] = image_token_id
+    input_ids[input_ids == old_vision_start_token_id] = vision_start_token_id
 
     # Make sure that our input IDs don't go beyond vocabulary size
     input_ids = input_ids % vocab_size
@@ -318,6 +321,7 @@ def prepare_config() -> Qwen3VLConfig:
     Returns:
         Qwen3VLConfig with reduced sizes suitable for quick testing.
     """
+    vocab_size = 1000
 
     cfg = Qwen3VLConfig(
         vision_config={
@@ -339,15 +343,17 @@ def prepare_config() -> Qwen3VLConfig:
             "attention_bias": False,
             "attention_dropout": 0.0,
             "max_position_embeddings": 1024,
-            "vocab_size": 1000,
+            "vocab_size": vocab_size,
             "use_cache": False,
             "rope_scaling": {"rope_type": "default", "mrope_section": [1, 1, 2]},
         },
-        image_token_id=998,
-        video_token_id=999,
+        image_token_id=vocab_size - 2,
+        video_token_id=vocab_size - 1,
+        vision_start_token_id=vocab_size - 3,
     )
     assert cfg.image_token_id < cfg.text_config.vocab_size
     assert cfg.video_token_id < cfg.text_config.vocab_size
+    assert cfg.vision_start_token_id < cfg.text_config.vocab_size
 
     # Ensure eager attention implementation so outputs are deterministic
     # and do not require GPU flash attention kernels.
@@ -385,7 +391,7 @@ def prepare_quantized_model(
         model_args={
             "vision": {
                 "grid_thw": thw,
-                "visual_start_idx": 0,
+                "visual_start_idx": 4,
             }
         },
     )
@@ -1092,6 +1098,7 @@ def main():
         model_name=args.model,
         cache_dir=args.cache_dir,
         image_token_id=cfg.image_token_id,
+        vision_start_token_id=cfg.vision_start_token_id,
         vocab_size=cfg.text_config.vocab_size,
         image_width=128,
         image_height=96,

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -25,98 +25,6 @@ from tico.quantization.wrapq.wrappers.registry import try_register
 from transformers.cache_utils import Cache
 
 
-def apply_interleaved_mrope(self, freqs, mrope_section):
-    """
-    Apply interleaved MRoPE to 3D rotary embeddings.
-    Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
-    interleaved [THWTHWTHW...TT], preserving frequency continuity.
-
-    Args:
-        freqs: (3, bs, seq_len, head_dim // 2)
-        mrope_section: (3,)
-
-    Returns:
-        freqs_t: (bs, seq_len, head_dim // 2)
-
-    Design Note:
-        This implementation is using slice_copy, index_select, and cat
-        to avoid yet unsupported slice_scatter with step=3 operation and
-        to avoid unsupported in-place operator index_put.default.
-    """
-    # Start with T dimension (will keep some, replace some)
-    freqs_t_base = freqs[0]
-
-    # For each dimension (H, W), extract frequency bands to be interleaved
-    h_w_bands = []
-
-    for dim, offset in enumerate((1, 2), start=1):  # H, W dimensions
-        length = mrope_section[dim] * 3
-        indices = torch.arange(offset, length, 3, device=freqs.device)
-
-        # Select frequency bands from H/W dimensions
-        # freqs[dim] has shape (bs, seq_len, head_dim//2)
-        # index_select on last dim: (bs, seq_len, num_selected)
-        freqs_bands = freqs[dim].index_select(dim=-1, index=indices)
-        h_w_bands.append(freqs_bands)
-
-    # Now we need to build the interleaved output
-    # Original T dimension indices range from 0 to (head_dim // 2 - 1)
-    # We want to replace specific indices with H/W bands
-
-    # The interleaving pattern: T0, H1, W2, T3, H4, W5, T6, H7, W8, ...
-    # - Positions where i % 3 == 0: T dimension (unchanged from freqs[0])
-    # - Positions where i % 3 == 1: H dimension (overwritten from freqs[1])
-    # - Positions where i % 3 == 2: W dimension (overwritten from freqs[2])
-    # After mrope_section[dim] * 3 positions, H/W bands are exhausted and
-    # fallback to T values for all remaining mod 1 and mod 2 positions.
-
-    # Build the output by slicing and concatenating
-    # Strategy: Slice T dimension into chunks, insert H/W bands, concatenate
-
-    chunks = []
-    pos = 0
-
-    # Total length in the last dimension
-    total_len = freqs_t_base.shape[-1]
-
-    for i in range(total_len):
-        # Determine which dimension this position belongs to
-        # Pattern: T, H, W, T, H, W, T, H, W, ... (repeating cycle)
-        mod = i % 3
-
-        if mod == 0:
-            # T dimension position - take from T
-            # Slice just this index from T
-            chunk = freqs_t_base[..., i : i + 1]
-            chunks.append(chunk)
-        elif mod == 1:
-            # H dimension position - take from H
-            # Calculate which band this is
-            band_idx = (i - 1) // 3
-            if band_idx < h_w_bands[0].shape[-1]:
-                chunk = h_w_bands[0][..., band_idx : band_idx + 1]
-                chunks.append(chunk)
-            else:
-                # Fallback to T if out of bounds
-                chunk = freqs_t_base[..., i : i + 1]
-                chunks.append(chunk)
-        else:  # mod == 2
-            # W dimension position - take from W
-            band_idx = (i - 2) // 3
-            if band_idx < h_w_bands[1].shape[-1]:
-                chunk = h_w_bands[1][..., band_idx : band_idx + 1]
-                chunks.append(chunk)
-            else:
-                # Fallback to T if out of bounds
-                chunk = freqs_t_base[..., i : i + 1]
-                chunks.append(chunk)
-
-    # Concatenate all chunks
-    freqs_t = torch.cat(chunks, dim=-1)
-
-    return freqs_t
-
-
 @try_register(
     "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLTextModel",
 )
@@ -130,6 +38,10 @@ class QuantQwen3VLTextModel(QuantModuleBase):
     - Final normalization layer (norm)
     - Rotary position embedding (rotary_emb) - NOT wrapped
     """
+
+    # This boolean flag enforces model behavior that is only activated during model graph tracing (torch.export.export).
+    # This flag is used in unit tests only in order to check the behavior without actually exporting the model.
+    force_export: bool = False
 
     def __init__(
         self,
@@ -178,11 +90,8 @@ class QuantQwen3VLTextModel(QuantModuleBase):
 
         # rotary_emb
         self.rotary_emb = fp_model.rotary_emb
-        # The original Qwen3VLTextRotaryEmbedding.apply_interleaved_mrope emits `slice_scatter with step > 1`.
-        # Replace it with pure functional implementation using basic tensor slicing, index_select, and cat.
-        self.rotary_emb.apply_interleaved_mrope = types.MethodType(
-            apply_interleaved_mrope, self.rotary_emb
-        )
+
+        device = next(fp_model.parameters()).device
 
         # ----- static buffers: causal mask template ---------------------------
         assert isinstance(self.config.max_position_embeddings, int)
@@ -190,6 +99,27 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         mask = torch.full((1, 1, max_seq, max_seq), float("-120"))
         mask.triu_(1)
         self.register_buffer("causal_mask_template", mask, persistent=False)
+
+        # ----- static buffers: position_ids -----------------------------------
+        visual_start_idx = self._get_visual_start_idx(qcfg)
+        grid_thw = self._get_vision_grid_thw(qcfg)
+        position_ids = self._compute_3d_position_ids(
+            device=device,
+            visual_start_idx=visual_start_idx,
+            seq_len=max_seq,
+            thw=grid_thw,
+            spatial_merge_size=2,  # WARNING: hard-coded value
+        )
+        self.register_buffer("position_ids_template", position_ids, persistent=False)
+
+        # ----- static buffers: position_embeddings -----------------------------------
+        _ = torch.empty(0, device=device)
+        # tuple of 2 tensors with shape (batch_size, seq_len, head_dim // 2)
+        cos, sin = self.rotary_emb(_, position_ids)
+        assert cos.shape[:-1] == (1, max_seq)
+        assert sin.shape[:-1] == (1, max_seq)
+        self.register_buffer("cos_template", cos, persistent=False)
+        self.register_buffer("sin_template", sin, persistent=False)
 
         # --- Observers for floating-point tensors -----------------------------
         mk = self._make_obs
@@ -388,6 +318,169 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             f"Expected None, 2D, or 4D mask, but got ndim={attention_mask.ndim}."
         )
 
+    @staticmethod
+    def _compute_3d_position_ids(
+        device: torch.device,
+        visual_start_idx: int | None,
+        seq_len: int,
+        thw: tuple[int, int, int] | None,
+        spatial_merge_size: int,
+    ) -> torch.Tensor:
+        """
+        Compute 3D position IDs for multimodal RoPE with simplified constraints.
+
+        This function assumes:
+        - Single sample in batch (batch_size = 1)
+        - Image tokens always begin at a fixed visual_start_idx position
+        - Fixed sequence length
+
+        Parameters:
+        - device: The device to create tensors on
+        - visual_start_idx: The fixed position where image tokens begin
+        - seq_len: The fixed sequence length
+        - thw: Tuple of (temporal, height, width) dimensions for vision tokens
+        - spatial_merge_size: Spatial merge size for vision tokens
+
+        Returns:
+        - position_ids: Tensor of shape (3, 1, seq_len) with 3D position IDs
+        """
+        if thw is None:
+            # Generate simple 1D position IDs for text-only input
+            position_ids = torch.arange(seq_len, device=device).expand(3, 1, seq_len)
+            return position_ids
+
+        assert visual_start_idx is not None
+
+        # Initialize position_ids tensor
+        position_ids = torch.ones(3, 1, seq_len, dtype=torch.long, device=device)
+
+        # List to store position ID segments
+        pos_ids_list: list[torch.Tensor] = []
+
+        # Text position IDs (before visual tokens)
+        if visual_start_idx > 0:
+            text_len = visual_start_idx
+            text_pos_ids = (
+                torch.arange(text_len, device=device).view(1, -1).expand(3, -1)
+            )
+            pos_ids_list.append(text_pos_ids)
+
+        # Vision position IDs (3D)
+        llm_grid_t = thw[0]
+        llm_grid_h = thw[1] // spatial_merge_size or 1
+        llm_grid_w = thw[2] // spatial_merge_size or 1
+
+        # Create 3D position indices
+        t_index = (
+            torch.arange(llm_grid_t, device=device)
+            .view(-1, 1)
+            .expand(-1, llm_grid_h * llm_grid_w)
+            .flatten()
+        )
+        h_index = (
+            torch.arange(llm_grid_h, device=device)
+            .view(1, -1, 1)
+            .expand(llm_grid_t, -1, llm_grid_w)
+            .flatten()
+        )
+        w_index = (
+            torch.arange(llm_grid_w, device=device)
+            .view(1, 1, -1)
+            .expand(llm_grid_t, llm_grid_h, -1)
+            .flatten()
+        )
+
+        # Starting index for vision tokens
+        st_idx = visual_start_idx
+        vision_pos_ids = torch.stack([t_index, h_index, w_index]) + st_idx
+        pos_ids_list.append(vision_pos_ids)
+
+        # Trailing text position IDs (after visual tokens)
+        num_visual_tokens = llm_grid_t * llm_grid_h * llm_grid_w
+        visual_end_idx = visual_start_idx + num_visual_tokens
+
+        if visual_end_idx < seq_len:
+            st_idx = pos_ids_list[-1].max() + 1 if len(pos_ids_list) > 0 else 0
+            trailing_text_len = seq_len - visual_end_idx
+            trailing_pos_ids = (
+                torch.arange(trailing_text_len, device=device).view(1, -1).expand(3, -1)
+                + st_idx
+            )
+            pos_ids_list.append(trailing_pos_ids)
+
+        # Concatenate all position ID segments
+        if pos_ids_list:
+            final_pos_ids = torch.cat(pos_ids_list, dim=1).reshape(3, -1)
+            position_ids[..., 0, :] = final_pos_ids
+
+        return position_ids  # shape = (3, 1, seq_len) where 3=THW, 1=batch_size
+
+    @staticmethod
+    def _get_vision_grid_thw(qcfg: Optional[PTQConfig]) -> torch.Tensor | None:
+        """
+        Extract vision grid shape from PTQConfig.model_args.
+
+        Expected format:
+            PTQConfig(
+                model_args={
+                    "vision": {
+                        "grid_thw": (T, H, W),
+                    }
+                }
+            )
+        """
+        if qcfg is None:
+            return None
+
+        vision_args = qcfg.get_model_arg("vision", {})
+        if not isinstance(vision_args, dict):
+            raise ValueError(
+                "PTQConfig.model_args['vision'] must be a mapping containing "
+                "'grid_thw'."
+            )
+
+        grid_thw = vision_args.get("grid_thw")
+        if grid_thw is not None:
+            assert type(grid_thw) is tuple
+            assert len(grid_thw) == 3
+
+        return grid_thw
+
+    @staticmethod
+    def _get_visual_start_idx(qcfg: Optional[PTQConfig]) -> int | None:
+        """
+        Extract vision tokens starting index in the input prompt
+        from PTQConfig.model_args.
+
+        Expected format:
+            PTQConfig(
+                model_args={
+                    "vision": {
+                        "visual_start_idx": img_start_idx,
+                    }
+                }
+            )
+        """
+        if qcfg is None:
+            return None
+
+        vision_args = qcfg.get_model_arg("vision", {})
+        if not isinstance(vision_args, dict):
+            raise ValueError(
+                "PTQConfig.model_args['vision'] must be a mapping containing "
+                "'visual_start_idx'."
+            )
+
+        visual_start_idx = vision_args.get("visual_start_idx")
+        if visual_start_idx is not None:
+            visual_start_idx = int(visual_start_idx)
+            if visual_start_idx < 0:
+                raise ValueError(
+                    f"vision.visual_start_idx must be greater than zero, but got {visual_start_idx}."
+                )
+
+        return visual_start_idx
+
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,
@@ -440,21 +533,32 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         else:
             inputs_embeds = self._fq(inputs_embeds, self.obs_inputs_embeds)
 
+        batch_size, seq_len, _ = inputs_embeds.shape
+        past_seen_tokens = (
+            past_key_values.get_seq_length() if past_key_values is not None else 0
+        )
+
         # Handle cache_position (integer tensor, not quantized)
         if cache_position is None:
-            past_seen_tokens = self._get_past_seen_tokens(past_key_values)
             cache_position = torch.arange(
                 past_seen_tokens,
-                past_seen_tokens + inputs_embeds.shape[1],
+                past_seen_tokens + seq_len,
                 device=inputs_embeds.device,
             )
 
-        # Handle position_ids (integer tensor, not quantized)
-        # the hard coded `3` is for temporal, height and width.
         if position_ids is None:
-            position_ids = cache_position.view(1, 1, -1).expand(
-                3, inputs_embeds.shape[0], -1
-            )
+            if torch.compiler.is_compiling() or self.force_export:
+                # Use precomputed position IDs at export time only
+                # Get position_ids from precomputed position_ids_template buffer.
+                # Take first seq_len positions. We obtain a tensor of shape (3, 1, seq_len).
+                position_ids = self.position_ids_template[
+                    ..., past_seen_tokens : past_seen_tokens + seq_len
+                ]
+            else:
+                position_ids = cache_position.view(1, 1, -1)
+            # Replicate position_ids across batch dimension
+            position_ids = position_ids.expand(3, batch_size, -1)
+            assert position_ids.shape == (3, batch_size, seq_len)
         elif position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
 
@@ -462,6 +566,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             text_position_ids = position_ids[0]
             position_ids = position_ids[1:]
         else:
+            # Take 0-th dimension (T - Temporal) from THW (Temporal, Height, Width)
             text_position_ids = position_ids[0]
 
         attention_mask = self._normalize_attention_mask(
@@ -475,8 +580,21 @@ class QuantQwen3VLTextModel(QuantModuleBase):
 
         # create position embeddings to be shared across the decoder layers
         # rotary_emb returns (cos, sin) which are float tensors and need quantization
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
-        cos, sin = position_embeddings
+
+        if torch.compiler.is_compiling() or self.force_export:
+            # Use precomputed position embeddings at export time only
+            # Get position embeddings from precomputed position_embeddings_template.
+            # Take seq_len positions starting from past_seen_tokens.
+            # We obtain a tensor of shape (1, seq_len, head_dim // 2)
+            cos = self.cos_template[:, past_seen_tokens : past_seen_tokens + seq_len, :]
+            sin = self.sin_template[:, past_seen_tokens : past_seen_tokens + seq_len, :]
+            # Replicate position_embeddings across batch dimension
+            cos = cos.expand(batch_size, -1, -1)
+            sin = sin.expand(batch_size, -1, -1)
+        else:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+        position_embeddings = (cos, sin)
+
         position_embeddings = (
             self._fq(cos, self.obs_cos),
             self._fq(sin, self.obs_sin),


### PR DESCRIPTION
# What

This PR implements precomputation of `position_ids` and `position_embeddings` in `QuantQwen3VLTextModel`.
- Three new buffers are registered in `QuantQwen3VLTextModel.__init__`: `position_ids_template`, `cos_template`, `sin_template`.
- `position_ids_template` is computed in `QuantQwen3VLTextModel._compute_3d_position_ids` static function.
  The returned position IDs depend on the configuration constants `visual_start_idx` and `grid_thw`.
- `cos_template` and `sin_template` are computed using `Qwen3VLTextRotaryEmbedding` submodule of the original (unquantized) model.
- Precomputed tensors are used only at export time (checked with `torch.compiler.is_compiling()`).

# Why

The detailed motivation for this change is described in the issue [Qwen3VL: Fixed Input Data Format At Inference Time](https://github.com/Samsung/TICO/issues/614).
Long story short:
- Precomputation of rotary position embeddings is common in TICO (see `tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_model.py` or `tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py`).
- Precomputation of `position_ids` and `position_embeddings` in `QuantQwen3VLTextModel` becomes possible due to the fixation of THW and starting position of visual data within the input prompt.
- Precomputing `position_embeddings` eliminates the need to wrap/quantize `Qwen3VLTextRotaryEmbedding` module.
- The change fixes the warning `[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).` appearing in the example scripts for qwen3-vl.

## BEFORE THE CHANGE

### quantize_model.py

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_model.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.055956
│ PEIR       : 4.344356 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 3.5┤                                            │
    │                                       •••  │
    │                                    ••••    │
 2.3┤                                 •••••      │
    │                              •••••         │
 1.0┤                            •••••           │
    │                        ••••••              │
    │                      ••••••                │
-0.2┤                   •••••                    │
    │                 •••••                      │
    │              ••••••                        │
-1.4┤           ••••••                           │
    │         •••••                              │
-2.6┤       ••••                                 │
    │     •••                                    │
    │  ••                                        │
-3.8┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -3.8       -2.0       -0.2       1.7       3.5 

[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).
Circle model saved as 'qwen3vl_model.q.circle'
```
Notice the warning: `[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).`

### quantize_text_model.py

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_text_model.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.132374
│ PEIR       : 9.924287 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 4.1┤                                            │
    │                                       •••  │
    │                                  •••••••   │
 2.5┤                                •••••• •    │
    │                            ••••••••        │
 1.0┤                          ••••••••          │
    │                       ••••••••             │
    │                    •••••••••               │
-0.5┤                  •••••••••                 │
    │               •••••••••                    │
    │             ••••••••                       │
-2.1┤           •••••••                          │
    │         ••••••                             │
-3.6┤      •••••                                 │
    │     •                                      │
    │  •                                         │
-5.1┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -5.1       -2.8       -0.5       1.8       4.1 

Circle model saved as 'qwen3vl_text_model.q.circle'
```

### quantize_for_conditional_generation.py 

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py 
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.009265
│ PEIR       : 5.209566 %
└──────────────────────────────────────────────────────
     ┌───────────────────────────────────────────┐
 0.72┤                                           │
     │                                      •••  │
     │                                   ••••    │
 0.48┤                                •••••      │
     │                             ••••••        │
 0.24┤                          ••••••           │
     │                        ••••••             │
     │                     ••••••                │
-0.00┤                   •••••                   │
     │                ••••••                     │
     │             ••••••                        │
-0.24┤           •••••                           │
     │         ••••                              │
-0.49┤      •••••                                │
     │    ••••                                   │
     │  •••                                      │
-0.73┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -0.73      -0.37     -0.00      0.36     0.72 

[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).
Circle model saved as 'qwen3vl_for_conditional_generation.q.circle'
```

## AFTER THE CHANGE

### quantize_model.py

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_model.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.055956
│ PEIR       : 4.344356 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 3.5┤                                            │
    │                                       •••  │
    │                                    ••••    │
 2.3┤                                 •••••      │
    │                              •••••         │
 1.0┤                            •••••           │
    │                        ••••••              │
    │                      ••••••                │
-0.2┤                   •••••                    │
    │                 •••••                      │
    │              ••••••                        │
-1.4┤           ••••••                           │
    │         •••••                              │
-2.6┤       ••••                                 │
    │     •••                                    │
    │  ••                                        │
-3.8┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -3.8       -2.0       -0.2       1.7       3.5 

Circle model saved as 'qwen3vl_model.q.circle'
```
Notice that the warning `[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).` has disappeared.

### quantize_text_model.py

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_text_model.py
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.132374
│ PEIR       : 9.924287 %
└──────────────────────────────────────────────────────
    ┌────────────────────────────────────────────┐
 4.1┤                                            │
    │                                       •••  │
    │                                  •••••••   │
 2.5┤                                •••••• •    │
    │                            ••••••••        │
 1.0┤                          ••••••••          │
    │                       ••••••••             │
    │                    •••••••••               │
-0.5┤                  •••••••••                 │
    │               •••••••••                    │
    │             ••••••••                       │
-2.1┤           •••••••                          │
    │         ••••••                             │
-3.6┤      •••••                                 │
    │     •                                      │
    │  •                                         │
-5.1┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -5.1       -2.8       -0.5       1.8       4.1 

Circle model saved as 'qwen3vl_text_model.q.circle'
```
PEIR is the same as before the change.

### quantize_for_conditional_generation.py

```bash
$ python tico/quantization/wrapq/examples/qwen/quantize_for_conditional_generation.py 
┌───────────── Quantization Error Summary ─────────────
│ Mean |diff|: 0.009265
│ PEIR       : 5.209566 %
└──────────────────────────────────────────────────────
     ┌───────────────────────────────────────────┐
 0.72┤                                           │
     │                                      •••  │
     │                                   ••••    │
 0.48┤                                •••••      │
     │                             ••••••        │
 0.24┤                          ••••••           │
     │                        ••••••             │
     │                     ••••••                │
-0.00┤                   •••••                   │
     │                ••••••                     │
     │             ••••••                        │
-0.24┤           •••••                           │
     │         ••••                              │
-0.49┤      •••••                                │
     │    ••••                                   │
     │  •••                                      │
-0.73┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -0.73      -0.37     -0.00      0.36     0.72 

Circle model saved as 'qwen3vl_for_conditional_generation.q.circle'
```
Notice that the warning `[QuantCheck] WARNING: 34 nodes without qparam detected (see logs).` has disappeared.

# Unit Tests

## test_quant_text_model.py

```bash
$ coverage run -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py -v
======================================================================= test session starts ========================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 31 items                                                                                                                                                 

test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_2d_batch_size_mismatch_raises PASSED       [  3%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_2d_decode_short_mask_gets_past_prefix PASSED [  6%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_2d_float_prefill PASSED                    [  9%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_2d_invalid_length_raises PASSED            [ 12%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_2d_prefill PASSED                          [ 16%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_4d_additive_passthrough PASSED             [ 19%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_4d_bool_converts_to_additive PASSED        [ 22%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_4d_int_converts_to_additive PASSED         [ 25%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_4d_shape_mismatch_raises PASSED            [ 29%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_bool_prefill PASSED                        [ 32%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_decode_with_cache PASSED                   [ 35%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_attention_mask_invalid_rank_raises PASSED                 [ 38%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_deepstack_injection PASSED                                [ 41%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_different_batch_sizes PASSED                              [ 45%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_different_sequence_lengths PASSED                         [ 48%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_embedding_layer_quantization PASSED                       [ 51%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_forward_diff PASSED                                       [ 54%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_forward_diff_export_time PASSED                           [ 58%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_inputs_embeds_path PASSED                                 [ 61%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_layers_wrapped PASSED                                     [ 64%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_mode_transitions PASSED                                   [ 67%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_no_cache_mode PASSED                                      [ 70%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_norm_wrapped PASSED                                       [ 74%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_normalize_attention_mask_shapes PASSED                    [ 77%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_observer_count PASSED                                     [ 80%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_output_shape PASSED                                       [ 83%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_per_module_override PASSED                                [ 87%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_registration_in_registry PASSED                           [ 90%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_return_dict_false_with_cache PASSED                       [ 93%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_return_dict_false_without_cache PASSED                    [ 96%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py::TestQuantQwen3VLTextModel::test_rotary_emb_not_wrapped PASSED                             [100%]

================================================================== 31 passed, 2 warnings in 9.96s ==================================================================
```

```bash
$ coverage report -m
Name                                                                           Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------------------------
...
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py                      136      3    98%   201-203
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py              42      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py                        43      0   100%
tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py                     223      8    96%   435, 467, 476, 518, 560-561, 564-565
------------------------------------------------------------------------------------------------------------
TOTAL                                                                          12169   7723    37%
```
Coverage of `quant_text_model.py` didn't change since an additional case was added for the "export behavior" testing (precomputed tensors are used only at export time).

## test_quant_model.py

```bash
$ $ python -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py -v
======================================================================= test session starts ========================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 22 items                                                                                                                                                 

test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_activation_stats_collected_text_only PASSED                        [  4%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_activation_stats_collected_with_images PASSED                      [  9%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_compute_3d_position_ids_reuses_cached_rope_deltas PASSED           [ 13%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_different_batch_sizes_text_only PASSED                             [ 18%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_dtype_override PASSED                                              [ 22%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_diff_text_only PASSED                                      [ 27%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_input_validation PASSED                                    [ 31%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_text_only PASSED                                           [ 36%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_both_images_and_videos PASSED                         [ 40%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_images PASSED                                         [ 45%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_inputs_embeds PASSED                                  [ 50%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_inputs_embeds_and_images PASSED                       [ 54%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_forward_with_videos PASSED                                         [ 59%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_get_rope_index_with_images_and_videos PASSED                       [ 63%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_graph_tracing_behavior_with_images PASSED                          [ 68%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_graph_tracing_behavior_with_videos PASSED                          [ 72%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_mode_transitions PASSED                                            [ 77%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_multiple_calibration_steps_text_only PASSED                        [ 81%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_observer_count PASSED                                              [ 86%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_registration_in_registry PASSED                                    [ 90%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_rope_deltas_computed_after_forward PASSED                          [ 95%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py::TestQuantQwen3VLModel::test_wraps_submodules PASSED                                            [100%]

================================================================= 22 passed, 2 warnings in 11.56s ==================================================================
```

## test_quant_for_conditional_generation.py

```bash
$ python -m pytest test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py -v
============================================================ test session starts ============================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 7 items                                                                                                                           

test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_text_only PASSED [ 14%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_both_images_and_videos PASSED [ 28%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_images PASSED [ 42%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_forward_with_videos PASSED [ 57%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_mode_transitions PASSED [ 71%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_registration_in_registry PASSED [ 85%]
test/quantization/wrapq/wrappers/qwen_vl/test_quant_for_conditional_generation.py::TestQuantQwen3VLForConditionalGeneration::test_wraps_submodules PASSED [100%]

======================================================= 7 passed, 2 warnings in 6.05s =======================================================
```

# trace_qwen.py

This is an additional validation step showing that wrapped model doesn't diverge from the original one.
As you can see from the report below, PEIR stays within 1e-07 order for all the submodules.

```bash
$ python tico/quantization/wrapq/examples/qwen/trace_qwen.py \
    --model Qwen/Qwen3-VL-2B-Instruct \
    --no-trace-unquantized \
    --no-trace-quantized

--------------------------------------------------------------------------------
MODULE NAME                                            DIFFERENCE
--------------------------------------------------------------------------------
model.language_model.embed_tokens                      {'mean': 0.0, 'min': 0.0, 'max': 0.0, 'stddev': 0.0, 'peir': 0.0}
model.visual.patch_embed.proj                          {'mean': 4.663015715777874e-07, 'min': 2.9802322387695312e-08, 'max': 3.337860107421875e-06, 'stddev': 5.199021302360052e-07, 'peir': 1.105467087481138e-06}
model.visual.patch_embed                               {'mean': 4.663015715777874e-07, 'min': 2.9802322387695312e-08, 'max': 3.337860107421875e-06, 'stddev': 5.199021302360052e-07, 'peir': 1.105467087481138e-06}
model.visual.blocks.0.norm1                            {'mean': 7.068174454616383e-07, 'min': 0.0, 'max': 5.0067901611328125e-06, 'stddev': 7.441490197379608e-07, 'peir': 1.0794899379200758e-06}
model.visual.blocks.0.attn.proj                        {'mean': 2.0012514312384155e-08, 'min': 0.0, 'max': 8.568167686462402e-08, 'stddev': 1.4615666898976087e-08, 'peir': 6.226254958535308e-07}
model.visual.blocks.0.attn                             {'mean': 2.0012514312384155e-08, 'min': 0.0, 'max': 8.568167686462402e-08, 'stddev': 1.4615666898976087e-08, 'peir': 6.226254958535308e-07}
model.visual.blocks.0.norm2                            {'mean': 7.065819431772979e-07, 'min': 0.0, 'max': 5.125999450683594e-06, 'stddev': 7.504190762119833e-07, 'peir': 1.102987083969945e-06}
model.visual.blocks.0.mlp.linear_fc1                   {'mean': 1.3309316670984117e-07, 'min': 0.0, 'max': 8.046627044677734e-07, 'stddev': 9.99122278244613e-08, 'peir': 6.697928960673929e-07}
model.visual.blocks.0.mlp.act_fn                       {'mean': 6.644943084666011e-08, 'min': 0.0, 'max': 4.76837158203125e-07, 'stddev': 5.4926250214748507e-08, 'peir': 8.851678399935205e-07}
model.visual.blocks.0.mlp.linear_fc2                   {'mean': 9.185099969499788e-08, 'min': 0.0, 'max': 4.172325134277344e-07, 'stddev': 7.270670465686635e-08, 'peir': 7.911474667232074e-07}
model.visual.blocks.0.mlp                              {'mean': 9.185099969499788e-08, 'min': 0.0, 'max': 4.172325134277344e-07, 'stddev': 7.270670465686635e-08, 'peir': 7.911474667232074e-07}
model.visual.blocks.0                                  {'mean': 4.587975581671344e-07, 'min': 0.0, 'max': 3.6954879760742188e-06, 'stddev': 5.522322226170218e-07, 'peir': 1.173452832722709e-06}
model.visual.deepstack_merger_list.0.norm              {'mean': 7.013782123976853e-07, 'min': 0.0, 'max': 5.125999450683594e-06, 'stddev': 7.394445447062026e-07, 'peir': 1.1283933148731685e-06}
model.visual.deepstack_merger_list.0.linear_fc1        {'mean': 2.68276977521964e-07, 'min': 0.0, 'max': 1.430511474609375e-06, 'stddev': 2.1168779085201095e-07, 'peir': 7.480482952446882e-07}
model.visual.deepstack_merger_list.0.act_fn            {'mean': 1.3604635284991673e-07, 'min': 0.0, 'max': 9.5367431640625e-07, 'stddev': 1.346237326060873e-07, 'peir': 8.673485761172101e-07}
model.visual.deepstack_merger_list.0.linear_fc2        {'mean': 4.759558436262523e-08, 'min': 0.0, 'max': 2.1606683731079102e-07, 'stddev': 3.4323463182772684e-08, 'peir': 7.058770839195359e-07}
model.visual.deepstack_merger_list.0                   {'mean': 4.759558436262523e-08, 'min': 0.0, 'max': 2.1606683731079102e-07, 'stddev': 3.4323463182772684e-08, 'peir': 7.058770839195359e-07}
model.visual.blocks.1.norm1                            {'mean': 7.013413778622635e-07, 'min': 0.0, 'max': 5.125999450683594e-06, 'stddev': 7.376598318842298e-07, 'peir': 1.1283843132117744e-06}
model.visual.blocks.1.attn.proj                        {'mean': 2.1018859541754864e-08, 'min': 0.0, 'max': 9.313225746154785e-08, 'stddev': 1.6517251566483537e-08, 'peir': 8.873934613158214e-07}
model.visual.blocks.1.attn                             {'mean': 2.1018859541754864e-08, 'min': 0.0, 'max': 9.313225746154785e-08, 'stddev': 1.6517251566483537e-08, 'peir': 8.873934613158214e-07}
model.visual.blocks.1.norm2                            {'mean': 7.027630317679723e-07, 'min': 0.0, 'max': 5.245208740234375e-06, 'stddev': 7.401367270176706e-07, 'peir': 1.1569141607555365e-06}
model.visual.blocks.1.mlp.linear_fc1                   {'mean': 1.356667951313284e-07, 'min': 0.0, 'max': 7.152557373046875e-07, 'stddev': 1.0176102449577229e-07, 'peir': 6.305338540982494e-07}
model.visual.blocks.1.mlp.act_fn                       {'mean': 6.82325520529048e-08, 'min': 0.0, 'max': 5.960464477539062e-07, 'stddev': 5.610988296211872e-08, 'peir': 1.0509633129726707e-06}
model.visual.blocks.1.mlp.linear_fc2                   {'mean': 1.0453614152083901e-07, 'min': 0.0, 'max': 4.917383193969727e-07, 'stddev': 8.643449689316185e-08, 'peir': 8.840372448641723e-07}
model.visual.blocks.1.mlp                              {'mean': 1.0453614152083901e-07, 'min': 0.0, 'max': 4.917383193969727e-07, 'stddev': 8.643449689316185e-08, 'peir': 8.840372448641723e-07}
model.visual.blocks.1                                  {'mean': 4.810713676306477e-07, 'min': 0.0, 'max': 3.6954879760742188e-06, 'stddev': 5.525105848391831e-07, 'peir': 1.1559264198393366e-06}
model.visual.deepstack_merger_list.1.norm              {'mean': 7.148904046516691e-07, 'min': 0.0, 'max': 5.125999450683594e-06, 'stddev': 7.432438451360213e-07, 'peir': 1.1252008352653642e-06}
model.visual.deepstack_merger_list.1.linear_fc1        {'mean': 2.753104979547061e-07, 'min': 0.0, 'max': 1.3709068298339844e-06, 'stddev': 2.101314038327473e-07, 'peir': 7.249544318859923e-07}
model.visual.deepstack_merger_list.1.act_fn            {'mean': 1.4055601127438422e-07, 'min': 0.0, 'max': 1.2814998626708984e-06, 'stddev': 1.3196120107750176e-07, 'peir': 1.536753789885015e-06}
model.visual.deepstack_merger_list.1.linear_fc2        {'mean': 5.033145455968224e-08, 'min': 0.0, 'max': 2.0116567611694336e-07, 'stddev': 3.896288447435836e-08, 'peir': 9.051681480581528e-07}
model.visual.deepstack_merger_list.1                   {'mean': 5.033145455968224e-08, 'min': 0.0, 'max': 2.0116567611694336e-07, 'stddev': 3.896288447435836e-08, 'peir': 9.051681480581528e-07}
model.visual.merger.norm                               {'mean': 7.155950356718677e-07, 'min': 0.0, 'max': 5.245208740234375e-06, 'stddev': 7.413484581775265e-07, 'peir': 1.150262322551123e-06}
model.visual.merger.linear_fc1                         {'mean': 2.6578467782201187e-07, 'min': 0.0, 'max': 1.4901161193847656e-06, 'stddev': 1.8878421315093874e-07, 'peir': 8.198243765661925e-07}
model.visual.merger.act_fn                             {'mean': 1.418277832954118e-07, 'min': 0.0, 'max': 1.4007091522216797e-06, 'stddev': 1.3855976987997565e-07, 'peir': 1.3944247220703849e-06}
model.visual.merger.linear_fc2                         {'mean': 4.9821920811154996e-08, 'min': 0.0, 'max': 2.2351741790771484e-07, 'stddev': 3.838153617152784e-08, 'peir': 8.512206958763238e-07}
model.visual.merger                                    {'mean': 4.9821920811154996e-08, 'min': 0.0, 'max': 2.2351741790771484e-07, 'stddev': 3.838153617152784e-08, 'peir': 8.512206958763238e-07}
model.visual                                           {
                                                           'last_hidden_state': {'mean': 4.810713676306477e-07, 'min': 0.0, 'max': 3.6954879760742188e-06, 'stddev': 5.525105848391831e-07, 'peir': 1.1559264198393366e-06},
                                                           'pooler_output': {'mean': 4.9821920811154996e-08, 'min': 0.0, 'max': 2.2351741790771484e-07, 'stddev': 3.838153617152784e-08, 'peir': 8.512206958763238e-07},
                                                           'deepstack_features':
                                                            {
                                                                '0': {'mean': 4.759558436262523e-08, 'min': 0.0, 'max': 2.1606683731079102e-07, 'stddev': 3.4323463182772684e-08, 'peir': 7.058770839195359e-07},
                                                                '1': {'mean': 5.033145455968224e-08, 'min': 0.0, 'max': 2.0116567611694336e-07, 'stddev': 3.896288447435836e-08, 'peir': 9.051681480581528e-07}
                                                            }
                                                       }
model.language_model.layers.0.input_layernorm          {'mean': 6.864223678348935e-07, 'min': 0.0, 'max': 3.337860107421875e-06, 'stddev': 6.451998046941299e-07, 'peir': 5.972501578873453e-07}
model.language_model.layers.0.self_attn.q_proj         {'mean': 1.20853741236715e-07, 'min': 0.0, 'max': 7.003545761108398e-07, 'stddev': 1.117294701202809e-07, 'peir': 6.995192665466073e-07}
model.language_model.layers.0.self_attn.q_norm         The size of tensor a (2) must match the size of tensor b (84) at non-singleton dimension 2
model.language_model.layers.0.self_attn.k_proj         {'mean': 1.19803686970954e-07, 'min': 0.0, 'max': 5.960464477539062e-07, 'stddev': 1.1144634015636257e-07, 'peir': 6.147229087311062e-07}
model.language_model.layers.0.self_attn.k_norm         The size of tensor a (2) must match the size of tensor b (84) at non-singleton dimension 2
model.language_model.layers.0.self_attn.v_proj         {'mean': 1.054959852808679e-07, 'min': 0.0, 'max': 7.171183824539185e-07, 'stddev': 1.0697030461415125e-07, 'peir': 7.13171060995813e-07}
model.language_model.layers.0.self_attn.o_proj         {'mean': 1.522814052634658e-08, 'min': 0.0, 'max': 6.705522537231445e-08, 'stddev': 1.1805225241801054e-08, 'peir': 4.621472160713851e-07}
model.language_model.layers.0.self_attn                {
                                                           '0': {'mean': 1.522814052634658e-08, 'min': 0.0, 'max': 6.705522537231445e-08, 'stddev': 1.1805225241801054e-08, 'peir': 4.621472160713851e-07},
                                                           '1': {'mean': 7.759426878806153e-09, 'min': 0.0, 'max': 8.046627044677734e-07, 'stddev': 2.4744107207652632e-08, 'peir': 8.046627044677734e-07}
                                                       }
model.language_model.layers.0.post_attention_layernorm {'mean': 7.155965704441769e-07, 'min': 0.0, 'max': 2.8926879167556763e-06, 'stddev': 5.5146887234514e-07, 'peir': 4.804503425335604e-07}
model.language_model.layers.0.mlp.gate_proj            {'mean': 1.2194884391192318e-07, 'min': 0.0, 'max': 6.854534149169922e-07, 'stddev': 1.0029209818185336e-07, 'peir': 5.15017184556005e-07}
model.language_model.layers.0.mlp.act_fn               {'mean': 6.037127064928427e-08, 'min': 0.0, 'max': 4.172325134277344e-07, 'stddev': 5.0611575375114626e-08, 'peir': 6.199233810125261e-07}
model.language_model.layers.0.mlp.up_proj              {'mean': 1.1492881668573318e-07, 'min': 0.0, 'max': 7.82194547355175e-07, 'stddev': 9.518202404024123e-08, 'peir': 7.250571333366631e-07}
model.language_model.layers.0.mlp.down_proj            {'mean': 3.9799177287136445e-09, 'min': 0.0, 'max': 2.10711732506752e-08, 'stddev': 3.1943592215810668e-09, 'peir': 7.466325469617847e-07}
model.language_model.layers.0.mlp                      {'mean': 3.9799177287136445e-09, 'min': 0.0, 'max': 2.10711732506752e-08, 'stddev': 3.1943592215810668e-09, 'peir': 7.466325469617847e-07}
model.language_model.layers.0                          {'mean': 4.4465600979037845e-08, 'min': 0.0, 'max': 2.1606683731079102e-07, 'stddev': 3.688285232783528e-08, 'peir': 7.328742204871804e-07}
model.language_model.layers.1.input_layernorm          {'mean': 7.095526939338015e-07, 'min': 0.0, 'max': 2.9802322387695312e-06, 'stddev': 5.499067583514261e-07, 'peir': 5.027720437184828e-07}
model.language_model.layers.1.self_attn.q_proj         {'mean': 1.1012804890242478e-07, 'min': 0.0, 'max': 4.76837158203125e-07, 'stddev': 8.652121152863401e-08, 'peir': 4.959085376047754e-07}
model.language_model.layers.1.self_attn.q_norm         The size of tensor a (2) must match the size of tensor b (84) at non-singleton dimension 2
model.language_model.layers.1.self_attn.k_proj         {'mean': 1.1010750711193396e-07, 'min': 0.0, 'max': 5.662441253662109e-07, 'stddev': 9.062441108653729e-08, 'peir': 4.929799652942105e-07}
model.language_model.layers.1.self_attn.k_norm         The size of tensor a (2) must match the size of tensor b (84) at non-singleton dimension 2
model.language_model.layers.1.self_attn.v_proj         {'mean': 1.1412760869689009e-07, 'min': 0.0, 'max': 6.258487701416016e-07, 'stddev': 9.011847623696667e-08, 'peir': 6.741437555701128e-07}
model.language_model.layers.1.self_attn.o_proj         {'mean': 1.3766582540597483e-08, 'min': 0.0, 'max': 5.820766091346741e-08, 'stddev': 1.1234423169526053e-08, 'peir': 4.89408357447201e-07}
model.language_model.layers.1.self_attn                {
                                                           '0': {'mean': 1.3766582540597483e-08, 'min': 0.0, 'max': 5.820766091346741e-08, 'stddev': 1.1234423169526053e-08, 'peir': 4.89408357447201e-07},
                                                           '1': {'mean': 6.1784759530780775e-09, 'min': 0.0, 'max': 4.470348358154297e-07, 'stddev': 1.665612714418785e-08, 'peir': 4.470348358154297e-07}
                                                       }
model.language_model.layers.1.post_attention_layernorm {'mean': 7.268141075655876e-07, 'min': 0.0, 'max': 3.0994415283203125e-06, 'stddev': 5.560037834584364e-07, 'peir': 5.735514428877768e-07}
model.language_model.layers.1.mlp.gate_proj            {'mean': 1.1743620831339285e-07, 'min': 0.0, 'max': 6.556510925292969e-07, 'stddev': 9.367396103243664e-08, 'peir': 5.522151558762822e-07}
model.language_model.layers.1.mlp.act_fn               {'mean': 5.80776671199601e-08, 'min': 0.0, 'max': 3.725290298461914e-07, 'stddev': 4.733313829774488e-08, 'peir': 5.93296602736189e-07}
model.language_model.layers.1.mlp.up_proj              {'mean': 1.1321057513669075e-07, 'min': 0.0, 'max': 6.109476089477539e-07, 'stddev': 8.96217500212515e-08, 'peir': 5.225604913475709e-07}
model.language_model.layers.1.mlp.down_proj            {'mean': 4.2314360904072146e-09, 'min': 0.0, 'max': 2.0489096641540527e-08, 'stddev': 3.404974524556792e-09, 'peir': 7.791580050268441e-07}
model.language_model.layers.1.mlp                      {'mean': 4.2314360904072146e-09, 'min': 0.0, 'max': 2.0489096641540527e-08, 'stddev': 3.404974524556792e-09, 'peir': 7.791580050268441e-07}
model.language_model.layers.1                          {'mean': 6.055260115545025e-08, 'min': 0.0, 'max': 2.8312206268310547e-07, 'stddev': 5.027870741969309e-08, 'peir': 6.816220768637234e-07}
model.language_model.norm                              {'mean': 8.807644462649478e-07, 'min': 0.0, 'max': 3.814697265625e-06, 'stddev': 6.968475076973846e-07, 'peir': 6.718078441459546e-07}
model.language_model                                   {'last_hidden_state': {'mean': 8.807644462649478e-07, 'min': 0.0, 'max': 3.814697265625e-06, 'stddev': 6.968475076973846e-07, 'peir': 6.718078441459546e-07}}
model                                                  Type mismatch: <class 'transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLModelOutputWithPast'> != <class 'transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLCausalLMOutputWithPast'>
lm_head                                                {'mean': 1.413558123886105e-07, 'min': 0.0, 'max': 8.493661880493164e-07, 'stddev': 1.1498394769660081e-07, 'peir': 7.12966422633687e-07}
```
