### PR TITLE
[passes] Introduce EliminateRankRoundTripRegion

### DIFF
--- a/test/unit_test/pass_test/test_eliminate_rank_round_trip_region.py
+++ b/test/unit_test/pass_test/test_eliminate_rank_round_trip_region.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from tico.passes import ops
+from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
+from tico.passes.eliminate_rank_round_trip_region import EliminateRankRoundTripRegion
+
+from test.utils.helper import num_of_ops
+from test.utils.pass_value_test import SinglePassValueTest
+
+
+class DecomposedLayerNormPermuteNet(torch.nn.Module):
+    """
+    A module that mimics the decomposed LayerNorm-style pattern followed by
+    a 3D permute and a weak sink reshape to 4D.
+
+    Expected behavior of the pass:
+      - remove the source reshape from 4D to 3D
+      - rewrite the internal region in 4D
+      - keep the final weak sink reshape, but update its input
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.rand(32))
+        self.bias = torch.nn.Parameter(torch.rand(32))
+
+    def forward(self, x):
+        """
+        Build a graph similar to the decomposed LayerNorm subgraph that
+        originally motivated this pass.
+        """
+        x = torch.reshape(x, [1, 16, 32])
+
+        mean = torch.mean(x, dim=[-1], keepdim=True)
+        sub = torch.sub(x, mean)
+        sq = torch.mul(sub, sub)
+        var = torch.mean(sq, dim=[-1], keepdim=True)
+        var_eps = torch.add(var, 1e-5)
+        inv_std = torch.rsqrt(var_eps)
+        normed = torch.mul(sub, inv_std)
+        scaled = torch.mul(normed, self.weight)
+        shifted = torch.add(scaled, self.bias)
+
+        y = torch.permute(shifted, [0, 2, 1])
+        y = torch.reshape(y, [1, 32, 16, 1])
+        return y
+
+    def get_example_inputs(self):
+        """
+        Return example inputs.
+        """
+        return (torch.rand([1, 1, 16, 32]),), {}
+
+
+class SplitWithSizesGLUNet(torch.nn.Module):
+    """
+    A module that tests the split_with_sizes/getitem/sigmoid/mul DAG pattern.
+
+    Expected behavior of the pass:
+      - remove the source reshape from 4D to 3D
+      - rewrite split/getitem/sigmoid/mul directly on 4D
+      - keep the final weak sink reshape, but update its input
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        """
+        Build a GLU-like pattern using split_with_sizes.
+        """
+        x = torch.reshape(x, [1, 64, 16])
+        xs = torch.ops.aten.split_with_sizes.default(x, [32, 32], 1)
+        x1 = xs[0]
+        x2 = xs[1]
+        y = torch.mul(x1, torch.sigmoid(x2))
+        y = torch.reshape(y, [1, 32, 16, 1])
+        return y
+
+    def get_example_inputs(self):
+        """
+        Return example inputs.
+        """
+        return (torch.rand([1, 64, 16, 1]),), {}
+
+
+class ChunkTransposeNet(torch.nn.Module):
+    """
+    A module that tests transpose and chunk in the same region.
+
+    Expected behavior of the pass:
+      - remove the source reshape from 4D to 3D
+      - remap transpose and chunk dimensions into 4D
+      - keep the final weak sink reshape, but update its input
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        """
+        Build a region that includes transpose, chunk, getitem, and add.
+        """
+        x = torch.reshape(x, [1, 16, 32])
+        x = torch.transpose(x, 1, 2)
+        xs = torch.chunk(x, 2, dim=1)
+        x1 = xs[0]
+        x2 = xs[1]
+        y = torch.add(x1, x2)
+        y = torch.reshape(y, [1, 16, 16, 1])
+        return y
+
+    def get_example_inputs(self):
+        """
+        Return example inputs.
+        """
+        return (torch.rand([1, 1, 16, 32]),), {}
+
+
+class UnsupportedMatmulNet(torch.nn.Module):
+    """
+    A module that contains an unsupported internal operator.
+
+    Expected behavior of the pass:
+      - do not rewrite the region
+      - keep both reshape operators unchanged
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.rand(32, 8))
+
+    def forward(self, x):
+        """
+        Build a graph that contains matmul, which is intentionally unsupported
+        by the current pass.
+        """
+        x = torch.reshape(x, [1, 16, 32])
+        y = torch.matmul(x, self.w)
+        y = torch.reshape(y, [1, 16, 8, 1])
+        return y
+
+    def get_example_inputs(self):
+        """
+        Return example inputs.
+        """
+        return (torch.rand([1, 1, 16, 32]),), {}
+
+
+class EliminateRankRoundTripRegionLayerNormStyleTest(SinglePassValueTest):
+    """
+    Test the decomposed LayerNorm-style region.
+    """
+
+    def test_pass(self):
+        """
+        Verify that the pass removes only the source reshape and preserves
+        value correctness.
+        """
+        self.setup(DecomposedLayerNormPermuteNet())
+        self.ep = self.ep.run_decompositions()
+        self.run_pass(ConvertLayoutOpToReshape())
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 2)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.mean), 2)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.rsqrt), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.permute), 1)
+
+        self.run_value_test(EliminateRankRoundTripRegion(enabled=True))
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.mean), 2)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.rsqrt), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.permute), 1)
+
+
+class EliminateRankRoundTripRegionSplitWithSizesTest(SinglePassValueTest):
+    """
+    Test the split_with_sizes/getitem/sigmoid/mul DAG pattern.
+    """
+
+    def test_pass(self):
+        """
+        Verify that the pass handles the GLU-like split pattern correctly.
+        """
+        self.setup(SplitWithSizesGLUNet())
+        self.ep = self.ep.run_decompositions()
+        self.run_pass(ConvertLayoutOpToReshape())
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 2)
+        self.assertEqual(
+            num_of_ops(self.exported_program(), ops.aten.split_with_sizes), 1
+        )
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.sigmoid), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.mul_tensor), 1)
+
+        self.run_value_test(EliminateRankRoundTripRegion(enabled=True))
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)
+        self.assertEqual(
+            num_of_ops(self.exported_program(), ops.aten.split_with_sizes), 1
+        )
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.sigmoid), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.mul_tensor), 1)
+
+
+class EliminateRankRoundTripRegionChunkTransposeTest(SinglePassValueTest):
+    """
+    Test a region containing transpose, chunk, getitem, and add.
+    """
+
+    def test_pass(self):
+        """
+        Verify that the pass remaps transpose and chunk correctly.
+        """
+        self.setup(ChunkTransposeNet())
+        self.ep = self.ep.run_decompositions()
+        self.run_pass(ConvertLayoutOpToReshape())
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 2)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.permute), 1)
+        self.assertEqual(
+            num_of_ops(self.exported_program(), ops.aten.split_with_sizes), 1
+        )
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.add), 1)
+
+        self.run_value_test(EliminateRankRoundTripRegion(enabled=True))
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.permute), 1)
+        self.assertEqual(
+            num_of_ops(self.exported_program(), ops.aten.split_with_sizes), 1
+        )
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.add), 1)
+
+
+class EliminateRankRoundTripRegionUnsupportedOpTest(SinglePassValueTest):
+    """
+    Test that the pass does not rewrite a region containing an unsupported op.
+    """
+
+    def test_pass(self):
+        """
+        Verify that the graph remains unchanged when an unsupported operator
+        appears inside the candidate region.
+        """
+        self.setup(UnsupportedMatmulNet())
+        self.ep = self.ep.run_decompositions()
+        self.run_pass(ConvertLayoutOpToReshape())
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 4)
+        self.assertEqual(
+            num_of_ops(self.exported_program(), [torch.ops.aten.mm.default]), 1
+        )
+
+        self.run_value_test(EliminateRankRoundTripRegion(enabled=True))
+
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 4)
+        self.assertEqual(
+            num_of_ops(self.exported_program(), [torch.ops.aten.mm.default]), 1
+        )

