### PR TITLE
[quantization] Add generate() support and export mode for LLaMA wrappers

### DIFF
--- a/test/quantization/wrapq/wrappers/llama/test_quant_attention.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_attention.py
@@ -20,6 +20,10 @@ from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.llama.export_adapters import (
+    LlamaAttentionDecodeExportAdapter,
+    LlamaAttentionPrefillExportAdapter,
+)
 from tico.quantization.wrapq.wrappers.llama.quant_attention import QuantLlamaAttention
 from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
 
@@ -60,6 +64,18 @@ class TestQuantLlamaAttention(unittest.TestCase):
         cls.n_h = cfg.num_attention_heads
         cls.hidden_size = cfg.hidden_size
 
+    def _make_qattn(self) -> QuantLlamaAttention:
+        qattn = QuantLlamaAttention(self.fp_attn, layer_idx=0)
+        qattn.enable_calibration()
+
+        for _ in range(3):
+            x = torch.randn(2, 4, self.hidden_size)
+            pos = self._rand_rope(2, 4)
+            _ = qattn(x, pos)
+
+        qattn.freeze_qparams()
+        return qattn
+
     def _rand_rope(self, batch_size: int, seq_len: int):
         emb = torch.randn(batch_size, seq_len, self.head_dim)
         return emb.cos(), emb.sin()
@@ -70,6 +86,14 @@ class TestQuantLlamaAttention(unittest.TestCase):
             valid_len = torch.randint(low=1, high=k_len + 1, size=(1,)).item()
             if valid_len < k_len:
                 mask[:, :, valid_len:] = float("-120")
+        return mask
+
+    def _rand_bool_mask(self, batch_size: int, q_len: int, k_len: int):
+        mask = torch.ones(batch_size, q_len, k_len, dtype=torch.bool)
+        if k_len > 1:
+            valid_len = torch.randint(low=1, high=k_len + 1, size=(1,)).item()
+            if valid_len < k_len:
+                mask[:, :, valid_len:] = False
         return mask
 
     def _rand_past(self, batch_size: int, past_len: int):
@@ -92,7 +116,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         self.assertIs(qattn._mode, Mode.QUANT)
 
     def test_mode_transitions_decode(self):
-        qattn = QuantLlamaAttention(self.fp_attn)
+        qattn = QuantLlamaAttention(self.fp_attn, layer_idx=0)
         self.assertIs(qattn._mode, Mode.NO_QUANT)
 
         qattn.enable_calibration()
@@ -165,16 +189,25 @@ class TestQuantLlamaAttention(unittest.TestCase):
         self.assertEqual(q_out.shape, (batch_size, seq_len, self.hidden_size))
         self.assertEqual(attn_w.shape, (batch_size, self.n_h, seq_len, seq_len))
 
-    def test_cache_tuple_concat_prefill(self):
+    def test_forward_with_bool_attention_mask_prefill(self):
+        qattn = self._make_qattn()
+
+        batch_size = 2
+        seq_len = 4
+        x = torch.randn(batch_size, seq_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, seq_len)
+        bool_mask = self._rand_bool_mask(batch_size, seq_len, seq_len)
+
+        with torch.no_grad():
+            out, attn_w = qattn(x, pos, attention_mask=bool_mask)
+
+        self.assertEqual(out.shape, (batch_size, seq_len, self.hidden_size))
+        self.assertEqual(attn_w.shape, (batch_size, self.n_h, seq_len, seq_len))
+
+    def test_cache_tuple_concat_prefill_and_present_decode(self):
         torch.manual_seed(0)
 
-        qattn = QuantLlamaAttention(self.fp_attn)
-        qattn.enable_calibration()
-        for _ in range(2):
-            x = torch.randn(2, 4, self.hidden_size)
-            pos = self._rand_rope(2, 4)
-            _ = qattn(x, pos)
-        qattn.freeze_qparams()
+        qattn = self._make_qattn()
 
         batch_size = 2
         seq_prefill = 4
@@ -219,23 +252,22 @@ class TestQuantLlamaAttention(unittest.TestCase):
             attn_w1.shape, (batch_size, self.n_h, seq_decode, seq_prefill + seq_decode)
         )
         k1, v1 = present1
-
-        # The unified wrapper returns the current K/V delta, not the fully concatenated cache.
-        self.assertEqual(k1.shape, (batch_size, self.n_kv, seq_decode, self.head_dim))
-        self.assertEqual(v1.shape, (batch_size, self.n_kv, seq_decode, self.head_dim))
+        self.assertEqual(
+            k1.shape, (batch_size, self.n_kv, seq_prefill + seq_decode, self.head_dim)
+        )
+        self.assertEqual(
+            v1.shape, (batch_size, self.n_kv, seq_prefill + seq_decode, self.head_dim)
+        )
+        # Decode with a legacy tuple past may requantize the cached prefix through
+        # obs_past_key/obs_past_value and obs_present_key/obs_present_value before
+        # returning the full present cache, so exact prefix equality is not guaranteed.
+        self.assertEqual(k1[:, :, :seq_prefill, :].shape, k0.shape)
+        self.assertEqual(v1[:, :, :seq_prefill, :].shape, v0.shape)
 
     def test_forward_shapes_and_cache_delta_decode(self):
         torch.manual_seed(1)
 
-        qattn = QuantLlamaAttention(self.fp_attn)
-        qattn.enable_calibration()
-        for _ in range(3):
-            x = torch.randn(1, 1, self.hidden_size)
-            pos = self._rand_rope(1, 1)
-            mask = self._rand_additive_mask(1, 1, self.max_seq)
-            past = self._rand_past(1, self.max_seq - 1)
-            _ = qattn(x, pos, mask, past, use_cache=True)
-        qattn.freeze_qparams()
+        qattn = self._make_qattn()
 
         batch_size = 1
         x = torch.randn(batch_size, 1, self.hidden_size)
@@ -250,12 +282,100 @@ class TestQuantLlamaAttention(unittest.TestCase):
                 attention_mask=mask,
                 past_key_value=(past_k, past_v),
                 use_cache=True,
+                cache_output_mode="delta",
             )
 
         self.assertEqual(out.shape, (batch_size, 1, self.hidden_size))
         new_k, new_v = new_kv
         self.assertEqual(new_k.shape, (batch_size, self.n_kv, 1, self.head_dim))
         self.assertEqual(new_v.shape, (batch_size, self.n_kv, 1, self.head_dim))
