### PR TITLE
[quantization] Normalize attention_mask in qwen3_vl text model

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
@@ -603,3 +603,226 @@ class TestQuantQwen3VLTextModel(unittest.TestCase):
             past_key_values=cache,
         )
         self.assertEqual(mask_decode.shape, (2, 1, 1, 5))
+
+    def test_attention_mask_2d_batch_size_mismatch_raises(self):
+        """
+        Test that a 2D attention mask with mismatched batch size raises ValueError.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        input_embeds = torch.randn(2, 6, self.hidden_size)
+        bad_mask = torch.ones(3, 6, dtype=torch.long)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "2D attention_mask batch size does not match inputs_embeds batch size",
+        ):
+            q_model._normalize_attention_mask(
+                attention_mask=bad_mask,
+                input_embeds=input_embeds,
+                past_key_values=None,
+            )
+
+    def test_attention_mask_2d_decode_short_mask_gets_past_prefix(self):
+        """
+        Test that a decode-time 2D mask with length equal to q_len is automatically
+        extended with a prefix for past cached tokens.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+
+        from transformers.cache_utils import DynamicCache
+
+        cache = DynamicCache(config=q_model.config)
+        dummy_k = torch.randn(
+            2,
+            q_model.config.num_key_value_heads,
+            4,
+            q_model.config.head_dim,
+        )
+        dummy_v = torch.randn(
+            2,
+            q_model.config.num_key_value_heads,
+            4,
+            q_model.config.head_dim,
+        )
+        cache.update(dummy_k, dummy_v, 0)
+
+        decode_embeds = torch.randn(2, 1, self.hidden_size)
+        short_mask = torch.ones(2, 1, dtype=torch.long)
+
+        mask = q_model._normalize_attention_mask(
+            attention_mask=short_mask,
+            input_embeds=decode_embeds,
+            past_key_values=cache,
+        )
+
+        self.assertEqual(mask.shape, (2, 1, 1, 5))
+
+    def test_attention_mask_2d_invalid_length_raises(self):
+        """
+        Test that a 2D attention mask with invalid length raises ValueError.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+
+        from transformers.cache_utils import DynamicCache
+
+        cache = DynamicCache(config=q_model.config)
+        dummy_k = torch.randn(
+            2,
+            q_model.config.num_key_value_heads,
+            4,
+            q_model.config.head_dim,
+        )
+        dummy_v = torch.randn(
+            2,
+            q_model.config.num_key_value_heads,
+            4,
+            q_model.config.head_dim,
+        )
+        cache.update(dummy_k, dummy_v, 0)
+
+        decode_embeds = torch.randn(2, 1, self.hidden_size)
+        bad_mask = torch.ones(2, 3, dtype=torch.long)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "2D attention_mask length does not match the expected KV length",
+        ):
+            q_model._normalize_attention_mask(
+                attention_mask=bad_mask,
+                input_embeds=decode_embeds,
+                past_key_values=cache,
+            )
+
+    def test_attention_mask_2d_float_prefill(self):
+        """
+        Test that a 2D floating-point mask is treated as a keep-mask via `!= 0`.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        input_embeds = torch.randn(2, 4, self.hidden_size)
+        float_mask = torch.tensor(
+            [
+                [1.0, 1.0, 0.0, 0.0],
+                [1.0, 0.5, 0.0, 0.0],
+            ],
+            dtype=torch.float32,
+        )
+
+        mask = q_model._normalize_attention_mask(
+            attention_mask=float_mask,
+            input_embeds=input_embeds,
+            past_key_values=None,
+        )
+
+        self.assertEqual(mask.shape, (2, 1, 4, 4))
+        self.assertTrue(torch.all(mask[0, 0, :, 2:] <= -120))
+        self.assertTrue(torch.all(mask[1, 0, :, 2:] <= -120))
+
+    def test_attention_mask_4d_shape_mismatch_raises(self):
+        """
+        Test that a 4D attention mask with mismatched q_len/kv_len raises ValueError.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        input_embeds = torch.randn(2, 4, self.hidden_size)
+        bad_mask = torch.zeros(2, 1, 3, 4)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "4D attention_mask shape does not match the expected query/KV lengths",
+        ):
+            q_model._normalize_attention_mask(
+                attention_mask=bad_mask,
+                input_embeds=input_embeds,
+                past_key_values=None,
+            )
+
+    def test_attention_mask_4d_bool_converts_to_additive(self):
+        """
+        Test that a 4D boolean mask is converted to an additive floating-point mask.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        input_embeds = torch.randn(1, 4, self.hidden_size)
+        bool_mask = torch.tensor(
+            [
+                [
+                    [
+                        [True, True, False, False],
+                        [True, True, False, False],
+                        [True, True, True, False],
+                        [True, True, True, True],
+                    ]
+                ]
+            ],
+            dtype=torch.bool,
+        )
+
+        mask = q_model._normalize_attention_mask(
+            attention_mask=bool_mask,
+            input_embeds=input_embeds,
+            past_key_values=None,
+        )
+
+        self.assertTrue(mask.dtype.is_floating_point)
+        self.assertEqual(mask.shape, (1, 1, 4, 4))
+        self.assertLess(mask[0, 0, 0, 2].item(), 0.0)
+
+    def test_attention_mask_4d_int_converts_to_additive(self):
+        """
+        Test that a 4D integer mask is converted to an additive floating-point mask.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        input_embeds = torch.randn(1, 4, self.hidden_size)
+        int_mask = torch.tensor(
+            [[[[1, 1, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]]]],
+            dtype=torch.long,
+        )
+
+        mask = q_model._normalize_attention_mask(
+            attention_mask=int_mask,
+            input_embeds=input_embeds,
+            past_key_values=None,
+        )
+
+        self.assertTrue(mask.dtype.is_floating_point)
+        self.assertEqual(mask.shape, (1, 1, 4, 4))
+        self.assertLess(mask[0, 0, 0, 2].item(), 0.0)
+
+    def test_attention_mask_invalid_rank_raises(self):
+        """
+        Test that an unsupported attention mask rank raises ValueError.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        input_embeds = torch.randn(2, 4, self.hidden_size)
+        bad_mask = torch.ones(2, 1, 1, 1, 4)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported attention_mask rank",
+        ):
+            q_model._normalize_attention_mask(
+                attention_mask=bad_mask,
+                input_embeds=input_embeds,
+                past_key_values=None,
+            )
+
+    def test_return_dict_false_without_cache(self):
+        """
+        Test that the wrapper returns a single-element tuple when
+        return_dict=False and use_cache=False.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs(batch_size=1, seq_len=8)
+        _ = q_model(input_ids=input_ids, use_cache=False)
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(
+                input_ids=input_ids,
+                use_cache=False,
+                return_dict=False,
+            )
+
+        self.assertIsInstance(q_out, tuple)
+        self.assertEqual(len(q_out), 1)
+        self.assertEqual(q_out[0].shape, (1, 8, self.hidden_size))

--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_model.py
@@ -51,6 +51,7 @@ class TestQuantQwen3VLTextModel(unittest.TestCase):
             head_dim=16,
             max_position_embeddings=1024,
             rope_scaling={"rope_type": "default", "mrope_section": [1, 1, 2]},
+            use_cache=True,
         )
 
         # Ensure eager attention implementation so outputs are deterministic
@@ -70,6 +71,14 @@ class TestQuantQwen3VLTextModel(unittest.TestCase):
         """Helper to create test inputs for TextModel."""
         input_ids = torch.randint(0, self.vocab_size, (batch_size, seq_len))
         return input_ids
+
+    def _create_padding_mask(self, batch_size=2, seq_len=16, valid_len=12):
+        """
+        Create a 2D padding mask with trailing padded positions.
+        """
+        attention_mask = torch.zeros(batch_size, seq_len, dtype=torch.long)
+        attention_mask[:, :valid_len] = 1
+        return attention_mask
 
     def test_mode_transitions(self):
         """Test quantization mode transitions: NO_QUANT → CALIB → QUANT"""
@@ -399,3 +408,198 @@ class TestQuantQwen3VLTextModel(unittest.TestCase):
         # past_key_values should be None when use_cache=False
         self.assertIsNone(q_out.past_key_values)
         self.assertIsNone(fp_out.past_key_values)
+
+    def test_return_dict_false_with_cache(self):
+        """
+        Test that the wrapper returns a tuple of hidden states and cache when
+        return_dict=False and use_cache=True.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs(batch_size=1, seq_len=8)
+        _ = q_model(input_ids=input_ids, use_cache=False)
+
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(
+                input_ids=input_ids,
+                use_cache=True,
+                return_dict=False,
+            )
+
+        self.assertIsInstance(q_out, tuple)
+        self.assertEqual(len(q_out), 2)
+        self.assertEqual(q_out[0].shape, (1, 8, self.hidden_size))
+        self.assertIsNotNone(q_out[1])
+
+    def test_attention_mask_2d_prefill(self):
+        """
+        Test that a 2D padding mask is accepted and produces the expected output
+        shape during prefill.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs(batch_size=2, seq_len=16)
+        attention_mask = self._create_padding_mask(
+            batch_size=2,
+            seq_len=16,
+            valid_len=12,
+        )
+
+        _ = q_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        )
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                use_cache=False,
+            )
+            fp_out = self.fp_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                use_cache=False,
+            )
+
+        self.assertEqual(q_out.last_hidden_state.shape, fp_out.last_hidden_state.shape)
+        diff = (fp_out.last_hidden_state - q_out.last_hidden_state).abs().mean().item()
+        self.assertLess(diff, 0.8)
+
+    def test_attention_mask_bool_prefill(self):
+        """
+        Test that a 2D boolean padding mask is normalized correctly.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs(batch_size=2, seq_len=16)
+        attention_mask = self._create_padding_mask(
+            batch_size=2,
+            seq_len=16,
+            valid_len=10,
+        ).bool()
+
+        _ = q_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        )
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                use_cache=False,
+            )
+
+        self.assertEqual(
+            q_out.last_hidden_state.shape,
+            (2, 16, self.hidden_size),
+        )
+
+    def test_attention_mask_4d_additive_passthrough(self):
+        """
+        Test that a 4D additive mask is accepted directly.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        input_ids = self._create_test_inputs(batch_size=1, seq_len=8)
+        additive_mask = torch.zeros(1, 1, 8, 8)
+        additive_mask[..., :, 6:] = -120.0
+
+        _ = q_model(
+            input_ids=input_ids,
+            attention_mask=additive_mask,
+            use_cache=False,
+        )
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            q_out = q_model(
+                input_ids=input_ids,
+                attention_mask=additive_mask,
+                use_cache=False,
+            )
+
+        self.assertEqual(q_out.last_hidden_state.shape, (1, 8, self.hidden_size))
+
+    def test_attention_mask_decode_with_cache(self):
+        """
+        Test that decoding with cache and a 2D attention mask works correctly.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+        q_model.enable_calibration()
+
+        prefill_ids = self._create_test_inputs(batch_size=1, seq_len=8)
+        _ = q_model(input_ids=prefill_ids, use_cache=False)
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            prefill_out = q_model(
+                input_ids=prefill_ids,
+                use_cache=True,
+            )
+
+        decode_ids = self._create_test_inputs(batch_size=1, seq_len=1)
+        decode_attention_mask = torch.ones(1, 9, dtype=torch.long)
+
+        with torch.no_grad():
+            decode_out = q_model(
+                input_ids=decode_ids,
+                attention_mask=decode_attention_mask,
+                past_key_values=prefill_out.past_key_values,
+                use_cache=True,
+            )
+
+        self.assertEqual(decode_out.last_hidden_state.shape, (1, 1, self.hidden_size))
+        self.assertIsNotNone(decode_out.past_key_values)
+
+    def test_normalize_attention_mask_shapes(self):
+        """
+        Test that the normalized additive mask has the expected shape for
+        prefill and decode.
+        """
+        q_model = QuantQwen3VLTextModel(self.fp_model)
+
+        prefill_embeds = torch.randn(2, 6, self.hidden_size)
+
+        mask_prefill = q_model._normalize_attention_mask(
+            attention_mask=None,
+            input_embeds=prefill_embeds,
+            past_key_values=None,
+        )
+        self.assertEqual(mask_prefill.shape, (1, 1, 6, 6))
+
+        from transformers.cache_utils import DynamicCache
+
+        cache = DynamicCache(config=q_model.config)
+        dummy_k = torch.randn(
+            2,
+            q_model.config.num_key_value_heads,
+            4,
+            q_model.config.head_dim,
+        )
+        dummy_v = torch.randn(
+            2,
+            q_model.config.num_key_value_heads,
+            4,
+            q_model.config.head_dim,
+        )
+        cache.update(dummy_k, dummy_v, 0)
+
+        decode_embeds = torch.randn(2, 1, self.hidden_size)
+        mask_decode = q_model._normalize_attention_mask(
+            attention_mask=torch.ones(2, 5, dtype=torch.long),
+            input_embeds=decode_embeds,
+            past_key_values=cache,
+        )
+        self.assertEqual(mask_decode.shape, (2, 1, 1, 5))