--- a/tico/config/v1.py
+++ b/tico/config/v1.py
@@ -25,6 +25,7 @@ class CompileConfigV1(CompileConfigBase):
     convert_rhs_const_mm_to_fc: bool = True
     convert_single_batch_lhs_const_bmm_to_fc: bool = False
     convert_expand_to_slice_cat: bool = False
+    eliminate_rank_round_trip: bool = False
 
     def get(self, name: str):
         return super().get(name)

--- a/tico/passes/eliminate_rank_round_trip_region.py
+++ b/tico/passes/eliminate_rank_round_trip_region.py
@@ -47,21 +47,21 @@ class RankMapping:
     axis_3d_to_4d: dict[int, int]
     inserted_axis_4d: int
 
-    def remap_axis(self, axis: int, rank_3d: int = 3) -> int:
+    def remap_axis(self, axis: int) -> int:
         """
         Remap one 3D axis into the corresponding 4D axis.
         """
         if axis < 0:
-            axis += rank_3d
+            axis += 3
         if axis not in self.axis_3d_to_4d:
             raise ValueError(f"Cannot remap 3D axis {axis}")
         return self.axis_3d_to_4d[axis]
 
-    def remap_axes(self, axes: list[int], rank_3d: int = 3) -> list[int]:
+    def remap_axes(self, axes: list[int]) -> list[int]:
         """
         Remap a list of 3D axes into 4D axes.
         """