+
+    def test_invalid_cache_output_mode_raises(self):
+        qattn = self._make_qattn()
+
+        x = torch.randn(1, 1, self.hidden_size)
+        pos = self._rand_rope(1, 1)
+
+        with self.assertRaises(ValueError):
+            _ = qattn(
+                x,
+                pos,
+                use_cache=True,
+                cache_output_mode="invalid",
+            )
+
+    def test_prefill_export_adapter_returns_delta_kv(self):
+        qattn = self._make_qattn()
+        adapter = LlamaAttentionPrefillExportAdapter(qattn, return_kv=True)
+
+        batch_size = 2
+        seq_len = 4
+        x = torch.randn(batch_size, seq_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, seq_len)
+
+        with torch.no_grad():
+            hidden, new_k, new_v = adapter(
+                hidden_states=x,
+                position_embeddings=pos,
+                attention_mask=None,
+            )
+
+        self.assertEqual(hidden.shape, (batch_size, seq_len, self.hidden_size))
+        self.assertEqual(new_k.shape, (batch_size, self.n_kv, seq_len, self.head_dim))
+        self.assertEqual(new_v.shape, (batch_size, self.n_kv, seq_len, self.head_dim))
+
+    def test_decode_export_adapter_returns_delta_kv(self):
+        qattn = self._make_qattn()
+        adapter = LlamaAttentionDecodeExportAdapter(qattn, return_kv=True)
+
+        batch_size = 1
+        q_len = 1
+        past_len = self.max_seq - 1
+        x = torch.randn(batch_size, q_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, q_len)
+        past = self._rand_past(batch_size, past_len)
+        mask = self._rand_additive_mask(batch_size, q_len, past_len + q_len)
+
+        with torch.no_grad():
+            hidden, new_k, new_v = adapter(
+                hidden_states=x,
+                position_embeddings=pos,
+                attention_mask=mask,
+                past_key_value=past,
+            )
+
+        self.assertEqual(hidden.shape, (batch_size, q_len, self.hidden_size))
+        self.assertEqual(new_k.shape, (batch_size, self.n_kv, q_len, self.head_dim))
+        self.assertEqual(new_v.shape, (batch_size, self.n_kv, q_len, self.head_dim))
+
+    def test_export_adapters_without_cache_return_hidden_only(self):
+        qattn = self._make_qattn()
+
+        prefill_adapter = LlamaAttentionPrefillExportAdapter(qattn, return_kv=False)
+        decode_adapter = LlamaAttentionDecodeExportAdapter(qattn, return_kv=False)
+
+        batch_size = 1
+        q_len = 1
+        x = torch.randn(batch_size, q_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, q_len)
+        past = self._rand_past(batch_size, self.max_seq - 1)
+        mask = self._rand_additive_mask(batch_size, q_len, self.max_seq)
+
+        with torch.no_grad():
+            prefill_hidden = prefill_adapter(
+                hidden_states=x,
+                position_embeddings=pos,
+                attention_mask=None,
+            )
+            decode_hidden = decode_adapter(
+                hidden_states=x,
+                position_embeddings=pos,
+                attention_mask=mask,
+                past_key_value=past,
+            )
+
+        self.assertEqual(prefill_hidden.shape, (batch_size, q_len, self.hidden_size))
+        self.assertEqual(decode_hidden.shape, (batch_size, q_len, self.hidden_size))
 
     def test_per_projection_override(self):
         cfg = PTQConfig(
@@ -277,7 +397,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
     def test_forward_diff_vs_self_consistency_decode(self):
         torch.manual_seed(7)
 
-        qattn = QuantLlamaAttention(self.fp_attn)
+        qattn = QuantLlamaAttention(self.fp_attn, layer_idx=0)
         qattn.enable_calibration()
 
         for _ in range(4):

--- a/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
@@ -20,6 +20,10 @@ from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.llama.export_adapters import (
+    LlamaDecoderLayerDecodeExportAdapter,
+    LlamaDecoderLayerPrefillExportAdapter,
+)
 from tico.quantization.wrapq.wrappers.llama.quant_decoder_layer import (
     QuantLlamaDecoderLayer,
 )
@@ -95,6 +99,7 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
 
     def test_mode_transitions_decode(self):
         qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        qlayer.return_type = "tuple"
         self.assertIs(qlayer._mode, Mode.NO_QUANT)
 
         qlayer.enable_calibration()
@@ -146,7 +151,7 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         self.assertLess(diff, 0.5)
         self.assertEqual(fp_out.shape, q_out.shape)
 
-    def test_forward_shapes_and_cache_decode(self):
+    def test_forward_shapes_and_full_present_cache_decode(self):
         torch.manual_seed(1)
 
         qlayer = QuantLlamaDecoderLayer(self.fp_layer)
@@ -173,7 +178,7 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         past_k, past_v = self._rand_past(batch_size, self.max_seq - 1)
 
         with torch.no_grad():
-            out = qlayer(
+            hidden_out, present = qlayer(
                 hidden_states=x,
                 attention_mask=mask,
                 past_key_value=(past_k, past_v),
@@ -181,14 +186,14 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
                 use_cache=True,
             )
 
-        self.assertIsInstance(out, tuple)
-        hidden_out, present = out
         self.assertEqual(hidden_out.shape, (batch_size, 1, self.hidden_size))
-
-        # The unified layer returns the attention wrapper's current K/V delta.
-        new_k, new_v = present
-        self.assertEqual(new_k.shape, (batch_size, self.n_kv, 1, self.head_dim))
-        self.assertEqual(new_v.shape, (batch_size, self.n_kv, 1, self.head_dim))
+        present_k, present_v = present
+        self.assertEqual(
+            present_k.shape, (batch_size, self.n_kv, self.max_seq, self.head_dim)
+        )
+        self.assertEqual(
+            present_v.shape, (batch_size, self.n_kv, self.max_seq, self.head_dim)
+        )
 
     def test_none_attention_mask_is_supported_in_decode_path(self):
         qlayer = QuantLlamaDecoderLayer(self.fp_layer)
@@ -210,6 +215,13 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
 
         self.assertIsInstance(out, tuple)
         self.assertEqual(out[0].shape, (batch_size, 1, self.hidden_size))
+        present_k, present_v = out[1]
+        self.assertEqual(
+            present_k.shape, (batch_size, self.n_kv, self.max_seq, self.head_dim)
+        )
+        self.assertEqual(
+            present_v.shape, (batch_size, self.n_kv, self.max_seq, self.head_dim)
+        )
 
     def test_bool_attention_mask_is_supported_in_decode_path(self):
         qlayer = QuantLlamaDecoderLayer(self.fp_layer)
@@ -232,6 +244,13 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
 
         self.assertIsInstance(out, tuple)
         self.assertEqual(out[0].shape, (batch_size, 1, self.hidden_size))
+        present_k, present_v = out[1]
+        self.assertEqual(
+            present_k.shape, (batch_size, self.n_kv, self.max_seq, self.head_dim)
+        )
+        self.assertEqual(
+            present_v.shape, (batch_size, self.n_kv, self.max_seq, self.head_dim)
+        )
 
     def test_dtype_override(self):
         cfg = PTQConfig(
@@ -269,7 +288,7 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         past = self._rand_past(1, self.max_seq - 1)
 
         with torch.no_grad():
-            cal_hidden, (cal_new_k, cal_new_v) = qlayer(
+            cal_hidden, (cal_present_k, cal_present_v) = qlayer(
                 hidden_states=x,
                 attention_mask=mask,
                 past_key_value=past,
@@ -281,7 +300,7 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         self.assertIs(qlayer._mode, Mode.QUANT)
 
         with torch.no_grad():
-            q_hidden, (q_new_k, q_new_v) = qlayer(
+            q_hidden, (q_present_k, q_present_v) = qlayer(
                 hidden_states=x,
                 attention_mask=mask,
                 past_key_value=past,
@@ -294,14 +313,79 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         self.assertLess(diff_h, 2.0)
         self.assertEqual(cal_hidden.shape, q_hidden.shape)
 
-        diff_k = (cal_new_k - q_new_k).abs().mean().item()
-        diff_v = (cal_new_v - q_new_v).abs().mean().item()
+        diff_k = (cal_present_k - q_present_k).abs().mean().item()
+        diff_v = (cal_present_v - q_present_v).abs().mean().item()
         self.assertGreater(diff_k, 0.0)
         self.assertGreater(diff_v, 0.0)
         self.assertLess(diff_k, 2.0)
         self.assertLess(diff_v, 2.0)
-        self.assertEqual(cal_new_k.shape, q_new_k.shape)
-        self.assertEqual(cal_new_v.shape, q_new_v.shape)
+        self.assertEqual(cal_present_k.shape, q_present_k.shape)
+        self.assertEqual(cal_present_v.shape, q_present_v.shape)
+
+    def test_export_prefill_adapter_returns_delta_kv(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        adapter = qlayer.as_export_module(mode="prefill", return_kv=True)
+        self.assertIsInstance(adapter, LlamaDecoderLayerPrefillExportAdapter)
+
+        batch_size = 2
+        seq_len = 4
+        hidden = torch.randn(batch_size, seq_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, seq_len)
+        mask = self._rand_additive_mask(batch_size, seq_len, seq_len)
+
+        with torch.no_grad():
+            hidden_out, new_k, new_v = adapter(
+                hidden_states=hidden,
+                attention_mask=mask,
+                position_embeddings=pos,
+            )
+
+        self.assertEqual(hidden_out.shape, (batch_size, seq_len, self.hidden_size))
+        self.assertEqual(new_k.shape, (batch_size, self.n_kv, seq_len, self.head_dim))
+        self.assertEqual(new_v.shape, (batch_size, self.n_kv, seq_len, self.head_dim))
+
+    def test_export_decode_adapter_returns_delta_kv(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        adapter = qlayer.as_export_module(mode="decode", return_kv=True)
+        self.assertIsInstance(adapter, LlamaDecoderLayerDecodeExportAdapter)
+
+        batch_size = 1
+        x = torch.randn(batch_size, 1, self.hidden_size)
+        pos = self._rand_rope(batch_size, 1)
+        mask = self._rand_additive_mask(batch_size, 1, self.max_seq)
+        past = self._rand_past(batch_size, self.max_seq - 1)
+
+        with torch.no_grad():
+            hidden_out, new_k, new_v = adapter(
+                hidden_states=x,
+                attention_mask=mask,
+                position_embeddings=pos,
+                past_key_value=past,
+            )
+
+        self.assertEqual(hidden_out.shape, (batch_size, 1, self.hidden_size))
+        self.assertEqual(new_k.shape, (batch_size, self.n_kv, 1, self.head_dim))
+        self.assertEqual(new_v.shape, (batch_size, self.n_kv, 1, self.head_dim))
+
+    def test_export_adapter_without_kv_returns_hidden_only(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        adapter = qlayer.as_export_module(mode="decode", return_kv=False)
+
+        batch_size = 1
+        x = torch.randn(batch_size, 1, self.hidden_size)
+        pos = self._rand_rope(batch_size, 1)
+        mask = self._rand_additive_mask(batch_size, 1, self.max_seq)
+        past = self._rand_past(batch_size, self.max_seq - 1)
+
+        with torch.no_grad():
+            hidden_out = adapter(
+                hidden_states=x,
+                attention_mask=mask,
+                position_embeddings=pos,
+                past_key_value=past,
+            )
+
+        self.assertEqual(hidden_out.shape, (batch_size, 1, self.hidden_size))
 
 
 if __name__ == "__main__":

--- a/test/quantization/wrapq/wrappers/llama/test_quant_model.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_model.py
@@ -20,8 +20,8 @@ The tests run only if *transformers* is available (they depend on the genuine
 import unittest
 
 import torch
-from tico.quantization.config.ptq import PTQConfig
 
+from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.version import has_transformers_for
 from tico.quantization.wrapq.wrappers.llama.quant_model import QuantLlamaModel
@@ -44,6 +44,7 @@ class TestQuantLlamaModel(unittest.TestCase):
 
         cls.seq_len = 16
         cls.vocab_size = 10000
+
         cfg = LlamaConfig(
             hidden_size=8,
             num_attention_heads=2,
@@ -57,6 +58,7 @@ class TestQuantLlamaModel(unittest.TestCase):
             use_cache=False,
             return_dict=False,
         )
+
         cls.fp_model = LlamaModel(cfg)
 
     def test_mode_transitions(self):
@@ -66,15 +68,8 @@ class TestQuantLlamaModel(unittest.TestCase):
         qmodel.enable_calibration()
         self.assertIs(qmodel._mode, Mode.CALIB)
 
-        x = torch.randint(
-            0,
-            self.vocab_size,
-            (
-                1,
-                self.seq_len,
-            ),
-        )
-        _ = qmodel(x)  # gather stats
+        x = torch.randint(0, self.vocab_size, (1, self.seq_len))
+        _ = qmodel(x, use_cache=False, return_dict=False)
 
         qmodel.freeze_qparams()
         self.assertIs(qmodel._mode, Mode.QUANT)
@@ -82,25 +77,30 @@ class TestQuantLlamaModel(unittest.TestCase):
     def test_forward_diff(self):
         qmodel = QuantLlamaModel(self.fp_model, qcfg=PTQConfig())
         qmodel.enable_calibration()
+
         calib_set = []
         for _ in range(4):
-            inp = torch.randint(
-                0,
-                self.vocab_size,
-                (
-                    1,
-                    self.seq_len,
-                ),
-            )
-            _ = qmodel(inp)
+            inp = torch.randint(0, self.vocab_size, (1, self.seq_len))
+            _ = qmodel(inp, use_cache=False, return_dict=False)
             calib_set.append(inp)
+
         qmodel.freeze_qparams()
 
         with torch.no_grad():
-            q_out = qmodel(calib_set[0])[0]
-            fp_out = self.fp_model(calib_set[0])[0]
+            q_out = qmodel(
+                calib_set[0],
+                use_cache=False,
+                return_dict=False,
+            )[0]
+
+            fp_out = self.fp_model(
+                calib_set[0],
+                use_cache=False,
+                return_dict=False,
+            )[0]
 
         diff = (fp_out - q_out).abs().mean().item()
+
         self.assertGreater(diff, 0.0)
         self.assertLess(diff, 0.4)
         self.assertEqual(fp_out.shape, q_out.shape)

--- a/test/quantization/wrapq/wrappers/llama/test_quant_model_for_casual_lm.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_model_for_casual_lm.py
@@ -46,6 +46,7 @@ class TestQuantLlamaForCausalLM(unittest.TestCase):
 
         cls.seq_len = 16
         cls.vocab_size = 10000
+
         cfg = LlamaConfig(
             hidden_size=8,
             num_attention_heads=2,
@@ -57,7 +58,9 @@ class TestQuantLlamaForCausalLM(unittest.TestCase):
             num_hidden_layers=2,
             max_position_embeddings=cls.seq_len,
             use_cache=False,
+            return_dict=True,  # 명시적으로 설정
         )
+
         cls.fp_model = LlamaForCausalLM(cfg)
 
     def test_mode_transitions(self):
@@ -67,42 +70,43 @@ class TestQuantLlamaForCausalLM(unittest.TestCase):
         qmodel.enable_calibration()
         self.assertIs(qmodel._mode, Mode.CALIB)
 
-        x = torch.randint(
-            0,
-            self.vocab_size,
-            (
-                1,
-                self.seq_len // 2,
-            ),
-        )
-        _ = qmodel(x)  # gather stats
+        x = torch.randint(0, self.vocab_size, (1, self.seq_len // 2))
+        _ = qmodel(x, return_dict=True, use_cache=False)
 
         qmodel.freeze_qparams()
         self.assertIs(qmodel._mode, Mode.QUANT)
-        ndf = 0
 
     def test_forward_diff(self):
         qmodel = QuantLlamaForCausalLM(self.fp_model, qcfg=PTQConfig())
         qmodel.enable_calibration()
+
         calib_set = []
         for index in range(4):
             inp = torch.randint(
                 0,
                 self.vocab_size,
-                (
-                    1,
-                    self.seq_len // (index + 1),
-                ),
+                (1, self.seq_len // (index + 1)),
             )
-            _ = qmodel(inp)
+            _ = qmodel(inp, return_dict=True, use_cache=False)
             calib_set.append(inp)
+
         qmodel.freeze_qparams()
 
         with torch.no_grad():
-            q_out = qmodel(calib_set[0])["logits"]
-            fp_out = self.fp_model(calib_set[0])["logits"]
+            q_out = qmodel(
+                calib_set[0],
+                return_dict=True,
+                use_cache=False,
+            ).logits
+
+            fp_out = self.fp_model(
+                calib_set[0],
+                return_dict=True,
+                use_cache=False,
+            ).logits
 
         diff = (fp_out - q_out).abs().mean().item()
+
         self.assertGreater(diff, 0.0)
         self.assertLess(diff, 0.4)
         self.assertEqual(fp_out.shape, q_out.shape)

--- a/tico/quantization/algorithm/spinquant/spin_llama.py
+++ b/tico/quantization/algorithm/spinquant/spin_llama.py
@@ -186,7 +186,7 @@ class SpinLlamaForCausalLM(SpinLlamaPreTrainedModel, GenerationMixin):
     Causal language modeling head for SpinLlama.
     """
 
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
     _tp_plan = {"lm_head": "colwise_rep"}
     _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
 

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -127,10 +127,10 @@ def inject_gptq_qparams(
         _print_sample("unused GPTQ entries", unused)
 
 
-# -------------------------------------------------------------------------
-# Save model in circle format
-# -------------------------------------------------------------------------
 def save_model_to(q_m, calib_inputs, save_circle_to_folder):
+    """
+    Export and save the whole quantized model in circle format.
+    """
     q_m.eval()
     q_m.cpu()
 
@@ -144,6 +144,9 @@ def save_model_to(q_m, calib_inputs, save_circle_to_folder):
 
 
 def save_layers_to(q_m, max_seq_len, save_layers_to_folder):
+    """
+    Export and save quantized decoder layers one by one in circle format.
+    """
     q_m.eval()
     q_m.cpu()
 
@@ -182,7 +185,71 @@ def save_layers_to(q_m, max_seq_len, save_layers_to_folder):
         cm.save(save_path)
 
 
+def calibrate_ptq_observers(
+    q_m: torch.nn.Module,
+    calib_inputs: list[torch.Tensor],
+    *,
+    device: torch.device,
+    decode_calibration_steps: int = 0,
+    no_tqdm: bool = False,
+):
+    """
+    Calibrate PTQ observers on prefill and optional decode paths.
+
+    The prefill phase uses full-sequence inputs. The optional decode
+    phase runs a short manual autoregressive loop with `use_cache=True`
+    so cache-related observers can see realistic decode-time values as well.
+
+    Args:
+        q_m: PTQ-prepared model.
+        calib_inputs: List of token tensors with shape [1, seq_len].
+        device: Device used for calibration.
+        decode_calibration_steps: Number of decode steps to run after each
+            prefill pass. Set to 0 to disable decode calibration.
+        no_tqdm: If True, disable progress bars.
+    """
+    q_m.eval()
+
+    iterator = calib_inputs
+    if not no_tqdm:
+        iterator = tqdm.tqdm(calib_inputs, desc="PTQ calibration")
+
+    with torch.no_grad():
+        for inp in iterator:
+            inp = inp.to(device)
+
+            # Prefill calibration
+            if decode_calibration_steps <= 0:
+                q_m(inp)
+                continue
+
+            # Prefill with cache enabled so decode can continue from it.
+            outputs = q_m(
+                input_ids=inp,
+                use_cache=True,
+                return_dict=True,
+            )
+            past_key_values = outputs.past_key_values
+            next_input_ids = outputs.logits[:, -1, :].argmax(dim=-1, keepdim=True)
+
+            # Short decode calibration for cache-related observers.
+            for _ in range(decode_calibration_steps):
+                outputs = q_m(
+                    input_ids=next_input_ids,
+                    past_key_values=past_key_values,
+                    use_cache=True,
+                    return_dict=True,
+                )
+                past_key_values = outputs.past_key_values
+
+                # Greedy next token is enough for calibration purposes.
+                next_input_ids = outputs.logits[:, -1, :].argmax(dim=-1, keepdim=True)
+
+
 def quantize_using_PTQ(q_m, calib_inputs, args):
+    """
+    Wrap the model with PTQ wrappers, calibrate observers, and convert it.
+    """
     print("Wrapping layers with PTQWrapper …")
 
     qcfg = build_llm_ptq_config(
@@ -198,12 +265,8 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
     )
     q_m = prepare(q_m, qcfg)
 
-    # -------------------------------------------------------------------------
-    # Single-pass activation calibration
-    # -------------------------------------------------------------------------
-    print("Calibrating PTQ obeservers…")
+    print("Calibrating PTQ observers…")
 
-    # Overwrite weight observers with GPTQ statistics
     if hasattr(q_m, "quantizers") and isinstance(q_m.quantizers, dict):
         inject_gptq_qparams(q_m, q_m.quantizers, verbose=args.verbose)
     elif (
@@ -218,20 +281,22 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
         )
 
     device = torch.device(args.device)
-    with torch.no_grad():
-        for inp in tqdm.tqdm(calib_inputs):
-            q_m(inp.to(device))
+    calibrate_ptq_observers(
+        q_m,
+        calib_inputs,
+        device=device,
+        decode_calibration_steps=args.decode_calibration_steps,
+        no_tqdm=args.no_tqdm,
+    )
 
-    # Freeze all Q-params (scale, zero-point)
     q_m = convert(q_m)
-
     return q_m
 
 
 def evaluate(q_m, tokenizer, dataset_test, args):
-    # -------------------------------------------------------------------------
-    # Evaluate perplexity on Wikitext-2
-    # -------------------------------------------------------------------------
+    """
+    Evaluate the quantized model with perplexity and optional lm-eval tasks.
+    """
     print("\nCalculating perplexities …")
     enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
     ppl_uint8 = perplexity(
@@ -251,6 +316,9 @@ def evaluate(q_m, tokenizer, dataset_test, args):
 
 
 def get_sensitivities_info_name(model, dataset, seed, n_samples):
+    """
+    Build a filename for stored sensitivity calibration results.
+    """
     model_name = model.config.name_or_path.replace("/", "_")
 
     name = (
@@ -269,6 +337,9 @@ def get_sensitivities_info_name(model, dataset, seed, n_samples):
 
 
 def get_ptq_model_name(model, args):
+    """
+    Build a filename for a saved PTQ checkpoint.
+    """
     model_name = model.config.name_or_path.replace("/", "_")
 
     name = (
@@ -387,6 +458,15 @@ def main():
         help="seq_len to use in quantized model calibration. More the better",
     )
     parser.add_argument(
+        "--decode_calibration_steps",
+        type=int,
+        default=0,
+        help=(
+            "Number of short decode steps to run after each prefill calibration pass. "
+            "Set to 0 to disable decode-path calibration."
+        ),
+    )
+    parser.add_argument(
         "--embedding_weight_bits",
         type=int,
         default=8,
@@ -456,7 +536,6 @@ def main():
     else:
         print("Skipping SpinQuant preprocessing …")
 
-    model.config.use_cache = False  # TODO use args for it
     if args.calibrate_seq_len is not None:
         model.config.max_position_embeddings = min(
             model.config.max_position_embeddings, args.calibrate_seq_len
@@ -491,7 +570,12 @@ def main():
     train_ids = tokenizer(calib_txt, return_tensors="pt").input_ids.to(device)
     calib_inputs = []
     nsamples = args.nsamples_for_qcalibration
-    seqlen = model.config.max_position_embeddings
+    seqlen = model.config.max_position_embeddings - args.decode_calibration_steps
+    if seqlen <= 0:
+        raise ValueError(
+            "decode_calibration_steps must be smaller than max_position_embeddings"
+        )
+
     random.seed(args.seed)
     for _ in range(nsamples):
         i = random.randint(0, train_ids.shape[1] - seqlen - 1)

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -547,13 +547,13 @@ def main():
 
     print("\nCalculating original perplexities …")
     enc = tokenizer("\n\n".join(dataset_test["text"]), return_tensors="pt")
-    ppl_fp32 = perplexity(
-        model, enc, device, max_length=args.max_seq_len, stride=args.max_seq_len
-    )
+    # ppl_fp32 = perplexity(
+    #     model, enc, device, max_length=args.max_seq_len, stride=args.max_seq_len
+    # )
 
-    print("\n┌── Wikitext-2 test perplexity ─────────────")
-    print(f"│ FP32 : {ppl_fp32:8.2f}")
-    print("└───────────────────────────────────────────")
+    # print("\n┌── Wikitext-2 test perplexity ─────────────")
+    # print(f"│ FP32 : {ppl_fp32:8.2f}")
+    # print("└───────────────────────────────────────────")
 
     if args.eval_tasks is not None:
         results = evaluate_llm_on_tasks(

--- a/tico/quantization/wrapq/examples/static_llama_layer_runtime.py
+++ b/tico/quantization/wrapq/examples/static_llama_layer_runtime.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import argparse
-import copy
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Sequence, Tuple
 
@@ -80,10 +79,10 @@ def parse_args():
 
 def _clone_quant_layer(layer: nn.Module) -> nn.Module:
     """
-    Build a wrapped decoder layer using the wrapper.
+    Build a quantized decoder layer wrapper.
 
-    The wrapper keeps a single HF-compatible forward for both prefill and decode.
-    Export-specific specialization is handled later through export adapters.
+    Export-specific specialization is handled through export adapters built
+    from the wrapped layer.
     """
     return prepare(layer, PTQConfig())
 
@@ -160,6 +159,31 @@ def _slice_rope(
     return cos, sin
 
 
+def _slice_prefill_rope(
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
+    seq_len: int,
+    batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Slice prefill RoPE tensors starting from position 0.
+
+    Returns:
+        cos: Tensor with shape (B, seq_len, head_dim).
+        sin: Tensor with shape (B, seq_len, head_dim).
+    """
+    cos = rope_cos[:, :seq_len, :].to(device=device, dtype=dtype)
+    sin = rope_sin[:, :seq_len, :].to(device=device, dtype=dtype)
+
+    if batch_size != 1:
+        cos = cos.expand(batch_size, -1, -1).contiguous()
+        sin = sin.expand(batch_size, -1, -1).contiguous()
+
+    return cos, sin
+
+
 def _build_decode_attention_mask(
     batch_size: int,
     past_len: int,
@@ -190,6 +214,24 @@ def _build_decode_attention_mask(
         mask[:, :, :past_len] = 0.0
 
     mask[:, :, max_seq - 1] = 0.0
+    return mask
+
+
+def _build_prefill_attention_mask(
+    seq_len: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    mask_value: float = -120.0,
+) -> torch.Tensor:
+    """
+    Build a standard additive causal mask for prefill.
+
+    Returns:
+        Tensor with shape (1, seq_len, seq_len).
+    """
+    mask = torch.full((1, seq_len, seq_len), mask_value, device=device, dtype=dtype)
+    mask = torch.triu(mask, diagonal=1)
+    mask = mask.masked_fill(mask == 0, 0.0)
     return mask
 
 
@@ -228,14 +270,25 @@ class StaticLlamaLayerRuntime:
             self.layers = nn.ModuleList(
                 [_clone_quant_layer(layer) for layer in self.layers_ref]
             ).to(self.device)
-            for layer in self.layers:
-                layer.wrapped.return_type = "tuple"
         else:
             self.layers = nn.ModuleList(layers).to(self.device)
 
         for layer in self.layers:
             assert hasattr(layer, "wrapped")
             assert isinstance(layer.wrapped, QuantLlamaDecoderLayer)
+
+        self.prefill_layers = nn.ModuleList(
+            [
+                layer.wrapped.as_export_module("prefill", return_kv=True)
+                for layer in self.layers
+            ]
+        ).to(self.device)
+        self.decode_layers = nn.ModuleList(
+            [
+                layer.wrapped.as_export_module("decode", return_kv=True)
+                for layer in self.layers
+            ]
+        ).to(self.device)
 
         self.config = self.model.config
         self.hidden_size = self.config.hidden_size
@@ -310,29 +363,39 @@ class StaticLlamaLayerRuntime:
 
         self.layer_caches = self._allocate_empty_cache(batch_size, runtime_dtype)
 
-        for layer_idx, layer in enumerate(self.layers):
+        attention_mask = _build_prefill_attention_mask(
+            seq_len=prompt_len,
+            device=self.device,
+            dtype=hidden_states.dtype,
+        )
+        position_embeddings = _slice_prefill_rope(
+            self.rope_cos,
+            self.rope_sin,
+            seq_len=prompt_len,
+            batch_size=batch_size,
+            device=self.device,
+            dtype=hidden_states.dtype,
+        )
+
+        for layer_idx, layer in enumerate(self.prefill_layers):
             out = layer(
                 hidden_states=hidden_states,
-                attention_mask=None,
-                position_embeddings=None,
-                past_key_value=None,
-                use_cache=True,
+                attention_mask=attention_mask,
+                position_embeddings=position_embeddings,
             )
 
-            if not isinstance(out, tuple) or len(out) != 2:
+            if not isinstance(out, tuple) or len(out) != 3:
                 raise RuntimeError(
-                    f"Expected unified decoder layer output as "
-                    f"(hidden_states, present_key_value) when use_cache=True. Got len(out) = {len(out)}."
+                    "Expected prefill adapter output as (hidden_states, new_k, new_v)."
                 )
 
-            hidden_states, present_key_value = out
-            present_k, present_v = present_key_value
+            hidden_states, new_k, new_v = out
 
-            assert present_k.size(2) == prompt_len
-            assert present_v.size(2) == prompt_len
+            assert new_k.size(2) == prompt_len
+            assert new_v.size(2) == prompt_len
 
-            self.layer_caches[layer_idx].past_k[:, :, :prompt_len, :] = present_k
-            self.layer_caches[layer_idx].past_v[:, :, :prompt_len, :] = present_v
+            self.layer_caches[layer_idx].past_k[:, :, :prompt_len, :] = new_k
+            self.layer_caches[layer_idx].past_v[:, :, :prompt_len, :] = new_v
 
         self.past_len = prompt_len
 
@@ -382,7 +445,7 @@ class StaticLlamaLayerRuntime:
             dtype=hidden_states.dtype,
         )
 
-        for layer_idx, layer in enumerate(self.layers):
+        for layer_idx, layer in enumerate(self.decode_layers):
             cache = self.layer_caches[layer_idx]
 
             out = layer(
@@ -390,17 +453,14 @@ class StaticLlamaLayerRuntime:
                 attention_mask=attention_mask,
                 past_key_value=(cache.past_k, cache.past_v),
                 position_embeddings=position_embeddings,
-                use_cache=True,
             )
 
-            if not isinstance(out, tuple) or len(out) != 2:
+            if not isinstance(out, tuple) or len(out) != 3:
                 raise RuntimeError(
-                    "Expected unified decoder layer output as "
-                    "(hidden_states, present_key_value) when use_cache=True."
+                    "Expected decode adapter output as (hidden_states, new_k, new_v)."
                 )
 
-            hidden_states, present_key_value = out
-            new_k, new_v = present_key_value
+            hidden_states, new_k, new_v = out
 
             cache.past_k[:, :, self.past_len : self.past_len + 1, :] = new_k
             cache.past_v[:, :, self.past_len : self.past_len + 1, :] = new_v
@@ -539,6 +599,35 @@ class StaticLlamaLayerRuntime:
             self.rope_sin,
             position=self.past_len,
             batch_size=1,
+            device=self.device,
+            dtype=hidden_states.dtype,
+        )
+
+        return hidden_states, attention_mask, position_embeddings
+
+    @torch.no_grad()
+    def dump_prefill_inputs(
+        self,
+        input_ids: torch.LongTensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        Prepare prefill inputs without running the layers.
+
+        This is useful when debugging export/runtime parity.
+        """
+        hidden_states = self.embed_tokens(input_ids.to(self.device))
+        batch_size, seq_len = input_ids.shape
+
+        attention_mask = _build_prefill_attention_mask(
+            seq_len=seq_len,
+            device=self.device,
+            dtype=hidden_states.dtype,
+        )
+        position_embeddings = _slice_prefill_rope(
+            self.rope_cos,
+            self.rope_sin,
+            seq_len=seq_len,
+            batch_size=batch_size,
             device=self.device,
             dtype=hidden_states.dtype,
         )

--- a/tico/quantization/wrapq/wrappers/llama/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/llama/export_adapters.py
@@ -17,19 +17,10 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
-
-class _AttentionExportAdapterBase(nn.Module):
-    """Base class for thin export adapters around a unified Llama attention wrapper."""
-
-    def __init__(self, attn: nn.Module):
-        super().__init__()
-        self.attn = attn
-
-    def extra_repr(self) -> str:
-        return f"attn={self.attn.__class__.__name__}"
+from transformers.cache_utils import Cache
 
 
-class LlamaAttentionPrefillExportAdapter(_AttentionExportAdapterBase):
+class LlamaAttentionPrefillExportAdapter(nn.Module):
     """
     Export adapter for prefill attention.
 
@@ -37,38 +28,44 @@ class LlamaAttentionPrefillExportAdapter(_AttentionExportAdapterBase):
     wrapper unchanged.
     """
 
-    def __init__(self, attn: nn.Module, *, return_kv: bool = True):
-        super().__init__(attn)
+    def __init__(self, wrapped, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
         self.return_kv = return_kv
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
         attention_mask: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        out = self.attn(
+        **kwargs,
+    ):
+        """
+        Run prefill attention with export-friendly cache semantics.
+
+        When `return_kv=True`, the wrapped attention module is asked to return
+        only the newly produced K/V tensors instead of the full present cache.
+        """
+        outputs = self.wrapped(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
             attention_mask=attention_mask,
             past_key_value=None,
-            output_attentions=False,
             use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
         )
 
-        if self.return_kv:
-            assert len(out) == 3
-            if not isinstance(out, tuple) or len(out) != 3:
-                raise RuntimeError(
-                    "Expected attention output as (hidden_states, attn_weights, (new_k, new_v))."
-                )
-            return (out[0], out[2])
+        hidden = outputs[0]
 
-        assert len(out) == 2
-        return out[0]
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[2]
+        return hidden, new_k, new_v
 
 
-class LlamaAttentionDecodeExportAdapter(_AttentionExportAdapterBase):
+class LlamaAttentionDecodeExportAdapter(nn.Module):
     """
     Export adapter for decode attention.
 
@@ -90,50 +87,46 @@ class LlamaAttentionDecodeExportAdapter(_AttentionExportAdapterBase):
         hidden_states
     """
 
-    def __init__(self, attn: nn.Module, *, return_kv: bool = True):
-        super().__init__(attn)
+    def __init__(self, wrapped, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
         self.return_kv = return_kv
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
-        attention_mask: torch.Tensor,
-        past_key_value: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs,
     ):
-        out = self.attn(
+        """
+        Run decode attention with delta-only cache output.
+
+        The wrapped attention module still builds the full present K/V for
+        attention computation, but only the newly produced K/V tensors are
+        returned to the caller.
+        """
+        outputs = self.wrapped(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
             attention_mask=attention_mask,
             past_key_value=past_key_value,
             use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
         )
 
-        if self.return_kv:
-            assert len(out) == 3
-            if not isinstance(out, tuple) or len(out) != 3:
-                raise RuntimeError(
-                    "Expected attention output as (hidden_states, attn_weights, (new_k, new_v))."
-                )
-            return (out[0], out[2])
+        hidden = outputs[0]
 
-        assert len(out) == 2
-        return out[0]
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[2]
+        return hidden, new_k, new_v
 
 
-class _DecoderLayerExportAdapterBase(nn.Module):
-    """Base class for thin export adapters around a unified decoder layer."""
-
-    def __init__(self, layer: nn.Module):
-        super().__init__()
-        self.layer = layer
-        self.layer.return_type = "tuple"
-
-    def extra_repr(self) -> str:
-        return f"layer={self.layer.__class__.__name__}"
-
-
-class LlamaDecoderLayerPrefillExportAdapter(_DecoderLayerExportAdapterBase):
+class LlamaDecoderLayerPrefillExportAdapter(nn.Module):
     """
     Export adapter for prefill.
 
@@ -141,31 +134,43 @@ class LlamaDecoderLayerPrefillExportAdapter(_DecoderLayerExportAdapterBase):
     wrapper unchanged.
     """
 
-    def __init__(self, layer: nn.Module, *, return_kv: bool = True):
-        super().__init__(layer)
+    def __init__(self, wrapped, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
+        self.wrapped.return_type = "tuple"
         self.return_kv = return_kv
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
-    ) -> torch.Tensor:
-        out = self.layer(
-            hidden_states=hidden_states,
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        **kwargs,
+    ):
+        """
+        Run the decoder layer prefill path and return delta-only K/V tensors
+        when caching is enabled.
+        """
+        outputs = self.wrapped(
+            hidden_states,
             attention_mask=attention_mask,
             position_embeddings=position_embeddings,
-            output_attentions=False,
+            past_key_value=None,
             use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
         )
 
-        if self.return_kv:
-            assert len(out) == 2
-            return out
-        return out[0] if isinstance(out, tuple) else out
+        hidden = outputs[0]
+
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[1]
+        return hidden, new_k, new_v
 
 
-class LlamaDecoderLayerDecodeExportAdapter(_DecoderLayerExportAdapterBase):
+class LlamaDecoderLayerDecodeExportAdapter(nn.Module):
     """
     Export adapter for decode.
 
@@ -187,27 +192,38 @@ class LlamaDecoderLayerDecodeExportAdapter(_DecoderLayerExportAdapterBase):
         hidden_states
     """
 
-    def __init__(self, layer: nn.Module, *, return_kv: bool = True):
-        super().__init__(layer)
+    def __init__(self, wrapped, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
+        self.wrapped.return_type = "tuple"
         self.return_kv = return_kv
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: torch.Tensor,
-        past_key_value: Tuple[torch.Tensor, torch.Tensor],
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        **kwargs,
     ):
-        out = self.layer(
-            hidden_states=hidden_states,
+        """
+        Run the decoder layer decode path and return delta-only K/V tensors
+        when caching is enabled.
+        """
+        outputs = self.wrapped(
+            hidden_states,
             attention_mask=attention_mask,
-            past_key_value=past_key_value,
             position_embeddings=position_embeddings,
-            output_attentions=False,
+            past_key_value=past_key_value,
             use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
         )
 
-        if self.return_kv:
-            assert len(out) == 2
-            return out
-        return out[0] if isinstance(out, tuple) else out
+        hidden = outputs[0]
+
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[1]
+        return hidden, new_k, new_v

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -272,6 +272,9 @@ class QuantLlamaAttention(QuantModuleBase):
                 past_v = getattr(layer_cache, v_name, None)
                 if past_k is not None and past_v is not None:
                     return past_k, past_v
+                # The layer object may exist but still empty, with keys/values=None
+                if hasattr(layer_cache, k_name) and hasattr(layer_cache, v_name):
+                    return None
 
         # 3) tuple-like indexing
         try:

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -204,6 +204,118 @@ class QuantLlamaAttention(QuantModuleBase):
         t_sin = self._fq(t_half * sin, obs_sin)
         return self._fq(t_cos + t_sin, obs_rot)
 
+    def _extract_layer_kv_from_cache(self, cache: Cache) -> Optional[LayerKV]:
+        """
+        Extract per-layer KV tensors from an HF Cache object across multiple
+        transformers cache layouts.
+
+        Returns:
+            A tuple `(past_k, past_v)` with shape `(B, n_kv, K, H)` if available,
+            otherwise None.
+        """
+        if self.layer_idx is None:
+            raise RuntimeError(
+                "layer_idx must be set to extract per-layer KV from an HF Cache."
+            )
+
+        layer_idx = self.layer_idx
+
+        # Empty cache should behave like no past KV.
+        get_seq_length = getattr(cache, "get_seq_length", None)
+        if callable(get_seq_length):
+            try:
+                if int(get_seq_length()) == 0:
+                    return None
+            except TypeError:
+                try:
+                    if int(get_seq_length(layer_idx)) == 0:
+                        return None
+                except Exception:
+                    pass
+            except Exception:
+                pass
+
+        # 1) key_cache / value_cache layout
+        key_cache = getattr(cache, "key_cache", None)
+        value_cache = getattr(cache, "value_cache", None)
+        if key_cache is not None and value_cache is not None:
+            if layer_idx >= len(key_cache) or layer_idx >= len(value_cache):
+                return None
+            past_k = key_cache[layer_idx]
+            past_v = value_cache[layer_idx]
+            if past_k is None or past_v is None:
+                return None
+            return past_k, past_v
+
+        # 2) layers[layer_idx] layout
+        layers = getattr(cache, "layers", None)
+        if layers is not None:
+            if layer_idx >= len(layers):
+                return None
+
+            layer_cache = layers[layer_idx]
+            if layer_cache is None:
+                return None
+
+            if isinstance(layer_cache, tuple):
+                if len(layer_cache) >= 2:
+                    past_k, past_v = layer_cache[0], layer_cache[1]
+                    if past_k is not None and past_v is not None:
+                        return past_k, past_v
+
+            for k_name, v_name in (
+                ("keys", "values"),
+                ("key", "value"),
+                ("k", "v"),
+            ):
+                past_k = getattr(layer_cache, k_name, None)
+                past_v = getattr(layer_cache, v_name, None)
+                if past_k is not None and past_v is not None:
+                    return past_k, past_v
+
+        # 3) tuple-like indexing
+        try:
+            layer_cache = cache[layer_idx]  # type: ignore[index]
+        except Exception:
+            layer_cache = None
+
+        if layer_cache is not None:
+            if isinstance(layer_cache, tuple) and len(layer_cache) >= 2:
+                past_k, past_v = layer_cache[0], layer_cache[1]
+                if past_k is not None and past_v is not None:
+                    return past_k, past_v
+
+        # 4) fallback: convert whole cache to legacy cache if supported
+        to_legacy_cache = getattr(cache, "to_legacy_cache", None)
+        if callable(to_legacy_cache):
+            try:
+                legacy_cache = to_legacy_cache()
+                if legacy_cache is None:
+                    return None
+                if layer_idx >= len(legacy_cache):
+                    return None
+
+                layer_cache = legacy_cache[layer_idx]
+                if layer_cache is None:
+                    return None
+
+                if isinstance(layer_cache, tuple) and len(layer_cache) >= 2:
+                    past_k, past_v = layer_cache[0], layer_cache[1]
+                    if past_k is None or past_v is None:
+                        return None
+                    return past_k, past_v
+            except Exception:
+                pass
+
+        raise RuntimeError(
+            "Unsupported Cache layout. "
+            f"type={type(cache)}, layer_idx={layer_idx}, "
+            f"has_key_cache={hasattr(cache, 'key_cache')}, "
+            f"has_value_cache={hasattr(cache, 'value_cache')}, "
+            f"has_layers={hasattr(cache, 'layers')}, "
+            f"has_to_legacy_cache={hasattr(cache, 'to_legacy_cache')}"
+        )
+
     def _normalize_past_key_value(
         self,
         past_key_value: Optional[Cache | LayerKV],
@@ -230,31 +342,7 @@ class QuantLlamaAttention(QuantModuleBase):
                 return None
             return past_key_value
 
-        if self.layer_idx is None:
-            raise RuntimeError(
-                "layer_idx must be set to convert a Cache object into per-layer KV."
-            )
-
-        if not hasattr(past_key_value, "to_legacy_cache"):
-            raise RuntimeError(
-                f"Unsupported Cache type without to_legacy_cache(): {type(past_key_value)}"
-            )
-
-        legacy_cache = past_key_value.to_legacy_cache()
-        if legacy_cache is None:
-            return None
-
-        if self.layer_idx >= len(legacy_cache):
-            return None
-
-        layer_cache = legacy_cache[self.layer_idx]
-        if layer_cache is None:
-            return None
-
-        past_k, past_v = layer_cache
-        if past_k is None or past_v is None:
-            return None
-        return past_k, past_v
+        return self._extract_layer_kv_from_cache(past_key_value)
 
     def _get_past_len(
         self,

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -17,6 +17,8 @@ from typing import List, Literal, Optional, Tuple
 import torch
 import torch.nn as nn
 
+from transformers.cache_utils import Cache
+
 from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
     LlamaAttentionDecodeExportAdapter,
@@ -25,6 +27,10 @@ from tico.quantization.wrapq.wrappers.llama.export_adapters import (
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+CacheOutputMode = Literal["present", "delta"]
+LayerKV = Tuple[torch.Tensor, torch.Tensor]
 
 
 @try_register(
@@ -45,8 +51,10 @@ class QuantLlamaAttention(QuantModuleBase):
     --------
     - If `past_key_value` is None, this behaves like a regular prefill step.
     - If `past_key_value` is not None, current K/V are concatenated to the past.
-    - If `use_cache=True`, the returned cache is always the full present K/V.
-      Export adapters may post-process this into a delta-only form if needed.
+    - If `use_cache=True`, the returned cache format is controlled by
+      `cache_output_mode`:
+        - "present": return the full present cache
+        - "delta": return only the newly produced K/V
     """
 
     def __init__(
@@ -55,11 +63,13 @@ class QuantLlamaAttention(QuantModuleBase):
         *,
         qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
+        layer_idx: Optional[int] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)
 
         cfg = fp_attn.config
         self.config = cfg
+        self.layer_idx = layer_idx
 
         assert hasattr(cfg, "hidden_size") and hasattr(cfg, "num_attention_heads")
         assert hasattr(cfg, "num_key_value_heads") and hasattr(
@@ -194,81 +204,296 @@ class QuantLlamaAttention(QuantModuleBase):
         t_sin = self._fq(t_half * sin, obs_sin)
         return self._fq(t_cos + t_sin, obs_rot)
 
-    def _concat_kv(
+    def _normalize_past_key_value(
         self,
-        past: Optional[Tuple[torch.Tensor, torch.Tensor]],
-        k_new: torch.Tensor,
-        v_new: torch.Tensor,
-        kv_idx: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Concat along sequence dim for one kv head."""
-        if past is None:
-            return k_new, v_new
-        past_k, past_v = past
-        past_k = self._fq(past_k, self.obs_past_key)
-        past_v = self._fq(past_v, self.obs_past_value)
-        k = torch.cat([past_k[:, kv_idx, :, :], k_new], dim=1)
-        v = torch.cat([past_v[:, kv_idx, :, :], v_new], dim=1)
-        return k, v
+        past_key_value: Optional[Cache | LayerKV],
+    ) -> Optional[LayerKV]:
+        """
+        Convert an HF cache object into a per-layer legacy KV tuple.
+
+        Args:
+            past_key_value: Input cache in HF `Cache` form or legacy tuple form.
+
+        Returns:
+            A per-layer tuple `(past_k, past_v)` if cache exists, otherwise None.
+
+        Raises:
+            RuntimeError: If a `Cache` object is provided but this module cannot
+                extract the current layer's KV tensors.
+        """
+        if past_key_value is None:
+            return None
+
+        if isinstance(past_key_value, tuple):
+            past_k, past_v = past_key_value
+            if past_k is None or past_v is None:
+                return None
+            return past_key_value
+
+        if self.layer_idx is None:
+            raise RuntimeError(
+                "layer_idx must be set to convert a Cache object into per-layer KV."
+            )
+
+        if not hasattr(past_key_value, "to_legacy_cache"):
+            raise RuntimeError(
+                f"Unsupported Cache type without to_legacy_cache(): {type(past_key_value)}"
+            )
+
+        legacy_cache = past_key_value.to_legacy_cache()
+        if legacy_cache is None:
+            return None
+
+        if self.layer_idx >= len(legacy_cache):
+            return None
+
+        layer_cache = legacy_cache[self.layer_idx]
+        if layer_cache is None:
+            return None
+
+        past_k, past_v = layer_cache
+        if past_k is None or past_v is None:
+            return None
+        return past_k, past_v
+
+    def _get_past_len(
+        self,
+        past_key_value: Optional[LayerKV],
+    ) -> int:
+        """
+        Return the cached sequence length for the current layer.
+
+        Args:
+            past_key_value: Per-layer legacy KV tuple or None.
+
+        Returns:
+            Cached key/value length for this layer.
+        """
+        if past_key_value is None:
+            return 0
+
+        past_k, past_v = past_key_value
+        if past_k is None or past_v is None:
+            return 0
+
+        return int(past_k.shape[2])
 
     def _build_attention_mask(
         self,
         *,
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor],
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        past_key_value: Optional[LayerKV],
         device: torch.device,
     ) -> torch.Tensor:
         """
-        Return an additive attention mask usable with per-head logits.
+        Build an additive attention mask for per-head logits.
 
         Supported cases:
         - None: build a causal mask slice.
-        - bool mask: convert to additive mask using 0 / -120.
+        - bool/int mask: convert to additive mask using 0 / -120.
         - additive mask: use as-is.
+
+        Args:
+            hidden_states: Current hidden states with shape `(B, S, D)`.
+            attention_mask: Optional attention mask from the caller.
+            past_key_value: Per-layer cached KV tuple or None.
+            device: Device where the mask should live.
+
+        Returns:
+            Additive attention mask with shape broadcastable to `(B, S, K)`.
         """
         q_len = hidden_states.size(1)
-        past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+        past_len = self._get_past_len(past_key_value)
         k_len = past_len + q_len
 
         if attention_mask is None:
             assert isinstance(self.causal_mask_template, torch.Tensor)
-            mask = self.causal_mask_template[..., :q_len, :k_len].to(device)
+            mask = self.causal_mask_template[
+                ..., past_len : past_len + q_len, :k_len
+            ].to(device)
             mask = mask.squeeze(0)
             return self._fq(mask, self.obs_attn_mask)
 
-        if attention_mask.dtype == torch.bool:
+        if attention_mask.dtype in (torch.bool, torch.int64):
+            if attention_mask.dtype == torch.int64:
+                attention_mask = attention_mask != 0
+
+            assert isinstance(self.causal_mask_template, torch.Tensor)
+            causal_mask = self.causal_mask_template[
+                ..., past_len : past_len + q_len, :k_len
+            ].to(device)
+
             additive = torch.zeros_like(attention_mask, dtype=torch.float32)
             additive = additive.masked_fill(~attention_mask, float("-120"))
-            return self._fq(additive, self.obs_attn_mask)
+
+            # Combine causal mask and padding mask.
+            mask = torch.clamp(causal_mask + additive, min=-120.0)
+            return self._fq(mask.squeeze(0), self.obs_attn_mask)
 
         return self._fq(attention_mask, self.obs_attn_mask)
+
+    def _get_past_kv_head(
+        self,
+        *,
+        past_key_value: Optional[LayerKV],
+        kv_idx: int,
+    ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """
+        Extract one KV head slice from the normalized past cache.
+
+        Args:
+            past_key_value: Per-layer legacy KV tuple or None.
+            kv_idx: KV-head index to read.
+
+        Returns:
+            A tuple `(past_k_i, past_v_i)` with shape `(B, Kpast, H)` for each
+            tensor, or `(None, None)` if no past cache exists.
+        """
+        if past_key_value is None:
+            return None, None
+
+        past_k, past_v = past_key_value
+        if past_k is None or past_v is None:
+            return None, None
+
+        past_k_i = self._fq(past_k[:, kv_idx, :, :], self.obs_past_key)
+        past_v_i = self._fq(past_v[:, kv_idx, :, :], self.obs_past_value)
+        return past_k_i, past_v_i
+
+    def _build_present_kv_head(
+        self,
+        *,
+        past_k_i: Optional[torch.Tensor],
+        past_v_i: Optional[torch.Tensor],
+        new_k_i: torch.Tensor,
+        new_v_i: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Build the full KV tensors used by attention for one KV head.
+
+        Args:
+            past_k_i: Past key states with shape `(B, Kpast, H)` or None.
+            past_v_i: Past value states with shape `(B, Kpast, H)` or None.
+            new_k_i: New key states with shape `(B, S, H)`.
+            new_v_i: New value states with shape `(B, S, H)`.
+
+        Returns:
+            A tuple `(present_k_i, present_v_i)` with shape `(B, K, H)`.
+        """
+        if past_k_i is None:
+            present_k_i = self._fq(new_k_i, self.obs_present_key)
+            present_v_i = self._fq(new_v_i, self.obs_present_value)
+            return present_k_i, present_v_i
+
+        present_k_i = self._fq(
+            torch.cat([past_k_i, new_k_i], dim=1),
+            self.obs_present_key,
+        )
+        present_v_i = self._fq(
+            torch.cat([past_v_i, new_v_i], dim=1),
+            self.obs_present_value,
+        )
+        return present_k_i, present_v_i
+
+    def _finalize_cache_output(
+        self,
+        *,
+        past_key_value_in: Optional[Cache | LayerKV],
+        new_k_parts: list[torch.Tensor],
+        new_v_parts: list[torch.Tensor],
+        present_k_parts: list[torch.Tensor],
+        present_v_parts: list[torch.Tensor],
+        cache_output_mode: CacheOutputMode,
+    ) -> Cache | LayerKV:
+        """
+        Finalize the cache object returned by forward.
+
+        Args:
+            past_key_value_in: Original input cache in HF `Cache` or legacy form.
+            new_k_parts: Per-head new key tensors of shape `(B, S, H)`.
+            new_v_parts: Per-head new value tensors of shape `(B, S, H)`.
+            present_k_parts: Per-head full key tensors of shape `(B, K, H)`.
+            present_v_parts: Per-head full value tensors of shape `(B, K, H)`.
+            cache_output_mode: Cache return policy.
+
+        Returns:
+            Cache object to return from forward:
+            - delta `(new_k, new_v)` if `cache_output_mode == "delta"`
+            - updated HF `Cache` if the input cache was an HF cache
+            - full present legacy tuple otherwise
+        """
+        if cache_output_mode not in ("present", "delta"):
+            raise ValueError(f"Unsupported cache_output_mode: {cache_output_mode!r}")
+
+        new_k = self._fq(torch.stack(new_k_parts, dim=1), self.obs_new_k)
+        new_v = self._fq(torch.stack(new_v_parts, dim=1), self.obs_new_v)
+
+        if cache_output_mode == "delta":
+            return new_k, new_v
+
+        if isinstance(past_key_value_in, Cache):
+            if self.layer_idx is None:
+                raise RuntimeError(
+                    "layer_idx must be set to update an HF Cache object."
+                )
+            past_key_value_in.update(new_k, new_v, self.layer_idx, cache_kwargs=None)
+            return past_key_value_in
+
+        present_k = self._fq(torch.stack(present_k_parts, dim=1), self.obs_present_key)
+        present_v = self._fq(
+            torch.stack(present_v_parts, dim=1), self.obs_present_value
+        )
+        return present_k, present_v
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: Optional[torch.Tensor] = None,
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        past_key_value: Optional[Cache | LayerKV] = None,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        cache_output_mode: CacheOutputMode = "present",
         **kwargs,
     ):
+        """
+        Run quantized Llama attention.
+
+        Args:
+            hidden_states: Input hidden states with shape `(B, S, D)`.
+            position_embeddings: Rotary cosine and sine tensors.
+            attention_mask: Optional additive or boolean attention mask.
+            past_key_value: Optional cache in HF `Cache` or legacy tuple form.
+            use_cache: Whether to return cache output.
+            cache_position: Unused compatibility placeholder.
+            cache_output_mode: Cache return policy.
+                - "present": return the full present cache.
+                - "delta": return only the newly produced K/V.
+            **kwargs: Extra compatibility arguments ignored by this wrapper.
+
+        Returns:
+            A tuple of:
+                - attention output
+                - attention weights
+                - optional cache output when `use_cache=True`
+        """
+        del cache_position, kwargs
+
+        past_key_value_in = past_key_value
+        past_key_value = self._normalize_past_key_value(past_key_value)
+
         hidden = self._fq(hidden_states, self.obs_hidden)
         B, S, _ = hidden.shape
         H = self.head_dim
 
-        q = self.q_proj(hidden).view(B, S, -1, H)  # (B, S, n_h, H)
-        k = self.k_proj(hidden).view(B, S, -1, H)  # (B, K, n_kv, H)
-        v = self.v_proj(hidden).view(B, S, -1, H)  # (B, K, n_kv, H)
+        q = self.q_proj(hidden).view(B, S, self.num_heads, H)
+        k = self.k_proj(hidden).view(B, S, self.num_kv_heads, H)
+        v = self.v_proj(hidden).view(B, S, self.num_kv_heads, H)
 
-        # Rope tables
         cos, sin = position_embeddings
         cos = self._fq(cos, self.obs_cos)
         sin = self._fq(sin, self.obs_sin)
-
-        past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
-        key_len = past_len + S
 
         attn_mask = self._build_attention_mask(
             hidden_states=hidden_states,
@@ -277,18 +502,20 @@ class QuantLlamaAttention(QuantModuleBase):
             device=hidden.device,
         )
 
-        attn_weights_parts: List[torch.Tensor] = []
-        attn_out_parts: List[torch.Tensor] = []
-        new_k_parts: List[torch.Tensor] = []
-        new_v_parts: List[torch.Tensor] = []
+        attn_weights_parts: list[torch.Tensor] = []
+        attn_out_parts: list[torch.Tensor] = []
+
+        new_k_parts: list[torch.Tensor] = []
+        new_v_parts: list[torch.Tensor] = []
+        present_k_parts: list[torch.Tensor] = []
+        present_v_parts: list[torch.Tensor] = []
 
         for kv_i in range(self.num_kv_heads):
-            # k_h, v_h: (B, K, H)
-            k_i_new = k[:, :, kv_i, :]
-            v_i_new = v[:, :, kv_i, :]
+            new_k_i = k[:, :, kv_i, :]
+            new_v_i = v[:, :, kv_i, :]
 
-            k_i_new = self._apply_rope(
-                k_i_new,
+            new_k_i = self._apply_rope(
+                new_k_i,
                 cos,
                 sin,
                 self.obs_k_x1,
@@ -298,17 +525,32 @@ class QuantLlamaAttention(QuantModuleBase):
                 self.obs_k_sin,
                 self.obs_k_rot,
             )
-            new_k_parts.append(k_i_new)
-            new_v_parts.append(v_i_new)
 
-            k_i, v_i = self._concat_kv(past_key_value, k_i_new, v_i_new, kv_i)
-            k_i = self._fq(k_i, self.obs_present_key)
-            v_i = self._fq(v_i, self.obs_present_value)
+            past_k_i, past_v_i = self._get_past_kv_head(
+                past_key_value=past_key_value,
+                kv_idx=kv_i,
+            )
+
+            present_k_i, present_v_i = self._build_present_kv_head(
+                past_k_i=past_k_i,
+                past_v_i=past_v_i,
+                new_k_i=new_k_i,
+                new_v_i=new_v_i,
+            )
+
+            new_k_parts.append(new_k_i)
+            new_v_parts.append(new_v_i)
+
+            if cache_output_mode == "present" and not isinstance(
+                past_key_value_in, Cache
+            ):
+                present_k_parts.append(present_k_i)
+                present_v_parts.append(present_v_i)
 
             for rep_i in range(self.kv_rep):
                 q_idx = kv_i * self.kv_rep + rep_i
-                # q_h: (B, S, H)
                 q_i = q[:, :, q_idx, :]
+
                 q_i = self._apply_rope(
                     q_i,
                     cos,
@@ -321,48 +563,52 @@ class QuantLlamaAttention(QuantModuleBase):
                     self.obs_q_rot,
                 )
 
-                # logits: (B, S, K)
-                logits_i = self._fq(q_i @ k_i.transpose(-2, -1), self.obs_logits)
+                logits_i = self._fq(
+                    q_i @ present_k_i.transpose(-2, -1),
+                    self.obs_logits,
+                )
 
                 assert attn_mask.shape[-2:] == logits_i.shape[-2:], (
                     attn_mask.shape,
                     logits_i.shape,
                 )
+
                 logits_i = self._fq(logits_i + attn_mask, self.obs_mask_add)
 
-                # softmax
                 attn_i = torch.softmax(logits_i, dim=-1, dtype=torch.float32).to(
                     q_i.dtype
                 )
                 attn_i = self._fq(attn_i, self.obs_softmax)
 
-                # out: (B, S, H)
-                out_i = self._fq(attn_i @ v_i, self.obs_attn_out)
+                out_i = self._fq(attn_i @ present_v_i, self.obs_attn_out)
 
                 attn_weights_parts.append(attn_i)
                 attn_out_parts.append(out_i)
 
-        # Concat heads back
-        # (B, n_h, S, K)
         attn_weights = self._fq(
-            torch.stack(attn_weights_parts, dim=1), self.obs_attn_weights
+            torch.stack(attn_weights_parts, dim=1),
+            self.obs_attn_weights,
         )
-        # (B, n_h, S, H)
-        attn_out_h = self._fq(torch.stack(attn_out_parts, dim=1), self.obs_attn_out_h)
-        # Attention output: (B, S, n_h * H)
+        attn_out_h = self._fq(
+            torch.stack(attn_out_parts, dim=1),
+            self.obs_attn_out_h,
+        )
+
         attn_out = attn_out_h.transpose(1, 2).reshape(B, S, -1)
-        # Final projection: (B, 1, D)
         out = self.o_proj(attn_out)
 
         outputs = (out, attn_weights)
 
         if use_cache:
-            # New kv delta: (B, n_kv, S, H)
-            new_k = torch.stack(new_k_parts, dim=1)
-            new_v = torch.stack(new_v_parts, dim=1)
-            new_k = self._fq(new_k, self.obs_new_k)
-            new_v = self._fq(new_v, self.obs_new_v)
-            outputs += ((new_k, new_v),)  # type: ignore[assignment]
+            cache_out = self._finalize_cache_output(
+                past_key_value_in=past_key_value_in,
+                new_k_parts=new_k_parts,
+                new_v_parts=new_v_parts,
+                present_k_parts=present_k_parts,
+                present_v_parts=present_v_parts,
+                cache_output_mode=cache_output_mode,
+            )
+            outputs += (cache_out,)  # type: ignore[assignment]
 
         return outputs
 

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -17,6 +17,8 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
+from transformers.cache_utils import Cache
+
 from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
     LlamaDecoderLayerDecodeExportAdapter,
@@ -46,6 +48,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
         return_type: Optional[str] = None,
+        layer_idx: Optional[int] = None,
     ):
         """
         Q) Why do we need `return_type`?
@@ -61,6 +64,8 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         assert self.return_type is not None
 
         super().__init__(qcfg, fp_name=fp_name)
+
+        self.layer_idx = layer_idx
 
         attn_cfg = qcfg.child("self_attn") if qcfg else None
         mlp_cfg = qcfg.child("mlp") if qcfg else None
@@ -83,6 +88,10 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
             qcfg=attn_cfg,
             fp_name=f"{fp_name}.self_attn" if fp_name else None,
         )
+        if hasattr(self.self_attn, "wrapped") and hasattr(
+            self.self_attn.wrapped, "layer_idx"
+        ):
+            self.self_attn.wrapped.layer_idx = layer_idx
         self.mlp = PTQWrapper(
             fp_layer.mlp,
             qcfg=mlp_cfg,
@@ -167,16 +176,31 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         sin = self.rope_sin_template[:, start:end, :].to(device=device, dtype=dtype)
         return cos, sin
 
+    def _get_past_len(
+        self,
+        past_key_value: Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
+    ) -> int:
+        if past_key_value is None:
+            return 0
+        if isinstance(past_key_value, Cache):
+            return past_key_value.get_seq_length()
+
+        past_k, past_v = past_key_value
+        if past_k is None or past_v is None:
+            return 0
+
+        return int(past_k.shape[2])
+
     def _normalize_position_embeddings(
         self,
         *,
         hidden_states: torch.Tensor,
         position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]],
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        past_key_value: Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if position_embeddings is None:
             q_len = hidden_states.size(1)
-            past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+            past_len = self._get_past_len(past_key_value)
             cos, sin = self._slice_rope(
                 start=past_len,
                 seq_len=q_len,
@@ -192,7 +216,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         *,
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor],
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        past_key_value: Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
         device: torch.device,
     ) -> torch.Tensor:
         """
@@ -204,19 +228,30 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         - additive mask: use as-is.
         """
         q_len = hidden_states.size(1)
-        past_len = 0 if past_key_value is None else int(past_key_value[0].shape[2])
+        past_len = self._get_past_len(past_key_value)
         k_len = past_len + q_len
 
         if attention_mask is None:
             assert isinstance(self.causal_mask_template, torch.Tensor)
-            mask = self.causal_mask_template[..., :q_len, :k_len].to(device)
-            mask = mask.squeeze(0)
-            return self._fq(mask, self.obs_attn_mask)
+            mask = self.causal_mask_template[
+                ..., past_len : past_len + q_len, :k_len
+            ].to(device)
+            return self._fq(mask.squeeze(0), self.obs_attn_mask)
 
-        if attention_mask.dtype == torch.bool:
+        if attention_mask.dtype in (torch.bool, torch.int64):
+            if attention_mask.dtype == torch.int64:
+                attention_mask = attention_mask != 0
+
+            assert isinstance(self.causal_mask_template, torch.Tensor)
+            causal_mask = self.causal_mask_template[
+                ..., past_len : past_len + q_len, :k_len
+            ].to(device)
+
             additive = torch.zeros_like(attention_mask, dtype=torch.float32)
             additive = additive.masked_fill(~attention_mask, float("-120"))
-            return self._fq(additive, self.obs_attn_mask)
+
+            mask = torch.clamp(causal_mask + additive, min=-120.0)
+            return self._fq(mask.squeeze(0), self.obs_attn_mask)
 
         return self._fq(attention_mask, self.obs_attn_mask)
 
@@ -229,7 +264,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
     ) -> tuple[
         torch.Tensor,
         Optional[torch.Tensor],
-        Optional[Tuple[torch.Tensor, torch.Tensor]],
+        Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
     ]:
         if not isinstance(attn_out, tuple):
             return attn_out, None, None
@@ -254,7 +289,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        past_key_value: Optional[Cache | Tuple[torch.Tensor, torch.Tensor]] = None,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -28,6 +28,9 @@ from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
 
 
+LegacyCache = Tuple[Tuple[torch.Tensor, torch.Tensor], ...]
+
+
 @try_register(
     "transformers.models.llama.modeling_llama.LlamaModel",
     "tico.quantization.algorithm.spinquant.spin_llama.SpinLlamaModel",
@@ -80,13 +83,29 @@ class QuantLlamaModel(QuantModuleBase):
         for idx, layer in enumerate(model_fp.layers):
             child_scope = f"{fp_name}.layers.{idx}"
             child_cfg = layers_cfg.child(child_scope) if layers_cfg is not None else None  # type: ignore[union-attr]
-            new_list.append(
-                PTQWrapper(
-                    layer,
-                    child_cfg,
-                    fp_name=child_scope,
-                )
+            wrapped_layer = PTQWrapper(
+                layer,
+                child_cfg,
+                fp_name=child_scope,
             )
+
+            # Generation/cache path needs tuple outputs from decoder layers.
+            if hasattr(wrapped_layer.wrapped, "return_type"):
+                wrapped_layer.wrapped.return_type = "tuple"
+
+            # Pass layer index down so QuantLlamaAttention can update the
+            # correct slot in Cache / DynamicCache.
+            if hasattr(wrapped_layer.wrapped, "layer_idx"):
+                wrapped_layer.wrapped.layer_idx = idx
+            if (
+                hasattr(wrapped_layer.wrapped, "self_attn")
+                and hasattr(wrapped_layer.wrapped.self_attn, "wrapped")
+                and hasattr(wrapped_layer.wrapped.self_attn.wrapped, "layer_idx")
+            ):
+                wrapped_layer.wrapped.self_attn.wrapped.layer_idx = idx
+
+            new_list.append(wrapped_layer)
+
         self.obs_causal_mask = self._make_obs("causal_mask")
         self.obs_cos = self._make_obs("cos")
         self.obs_sin = self._make_obs("sin")
@@ -143,24 +162,112 @@ class QuantLlamaModel(QuantModuleBase):
         self.register_buffer("rope_cos_template", cos_t, persistent=False)
         self.register_buffer("rope_sin_template", sin_t, persistent=False)
 
-    def _slice_causal(self, seq_len: int, device: torch.device) -> torch.Tensor:
-        """Return `[1,1,L,L]` causal mask slice on *device*."""
+    def _normalize_past_key_values(
+        self,
+        past_key_values: Optional[Cache | LegacyCache],
+        *,
+        use_cache: bool,
+    ) -> tuple[Optional[Cache], bool]:
+        """
+        Returns:
+            normalized_cache: Cache | None
+            return_legacy_cache: whether output should be converted back to legacy tuple
+        """
+        if past_key_values is None:
+            if use_cache:
+                return DynamicCache(config=self.config), False
+            return None, False
+
+        if isinstance(past_key_values, Cache):
+            return past_key_values, False
+
+        # legacy tuple path
+        return DynamicCache.from_legacy_cache(past_key_values), True
+
+    def _format_output_cache(
+        self,
+        cache: Optional[Cache],
+        *,
+        use_cache: bool,
+        return_legacy_cache: bool,
+    ):
+        if not use_cache or cache is None:
+            return None
+        if return_legacy_cache:
+            if hasattr(cache, "to_legacy_cache"):
+                return cache.to_legacy_cache()
+            raise RuntimeError(
+                "Cache does not support to_legacy_cache(), but legacy cache output was requested."
+            )
+        return cache
+
+    def _slice_causal(
+        self,
+        *,
+        q_len: int,
+        k_len: int,
+        past_len: int,
+        device: torch.device,
+    ) -> torch.Tensor:
         assert isinstance(self.causal_mask_template, torch.Tensor)
-        return self.causal_mask_template[..., :seq_len, :seq_len].to(device)
+        return self.causal_mask_template[..., past_len : past_len + q_len, :k_len].to(
+            device
+        )
 
-    def get_attention_mask_for(self, x):
-        L = x.size(1)
-        attention_mask = self._slice_causal(L, x.device)
-        return attention_mask
+    def get_attention_mask_for(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        *,
+        past_len: int,
+    ) -> torch.Tensor:
+        q_len = hidden_states.size(1)
+        k_len = past_len + q_len
+        device = hidden_states.device
 
-    def get_position_embeddings_for(self, hidden_states):
+        if attention_mask is None:
+            causal_mask = self._slice_causal(
+                q_len=q_len,
+                k_len=k_len,
+                past_len=past_len,
+                device=device,
+            )
+            return self._fq(causal_mask.squeeze(0), self.obs_causal_mask)
+
+        if attention_mask.dtype in (torch.bool, torch.int64):
+            if attention_mask.dtype == torch.int64:
+                attention_mask = attention_mask != 0
+
+            causal_mask = self._slice_causal(
+                q_len=q_len,
+                k_len=k_len,
+                past_len=past_len,
+                device=device,
+            )
+
+            additive = torch.zeros_like(attention_mask, dtype=torch.float32)
+            additive = additive.masked_fill(~attention_mask, float("-120"))
+            mask = torch.clamp(causal_mask + additive, min=-120.0)
+            return self._fq(mask.squeeze(0), self.obs_causal_mask)
+
+        return self._fq(attention_mask, self.obs_causal_mask)
+
+    def get_position_embeddings_for(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        start: int,
+    ):
+        end = start + hidden_states.size(1)
+        cos = self.rope_cos_template[:, start:end, :].to(
+            dtype=hidden_states.dtype, device=hidden_states.device
+        )
+        sin = self.rope_sin_template[:, start:end, :].to(
+            dtype=hidden_states.dtype, device=hidden_states.device
+        )
         return (
-            self.rope_cos_template.to(
-                dtype=hidden_states.dtype, device=hidden_states.device
-            ),
-            self.rope_sin_template.to(
-                dtype=hidden_states.dtype, device=hidden_states.device
-            ),
+            self._fq(cos, self.obs_cos),
+            self._fq(sin, self.obs_sin),
         )
 
     def forward(
@@ -168,7 +275,7 @@ class QuantLlamaModel(QuantModuleBase):
         input_ids: torch.LongTensor = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Cache] = None,
+        past_key_values: Optional[Cache | LegacyCache] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
@@ -201,13 +308,14 @@ class QuantLlamaModel(QuantModuleBase):
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        if use_cache and past_key_values is None:
-            past_key_values = DynamicCache()
+        cache, return_legacy_cache = self._normalize_past_key_values(
+            past_key_values,
+            use_cache=bool(use_cache),
+        )
+
+        past_seen_tokens = cache.get_seq_length() if cache is not None else 0
 
         if cache_position is None:
-            past_seen_tokens = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
             cache_position = torch.arange(
                 past_seen_tokens,
                 past_seen_tokens + inputs_embeds.shape[1],
@@ -224,15 +332,14 @@ class QuantLlamaModel(QuantModuleBase):
             hidden_states = self.rotate_embedding(hidden_states)
 
         # create position_embeddings and causal_mask to be shared across all the decoder layers
-        causal_mask = self.get_attention_mask_for(hidden_states)
-        causal_mask = causal_mask.squeeze(0)
-        causal_mask = self._fq(causal_mask, self.obs_causal_mask)
-
-        position_embeddings = self.get_position_embeddings_for(hidden_states)
-        cos, sin = position_embeddings
-        position_embeddings = (
-            self._fq(cos[:, : hidden_states.size(1), :], self.obs_cos),
-            self._fq(sin[:, : hidden_states.size(1), :], self.obs_sin),
+        model_attention_mask = self.get_attention_mask_for(
+            hidden_states,
+            attention_mask,
+            past_len=past_seen_tokens,
+        )
+        position_embeddings = self.get_position_embeddings_for(
+            hidden_states,
+            start=past_seen_tokens,
         )
 
         # decoder layers
@@ -245,9 +352,9 @@ class QuantLlamaModel(QuantModuleBase):
 
             layer_outputs = decoder_layer(
                 hidden_states,
-                attention_mask=causal_mask,
+                attention_mask=model_attention_mask,
                 position_ids=position_ids,
-                past_key_value=past_key_values,
+                past_key_value=cache,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
                 cache_position=cache_position,
@@ -255,10 +362,7 @@ class QuantLlamaModel(QuantModuleBase):
                 **flash_attn_kwargs,
             )
 
-            if decoder_layer.wrapped.return_type == "tuple":
-                hidden_states = layer_outputs[0]
-            else:
-                hidden_states = layer_outputs
+            hidden_states = layer_outputs[0]
 
             if output_attentions:
                 all_self_attns += (layer_outputs[1],)  # type: ignore[operator]
@@ -269,9 +373,15 @@ class QuantLlamaModel(QuantModuleBase):
         if output_hidden_states:
             all_hidden_states += (hidden_states,)  # type: ignore[operator]
 
+        formatted_cache = self._format_output_cache(
+            cache,
+            use_cache=bool(use_cache),
+            return_legacy_cache=return_legacy_cache,
+        )
+
         output = BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=past_key_values if use_cache else None,
+            past_key_values=formatted_cache,
             hidden_states=all_hidden_states,
             attentions=all_self_attns,
         )

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -162,6 +162,202 @@ class QuantLlamaModel(QuantModuleBase):
         self.register_buffer("rope_cos_template", cos_t, persistent=False)
         self.register_buffer("rope_sin_template", sin_t, persistent=False)
 
+    def _make_empty_cache(self) -> Cache:
+        """
+        Create an empty HF cache object in a version-tolerant way.
+
+        Returns:
+            An empty cache instance.
+
+        Raises:
+            RuntimeError: If no compatible cache constructor is available.
+        """
+        try:
+            return DynamicCache(config=self.config)
+        except TypeError:
+            pass
+        except Exception:
+            pass
+
+        try:
+            return DynamicCache()
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to create an empty DynamicCache for type={DynamicCache}: {e}"
+            ) from e
+
+    def _legacy_cache_seq_length(self, past_key_values: LegacyCache) -> int:
+        """
+        Infer sequence length from a legacy tuple cache.
+
+        Args:
+            past_key_values: Legacy tuple of per-layer key/value tensors.
+
+        Returns:
+            Cached sequence length inferred from the first layer.
+        """
+        if len(past_key_values) == 0:
+            return 0
+
+        first_layer = past_key_values[0]
+        if first_layer is None or len(first_layer) < 2:
+            return 0
+
+        past_k, past_v = first_layer
+        if past_k is None or past_v is None:
+            return 0
+
+        return int(past_k.shape[2])
+
+    def _cache_seq_length(self, cache: Optional[Cache | LegacyCache]) -> int:
+        """
+        Return cached sequence length for either HF Cache or legacy tuple cache.
+
+        Args:
+            cache: Cache object or legacy tuple cache.
+
+        Returns:
+            Cached sequence length. Returns zero when no cache is available.
+        """
+        if cache is None:
+            return 0
+
+        if isinstance(cache, tuple):
+            return self._legacy_cache_seq_length(cache)
+
+        get_seq_length = getattr(cache, "get_seq_length", None)
+        if callable(get_seq_length):
+            try:
+                return int(get_seq_length())
+            except TypeError:
+                try:
+                    return int(get_seq_length(0))
+                except Exception:
+                    pass
+            except Exception:
+                pass
+
+        key_cache = getattr(cache, "key_cache", None)
+        if key_cache is not None and len(key_cache) > 0 and key_cache[0] is not None:
+            return int(key_cache[0].shape[2])
+
+        layers = getattr(cache, "layers", None)
+        if layers is not None and len(layers) > 0 and layers[0] is not None:
+            layer0 = layers[0]
+
+            if isinstance(layer0, tuple) and len(layer0) >= 2 and layer0[0] is not None:
+                return int(layer0[0].shape[2])
+
+            for name in ("keys", "key", "k"):
+                t = getattr(layer0, name, None)
+                if t is not None:
+                    return int(t.shape[2])
+
+        return 0
+
+    def _legacy_to_cache(self, past_key_values: LegacyCache) -> Cache:
+        """
+        Convert a legacy tuple cache into an HF cache object.
+
+        Args:
+            past_key_values: Legacy tuple of per-layer key/value tensors.
+
+        Returns:
+            Cache object containing the same cached tensors.
+
+        Raises:
+            RuntimeError: If no compatible conversion or update path exists.
+        """
+        from_legacy_cache = getattr(DynamicCache, "from_legacy_cache", None)
+        if callable(from_legacy_cache):
+            return from_legacy_cache(past_key_values)
+
+        cache = self._make_empty_cache()
+
+        for layer_idx, layer_kv in enumerate(past_key_values):
+            if layer_kv is None or len(layer_kv) < 2:
+                continue
+
+            past_k, past_v = layer_kv
+            if past_k is None or past_v is None:
+                continue
+
+            update = getattr(cache, "update", None)
+            if not callable(update):
+                raise RuntimeError(
+                    "Cache does not support update(), so legacy cache cannot be converted."
+                )
+
+            update(past_k, past_v, layer_idx, cache_kwargs=None)
+
+        return cache
+
+    def _cache_to_legacy(self, cache: Cache) -> LegacyCache:
+        """
+        Convert an HF cache object into a legacy tuple cache.
+
+        Args:
+            cache: HF cache object.
+
+        Returns:
+            Legacy tuple cache.
+
+        Raises:
+            RuntimeError: If the cache layout cannot be converted.
+        """
+        to_legacy_cache = getattr(cache, "to_legacy_cache", None)
+        if callable(to_legacy_cache):
+            return to_legacy_cache()
+
+        key_cache = getattr(cache, "key_cache", None)
+        value_cache = getattr(cache, "value_cache", None)
+        if key_cache is not None and value_cache is not None:
+            out = []
+            n = min(len(key_cache), len(value_cache))
+            for i in range(n):
+                k = key_cache[i]
+                v = value_cache[i]
+                if k is None or v is None:
+                    break
+                out.append((k, v))
+            return tuple(out)
+
+        layers = getattr(cache, "layers", None)
+        if layers is not None:
+            out = []
+            for layer in layers:
+                if layer is None:
+                    break
+
+                if isinstance(layer, tuple) and len(layer) >= 2:
+                    k, v = layer[0], layer[1]
+                    if k is None or v is None:
+                        break
+                    out.append((k, v))
+                    continue
+
+                found = False
+                for k_name, v_name in (
+                    ("keys", "values"),
+                    ("key", "value"),
+                    ("k", "v"),
+                ):
+                    k = getattr(layer, k_name, None)
+                    v = getattr(layer, v_name, None)
+                    if k is not None and v is not None:
+                        out.append((k, v))
+                        found = True
+                        break
+
+                if not found:
+                    break
+
+            return tuple(out)
+
+        raise RuntimeError(
+            f"Cache does not support legacy conversion: type={type(cache)}"
+        )
+
     def _normalize_past_key_values(
         self,
         past_key_values: Optional[Cache | LegacyCache],
@@ -169,20 +365,26 @@ class QuantLlamaModel(QuantModuleBase):
         use_cache: bool,
     ) -> tuple[Optional[Cache], bool]:
         """
+        Normalize cache input into an HF cache object.
+
+        Args:
+            past_key_values: Input cache in HF or legacy tuple form.
+            use_cache: Whether cache should be used in the current forward pass.
+
         Returns:
-            normalized_cache: Cache | None
-            return_legacy_cache: whether output should be converted back to legacy tuple
+            A tuple of:
+                - normalized cache object or None
+                - whether the output cache should be converted back to legacy form
         """
         if past_key_values is None:
             if use_cache:
-                return DynamicCache(config=self.config), False
+                return self._make_empty_cache(), False
             return None, False
 
         if isinstance(past_key_values, Cache):
             return past_key_values, False
 
-        # legacy tuple path
-        return DynamicCache.from_legacy_cache(past_key_values), True
+        return self._legacy_to_cache(past_key_values), True
 
     def _format_output_cache(
         self,
@@ -191,14 +393,23 @@ class QuantLlamaModel(QuantModuleBase):
         use_cache: bool,
         return_legacy_cache: bool,
     ):
+        """
+        Format cache output to match the caller's expected cache representation.
+
+        Args:
+            cache: Cache object produced during forward.
+            use_cache: Whether cache output is enabled.
+            return_legacy_cache: Whether output should be converted to legacy form.
+
+        Returns:
+            Cache output in HF or legacy form, or None when caching is disabled.
+        """
         if not use_cache or cache is None:
             return None
+
         if return_legacy_cache:
-            if hasattr(cache, "to_legacy_cache"):
-                return cache.to_legacy_cache()
-            raise RuntimeError(
-                "Cache does not support to_legacy_cache(), but legacy cache output was requested."
-            )
+            return self._cache_to_legacy(cache)
+
         return cache
 
     def _slice_causal(
@@ -313,7 +524,7 @@ class QuantLlamaModel(QuantModuleBase):
             use_cache=bool(use_cache),
         )
 
-        past_seen_tokens = cache.get_seq_length() if cache is not None else 0
+        past_seen_tokens = self._cache_seq_length(cache)
 
         if cache_position is None:
             cache_position = torch.arange(

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
 
 from transformers.cache_utils import Cache
+from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from tico.quantization.config.ptq import PTQConfig
@@ -26,11 +27,16 @@ from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
 
 
+LegacyCache = Tuple[Tuple[torch.Tensor, torch.Tensor], ...]
+
+
 @try_register(
     "transformers.models.llama.modeling_llama.LlamaForCausalLM",
     "tico.quantization.algorithm.spinquant.spin_llama.SpinLlamaForCausalLM",
 )
-class QuantLlamaForCausalLM(QuantModuleBase):
+class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
+    _is_stateful = False
+
     def __init__(
         self,
         model_fp: nn.Module,
@@ -74,29 +80,148 @@ class QuantLlamaForCausalLM(QuantModuleBase):
             )
 
         self.config = model_fp.config
+        self.generation_config = getattr(model_fp, "generation_config", None)
+        self.main_input_name = getattr(model_fp, "main_input_name", "input_ids")
         self.loss_function = model_fp.loss_function
         self.device = model_fp.device
 
     def tie_weights(self):
         pass
 
+    def get_input_embeddings(self):
+        return self.model.wrapped.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.wrapped.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def get_decoder(self):
+        return self.model
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids: torch.LongTensor,
+        past_key_values: Optional[Cache | LegacyCache] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = True,
+        **kwargs,
+    ):
+        # Decode step: only feed the newest token ids.
+        past_seen_tokens = 0
+        if past_key_values is not None:
+            if isinstance(past_key_values, Cache):
+                past_seen_tokens = past_key_values.get_seq_length()
+            else:
+                past_seen_tokens = int(past_key_values[0][0].shape[2])
+
+        if past_seen_tokens > 0:
+            input_ids = input_ids[:, -1:]
+
+        # Standard HF-style position_ids fallback from attention_mask.
+        if attention_mask is not None and position_ids is None:
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 0)
+            position_ids = position_ids[:, -input_ids.shape[1] :]
+
+        # Keep cache_position aligned with the current decoding step.
+        if cache_position is None:
+            past_seen_tokens = 0
+            if past_key_values is not None:
+                if isinstance(past_key_values, Cache):
+                    past_seen_tokens = past_key_values.get_seq_length()
+                else:
+                    past_seen_tokens = int(past_key_values[0][0].shape[2])
+
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + input_ids.shape[1],
+                device=input_ids.device,
+            )
+
+        model_inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": past_key_values,
+            "use_cache": use_cache,
+            "cache_position": cache_position,
+        }
+
+        # HF convention: inputs_embeds are only used on the first step.
+        if inputs_embeds is not None and past_key_values is None:
+            model_inputs["inputs_embeds"] = inputs_embeds
+            model_inputs.pop("input_ids", None)
+
+        return model_inputs
+
+    @staticmethod
+    def _reorder_cache(
+        past_key_values: Optional[Cache | LegacyCache],
+        beam_idx: torch.LongTensor,
+    ):
+        if past_key_values is None:
+            return past_key_values
+
+        # Cache classes may implement their own reorder logic depending on the
+        # transformers version. Use it if present.
+        if isinstance(past_key_values, Cache):
+            if hasattr(past_key_values, "reorder_cache"):
+                return past_key_values.reorder_cache(beam_idx)
+            return past_key_values
+
+        reordered = []
+        for layer_past in past_key_values:
+            past_k, past_v = layer_past
+            reordered.append(
+                (
+                    past_k.index_select(0, beam_idx),
+                    past_v.index_select(0, beam_idx),
+                )
+            )
+        return tuple(reordered)
+
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        past_key_values: Cache | None = None,
+        past_key_values: Cache | LegacyCache | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
         cache_position: torch.LongTensor | None = None,
         logits_to_keep: int | torch.Tensor = 0,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
     ) -> CausalLMOutputWithPast:
 
-        output_attentions = self.config.output_attentions
-        output_hidden_states = self.config.output_hidden_states
-        return_dict = self.config.use_return_dict
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs = self.model(
@@ -121,12 +246,14 @@ class QuantLlamaForCausalLM(QuantModuleBase):
         if self.rotate_lm_head is not None:
             hidden_states = self.rotate_lm_head(hidden_states)
 
-        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = (
-            slice(-logits_to_keep, None)
-            if isinstance(logits_to_keep, int)
-            else logits_to_keep
-        )
+        if isinstance(logits_to_keep, int):
+            if logits_to_keep > 0:
+                slice_indices = slice(-logits_to_keep, None)
+            else:
+                slice_indices = slice(None)
+        else:
+            slice_indices = logits_to_keep
+
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None


### PR DESCRIPTION
- Enable HF generate() compatibility
- Introduce export mode for accelerator-friendly I/O
- Preserve original LLaMA runtime interface

Related: #617
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>