### PR TITLE
[quantization] Ensure qparams match input device in fake_quant

### DIFF
--- a/tico/passes/decompose_fake_quantize_tensor_qparams.py
+++ b/tico/passes/decompose_fake_quantize_tensor_qparams.py
@@ -94,6 +94,10 @@ def get_constant_from_tensor(
     if node.target.__name__ == "_to_copy.default":
         assert len(node.args) == 1
         return get_constant_from_tensor(node.args[0], ep)  # type: ignore[arg-type]
+    if node.target.__name__ == "to.dtype_layout":
+        return get_constant_from_tensor(node.args[0], ep)  # type: ignore[arg-type]
+    if node.target.__name__ == "to.device":
+        return get_constant_from_tensor(node.args[0], ep)  # type: ignore[arg-type]
     if node.target.__name__ == "lift_fresh_copy.default":
         assert len(node.args) == 1
         assert isinstance(node.args[0], torch.fx.Node)

--- a/tico/quantization/wrapq/observers/affine_base.py
+++ b/tico/quantization/wrapq/observers/affine_base.py
@@ -135,7 +135,10 @@ class AffineObserverBase(ObserverBase):
             raise RuntimeError(
                 "Call compute_qparams()/freeze_qparams() or load_qparams() first."
             )
-        scale, zp = self._cached_scale, self._cached_zp
+
+        scale = self._cached_scale.to(x.device)
+        zp = self._cached_zp.to(x.device, dtype=torch.int)
+
         if self.channel_axis is None:
             return torch.fake_quantize_per_tensor_affine(
                 x,


### PR DESCRIPTION
This commit ensures qparams match input device in fake_quant.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>