-        return [self.remap_axis(axis, rank_3d=rank_3d) for axis in axes]
+        return [self.remap_axis(axis) for axis in axes]
 
     def remap_permute(self, perm_3d: list[int]) -> list[int]:
         """
@@ -81,15 +81,11 @@ class RankMapping:
 
         return perm_4d
 
-    def remap_transpose(
-        self, dim0: int, dim1: int, rank_3d: int = 3
-    ) -> tuple[int, int]:
+    def remap_transpose(self, dim0: int, dim1: int) -> tuple[int, int]:
         """
         Convert a 3D transpose pair into the equivalent 4D transpose pair.
         """
-        return self.remap_axis(dim0, rank_3d=rank_3d), self.remap_axis(
-            dim1, rank_3d=rank_3d
-        )
+        return self.remap_axis(dim0), self.remap_axis(dim1)
 
 
 @dataclass
@@ -357,20 +353,22 @@ class EliminateRankRoundTripRegion(PassBase):
 
         return len(src_shape) == 3 and len(dst_shape) == 4
 
-    def _is_allowed_external_input(
+    def _is_allowed_input_dependency(
         self,
         arg,
         region_nodes: set[torch.fx.Node],
         source_reshape: torch.fx.Node,
     ) -> bool:
         """
-        Check whether an external input is allowed for a region internal node.
+        Check whether an input argument is allowed for a region internal node.
 
-        Allowed external inputs:
-          - non-node constants
-          - the source reshape itself
-          - nodes already inside the region
-          - get_attr / placeholder nodes
+        Allowed inputs include:
+        - the source reshape (region entry)
+        - nodes already collected inside the region
+        - non-node constants
+        - external immutable inputs such as get_attr / placeholder
+
+        Any other dependency is considered invalid and breaks region closure.
         """
         if not isinstance(arg, torch.fx.Node):
             return True
@@ -406,14 +404,14 @@ class EliminateRankRoundTripRegion(PassBase):
         Weak sink reshapes are treated as region boundaries and are not required
         to be the exact inverse of the source reshape.
         """
-        region_nodes: set[torch.fx.Node] = {source_reshape}
+        visited: set[torch.fx.Node] = {source_reshape}
         internal_nodes: list[torch.fx.Node] = []
         sink_reshapes: list[torch.fx.Node] = []
 
         q = deque([source_reshape])
 
         # Phase 1: collect candidates without requiring all inputs to already be
-        # present in region_nodes.
+        # present in region (visited).
         while q:
             producer = q.popleft()
 
@@ -426,8 +424,8 @@ class EliminateRankRoundTripRegion(PassBase):
                 if not self._is_supported_internal_node(user):
                     continue
 
-                if user not in region_nodes:
-                    region_nodes.add(user)
+                if user not in visited:
+                    visited.add(user)
                     internal_nodes.append(user)
                     q.append(user)
 
@@ -444,7 +442,7 @@ class EliminateRankRoundTripRegion(PassBase):
                     continue
                 if arg in internal_set:
                     continue