--- a/tico/quantization/wrapq/examples/qwen/quantize_text_model.py
+++ b/tico/quantization/wrapq/examples/qwen/quantize_text_model.py
@@ -126,7 +126,9 @@ def main():
     # Convert to Circle format
     example_input = (calibration_data[0],)
     circle_model = tico.convert(
-        quantized_model.eval(), example_input, kwargs={"use_cache": False}
+        quantized_model.eval(),
+        example_input,
+        kwargs={"use_cache": False, "return_dict": False},
     )
 
     # Save the Circle model

--- a/tico/quantization/wrapq/examples/qwen/trace_qwen.py
+++ b/tico/quantization/wrapq/examples/qwen/trace_qwen.py
@@ -385,6 +385,7 @@ def prepare_quantized_model(
         model_args={
             "vision": {
                 "grid_thw": thw,
+                "visual_start_idx": 0,
             }
         },
     )

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -206,9 +206,187 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             self.obs_deepstack_visual_embeds.append(obs)
             self.add_module(obs_name, obs)
 
-    def _slice_causal(self, seq_len: int, device: torch.device) -> torch.Tensor:
+    def _get_past_seen_tokens(self, past_key_values: Cache | None) -> int:
+        """
+        Return the number of cached tokens already stored in the KV cache.
+
+        Args:
+            past_key_values: Cache object or None.
+
+        Returns:
+            The cached sequence length. Returns 0 when no cache is present.
+        """
+        if past_key_values is None:
+            return 0
+        return int(past_key_values.get_seq_length())
+
+    def _slice_causal(
+        self,
+        q_len: int,
+        kv_len: int,
+        *,
+        past_seen_tokens: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """
+        Slice the static causal mask template for the current query/key sizes.
+
+        The row offset is shifted by `past_seen_tokens` so that decode steps
+        produce the correct `q_len x kv_len` causal region.
+
+        Args:
+            q_len: Query length for the current step.
+            kv_len: Total key/value length visible to the query.
+            past_seen_tokens: Number of cached tokens before the current step.
+            device: Target device.
+            dtype: Target floating-point dtype.
+
+        Returns:
+            A 4D additive causal mask with shape `(1, 1, q_len, kv_len)`.
+        """
         assert isinstance(self.causal_mask_template, torch.Tensor)
-        return self.causal_mask_template[..., :seq_len, :seq_len].to(device)
+
+        row_start = past_seen_tokens
+        row_end = past_seen_tokens + q_len
+
+        return self.causal_mask_template[..., row_start:row_end, :kv_len].to(
+            device=device, dtype=dtype
+        )
+
+    def _normalize_attention_mask(
+        self,
+        attention_mask: torch.Tensor | None,
+        *,
+        input_embeds: torch.Tensor,
+        past_key_values: Cache | None,
+    ) -> torch.Tensor:
+        """
+        Normalize the input attention mask into a 4D additive causal mask.
+
+        Supported inputs:
+        - None
+        - 2D padding masks of shape `(batch, kv_len)`
+        - 4D masks of shape `(batch, 1, q_len, kv_len)` in bool or float form
+
+        For 2D masks, padding semantics are preserved and combined with the
+        causal mask. For 4D floating-point masks, the input is assumed to
+        already be additive and is returned as-is.
+
+        Args:
+            attention_mask: User-provided attention mask.
+            input_embeds: Input embeddings for dtype/device/shape reference.
+            past_key_values: Cache object used to infer past length.
+
+        Returns:
+            A 4D floating-point additive mask with shape
+            `(batch, 1, q_len, kv_len)`.
+
+        Raises:
+            ValueError: If the provided mask shape is unsupported.
+        """
+        batch_size, q_len = input_embeds.shape[:2]
+        past_seen_tokens = self._get_past_seen_tokens(past_key_values)
+        kv_len = past_seen_tokens + q_len
+
+        causal_mask = self._slice_causal(
+            q_len,
+            kv_len,
+            past_seen_tokens=past_seen_tokens,
+            device=input_embeds.device,
+            dtype=input_embeds.dtype,
+        )
+
+        if attention_mask is None:
+            return causal_mask
+
+        if attention_mask.ndim == 2:
+            if attention_mask.shape[0] != batch_size:
+                raise ValueError(
+                    "2D attention_mask batch size does not match inputs_embeds batch size. "
+                    f"Got mask batch={attention_mask.shape[0]}, input batch={batch_size}."
+                )
+
+            mask_len = attention_mask.shape[1]
+            if mask_len == q_len and past_seen_tokens > 0:
+                past_prefix = torch.ones(
+                    batch_size,
+                    past_seen_tokens,
+                    device=attention_mask.device,
+                    dtype=attention_mask.dtype,
+                )
+                attention_mask = torch.cat((past_prefix, attention_mask), dim=-1)
+                mask_len = attention_mask.shape[1]
+
+            if mask_len != kv_len:
+                raise ValueError(
+                    "2D attention_mask length does not match the expected KV length. "
+                    f"Got mask length={mask_len}, expected kv_len={kv_len}."
+                )
+
+            if attention_mask.dtype == torch.bool:
+                padding_keep = attention_mask
+            elif torch.is_floating_point(attention_mask):
+                padding_keep = attention_mask != 0
+            else:
+                padding_keep = attention_mask.to(torch.long) != 0
+
+            padding_mask = torch.zeros(
+                batch_size,
+                1,
+                1,
+                kv_len,
+                device=input_embeds.device,
+                dtype=input_embeds.dtype,
+            )
+            padding_mask = padding_mask.masked_fill(
+                ~padding_keep[:, None, None, :].to(device=input_embeds.device),
+                float("-120"),
+            )
+
+            return causal_mask + padding_mask
+
+        if attention_mask.ndim == 4:
+            if attention_mask.shape[-2] != q_len or attention_mask.shape[-1] != kv_len:
+                raise ValueError(
+                    "4D attention_mask shape does not match the expected query/KV lengths. "
+                    f"Got shape={tuple(attention_mask.shape)}, expected (*, *, {q_len}, {kv_len})."
+                )
+
+            if torch.is_floating_point(attention_mask):
+                return attention_mask.to(
+                    device=input_embeds.device,
+                    dtype=input_embeds.dtype,
+                )
+
+            if attention_mask.dtype == torch.bool:
+                additive_mask = torch.zeros_like(
+                    attention_mask,
+                    device=input_embeds.device,
+                    dtype=input_embeds.dtype,
+                )
+                additive_mask = additive_mask.masked_fill(
+                    ~attention_mask.to(device=input_embeds.device),
+                    float("-120"),
+                )
+                return additive_mask
+
+            bool_mask = attention_mask.to(torch.long) != 0
+            additive_mask = torch.zeros_like(
+                bool_mask,
+                device=input_embeds.device,
+                dtype=input_embeds.dtype,
+            )
+            additive_mask = additive_mask.masked_fill(
+                ~bool_mask.to(device=input_embeds.device),
+                float("-120"),
+            )
+            return additive_mask
+
+        raise ValueError(
+            "Unsupported attention_mask rank. "
+            f"Expected None, 2D, or 4D mask, but got ndim={attention_mask.ndim}."
+        )
 
     def forward(
         self,
@@ -219,9 +397,9 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         inputs_embeds: torch.FloatTensor | None = None,
         use_cache: bool | None = None,
         cache_position: torch.LongTensor | None = None,
-        # args for deepstack
         visual_pos_masks: torch.Tensor | None = None,
         deepstack_visual_embeds: list[torch.Tensor] | None = None,
+        return_dict: bool = True,
         **kwargs,
     ):
         """
@@ -237,6 +415,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             cache_position: Cache position indices (LongTensor, not quantized)
             visual_pos_masks: Mask indicating visual positions (may be int/bool, not quantized)
             deepstack_visual_embeds: Visual feature embeddings to inject (list of float tensors)
+            return_dict: Whether to return a Hugging Face-style output object.
             **kwargs: Additional keyword arguments
 
         Returns:
@@ -263,9 +442,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
 
         # Handle cache_position (integer tensor, not quantized)
         if cache_position is None:
-            past_seen_tokens = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
+            past_seen_tokens = self._get_past_seen_tokens(past_key_values)
             cache_position = torch.arange(
                 past_seen_tokens,
                 past_seen_tokens + inputs_embeds.shape[1],
@@ -287,22 +464,12 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         else:
             text_position_ids = position_ids[0]
 
-        # Build causal mask if not provided (or provided as bool)
-        if attention_mask is None or attention_mask.dtype == torch.bool:
-            attention_mask = self._slice_causal(
-                inputs_embeds.shape[1], inputs_embeds.device
-            )
-            # from transformers.masking_utils import create_causal_mask
-            # attention_mask = create_causal_mask(
-            #    config=self.config,
-            #    input_embeds=inputs_embeds,
-            #    attention_mask=attention_mask,
-            #    cache_position=cache_position,
-            #    past_key_values=past_key_values,
-            #    position_ids=text_position_ids,
-            # )
-        if torch.is_floating_point(attention_mask):
-            attention_mask = self._fq(attention_mask, self.obs_attention_mask)
+        attention_mask = self._normalize_attention_mask(
+            attention_mask,
+            input_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+        )
+        attention_mask = self._fq(attention_mask, self.obs_attention_mask)
 
         hidden_states = inputs_embeds
 
@@ -323,6 +490,8 @@ class QuantQwen3VLTextModel(QuantModuleBase):
                 position_ids=text_position_ids,
                 past_key_values=past_key_values,
                 position_embeddings=position_embeddings,
+                cache_position=cache_position,
+                use_cache=use_cache,
                 **kwargs,
             )
             hidden_states = layer_outputs
@@ -344,6 +513,11 @@ class QuantQwen3VLTextModel(QuantModuleBase):
 
         # Final normalization
         hidden_states = self.norm(hidden_states)
+
+        if not return_dict:
+            if use_cache:
+                return hidden_states, past_key_values
+            return (hidden_states,)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -344,7 +344,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
                 float("-120"),
             )
 
-            return causal_mask + padding_mask
+            return torch.clamp(causal_mask + padding_mask, min=-120.0, max=0.0)
 
         if attention_mask.ndim == 4:
             if attention_mask.shape[-2] != q_len or attention_mask.shape[-1] != kv_len:


### PR DESCRIPTION
- Convert 2D/4D masks to additive causal form
- Preserve padding semantics and support cache-aware shapes
- Return tuple when return_dict=False to fix Dynamo export

Related: #630 
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>