-                if self._is_allowed_external_input(
+                if self._is_allowed_input_dependency(
                     arg, internal_set | {source_reshape}, source_reshape
                 ):
                     continue

--- a/tico/passes/eliminate_rank_round_trip_region.py
+++ b/tico/passes/eliminate_rank_round_trip_region.py
@@ -1,0 +1,855 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+from collections import deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.fx
+
+import torch
+from torch.export import ExportedProgram
+
+from tico.serialize.circle_mapping import extract_shape
+from tico.utils.graph import create_node
+from tico.utils.passes import PassBase, PassResult
+from tico.utils.trace_decorators import trace_graph_diff_on_pass
+from tico.utils.utils import set_new_meta_val
+
+
+@dataclass
+class RankMapping:
+    """
+    Mapping from a 3D tensor view to its original 4D tensor view.
+
+    Example:
+        4D: [B, 1, T, D]
+        3D: [B, T, D]
+
+    Then:
+        axis_3d_to_4d = {0: 0, 1: 2, 2: 3}
+        inserted_axis_4d = 1
+    """
+
+    axis_3d_to_4d: dict[int, int]
+    inserted_axis_4d: int
+
+    def remap_axis(self, axis: int, rank_3d: int = 3) -> int:
+        """
+        Remap one 3D axis into the corresponding 4D axis.
+        """
+        if axis < 0:
+            axis += rank_3d
+        if axis not in self.axis_3d_to_4d:
+            raise ValueError(f"Cannot remap 3D axis {axis}")
+        return self.axis_3d_to_4d[axis]
+
+    def remap_axes(self, axes: list[int], rank_3d: int = 3) -> list[int]:
+        """
+        Remap a list of 3D axes into 4D axes.
+        """
+        return [self.remap_axis(axis, rank_3d=rank_3d) for axis in axes]
+
+    def remap_permute(self, perm_3d: list[int]) -> list[int]:
+        """
+        Convert a 3D permutation into the equivalent 4D permutation by
+        keeping the inserted singleton axis at its original 4D position.
+        """
+        mapped = [self.remap_axis(axis) for axis in perm_3d]
+
+        perm_4d = []
+        mapped_idx = 0
+        for out_axis_4d in range(4):
+            if out_axis_4d == self.inserted_axis_4d:
+                perm_4d.append(self.inserted_axis_4d)
+            else:
+                perm_4d.append(mapped[mapped_idx])
+                mapped_idx += 1
+
+        return perm_4d
+
+    def remap_transpose(
+        self, dim0: int, dim1: int, rank_3d: int = 3
+    ) -> tuple[int, int]:
+        """
+        Convert a 3D transpose pair into the equivalent 4D transpose pair.
+        """
+        return self.remap_axis(dim0, rank_3d=rank_3d), self.remap_axis(
+            dim1, rank_3d=rank_3d
+        )
+
+
+@dataclass
+class Region:
+    """
+    A supported subgraph region between:
+      - a source reshape that removes one singleton axis from 4D to 3D
+      - one or more sink reshapes that lift a 3D value to 4D
+
+    Internal nodes are supported ops that can be rewritten from 3D semantics
+    into 4D semantics.
+    """
+
+    source_reshape: torch.fx.Node
+    original_4d: torch.fx.Node
+    mapping: RankMapping
+    internal_nodes: list[torch.fx.Node]
+    sink_reshapes: list[torch.fx.Node]
+
+
+@trace_graph_diff_on_pass
+class EliminateRankRoundTripRegion(PassBase):
+    """
+    Eliminate a source rank-reducing reshape and rewrite the reachable supported
+    3D subgraph directly on the original 4D tensor.
+
+    Pattern:
+        reshape(4D -> 3D)
+          -> supported small DAG region
+          -> one or more reshape(3D -> 4D)
+
+    Important behavior:
+      - The source reshape must remove exactly one singleton axis.
+      - Sink reshapes are treated as weak boundaries. They do not need to be the
+        exact inverse of the source reshape.
+      - After region rewrite, each sink reshape is updated to consume the new 4D
+        producer. If the sink becomes an identity/no-op later, another peephole
+        pass may remove it.
+    """
+
+    def __init__(self, enabled: bool = False):
+        super().__init__()
+        self.enabled = enabled
+
+    @staticmethod
+    def _is_call_function(node: torch.fx.Node, target) -> bool:
+        """
+        Check whether a node is a call_function node targeting the given op.
+        """
+        return node.op == "call_function" and node.target == target
+
+    @staticmethod
+    def _normalize_shape(shape) -> list[int]:
+        """
+        Normalize a shape-like object into a plain Python list.
+        """
+        return list(shape)
+
+    @staticmethod
+    def _tensor_node_inputs(node: torch.fx.Node) -> list[torch.fx.Node]:
+        """
+        Collect tensor-like node inputs from node.args.
+
+        This function intentionally inspects only positional arguments because
+        the supported operators in this pass use positional tensor inputs.
+        """
+        return [arg for arg in node.args if isinstance(arg, torch.fx.Node)]
+
+    def _match_reshape_4d_to_3d(
+        self, node: torch.fx.Node
+    ) -> tuple[torch.fx.Node, RankMapping] | None:
+        """
+        Match a reshape that removes exactly one singleton dimension.
+
+        Examples:
+            [B, 1, T, D] -> [B, T, D]
+            [B, T, 1, D] -> [B, T, D]
+            [B, T, D, 1] -> [B, T, D]
+
+        If multiple singleton axes could be removed to produce the same 3D shape,
+        prefer removing a non-leading singleton axis first. This avoids
+        accidentally interpreting the batch axis as the removed singleton axis
+        in shapes such as [1, 1, T, D] -> [1, T, D].
+        """
+        if not self._is_call_function(node, torch.ops.aten.reshape.default):
+            return None
+
+        src = node.args[0]
+        dst_shape = node.args[1]
+
+        if not isinstance(src, torch.fx.Node):
+            return None
+
+        src_shape = self._normalize_shape(extract_shape(src))
+        dst_shape = self._normalize_shape(dst_shape)
+
+        if len(src_shape) != 4 or len(dst_shape) != 3:
+            return None
+
+        candidate_axes = [i for i, dim in enumerate(src_shape) if dim == 1]
+
+        # Prefer removing a non-leading singleton axis first.
+        candidate_axes.sort(key=lambda i: (i == 0, i))
+
+        for inserted_axis in candidate_axes:
+            squeezed = src_shape[:inserted_axis] + src_shape[inserted_axis + 1 :]
+            if squeezed == dst_shape:
+                axis_3d_to_4d = {}
+                j = 0
+                for i in range(4):
+                    if i == inserted_axis:
+                        continue
+                    axis_3d_to_4d[j] = i
+                    j += 1
+                return src, RankMapping(
+                    axis_3d_to_4d=axis_3d_to_4d,
+                    inserted_axis_4d=inserted_axis,
+                )
+
+        return None
+
+    def _is_supported_unary(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a unary op is supported.
+        """
+        return node.op == "call_function" and node.target in {
+            torch.ops.aten.sigmoid.default,
+            torch.ops.aten.relu.default,
+            torch.ops.aten.rsqrt.default,
+            torch.ops.aten.silu.default,
+            torch.ops.aten.neg.default,
+        }
+
+    def _is_supported_binary(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a binary elementwise op is supported.
+        """
+        return node.op == "call_function" and node.target in {
+            torch.ops.aten.add.Tensor,
+            torch.ops.aten.sub.Tensor,
+            torch.ops.aten.mul.Tensor,
+            torch.ops.aten.div.Tensor,
+        }
+
+    def _is_supported_pow(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a scalar power op is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.pow.Tensor_Scalar
+            and len(node.args) == 2
+            and isinstance(node.args[1], (int, float))
+        )
+
+    def _is_supported_mean(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a mean reduction is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.mean.dim
+            and len(node.args) >= 2
+            and isinstance(node.args[1], (list, tuple))
+        )
+
+    def _is_supported_permute(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a 3D permute is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.permute.default
+            and len(node.args) == 2
+            and isinstance(node.args[1], (list, tuple))
+            and len(node.args[1]) == 3
+        )
+
+    def _is_supported_transpose(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a 3D transpose is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.transpose.int
+            and len(node.args) == 3
+            and isinstance(node.args[1], int)
+            and isinstance(node.args[2], int)
+        )
+
+    def _is_supported_split(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether split_with_sizes is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.split_with_sizes.default
+            and len(node.args) == 3
+            and isinstance(node.args[1], (list, tuple))
+            and isinstance(node.args[2], int)
+        )
+
+    def _is_supported_chunk(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether chunk is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.chunk.default
+            and len(node.args) == 3
+            and isinstance(node.args[1], int)
+            and isinstance(node.args[2], int)
+        )
+
+    def _is_supported_getitem(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether tuple indexing is supported.
+        """
+        return (
+            node.op == "call_function"
+            and node.target == operator.getitem
+            and len(node.args) == 2
+            and isinstance(node.args[1], int)
+        )
+
+    def _is_supported_internal_node(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a node is supported inside the region.
+        """
+        return (
+            self._is_supported_unary(node)
+            or self._is_supported_binary(node)
+            or self._is_supported_pow(node)
+            or self._is_supported_mean(node)
+            or self._is_supported_permute(node)
+            or self._is_supported_transpose(node)
+            or self._is_supported_split(node)
+            or self._is_supported_chunk(node)
+            or self._is_supported_getitem(node)
+        )
+
+    def _is_weak_sink_reshape(self, node: torch.fx.Node) -> bool:
+        """
+        Check whether a node is a weak sink reshape from rank 3 to rank 4.
+
+        Unlike a strict restore matcher, this only checks rank change.
+        It does not require the output shape to be the exact inverse of the
+        source reshape.
+        """
+        if not self._is_call_function(node, torch.ops.aten.reshape.default):
+            return False
+
+        src = node.args[0]
+        dst_shape = node.args[1]
+
+        if not isinstance(src, torch.fx.Node):
+            return False
+
+        try:
+            src_shape = self._normalize_shape(extract_shape(src))
+        except Exception:
+            return False
+
+        dst_shape = self._normalize_shape(dst_shape)
+
+        return len(src_shape) == 3 and len(dst_shape) == 4
+
+    def _is_allowed_external_input(
+        self,
+        arg,
+        region_nodes: set[torch.fx.Node],
+        source_reshape: torch.fx.Node,
+    ) -> bool:
+        """
+        Check whether an external input is allowed for a region internal node.
+
+        Allowed external inputs:
+          - non-node constants
+          - the source reshape itself
+          - nodes already inside the region
+          - get_attr / placeholder nodes
+        """
+        if not isinstance(arg, torch.fx.Node):
+            return True
+
+        if arg is source_reshape:
+            return True
+
+        if arg in region_nodes:
+            return True
+
+        if arg.op in {"get_attr", "placeholder"}:
+            return True
+
+        return False
+
+    def _collect_region(
+        self,
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> Region | None:
+        """
+        Collect a supported region reachable from the source reshape.
+
+        The collection is performed in two phases:
+          1. Collect candidate internal nodes and weak sink reshapes by forward
+             traversal over supported nodes.
+          2. Validate closure: every internal node must depend only on
+             - the source reshape,
+             - other internal nodes,
+             - or allowed external inputs.
+
+        Weak sink reshapes are treated as region boundaries and are not required
+        to be the exact inverse of the source reshape.
+        """
+        region_nodes: set[torch.fx.Node] = {source_reshape}
+        internal_nodes: list[torch.fx.Node] = []
+        sink_reshapes: list[torch.fx.Node] = []
+
+        q = deque([source_reshape])
+
+        # Phase 1: collect candidates without requiring all inputs to already be
+        # present in region_nodes.
+        while q:
+            producer = q.popleft()
+
+            for user in list(producer.users):
+                if self._is_weak_sink_reshape(user):
+                    if user not in sink_reshapes:
+                        sink_reshapes.append(user)
+                    continue
+
+                if not self._is_supported_internal_node(user):
+                    continue
+
+                if user not in region_nodes:
+                    region_nodes.add(user)
+                    internal_nodes.append(user)
+                    q.append(user)
+
+        if not sink_reshapes:
+            return None
+
+        internal_set = set(internal_nodes)
+
+        # Phase 2: validate input closure.
+        for node in internal_nodes:
+            tensor_inputs = self._tensor_node_inputs(node)
+            for arg in tensor_inputs:
+                if arg is source_reshape:
+                    continue
+                if arg in internal_set:
+                    continue
+                if self._is_allowed_external_input(
+                    arg, internal_set | {source_reshape}, source_reshape
+                ):
+                    continue
+                return None
+
+        # Phase 3: ensure region does not leak to unsupported users except sinks.
+        for node in internal_nodes:
+            for user in node.users:
+                if user in internal_set:
+                    continue
+                if user in sink_reshapes:
+                    continue
+                return None
+
+        return Region(
+            source_reshape=source_reshape,
+            original_4d=original_4d,
+            mapping=mapping,
+            internal_nodes=internal_nodes,
+            sink_reshapes=sink_reshapes,
+        )
+
+    def _topo_sort_region(self, region: Region) -> list[torch.fx.Node]:
+        """
+        Topologically sort internal region nodes according to graph order.
+        """
+        internal_set = set(region.internal_nodes)
+        return [
+            node for node in region.source_reshape.graph.nodes if node in internal_set
+        ]
+
+    def _map_arg(
+        self,
+        arg,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+    ):
+        """
+        Map one old argument to its rewritten equivalent.
+        """
+        if not isinstance(arg, torch.fx.Node):
+            return arg
+
+        if arg is source_reshape:
+            return original_4d
+
+        if arg in env:
+            return env[arg]
+
+        return arg
+
+    def _rewrite_unary(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a unary operator.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(inp,),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_binary(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a binary elementwise operator.
+        """
+        lhs = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        rhs = self._map_arg(node.args[1], env, source_reshape, original_4d)
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(lhs, rhs),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_pow(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a scalar power operator.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        exponent = node.args[1]
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(inp, exponent),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_mean(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a mean reduction by remapping 3D dims into 4D dims.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        dims_3d = list(node.args[1])  # type: ignore[arg-type]
+        dims_4d = mapping.remap_axes(dims_3d)
+        args = (inp, dims_4d)
+        if len(node.args) == 3:
+            keep_dim = node.args[2]
+            args = (inp, dims_4d, keep_dim)  # type: ignore[assignment]
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=args,
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_permute(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a 3D permute into the equivalent 4D permute.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        perm_3d = list(node.args[1])  # type: ignore[arg-type]
+        perm_4d = mapping.remap_permute(perm_3d)
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(inp, perm_4d),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_transpose(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a 3D transpose into the equivalent 4D transpose.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        dim0_3d = node.args[1]
+        dim1_3d = node.args[2]
+        assert isinstance(dim0_3d, int) and isinstance(dim1_3d, int)
+        dim0_4d, dim1_4d = mapping.remap_transpose(dim0_3d, dim1_3d)
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(inp, dim0_4d, dim1_4d),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_split(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> torch.fx.Node:
+        """
+        Rewrite split_with_sizes by remapping its split dimension.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        split_sizes = list(node.args[1])  # type: ignore[arg-type]
+        dim_3d = node.args[2]
+        assert isinstance(dim_3d, int)
+        dim_4d = mapping.remap_axis(dim_3d)
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(inp, split_sizes, dim_4d),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_chunk(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> torch.fx.Node:
+        """
+        Rewrite chunk by remapping its chunk dimension.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        chunks = node.args[1]
+        dim_3d = node.args[2]
+        assert isinstance(dim_3d, int)
+        dim_4d = mapping.remap_axis(dim_3d)
+        assert isinstance(node.target, torch._ops.OpOverload), type(node.target)
+        return create_node(
+            graph,
+            node.target,
+            args=(inp, chunks, dim_4d),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_getitem(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+    ) -> torch.fx.Node:
+        """
+        Rewrite a tuple getitem.
+
+        The producer is expected to be a rewritten split or chunk node.
+        """
+        inp = self._map_arg(node.args[0], env, source_reshape, original_4d)
+        idx = node.args[1]
+        return create_node(
+            graph,
+            operator.getitem,  # type: ignore[arg-type]
+            args=(inp, idx),
+            kwargs=node.kwargs,
+            origin=node,
+        )
+
+    def _rewrite_node(
+        self,
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        env: dict[torch.fx.Node, torch.fx.Node],
+        source_reshape: torch.fx.Node,
+        original_4d: torch.fx.Node,
+        mapping: RankMapping,
+    ) -> torch.fx.Node:
+        """
+        Rewrite one supported region-internal node.
+        """
+        if self._is_supported_unary(node):
+            return self._rewrite_unary(graph, node, env, source_reshape, original_4d)
+
+        if self._is_supported_binary(node):
+            return self._rewrite_binary(graph, node, env, source_reshape, original_4d)
+
+        if self._is_supported_pow(node):
+            return self._rewrite_pow(graph, node, env, source_reshape, original_4d)
+
+        if self._is_supported_mean(node):
+            return self._rewrite_mean(
+                graph, node, env, source_reshape, original_4d, mapping
+            )
+
+        if self._is_supported_permute(node):
+            return self._rewrite_permute(
+                graph, node, env, source_reshape, original_4d, mapping
+            )
+
+        if self._is_supported_transpose(node):
+            return self._rewrite_transpose(
+                graph, node, env, source_reshape, original_4d, mapping
+            )
+
+        if self._is_supported_split(node):
+            return self._rewrite_split(
+                graph, node, env, source_reshape, original_4d, mapping
+            )
+
+        if self._is_supported_chunk(node):
+            return self._rewrite_chunk(
+                graph, node, env, source_reshape, original_4d, mapping
+            )
+
+        if self._is_supported_getitem(node):
+            return self._rewrite_getitem(graph, node, env, source_reshape, original_4d)
+
+        raise RuntimeError(f"Unsupported node in region rewrite: {node.target}")
+
+    def _rewrite_region(
+        self,
+        exported_program: ExportedProgram,
+        region: Region,
+    ) -> bool:
+        """
+        Rewrite all internal region nodes in topological order and update each
+        sink reshape to consume the rewritten 4D producer.
+
+        The sink reshape is not required to be removed here. This pass focuses
+        on eliminating the source rank-reducing reshape and lifting the region
+        into 4D semantics.
+        """
+        gm = exported_program.graph_module
+        graph = gm.graph
+
+        env: dict[torch.fx.Node, torch.fx.Node] = {}
+        topo_nodes = self._topo_sort_region(region)
+
+        with graph.inserting_before(region.source_reshape):
+            for node in topo_nodes:
+                rewritten = self._rewrite_node(
+                    graph=graph,
+                    node=node,
+                    env=env,
+                    source_reshape=region.source_reshape,
+                    original_4d=region.original_4d,
+                    mapping=region.mapping,
+                )
+                set_new_meta_val(rewritten)
+                env[node] = rewritten
+
+        for sink in region.sink_reshapes:
+            old_input = sink.args[0]
+            if not isinstance(old_input, torch.fx.Node):
+                return False
+
+            if old_input is region.source_reshape:
+                new_input = region.original_4d
+            elif old_input in env:
+                new_input = env[old_input]
+            else:
+                return False
+
+            sink.update_arg(0, new_input)
+
+        return True
+
+    def call(self, exported_program: ExportedProgram) -> PassResult:
+        """
+        Run the pass over the graph.
+        """
+        if not self.enabled:
+            return PassResult(False)
+
+        gm = exported_program.graph_module
+        graph = gm.graph
+        modified = False
+
+        for node in list(graph.nodes):
+            matched = self._match_reshape_4d_to_3d(node)
+            if matched is None:
+                continue
+
+            original_4d, mapping = matched
+            region = self._collect_region(
+                source_reshape=node,
+                original_4d=original_4d,
+                mapping=mapping,
+            )
+            if region is None:
+                continue
+
+            if not region.internal_nodes:
+                continue
+
+            modified |= self._rewrite_region(
+                exported_program=exported_program,
+                region=region,
+            )
+
+        if modified:
+            graph.eliminate_dead_code()
+            graph.lint()
+            gm.recompile()
+
+        return PassResult(modified)

--- a/tico/passes/ops.py
+++ b/tico/passes/ops.py
@@ -56,12 +56,15 @@ class AtenOps:
         self.mul_tensor = [torch.ops.aten.mul.Tensor]
         self.permute = [torch.ops.aten.permute.default]
         self.reshape = [torch.ops.aten.reshape.default]
+        self.rsqrt = [torch.ops.aten.rsqrt.default]
         self.select = [torch.ops.aten.select_copy.int, torch.ops.aten.select.int]
+        self.sigmoid = [torch.ops.aten.sigmoid.default]
         self.slice = [torch.ops.aten.slice.Tensor, torch.ops.aten.slice_copy.Tensor]
         self.softmax = [
             torch.ops.aten._softmax.default,
             torch.ops.aten._safe_softmax.default,
         ]
+        self.split_with_sizes = [torch.ops.aten.split_with_sizes.default]
         self.squeeze = [torch.ops.aten.squeeze.dims, torch.ops.aten.squeeze_copy.dims]
         self.to_copy = [
             torch.ops.aten._to_copy.default,

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -41,6 +41,7 @@ from tico.passes.decompose_fake_quantize_tensor_qparams import (
 from tico.passes.decompose_group_norm import DecomposeGroupNorm
 from tico.passes.decompose_grouped_conv2d import DecomposeGroupedConv2d
 from tico.passes.decompose_slice_scatter import DecomposeSliceScatter
+from tico.passes.eliminate_rank_round_trip_region import EliminateRankRoundTripRegion
 from tico.passes.extract_dtype_kwargs import ExtractDtypeKwargsPass
 from tico.passes.fill_meta_val import FillMetaVal
 from tico.passes.fuse_leading_unsqueeze_reshape import FuseLeadingUnsqueezeReshape
@@ -279,6 +280,9 @@ def convert_exported_module_to_circle(
             *LowerToSlicePasses(),
             FuseLeadingUnsqueezeReshape(),
             CastClampMixedTypeArgs(),
+            EliminateRankRoundTripRegion(
+                enabled=config.get("eliminate_rank_round_trip")
+            ),
         ]
     )
     circle_legalize.run(exported_program)
@@ -320,6 +324,9 @@ def convert_exported_module_to_circle(
 
     if os.environ.get("TICO_GRAPH_DUMP"):
         save_fx_graph_as_png(exported_program, file_name="3_after_quantfold")
+
+    logger.debug("Output ExportedProgram")
+    logger.debug(exported_program)
 
     check_unsupported_target(exported_program)
     check_training_ops(exported_program)

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -280,9 +280,7 @@ def convert_exported_module_to_circle(
             *LowerToSlicePasses(),
             FuseLeadingUnsqueezeReshape(),
             CastClampMixedTypeArgs(),
-            EliminateRankRoundTripRegion(
-                enabled=config.get("eliminate_rank_round_trip")
-            ),
+            EliminateRankRoundTripRegion(enabled=True),
         ]
     )
     circle_legalize.run(exported_program)


### PR DESCRIPTION
### eliminate_rank_round_trip (experimental)

Eliminates reshape round-trip patterns (4D → 3D → 4D) by lifting the intermediate
3D computation region back to 4D.

This pass:
- Removes the source rank-reducing reshape
- Rewrites supported intermediate ops (e.g., elementwise, permute, transpose, split/chunk)
  to operate directly on the original 4D tensor
- Updates sink reshapes to consume the rewritten 4D values

Note:
This is a semantic region rewrite rather than a simple peephole optimization.
It is currently disabled by default until broader correctness coverage is verified.

### Before

<img width="179" height="908" alt="image" src="https://github.com/user-attachments/assets/159e6ffa-b522-48a2-a2fe-b1007409c8ef" />

### After

<img width="192" height="864" alt="image" src="https://github.com/user-attachments/assets/b71abd6b-e4fb-4315-9df8-7ce6070cf2fb" />

