### PR TITLE
[quantization] Refactor tracing/debugging utilities to share common core between introspection and trace_qwen

### DIFF
--- a/test/quantization/wrapq/utils/test_introspection.py
+++ b/test/quantization/wrapq/utils/test_introspection.py
@@ -24,7 +24,11 @@ from tico.quantization.config.smoothquant import SmoothQuantConfig
 from tico.quantization.wrapq.utils.introspection import (
     build_fqn_map,
     compare_layer_outputs,
+    ModuleInputOutput,
+    ModuleName,
+    ModuleOutput,
     save_fp_outputs,
+    TensorStatistics,
 )
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 
@@ -242,3 +246,1395 @@ class TestSmoothQuantPTQDiff(unittest.TestCase):
         )
         for metric_dict in stats.values():
             self.assertIn("mae", metric_dict)
+
+
+class TestTensorStatistics(unittest.TestCase):
+    """Unit tests for TensorStatistics class."""
+
+    def test_tensor_statistics_creation(self):
+        """Test that TensorStatistics can be created with correct values."""
+        from tico.quantization.wrapq.utils.introspection import (
+            DifferenceStatistics,
+            get_tensor_statistics,
+            TensorStatistics,
+        )
+
+        stats = TensorStatistics(mean=1.5, min=-2.0, max=3.0, stddev=0.5)
+
+        self.assertEqual(stats.mean, 1.5)
+        self.assertEqual(stats.min, -2.0)
+        self.assertEqual(stats.max, 3.0)
+        self.assertEqual(stats.stddev, 0.5)
+
+    def test_tensor_statistics_asdict(self):
+        """Test that _asdict method returns correct dictionary."""
+        from tico.quantization.wrapq.utils.introspection import TensorStatistics
+
+        stats = TensorStatistics(mean=1.5, min=-2.0, max=3.0, stddev=0.5)
+        result = stats._asdict()
+
+        expected = {"mean": 1.5, "min": -2.0, "max": 3.0, "stddev": 0.5}
+
+        self.assertEqual(result, expected)
+
+    def test_tensor_statistics_frozen(self):
+        """Test that TensorStatistics is frozen and cannot be modified."""
+        from tico.quantization.wrapq.utils.introspection import TensorStatistics
+
+        stats = TensorStatistics(mean=1.5, min=-2.0, max=3.0, stddev=0.5)
+
+        with self.assertRaises(Exception):
+            stats.mean = 2.0  # type: ignore[misc]
+
+    def test_get_tensor_statistics(self):
+        """Test get_tensor_statistics function with various tensors."""
+        from tico.quantization.wrapq.utils.introspection import get_tensor_statistics
+
+        # Test with simple tensor
+        tensor = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+        stats = get_tensor_statistics(tensor)
+
+        self.assertIsInstance(stats, TensorStatistics)
+        self.assertAlmostEqual(stats.mean, 3.0, places=5)
+        self.assertAlmostEqual(stats.min, 1.0, places=5)
+        self.assertAlmostEqual(stats.max, 5.0, places=5)
+        self.assertAlmostEqual(stats.stddev, 1.414213538, places=5)
+
+        # Test with 2D tensor
+        tensor_2d = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        stats_2d = get_tensor_statistics(tensor_2d)
+
+        self.assertIsInstance(stats_2d, TensorStatistics)
+        self.assertAlmostEqual(stats_2d.mean, 2.5, places=5)
+        self.assertAlmostEqual(stats_2d.min, 1.0, places=5)
+        self.assertAlmostEqual(stats_2d.max, 4.0, places=5)
+
+        # Test with single element tensor
+        tensor_single = torch.tensor([42.0])
+        stats_single = get_tensor_statistics(tensor_single)
+
+        self.assertIsInstance(stats_single, TensorStatistics)
+        self.assertAlmostEqual(stats_single.mean, 42.0, places=5)
+        self.assertAlmostEqual(stats_single.min, 42.0, places=5)
+        self.assertAlmostEqual(stats_single.max, 42.0, places=5)
+
+    def test_difference_statistics_creation(self):
+        """Test that DifferenceStatistics can be created with correct values."""
+        from tico.quantization.wrapq.utils.introspection import DifferenceStatistics
+
+        diff_stats = DifferenceStatistics(
+            mean=0.1, min=0.0, max=0.5, stddev=0.05, peir=0.02
+        )
+
+        self.assertEqual(diff_stats.mean, 0.1)
+        self.assertEqual(diff_stats.min, 0.0)
+        self.assertEqual(diff_stats.max, 0.5)
+        self.assertEqual(diff_stats.stddev, 0.05)
+        self.assertEqual(diff_stats.peir, 0.02)
+
+    def test_difference_statistics_inheritance(self):
+        """Test that DifferenceStatistics inherits from TensorStatistics."""
+        from tico.quantization.wrapq.utils.introspection import (
+            DifferenceStatistics,
+            TensorStatistics,
+        )
+
+        diff_stats = DifferenceStatistics(
+            mean=0.1, min=0.0, max=0.5, stddev=0.05, peir=0.02
+        )
+
+        # Should have all TensorStatistics attributes
+        self.assertTrue(hasattr(diff_stats, "mean"))
+        self.assertTrue(hasattr(diff_stats, "min"))
+        self.assertTrue(hasattr(diff_stats, "max"))
+        self.assertTrue(hasattr(diff_stats, "stddev"))
+        # Plus the additional peir attribute
+        self.assertTrue(hasattr(diff_stats, "peir"))
+        # Should be an instance of TensorStatistics
+        self.assertIsInstance(diff_stats, TensorStatistics)
+
+    def test_difference_statistics_asdict(self):
+        """Test that DifferenceStatistics _asdict method includes peir."""
+        from tico.quantization.wrapq.utils.introspection import DifferenceStatistics
+
+        diff_stats = DifferenceStatistics(
+            mean=0.1, min=0.0, max=0.5, stddev=0.05, peir=0.02
+        )
+        result = diff_stats._asdict()
+
+        expected = {"mean": 0.1, "min": 0.0, "max": 0.5, "stddev": 0.05, "peir": 0.02}
+
+        self.assertEqual(result, expected)
+
+
+class TestDetachTensors(unittest.TestCase):
+    """Unit tests for detach_tensors function."""
+
+    def test_detach_plain_tensor(self):
+        """Test that a plain tensor is detached and cloned."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        t = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+        result = detach_tensors(t)
+
+        # Should be a tensor with the same values
+        self.assertTrue(torch.equal(result, t))
+        # Should not require grad (detached)
+        self.assertFalse(result.requires_grad)
+        # Should be a different object (cloned)
+        self.assertIsNot(result, t)
+        # Modifying the clone should not affect the original
+        result[0] = 99.0
+        self.assertAlmostEqual(t[0].item(), 1.0)
+
+    def test_detach_tensor_no_grad(self):
+        """Test detach_tensors on a tensor that already doesn't require grad."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        t = torch.tensor([4.0, 5.0, 6.0])
+        result = detach_tensors(t)
+
+        self.assertTrue(torch.equal(result, t))
+        self.assertFalse(result.requires_grad)
+        self.assertIsNot(result, t)
+
+    def test_detach_dict(self):
+        """Test that tensors inside a dict are recursively detached."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        t1 = torch.tensor([1.0, 2.0], requires_grad=True)
+        t2 = torch.tensor([3.0, 4.0], requires_grad=True)
+        d = {"a": t1, "b": t2, "c": "not_a_tensor"}
+
+        result = detach_tensors(d)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(set(result.keys()), {"a", "b", "c"})
+        # Tensors should be detached and cloned
+        self.assertTrue(torch.equal(result["a"], t1))
+        self.assertFalse(result["a"].requires_grad)
+        self.assertTrue(torch.equal(result["b"], t2))
+        self.assertFalse(result["b"].requires_grad)
+        # Non-tensor values should pass through unchanged
+        self.assertEqual(result["c"], "not_a_tensor")
+
+    def test_detach_list(self):
+        """Test that tensors inside a list are recursively detached."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        t1 = torch.tensor([1.0], requires_grad=True)
+        t2 = torch.tensor([2.0], requires_grad=True)
+        lst = [t1, t2, 42]
+
+        result = detach_tensors(lst)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
+        self.assertTrue(torch.equal(result[0], t1))
+        self.assertFalse(result[0].requires_grad)
+        self.assertTrue(torch.equal(result[1], t2))
+        self.assertFalse(result[1].requires_grad)
+        self.assertEqual(result[2], 42)
+
+    def test_detach_tuple(self):
+        """Test that tensors inside a tuple are recursively detached."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        t1 = torch.tensor([1.0], requires_grad=True)
+        t2 = torch.tensor([2.0], requires_grad=True)
+        tup = (t1, t2)
+
+        result = detach_tensors(tup)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(torch.equal(result[0], t1))
+        self.assertFalse(result[0].requires_grad)
+        self.assertTrue(torch.equal(result[1], t2))
+        self.assertFalse(result[1].requires_grad)
+
+    def test_detach_nested_structure(self):
+        """Test that tensors inside nested dicts/lists are recursively detached."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        t = torch.tensor([1.0, 2.0], requires_grad=True)
+        nested = {"outer": {"inner": [t, 42]}}
+
+        result = detach_tensors(nested)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertIsInstance(result["outer"], dict)
+        self.assertIsInstance(result["outer"]["inner"], list)
+        self.assertTrue(torch.equal(result["outer"]["inner"][0], t))
+        self.assertFalse(result["outer"]["inner"][0].requires_grad)
+        self.assertEqual(result["outer"]["inner"][1], 42)
+
+    def test_detach_non_tensor_scalar(self):
+        """Test that non-tensor, non-iterable values pass through unchanged."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+
+        self.assertEqual(detach_tensors(42), 42)
+        self.assertEqual(detach_tensors(3.14), 3.14)
+        self.assertEqual(detach_tensors("hello"), "hello")
+        self.assertIsNone(detach_tensors(None))
+
+    def test_detach_model_output(self):
+        """Test that tensors inside a ModelOutput are recursively detached."""
+        from tico.quantization.wrapq.utils.introspection import detach_tensors
+        from transformers.modeling_outputs import BaseModelOutput
+
+        t = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+        output = BaseModelOutput(last_hidden_state=t)
+
+        result = detach_tensors(output)
+
+        self.assertIsInstance(result, BaseModelOutput)
+        self.assertTrue(torch.equal(result.last_hidden_state, t))
+        self.assertFalse(result.last_hidden_state.requires_grad)
+
+
+class TestModelOutputToSerializable(unittest.TestCase):
+    """Unit tests for model_output_to_serializable function."""
+
+    def test_tensor_with_type(self):
+        """Test serialization of a tensor with type information included."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = model_output_to_serializable(t, include_type=True)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "Tensor")
+        self.assertEqual(result["dtype"], str(t.dtype))
+        self.assertEqual(result["shape"], str(t.shape))
+        # numel > 1, so statistics should be present
+        self.assertIn("statistics", result)
+        self.assertIsInstance(result["statistics"], dict)
+        assert isinstance(result["statistics"], dict)  # for mypy type narrowing
+        self.assertIn("mean", result["statistics"])
+        self.assertIn("min", result["statistics"])
+        self.assertIn("max", result["statistics"])
+        self.assertIn("stddev", result["statistics"])
+        # numel > 1 and include_tensor_content=False, so no value key
+        self.assertNotIn("value", result)
+
+    def test_tensor_without_type(self):
+        """Test serialization of a tensor with type information excluded."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([1.0, 2.0, 3.0])
+        result = model_output_to_serializable(t, include_type=False)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertNotIn("type", result)
+        self.assertIn("dtype", result)
+        self.assertIn("shape", result)
+
+    def test_tensor_with_content(self):
+        """Test serialization of a tensor with content included."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([1.0, 2.0, 3.0])
+        result = model_output_to_serializable(t, include_tensor_content=True)
+
+        assert isinstance(result, dict)
+        self.assertIn("value", result)
+        self.assertEqual(result["value"], [1.0, 2.0, 3.0])
+
+    def test_single_element_tensor(self):
+        """Test serialization of a single-element tensor (value always included)."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([42.0])
+        result = model_output_to_serializable(t)
+
+        # Single element: value is included even without include_tensor_content
+        assert isinstance(result, dict)
+        self.assertIn("value", result)
+        self.assertEqual(result["value"], [42.0])
+        # Single element: no statistics
+        self.assertNotIn("statistics", result)
+
+    def test_scalar_tensor(self):
+        """Test serialization of a scalar tensor (0-dim)."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor(3.14)
+        result = model_output_to_serializable(t)
+
+        # Scalar: numel == 1, value is included
+        assert isinstance(result, dict)
+        self.assertIn("value", result)
+        assert isinstance(result["value"], float)  # for mypy type narrowing
+        self.assertAlmostEqual(result["value"], 3.14, places=4)
+        self.assertNotIn("statistics", result)
+
+    def test_dict_serialization(self):
+        """Test serialization of a dict containing tensors."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([1.0, 2.0])
+        d = {"key1": t, "key2": "hello"}
+        result = model_output_to_serializable(d)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "dict")
+        self.assertIn("key1", result)
+        self.assertIn("key2", result)
+        # key1 should be a serialized tensor
+        self.assertEqual(result["key1"]["type"], "Tensor")
+        # key2 should be a serialized string
+        self.assertEqual(result["key2"], "hello")
+
+    def test_list_serialization(self):
+        """Test serialization of a list containing tensors."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([1.0, 2.0])
+        lst = [t, 42]
+        result = model_output_to_serializable(lst)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "list")
+        self.assertIn("0", result)
+        self.assertIn("1", result)
+        # First element should be a serialized tensor
+        self.assertEqual(result["0"]["type"], "Tensor")
+        # Second element (int) should be converted to string
+        self.assertEqual(result["1"], 42)
+
+    def test_tuple_serialization(self):
+        """Test serialization of a tuple containing tensors."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t = torch.tensor([1.0])
+        tup = (t,)
+        result = model_output_to_serializable(tup)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "tuple")
+        self.assertIn("0", result)
+
+    def test_model_output_serialization(self):
+        """Test serialization of a ModelOutput object."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+        from transformers.modeling_outputs import BaseModelOutput
+
+        t = torch.tensor([1.0, 2.0, 3.0])
+        output = BaseModelOutput(last_hidden_state=t)
+        result = model_output_to_serializable(output)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "BaseModelOutput")
+        self.assertIn("last_hidden_state", result)
+        self.assertEqual(result["last_hidden_state"]["type"], "Tensor")
+
+    def test_namedtuple_serialization(self):
+        """Test serialization of a NamedTuple."""
+        from typing import NamedTuple
+
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        class Point(NamedTuple):
+            x: int
+            y: int
+
+        p = Point(x=1, y=2)
+        result = model_output_to_serializable(p)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "Point")
+        # NamedTuple uses _asdict, so fields are inlined
+        self.assertIn("x", result)
+        self.assertIn("y", result)
+
+    def test_non_tensor_primitive(self):
+        """Test serialization of non-tensor primitive types returns string."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        # Integer
+        result_int = model_output_to_serializable(42)
+        self.assertEqual(result_int, 42)
+
+        # Float
+        result_float = model_output_to_serializable(3.14)
+        self.assertEqual(result_float, 3.14)
+
+        # String
+        result_str = model_output_to_serializable("hello")
+        self.assertEqual(result_str, "hello")
+
+    def test_none_serialization(self):
+        """Test serialization of None returns string representation."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        result = model_output_to_serializable(None)
+        self.assertEqual(result, "None")
+
+    def test_nested_dict_with_tensors(self):
+        """Test serialization of a nested dict with tensors."""
+        from tico.quantization.wrapq.utils.introspection import (
+            model_output_to_serializable,
+        )
+
+        t1 = torch.tensor([1.0, 2.0])
+        t2 = torch.tensor([3.0])
+        nested = {"outer": {"inner": t1}, "single": t2}
+        result = model_output_to_serializable(nested)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertEqual(result["type"], "dict")
+        self.assertIn("outer", result)
+        self.assertIn("single", result)
+        self.assertEqual(result["outer"]["type"], "dict")  # type: ignore[index]
+        self.assertIn("inner", result["outer"])
+        self.assertEqual(result["outer"]["inner"]["type"], "Tensor")  # type: ignore[index]
+
+
+class TestModuleInputOutput(unittest.TestCase):
+    """Unit tests for ModuleInputOutput NamedTuple."""
+
+    def setUp(self):
+        from tico.quantization.wrapq.utils.introspection import ModuleInputOutput
+
+        self.module = nn.Linear(4, 4)
+        self.inputs = (torch.tensor([1.0, 2.0, 3.0, 4.0]),)
+        self.kwargs = {"mask": None}
+        self.output = torch.tensor([5.0, 6.0, 7.0, 8.0])
+        self.mio = ModuleInputOutput(
+            module=self.module,
+            module_name="linear1",
+            inputs=self.inputs,
+            kwargs=self.kwargs,
+            output=self.output,
+        )
+
+    def test_field_access(self):
+        """Test that all fields of ModuleInputOutput are accessible."""
+        self.assertIs(self.mio.module, self.module)
+        self.assertEqual(self.mio.module_name, "linear1")
+        self.assertEqual(self.mio.inputs, self.inputs)
+        self.assertEqual(self.mio.kwargs, self.kwargs)
+        self.assertIs(self.mio.output, self.output)
+
+    def test_is_named_tuple(self):
+        """Test that ModuleInputOutput is a NamedTuple."""
+        from tico.quantization.wrapq.utils.introspection import ModuleInputOutput
+
+        self.assertTrue(hasattr(ModuleInputOutput, "_fields"))
+        self.assertEqual(
+            ModuleInputOutput._fields,
+            ("module", "module_name", "inputs", "kwargs", "output"),
+        )
+        self.assertIsInstance(self.mio, tuple)
+
+    def test_as_serializable_keys(self):
+        """Test that as_serializable returns dict with expected top-level keys."""
+        result = self.mio.as_serializable()
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertIn("module_name", result)
+        self.assertIn("module_type", result)
+        self.assertIn("inputs", result)
+        self.assertIn("kwargs", result)
+        self.assertIn("output", result)
+        self.assertEqual(result["module_name"], "linear1")
+        self.assertEqual(result["module_type"], "Linear")
+
+    def test_as_serializable_with_type(self):
+        """Test as_serializable with include_type=True (default)."""
+        result = self.mio.as_serializable(include_type=True)
+
+        # Input tuple should have type info
+        self.assertIsInstance(result["inputs"], dict)
+        self.assertIn("type", result["inputs"])
+        self.assertEqual(result["inputs"]["type"], "tuple")
+
+    def test_as_serializable_without_type(self):
+        """Test as_serializable with include_type=False."""
+        result = self.mio.as_serializable(include_type=False)
+
+        # Top-level should not have type, but nested serialization
+        # also respects include_type
+        self.assertNotIn("type", result)
+
+    def test_as_serializable_with_tensor_content(self):
+        """Test as_serializable with include_tensor_content=True."""
+        result = self.mio.as_serializable(include_tensor_content=True)
+
+        # The output tensor should include its value when include_tensor_content is True
+        self.assertIn("output", result)
+        output_data = result["output"]
+        self.assertIn("value", output_data)
+
+    def test_as_serializable_empty_kwargs(self):
+        """Test as_serializable with empty kwargs."""
+        from tico.quantization.wrapq.utils.introspection import ModuleInputOutput
+
+        mio = ModuleInputOutput(
+            module=self.module,
+            module_name="linear1",
+            inputs=self.inputs,
+            kwargs={},
+            output=self.output,
+        )
+        result = mio.as_serializable()
+
+        self.assertIsInstance(result["kwargs"], dict)
+        self.assertEqual(len(result["kwargs"]), 0)
+
+    def test_as_serializable_tensor_output(self):
+        """Test as_serializable correctly serializes a tensor output."""
+        result = self.mio.as_serializable()
+
+        output_data = result["output"]
+        self.assertIsInstance(output_data, dict)
+        self.assertIn("dtype", output_data)
+        self.assertIn("shape", output_data)
+        # numel > 1 so statistics should be present
+        self.assertIn("statistics", output_data)
+
+
+class TestModuleHook(unittest.TestCase):
+    """Unit tests for module_hook context manager."""
+
+    def test_hook_called_during_context(self):
+        """Test that the hook is called for module forward passes within the context."""
+        from tico.quantization.wrapq.utils.introspection import module_hook
+
+        called = []
+
+        def hook(module, inputs, kwargs, output):
+            called.append(type(module).__name__)
+
+        model = nn.Sequential(nn.Linear(2, 2), nn.ReLU())
+        x = torch.randn(1, 2)
+
+        with module_hook(hook):
+            with torch.no_grad():
+                model(x)
+
+        # Hook should have been called for each module in the model
+        self.assertGreater(len(called), 0)
+        self.assertIn("Linear", called)
+        self.assertIn("ReLU", called)
+
+    def test_hook_not_called_after_context(self):
+        """Test that the hook is removed after exiting the context."""
+        from tico.quantization.wrapq.utils.introspection import module_hook
+
+        called = []
+
+        def hook(module, inputs, kwargs, output):
+            called.append(type(module).__name__)
+
+        model = nn.Sequential(nn.Linear(2, 2), nn.ReLU())
+        x = torch.randn(1, 2)
+
+        with module_hook(hook):
+            with torch.no_grad():
+                model(x)
+
+        count_during = len(called)
+
+        # Run again after the context is exited
+        with torch.no_grad():
+            model(x)
+
+        # No additional calls should have been made
+        self.assertEqual(len(called), count_during)
+
+    def test_hook_receives_kwargs(self):
+        """Test that the hook receives keyword arguments (with_kwargs=True)."""
+        from tico.quantization.wrapq.utils.introspection import module_hook
+
+        received_kwargs = []
+
+        def hook(module, inputs, kwargs, output):
+            received_kwargs.append(kwargs)
+
+        model = nn.Linear(2, 2)
+        x = torch.randn(1, 2)
+
+        with module_hook(hook):
+            with torch.no_grad():
+                model(x)
+
+        # Hook should have been called and kwargs should be a dict
+        self.assertEqual(len(received_kwargs), 1)
+        self.assertIsInstance(received_kwargs[0], dict)
+
+    def test_hook_receives_inputs_and_output(self):
+        """Test that the hook receives inputs and output correctly."""
+        from tico.quantization.wrapq.utils.introspection import module_hook
+
+        captured = []
+
+        def hook(module, inputs, kwargs, output):
+            captured.append({"inputs": inputs, "output": output})
+
+        model = nn.Linear(2, 2)
+        x = torch.randn(1, 2)
+
+        with module_hook(hook):
+            with torch.no_grad():
+                model(x)
+
+        self.assertEqual(len(captured), 1)
+        # Inputs should be a tuple of tensors
+        self.assertIsInstance(captured[0]["inputs"], tuple)
+        self.assertEqual(len(captured[0]["inputs"]), 1)
+        self.assertIsInstance(captured[0]["inputs"][0], torch.Tensor)
+        # Output should be a tensor
+        self.assertIsInstance(captured[0]["output"], torch.Tensor)
+
+    def test_hook_called_on_nested_modules(self):
+        """Test that the hook is called on all nested modules."""
+        from tico.quantization.wrapq.utils.introspection import module_hook
+
+        called = []
+
+        def hook(module, inputs, kwargs, output):
+            called.append(type(module).__name__)
+
+        class InnerModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(2, 2)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class OuterModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = InnerModule()
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.inner(x))
+
+        model = OuterModule()
+        x = torch.randn(1, 2)
+
+        with module_hook(hook):
+            with torch.no_grad():
+                model(x)
+
+        # Should capture all modules: OuterModule, InnerModule, Linear, ReLU
+        self.assertIn("OuterModule", called)
+        self.assertIn("InnerModule", called)
+        self.assertIn("Linear", called)
+        self.assertIn("ReLU", called)
+
+    def test_multiple_contexts_stacked(self):
+        """Test that multiple module_hook contexts can be stacked."""
+        from tico.quantization.wrapq.utils.introspection import module_hook
+
+        calls_a = []
+        calls_b = []
+
+        def hook_a(module, inputs, kwargs, output):
+            calls_a.append(type(module).__name__)
+
+        def hook_b(module, inputs, kwargs, output):
+            calls_b.append(type(module).__name__)
+
+        model = nn.Linear(2, 2)
+        x = torch.randn(1, 2)
+
+        with module_hook(hook_a):
+            with module_hook(hook_b):
+                with torch.no_grad():
+                    model(x)
+
+        # Both hooks should have been called
+        self.assertGreater(len(calls_a), 0)
+        self.assertGreater(len(calls_b), 0)
+
+        # After both contexts exit, neither hook should be active
+        count_a = len(calls_a)
+        count_b = len(calls_b)
+        with torch.no_grad():
+            model(x)
+        self.assertEqual(len(calls_a), count_a)
+        self.assertEqual(len(calls_b), count_b)
+
+
+class TestFullTensorPrinting(unittest.TestCase):
+    """Unit tests for full_tensor_printing context manager."""
+
+    def test_large_tensor_printing(self):
+        """Test that a large tensor is fully printed within the context."""
+        from tico.quantization.wrapq.utils.introspection import full_tensor_printing
+
+        # Create a tensor larger than default threshold
+        large_tensor = torch.arange(2000)
+
+        # Outside context, printing would truncate
+        default_str = str(large_tensor)
+        self.assertIn("...", default_str)  # Default truncates
+
+        # Inside context, printing should show all elements
+        with full_tensor_printing():
+            full_str = str(large_tensor)
+            self.assertNotIn("...", full_str)
+            # Should contain the first and last elements
+            self.assertIn("0", full_str)
+            self.assertIn("1999", full_str)
+
+
+class TestCreateTracingHook(unittest.TestCase):
+    """Unit tests for create_tracing_hook function."""
+
+    def setUp(self):
+        from tico.quantization.wrapq.utils.introspection import ModuleInputOutput
+
+        self.module = nn.Linear(2, 2)
+        self.mio = ModuleInputOutput(
+            module=self.module,
+            module_name="linear1",
+            inputs=(torch.randn(1, 2),),
+            kwargs={},
+            output=torch.randn(1, 2),
+        )
+
+    def test_stores_output_in_module_outputs(self):
+        """Test that the hook stores module output in the provided dict."""
+        from tico.quantization.wrapq.utils.introspection import create_tracing_hook
+
+        module_outputs: dict[ModuleName, ModuleOutput] = {}
+        hook = create_tracing_hook(
+            print_input_output=False,
+            module_outputs=module_outputs,
+        )
+
+        hook(self.mio)
+
+        self.assertIn("linear1", module_outputs)
+        self.assertTrue(torch.equal(module_outputs["linear1"], self.mio.output))
+
+    def test_no_store_when_module_outputs_is_none(self):
+        """Test that the hook does not crash when module_outputs is None."""
+        from tico.quantization.wrapq.utils.introspection import create_tracing_hook
+
+        hook = create_tracing_hook(
+            print_input_output=False,
+            module_outputs=None,
+        )
+
+        # Should not raise
+        hook(self.mio)
+
+    def test_print_input_output(self):
+        """Test that the hook prints when print_input_output=True."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import create_tracing_hook
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            hook = create_tracing_hook(
+                print_input_output=True,
+                module_outputs=None,
+            )
+            hook(self.mio)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        self.assertIn("linear1", output)
+        self.assertIn("Linear", output)
+
+    def test_no_print_when_print_input_output_false(self):
+        """Test that the hook does not print when print_input_output=False."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import create_tracing_hook
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            hook = create_tracing_hook(
+                print_input_output=False,
+                module_outputs=None,
+            )
+            hook(self.mio)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        self.assertEqual(output, "")
+
+    def test_interesting_modules_include_tensor_content(self):
+        """Test that interesting modules get tensor content in the serialized output."""
+        import json
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import (
+            create_tracing_hook,
+            ModuleInputOutput,
+        )
+
+        mio_interesting = ModuleInputOutput(
+            module=self.module,
+            module_name="target_layer",
+            inputs=(torch.tensor([1.0, 2.0]),),
+            kwargs={},
+            output=torch.tensor([3.0, 4.0]),
+        )
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            hook = create_tracing_hook(
+                print_input_output=True,
+                module_outputs=None,
+                interesting_modules=["target_layer"],
+            )
+            hook(mio_interesting)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        # The serialized output for interesting modules should include tensor values
+        self.assertIn("target_layer", output)
+        # Since include_tensor_content=True for interesting modules, "value" should appear
+        self.assertIn("value", output)
+
+    def test_non_interesting_modules_exclude_tensor_content(self):
+        """Test that non-interesting modules do not get tensor content by default."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import create_tracing_hook
+
+        mio_boring = ModuleInputOutput(
+            module=self.module,
+            module_name="boring_layer",
+            inputs=(torch.tensor([1.0, 2.0]),),
+            kwargs={},
+            output=torch.tensor([3.0, 4.0, 5.0, 6.0]),
+        )
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            hook = create_tracing_hook(
+                print_input_output=True,
+                module_outputs=None,
+                interesting_modules=["target_layer"],
+            )
+            hook(mio_boring)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        # "boring_layer" should be printed but without "value" key
+        # (since numel > 1 and include_tensor_content=False for non-interesting)
+        self.assertIn("boring_layer", output)
+
+    def test_multiple_modules_stored(self):
+        """Test that the hook stores outputs for multiple modules."""
+        from tico.quantization.wrapq.utils.introspection import (
+            create_tracing_hook,
+            ModuleInputOutput,
+        )
+
+        module_outputs: dict[ModuleName, ModuleOutput] = {}
+        hook = create_tracing_hook(
+            print_input_output=False,
+            module_outputs=module_outputs,
+        )
+
+        mio1 = ModuleInputOutput(
+            module=nn.Linear(2, 2),
+            module_name="layer1",
+            inputs=(torch.randn(1, 2),),
+            kwargs={},
+            output=torch.tensor([1.0]),
+        )
+        mio2 = ModuleInputOutput(
+            module=nn.ReLU(),
+            module_name="layer2",
+            inputs=(torch.randn(1, 2),),
+            kwargs={},
+            output=torch.tensor([2.0]),
+        )
+
+        hook(mio1)
+        hook(mio2)
+
+        self.assertIn("layer1", module_outputs)
+        self.assertIn("layer2", module_outputs)
+        self.assertTrue(torch.equal(module_outputs["layer1"], torch.tensor([1.0])))
+        self.assertTrue(torch.equal(module_outputs["layer2"], torch.tensor([2.0])))
+
+
+class TestTraceModelInputOutput(unittest.TestCase):
+    """Unit tests for trace_model_input_output function."""
+
+    def setUp(self):
+        """Set up a simple model for testing."""
+        self.model = nn.Sequential(
+            nn.Linear(4, 4),
+            nn.ReLU(),
+            nn.Linear(4, 2),
+        )
+        self.model.eval()
+        self.model_inputs = {"input": torch.randn(2, 4)}
+
+    def test_hook_called_for_each_module(self):
+        """Test that the hook is called for each module in the model."""
+        from tico.quantization.wrapq.utils.introspection import (
+            ModuleInputOutput,
+            trace_model_input_output,
+        )
+
+        captured: list[ModuleInputOutput] = []
+
+        def hook(data: ModuleInputOutput):
+            captured.append(data)
+
+        trace_model_input_output(self.model, self.model_inputs, hook=hook)
+
+        # Should capture: Linear(4,4), ReLU, Linear(4,2), and the Sequential itself
+        captured_names = [d.module_name for d in captured]
+        self.assertIn("", captured_names)  # root Sequential
+        self.assertIn("0", captured_names)  # Linear(4,4)
+        self.assertIn("1", captured_names)  # ReLU
+        self.assertIn("2", captured_names)  # Linear(4,2)
+
+    def test_module_output_is_detached(self):
+        """Test that captured outputs are detached (no grad tracking)."""
+        from tico.quantization.wrapq.utils.introspection import (
+            ModuleInputOutput,
+            trace_model_input_output,
+        )
+
+        captured: list[ModuleInputOutput] = []
+
+        def hook(data: ModuleInputOutput):
+            captured.append(data)
+
+        trace_model_input_output(self.model, self.model_inputs, hook=hook)
+
+        for data in captured:
+            if isinstance(data.output, torch.Tensor):
+                self.assertFalse(data.output.requires_grad)
+
+    def test_module_input_output_fields(self):
+        """Test that ModuleInputOutput has correct fields."""
+        from tico.quantization.wrapq.utils.introspection import (
+            ModuleInputOutput,
+            trace_model_input_output,
+        )
+
+        captured: list[ModuleInputOutput] = []
+
+        def hook(data: ModuleInputOutput):
+            captured.append(data)
+
+        trace_model_input_output(self.model, self.model_inputs, hook=hook)
+
+        # Find the first Linear module's data
+        linear_data = [d for d in captured if isinstance(d.module, nn.Linear)][0]
+        self.assertIsInstance(linear_data.module, nn.Linear)
+        self.assertIsInstance(linear_data.module_name, str)
+        self.assertIsInstance(linear_data.inputs, tuple)
+        self.assertIsInstance(linear_data.kwargs, dict)
+        self.assertIsInstance(linear_data.output, torch.Tensor)
+
+    def test_hook_receives_correct_module_names(self):
+        """Test that module names match the expected FQN pattern."""
+        from tico.quantization.wrapq.utils.introspection import (
+            ModuleInputOutput,
+            trace_model_input_output,
+        )
+
+        captured: list[ModuleInputOutput] = []
+
+        def hook(data: ModuleInputOutput):
+            captured.append(data)
+
+        trace_model_input_output(self.model, self.model_inputs, hook=hook)
+
+        name_to_module = {d.module_name: d.module for d in captured}
+        self.assertIsInstance(name_to_module["0"], nn.Linear)
+        self.assertIsInstance(name_to_module["1"], nn.ReLU)
+        self.assertIsInstance(name_to_module["2"], nn.Linear)
+
+
+class TestCompareOutputs(unittest.TestCase):
+    """Unit tests for compare_outputs function."""
+
+    def test_none_outputs(self):
+        """Test that comparing two None values returns None."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        result = compare_outputs(None, None)
+        self.assertIsNone(result)
+
+    def test_type_mismatch_raises(self):
+        """Test that type mismatch raises DataMismatchError."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            DataMismatchError,
+        )
+
+        with self.assertRaises(DataMismatchError):
+            compare_outputs(torch.tensor([1.0]), [1.0])
+
+        with self.assertRaises(DataMismatchError):
+            compare_outputs({"a": 1}, [1])
+
+    def test_key_mismatch_raises(self):
+        """Test that key mismatch raises DataMismatchError."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            DataMismatchError,
+        )
+
+        with self.assertRaises(DataMismatchError):
+            compare_outputs({"a": 1, "b": 2}, {"a": 1, "c": 2})
+
+        with self.assertRaises(DataMismatchError):
+            compare_outputs({"a": 1, "b": 2}, {"a": 1})
+
+    def test_tensor_difference_returns_difference_statistics(self):
+        """Test that comparing two tensors returns DifferenceStatistics with PEIR."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            DifferenceStatistics,
+        )
+
+        lhs = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+        rhs = torch.tensor([1.1, 2.2, 3.0, 3.8, 5.3])
+
+        result = compare_outputs(lhs, rhs)
+
+        assert isinstance(result, DifferenceStatistics)  # for mypy type narrowing
+        self.assertIn("mean", result._asdict())
+        self.assertIn("min", result._asdict())
+        self.assertIn("max", result._asdict())
+        self.assertIn("stddev", result._asdict())
+        self.assertIn("peir", result._asdict())
+        # PEIR should be non-negative
+        self.assertGreaterEqual(result.peir, 0.0)
+
+    def test_tensor_difference_zero_interval(self):
+        """Test that comparing tensors with zero interval returns TensorStatistics (no PEIR)."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            TensorStatistics,
+        )
+
+        # All same values → interval = max - min = 0
+        lhs = torch.tensor([3.0, 3.0, 3.0])
+        rhs = torch.tensor([3.1, 3.2, 3.0])
+
+        result = compare_outputs(lhs, rhs)
+
+        # When interval is 0, PEIR cannot be computed, so TensorStatistics is returned
+        self.assertIsInstance(result, TensorStatistics)
+
+    def test_tensor_full_diff(self):
+        """Test that full_tensor_diff=True returns the full difference tensor."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        lhs = torch.tensor([1.0, 2.0, 3.0])
+        rhs = torch.tensor([1.5, 2.5, 3.5])
+
+        result = compare_outputs(lhs, rhs, full_tensor_diff=True)
+
+        self.assertIsInstance(result, torch.Tensor)
+        expected = lhs.to(torch.float) - rhs.to(torch.float)
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_identical_tensors(self):
+        """Test that comparing identical tensors returns zero difference."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            DifferenceStatistics,
+        )
+
+        t = torch.tensor([1.0, 2.0, 3.0])
+        result = compare_outputs(t, t)
+
+        assert isinstance(result, DifferenceStatistics)  # for mypy type narrowing
+        self.assertAlmostEqual(result.max, 0.0, places=5)
+        self.assertAlmostEqual(result.peir, 0.0, places=5)
+
+    def test_number_difference(self):
+        """Test that comparing two numbers returns absolute difference."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        result = compare_outputs(5.0, 3.0)
+        assert isinstance(result, float)
+        self.assertAlmostEqual(result, 2.0, places=5)
+
+        result_int = compare_outputs(10, 7)
+        assert isinstance(result_int, int)
+        self.assertAlmostEqual(result_int, 3, places=5)
+
+    def test_list_difference(self):
+        """Test that comparing two lists returns dict of element-wise differences."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        lhs = [1.0, 2.0, 3.0]
+        rhs = [1.5, 2.0, 2.5]
+
+        result = compare_outputs(lhs, rhs)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertIn("0", result)
+        self.assertIn("1", result)
+        self.assertIn("2", result)
+        self.assertAlmostEqual(result["0"], 0.5, places=5)
+        self.assertAlmostEqual(result["1"], 0.0, places=5)
+        self.assertAlmostEqual(result["2"], 0.5, places=5)
+
+    def test_list_length_mismatch_raises(self):
+        """Test that comparing lists of different lengths raises DataMismatchError."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            DataMismatchError,
+        )
+
+        with self.assertRaises(DataMismatchError):
+            compare_outputs([1.0, 2.0], [1.0])
+
+    def test_dict_difference(self):
+        """Test that comparing two dicts returns dict of key-wise differences."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        lhs = {"a": 1.0, "b": 2.0}
+        rhs = {"a": 1.5, "b": 2.0}
+
+        result = compare_outputs(lhs, rhs)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertIn("a", result)
+        self.assertIn("b", result)
+        self.assertAlmostEqual(result["a"], 0.5, places=5)
+        self.assertAlmostEqual(result["b"], 0.0, places=5)
+
+    def test_tuple_difference(self):
+        """Test that comparing two tuples returns dict of element-wise differences."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        lhs = (10.0, 20.0)
+        rhs = (8.0, 22.0)
+
+        result = compare_outputs(lhs, rhs)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertAlmostEqual(result["0"], 2.0, places=5)
+        self.assertAlmostEqual(result["1"], 2.0, places=5)
+
+    def test_nested_dict_difference(self):
+        """Test that comparing nested dicts returns nested difference dict."""
+        from tico.quantization.wrapq.utils.introspection import compare_outputs
+
+        lhs = {"outer": {"a": 1.0, "b": 2.0}}
+        rhs = {"outer": {"a": 1.5, "b": 2.0}}
+
+        result = compare_outputs(lhs, rhs)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertIn("outer", result)
+        self.assertIsInstance(result["outer"], dict)
+        self.assertAlmostEqual(result["outer"]["a"], 0.5, places=5)
+        self.assertAlmostEqual(result["outer"]["b"], 0.0, places=5)
+
+    def test_tensor_in_list_difference(self):
+        """Test that comparing lists of tensors returns proper differences."""
+        from tico.quantization.wrapq.utils.introspection import (
+            compare_outputs,
+            DifferenceStatistics,
+        )
+
+        lhs = [torch.tensor([1.0, 2.0, 3.0])]
+        rhs = [torch.tensor([1.1, 2.2, 3.0])]
+
+        result = compare_outputs(lhs, rhs)
+
+        assert isinstance(result, dict)  # for mypy type narrowing
+        self.assertIn("0", result)
+        self.assertIsInstance(result["0"], DifferenceStatistics)
+
+
+class TestCompareSideBySide(unittest.TestCase):
+    """Unit tests for compare_side_by_side function."""
+
+    def test_prints_common_modules(self):
+        """Test that compare_side_by_side prints differences for common module names."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import compare_side_by_side
+
+        t_a = torch.tensor([1.0, 2.0, 3.0])
+        t_b = torch.tensor([1.1, 2.2, 3.3])
+
+        outputs_a = {"layer1": t_a, "layer2": t_a}
+        outputs_b = {"layer1": t_b, "layer2": t_b}
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            compare_side_by_side(outputs_a, outputs_b)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        # Should print a header line and entries for both layers
+        self.assertIn("layer1", output)
+        self.assertIn("layer2", output)
+
+    def test_skips_modules_only_in_a(self):
+        """Test that modules only in outputs_a are skipped."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import compare_side_by_side
+
+        t = torch.tensor([1.0, 2.0, 3.0])
+
+        outputs_a = {"layer1": t, "only_in_a": t}
+        outputs_b = {"layer1": t}
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            compare_side_by_side(outputs_a, outputs_b)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        self.assertIn("layer1", output)
+        self.assertNotIn("only_in_a", output)
+
+    def test_identical_outputs(self):
+        """Test that comparing identical outputs shows zero difference."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import compare_side_by_side
+
+        t = torch.tensor([1.0, 2.0, 3.0])
+        outputs = {"layer1": t}
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            compare_side_by_side(outputs, outputs)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        self.assertIn("layer1", output)
+        self.assertIn("'mean': 0.0", output)
+        self.assertIn("'min': 0.0", output)
+        self.assertIn("'max': 0.0", output)
+        self.assertIn("'stddev': 0.0", output)
+        self.assertIn("'peir': 0.0", output)
+
+    def test_interesting_module_gets_full_tensor_diff(self):
+        """Test that interesting modules get full tensor diff in the output."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import compare_side_by_side
+
+        t_a = torch.tensor([1.0, 2.0, 3.0])
+        t_b = torch.tensor([1.1, 2.2, 3.3])
+
+        outputs_a = {"target": t_a}
+        outputs_b = {"target": t_b}
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            compare_side_by_side(outputs_a, outputs_b, interesting_modules=["target"])
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        self.assertIn("target", output)
+
+    def test_empty_outputs(self):
+        """Test that compare_side_by_side handles empty output dicts."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import compare_side_by_side
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            compare_side_by_side({}, {})
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        # Should print header but no module entries
+        self.assertIn("MODULE NAME", output)
+
+    def test_number_outputs(self):
+        """Test that compare_side_by_side handles number (non-tensor) outputs."""
+        import sys
+        from io import StringIO
+
+        from tico.quantization.wrapq.utils.introspection import compare_side_by_side
+
+        outputs_a = {"loss": 1.5}
+        outputs_b = {"loss": 1.8}
+
+        captured = StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            compare_side_by_side(outputs_a, outputs_b)
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        self.assertIn("loss", output)

--- a/tico/quantization/wrapq/examples/qwen/trace_qwen.py
+++ b/tico/quantization/wrapq/examples/qwen/trace_qwen.py
@@ -107,21 +107,15 @@ Large differences in the side-by-side comparison can indicate quantization issue
 that may need investigation.
 """
 
-import json
 import os
 import sys
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping, MutableMapping, Sequence
-from contextlib import contextmanager
-from dataclasses import dataclass
-from numbers import Number
-from typing import Any, Callable, NamedTuple
+from typing import Any
 
 import torch
 import torch.nn as nn
 
 from transformers import AutoProcessor
-from transformers.modeling_outputs import ModelOutput
 from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration,
@@ -131,9 +125,15 @@ import tico
 import tico.quantization
 import tico.quantization.config.ptq
 from tico.quantization.wrapq.dtypes import DType, INT16, INT4, INT8, UINT4, UINT8
-from tico.quantization.wrapq.utils.introspection import build_fqn_map
-from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
-from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.utils.introspection import (
+    ArgName,
+    compare_side_by_side,
+    create_tracing_hook,
+    ModuleName,
+    ModuleOutput,
+    trace_model_input_output,
+)
+from tico.utils.version import package_version_is_at_least
 
 # Names exposed to wildcard imports from this module
 __all__ = [
@@ -141,28 +141,10 @@ __all__ = [
     "prepare_inputs",
     "prepare_config",
     "prepare_quantized_model",
-    # Data structures
-    "TensorStatistics",
-    "ModuleInputOutput",
-    # Core tracing
-    "trace_model_input_output",
-    "module_hook",
-    # Comparison utilities
-    "compare_outputs",
-    "compare_side_by_side",
-    # Tensor utilities
-    "get_tensor_statistics",
-    "detach_tensors",
-    "model_output_to_serializable",
-    "full_tensor_printing",
 ]
 
 # Type aliases (for more descriptive type hints)
-ArgName = str
-ArgValue = Any
-ModuleOutput = Any
 ModelNameOrPath = str
-ModuleName = str
 DirPath = str
 
 
@@ -392,6 +374,7 @@ def prepare_quantized_model(
             "vision": {
                 "grid_thw": thw,
                 "visual_start_idx": 4,
+                "spatial_merge_size": 2,
             }
         },
     )
@@ -411,438 +394,6 @@ def prepare_quantized_model(
     return prepared_model
 
 
-@contextmanager
-def module_hook(
-    hook: Callable[
-        [nn.Module, tuple[torch.Tensor, ...], dict[str, Any], ModuleOutput], Any
-    ]
-):
-    """
-    Context manager for registering a global forward hook on all modules.
-
-    Args:
-        hook: Callback function to be called for each module's forward pass.
-
-    Yields:
-        None. The hook is automatically removed when exiting the context.
-    """
-    handle = nn.modules.module.register_module_forward_hook(
-        hook, with_kwargs=True, always_call=True
-    )
-    yield
-    handle.remove()
-
-
-@contextmanager
-def full_tensor_printing():
-    """
-    Context manager for enabling full tensor printing.
-
-    Sets torch print options to 'full' profile to show all tensor elements,
-    then restores default settings on exit.
-    """
-    torch.set_printoptions(profile="full")
-    yield
-    torch.set_printoptions(profile="default")
-
-
-class DataMismatchError(Exception):
-    ...
-
-
-def compare_outputs(
-    lhs: ModuleOutput,
-    rhs: ModuleOutput,
-    full_tensor_diff: bool = False,
-) -> Number | torch.Tensor | dict[str, Any] | Exception | None:
-    """
-    Compare two module outputs and compute their difference.
-
-    Recursively compares outputs of various types (tensors, numbers, dicts,
-    lists, named tuples, ModelOutput objects) and returns the difference.
-
-    Args:
-        lhs: Left-hand side output (from unquantized model).
-        rhs: Right-hand side output (from quantized model).
-        full_tensor_diff: If True, return full tensor difference instead of statistics.
-
-    Returns:
-        The difference between outputs. For tensors, returns statistics or full tensor.
-        For containers, returns a dict of differences. Returns None if both are None.
-
-    Raises:
-        DataMismatchError: If the types or structure of lhs and rhs don't match.
-    """
-    if type(lhs) != type(rhs):
-        raise DataMismatchError(f"Type mismatch: {type(lhs)} != {type(rhs)}")
-
-    # None
-    if lhs is None:
-        return None
-
-    # Tensor
-    if isinstance(lhs, torch.Tensor):
-        if full_tensor_diff:
-            return lhs.to(torch.float) - rhs.to(torch.float)
-        else:
-            abs_delta: torch.Tensor = (lhs - rhs).abs().to(torch.float)
-            delta_stats: TensorStatistics = get_tensor_statistics(abs_delta)
-            interval = (lhs.max() - lhs.min()).item()
-            if interval != 0.0:
-                peir = delta_stats.max / interval
-                return DifferenceStatistics(**delta_stats._asdict(), peir=peir)
-            return delta_stats
-
-    # Number
-    if isinstance(lhs, Number):
-        return abs(lhs - rhs)
-
-    diff: dict[str, Any] = {}
-
-    # List, Tuple: compare element-wise
-    if isinstance(lhs, Sequence):
-        if len(lhs) != len(rhs):
-            raise DataMismatchError(f"Length mismatch: {len(lhs)} != {len(rhs)}")
-        for i, (lhs_val, rhs_val) in enumerate(zip(lhs, rhs)):
-            try:
-                diff[str(i)] = compare_outputs(lhs_val, rhs_val)
-            except Exception as ex:
-                diff[str(i)] = ex
-        return diff
-
-    # Dict
-    if isinstance(lhs, dict):
-        dict_keys = lhs.keys()
-        for key in dict_keys:
-            lhs_val = lhs[key]
-            rhs_val = rhs[key]
-            try:
-                diff[key] = compare_outputs(lhs_val, rhs_val)
-            except Exception as ex:
-                diff[key] = ex
-        return diff
-
-    # Arbitrary type: compare by fields
-    attr_names = lhs.__dict__.keys()
-    for attr_name in attr_names:
-        lhs_val = lhs.__dict__[attr_name]
-        rhs_val = rhs.__dict__[attr_name]
-        try:
-            diff[attr_name] = compare_outputs(lhs_val, rhs_val)
-        except Exception as ex:
-            diff[attr_name] = ex
-    return diff
-
-
-@dataclass(frozen=True)
-class TensorStatistics:
-    """Statistical summary of a tensor's elements."""
-
-    mean: float
-    """Mean value of all tensor elements."""
-
-    min: float
-    """Minimum value among all tensor elements."""
-
-    max: float
-    """Maximum value among all tensor elements."""
-
-    stddev: float
-    """Standard deviation of all tensor elements."""
-
-    def _asdict(self) -> dict[str, Any]:
-        return self.__dict__
-
-
-@dataclass(frozen=True)
-class DifferenceStatistics(TensorStatistics):
-    peir: float
-    """PEIR (Peak Error To Interval Ratio)."""
-
-
-def get_tensor_statistics(x: torch.Tensor) -> TensorStatistics:
-    """
-    Compute statistical summary of a tensor's elements.
-
-    Args:
-        x: Input tensor.
-
-    Returns:
-        TensorStatistics containing mean, min, max, and stddev.
-    """
-    x = x.to(torch.float)
-    return TensorStatistics(
-        mean=torch.mean(x).item(),
-        min=torch.min(x).item(),
-        max=torch.max(x).item(),
-        stddev=torch.std(x).item(),
-    )
-
-
-class ModuleInputOutput(NamedTuple):
-    """
-    Captured input/output data for a single module during forward pass.
-
-    This named tuple stores all information about a module's execution,
-    including its inputs, keyword arguments, and output.
-    """
-
-    module: nn.Module
-    """The module instance that was executed."""
-
-    module_name: ModuleName
-    """Fully qualified name of the module in the model hierarchy."""
-
-    inputs: tuple[torch.Tensor, ...]
-    """Positional arguments passed to the module's forward method."""
-
-    kwargs: dict[str, Any]
-    """Keyword arguments passed to the module's forward method."""
-
-    output: ModuleOutput
-    """Output returned by the module's forward method."""
-
-    def as_serializable(
-        self,
-        include_tensor_content: bool = False,
-        include_type: bool = True,
-    ) -> dict[str, Any]:
-        """
-        Convert the module input/output data to a JSON-serializable dictionary.
-
-        Args:
-            include_tensor_content: If True, include actual tensor elements
-                (for small tensors or "interesting" modules).
-            include_type: If True, include 'type' field in the output dictionary.
-
-        Returns:
-            Dictionary containing module_name, module_type, inputs, kwargs, and output,
-            all in JSON-serializable format.
-        """
-        data: dict[str, Any] = {
-            "module_name": self.module_name,
-            "module_type": type(self.module).__name__,
-            "inputs": model_output_to_serializable(
-                self.inputs,
-                include_tensor_content=include_tensor_content,
-                include_type=include_type,
-            ),
-            "kwargs": {
-                k: model_output_to_serializable(
-                    v,
-                    include_tensor_content=include_tensor_content,
-                    include_type=include_type,
-                )
-                for k, v in self.kwargs.items()
-            },
-            "output": model_output_to_serializable(
-                self.output,
-                include_tensor_content=include_tensor_content,
-                include_type=include_type,
-            ),
-        }
-        return data
-
-
-def model_output_to_serializable(
-    x: ModuleOutput,
-    include_tensor_content: bool = False,
-    include_type: bool = True,
-) -> str | dict[str, Any]:
-    """
-    Convert a module output to a JSON-serializable format.
-
-    Recursively converts tensors, ModelOutput objects, named tuples,
-    dicts, and iterables to dictionaries with type information.
-
-    Args:
-        x: The output value to convert.
-        include_tensor_content: If True, include actual tensor elements
-            (for small tensors or "interesting" modules).
-        include_type: If True, include 'type' field in the output dictionary.
-
-    Returns:
-        A JSON-serializable representation of the output.
-    """
-    data: dict[str, Any] = {}
-    if include_type:
-        data["type"] = x.__class__.__name__
-
-    if isinstance(x, torch.Tensor):
-        data["dtype"] = str(x.dtype)
-        data["shape"] = str(x.shape)
-        if x.numel() > 1:
-            data["statistics"] = get_tensor_statistics(x)._asdict()
-        if x.numel() <= 1 or include_tensor_content:
-            data["value"] = x.tolist()
-        return data
-
-    if isinstance(x, ModelOutput):
-        data.update(
-            {
-                k: model_output_to_serializable(
-                    v,
-                    include_tensor_content=include_tensor_content,
-                    include_type=include_type,
-                )
-                for k, v in x.__dict__.items()
-            }
-        )
-        return data
-
-    # NamedTuple
-    if hasattr(x, "_asdict"):
-        data.update(x._asdict())
-        return data
-
-    if isinstance(x, dict):
-        data.update(
-            {
-                str(k): model_output_to_serializable(
-                    v,
-                    include_tensor_content=include_tensor_content,
-                    include_type=include_type,
-                )
-                for k, v in x.items()
-            }
-        )
-        return data
-
-    if isinstance(x, Iterable):
-        data.update(
-            {
-                str(i): model_output_to_serializable(
-                    v,
-                    include_tensor_content=include_tensor_content,
-                    include_type=include_type,
-                )
-                for i, v in enumerate(x)
-            }
-        )
-        return data
-
-    return str(x)
-
-
-def trim_prefix_up_to(s: str, char: str) -> str:
-    """
-    Remove prefix from a string up to and including the first occurrence of a character.
-
-    Args:
-        s: Input string.
-        char: Character to search for.
-
-    Returns:
-        String with prefix removed, or original string if character not found.
-    """
-    char_index: int = s.find(char)
-    if char_index >= 0:
-        return s[char_index + 1 :]
-    else:
-        return s
-
-
-def detach_tensors(x: ModuleOutput) -> ModuleOutput:
-    """
-    Recursively detach and clone tensors in a module output.
-
-    Creates detached copies of tensors to prevent gradient tracking and
-    preserve tensor values for later comparison.
-
-    Args:
-        x: Module output (tensor, ModelOutput, dict, or iterable).
-
-    Returns:
-        A copy of the input with all tensors detached and cloned.
-    """
-    if isinstance(x, torch.Tensor):
-        return x.detach().clone()
-
-    data: dict[str, Any] | Iterable
-
-    if isinstance(x, ModelOutput):
-        data = {str(k): detach_tensors(v) for k, v in x.__dict__.items()}
-        return x.__class__(**data)
-
-    if isinstance(x, dict):
-        data = {k: detach_tensors(v) for k, v in x.items()}
-        return data
-
-    if isinstance(x, Iterable):
-        data = (detach_tensors(i) for i in x)
-        # For iterables like lists/tuples, we need to convert the generator to the appropriate type
-        if hasattr(x, "__class__"):
-            try:
-                return x.__class__(data)  # type: ignore[call-arg]
-            except TypeError:
-                # If the constructor doesn't accept a generator, convert to list first
-                return x.__class__(list(data))  # type: ignore[call-arg]
-        return list(data)
-
-    return x
-
-
-def trace_model_input_output(
-    model: torch.nn.Module,
-    model_inputs: dict[ArgName, torch.Tensor],
-    hook: Callable[[ModuleInputOutput], Any],
-    skip_ptqwrappers: bool = True,
-):
-    """
-    Run model forward pass and trace all module inputs/outputs.
-
-    Registers a forward hook on all modules, runs the model, and calls
-    the provided hook function for each module's execution.
-
-    Args:
-        model: The model to trace.
-        model_inputs: Input data for the model forward pass.
-        hook: Callback function called for each module with ModuleInputOutput data.
-        skip_ptqwrappers: If True, skip PTQWrapper modules (default: True).
-    """
-    module_to_name: dict[nn.Module, ModuleName] | None
-    if isinstance(model, QuantModuleBase):
-        module_to_name = None
-    else:
-        module_to_name = build_fqn_map(model)
-
-    def _hook(
-        module: nn.Module,
-        inputs: tuple[torch.Tensor, ...],
-        kwargs: dict[str, Any],
-        output: ModuleOutput,
-    ):
-        if isinstance(module, PTQWrapper) and skip_ptqwrappers:
-            return
-
-        if not module_to_name and not hasattr(module, "fp_name"):
-            return
-
-        module_name: ModuleName
-        if module_to_name:
-            module_name = module_to_name[module]
-        else:
-            module_name = module.fp_name
-            # PTQWrapper adds an fp_name "model" to the top-level model,
-            # which is why every submodule obtains an additional "model."
-            # prefix in its fp_name. We trim that prefix in order to be
-            # consistent with usual (unquantized, unwrapped) models.
-            module_name = trim_prefix_up_to(module_name, char=".")
-
-        data = ModuleInputOutput(
-            module=module,
-            module_name=module_name,
-            inputs=inputs,
-            kwargs=kwargs,
-            output=detach_tensors(output),
-        )
-        hook(data)
-
-    with module_hook(_hook):
-        with torch.no_grad():
-            _ = model(**model_inputs)
-
-
 def print_header(header: str, char: str = "*"):
     """
     Print a formatted header with centered text.
@@ -856,104 +407,6 @@ def print_header(header: str, char: str = "*"):
     print(f"{char} {header :^76} {char}")
     print(char * 80)
     print()
-
-
-def compare_side_by_side(
-    model_outputs_a: Mapping[str, ModuleOutput],
-    model_outputs_b: Mapping[str, ModuleOutput],
-    interesting_modules: Iterable[str] = [],
-    breakpoint_on_interesting_modules: bool = False,
-) -> None:
-    """
-    Compare outputs from two models side-by-side and print differences.
-
-    For similarly named submodules that are present in both models, computes and prints the difference
-    between outputs. Useful for comparing quantized vs unquantized model outputs.
-
-    Args:
-        model_outputs_a: First model's outputs (keyed by module name).
-        model_outputs_b: Second model's outputs (keyed by module name).
-        interesting_modules: Modules to inspect in detail (full tensor diff).
-        breakpoint_on_interesting_modules: If True, break into debugger for interesting modules.
-    """
-    common_module_names: set[ModuleName] = (
-        model_outputs_a.keys() & model_outputs_b.keys()
-    )
-    max_module_name_len = max(len(name) for name in common_module_names)
-    format_str = f"{{: <{max_module_name_len}}} {{:}}"
-
-    print("-" * 80)
-    print(format_str.format("MODULE NAME", "DIFFERENCE"))
-    print("-" * 80)
-
-    for module_name in model_outputs_a.keys():
-        if module_name not in model_outputs_b:
-            continue
-        output_a = model_outputs_a[module_name]
-        output_b = model_outputs_b[module_name]
-        diff: Number | torch.Tensor | dict[str, Any] | Exception | None
-        this_module_is_interesting = module_name in interesting_modules
-        try:
-            diff = compare_outputs(
-                output_a, output_b, full_tensor_diff=this_module_is_interesting
-            )
-        except Exception as ex:
-            diff = ex
-        print(
-            format_str.format(
-                module_name,
-                model_output_to_serializable(
-                    diff,
-                    include_tensor_content=this_module_is_interesting,
-                    include_type=False,
-                ),
-            )
-        )
-
-        if this_module_is_interesting and breakpoint_on_interesting_modules:
-            breakpoint()
-
-
-def create_tracing_hook(
-    print_input_output: bool,
-    module_outputs: MutableMapping[ModuleName, ModuleOutput] | None,
-    interesting_modules: Iterable[str] = [],
-    breakpoint_on_interesting_modules: bool = False,
-):
-    """
-    Create a hook function for tracing module inputs/outputs.
-
-    Args:
-        print_input_output: If True, print module input/output data.
-        module_outputs: Dictionary to store module outputs (keyed by module name).
-        interesting_modules: List of module names to inspect in detail.
-        breakpoint_on_interesting_modules: If True, break into debugger for interesting modules.
-
-    Returns:
-        A hook function suitable for use with trace_model_input_output.
-    """
-
-    def hook(data: ModuleInputOutput):
-        this_module_is_interesting = data.module_name in interesting_modules
-        if print_input_output:
-            print(f"\n{'='*80}")
-            print(
-                json.dumps(
-                    data.as_serializable(
-                        include_tensor_content=this_module_is_interesting
-                    ),
-                    indent=4,
-                )
-            )
-            print(f"{'='*80}")
-
-        if module_outputs is not None:
-            module_outputs[data.module_name] = data.output
-
-        if this_module_is_interesting and breakpoint_on_interesting_modules:
-            breakpoint()
-
-    return hook
 
 
 def parse_arguments():

--- a/tico/quantization/wrapq/utils/introspection.py
+++ b/tico/quantization/wrapq/utils/introspection.py
@@ -12,13 +12,271 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+import json
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from numbers import Number
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import torch
+from transformers.modeling_outputs import ModelOutput
 
 from tico.quantization.evaluation.metric import MetricCalculator
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.utils.version import package_version_is_at_least
+
+
+# Type aliases (for more descriptive type hints)
+ArgName = str
+ModuleOutput = Any
+ModuleName = str
+
+
+@dataclass(frozen=True)
+class TensorStatistics:
+    """Statistical summary of a tensor's elements."""
+
+    mean: float
+    """Mean value of all tensor elements."""
+
+    min: float
+    """Minimum value among all tensor elements."""
+
+    max: float
+    """Maximum value among all tensor elements."""
+
+    stddev: float
+    """Standard deviation of all tensor elements."""
+
+    def _asdict(self) -> dict[str, Any]:
+        return self.__dict__
+
+
+@dataclass(frozen=True)
+class DifferenceStatistics(TensorStatistics):
+    peir: float
+    """PEIR (Peak Error To Interval Ratio)."""
+
+
+class ModuleInputOutput(NamedTuple):
+    """
+    Captured input/output data for a single module during forward pass.
+
+    This named tuple stores all information about a module's execution,
+    including its inputs, keyword arguments, and output.
+    """
+
+    module: torch.nn.Module
+    """The module instance that was executed."""
+
+    module_name: ModuleName
+    """Fully qualified name of the module in the model hierarchy."""
+
+    inputs: tuple[torch.Tensor, ...]
+    """Positional arguments passed to the module's forward method."""
+
+    kwargs: dict[str, Any]
+    """Keyword arguments passed to the module's forward method."""
+
+    output: ModuleOutput
+    """Output returned by the module's forward method."""
+
+    def as_serializable(
+        self,
+        include_tensor_content: bool = False,
+        include_type: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Convert the module input/output data to a JSON-serializable dictionary.
+
+        Args:
+            include_tensor_content: If True, include actual tensor elements
+                (for small tensors or "interesting" modules).
+            include_type: If True, include 'type' field in the output dictionary.
+
+        Returns:
+            Dictionary containing module_name, module_type, inputs, kwargs, and output,
+            all in JSON-serializable format.
+        """
+        data: dict[str, Any] = {
+            "module_name": self.module_name,
+            "module_type": type(self.module).__name__,
+            "inputs": model_output_to_serializable(
+                self.inputs,
+                include_tensor_content=include_tensor_content,
+                include_type=include_type,
+            ),
+            "kwargs": {
+                k: model_output_to_serializable(
+                    v,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                )
+                for k, v in self.kwargs.items()
+            },
+            "output": model_output_to_serializable(
+                self.output,
+                include_tensor_content=include_tensor_content,
+                include_type=include_type,
+            ),
+        }
+        return data
+
+
+def get_tensor_statistics(x: torch.Tensor) -> TensorStatistics:
+    """
+    Compute statistical summary of a tensor's elements.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        TensorStatistics containing mean, min, max, and stddev.
+    """
+    x = x.to(torch.float)
+    return TensorStatistics(
+        mean=torch.mean(x).item(),
+        min=torch.min(x).item(),
+        max=torch.max(x).item(),
+        stddev=torch.std(x, correction=0).item(),
+    )
+
+
+def detach_tensors(x: ModuleOutput) -> ModuleOutput:
+    """
+    Recursively detach and clone tensors in a module output.
+
+    Creates detached copies of tensors to prevent gradient tracking and
+    preserve tensor values for later comparison.
+
+    Args:
+        x: Module output (tensor, ModelOutput, dict, or iterable).
+
+    Returns:
+        A copy of the input with all tensors detached and cloned.
+    """
+    if isinstance(x, torch.Tensor):
+        return x.detach().clone()
+
+    data: dict[str, Any] | Iterable
+
+    if isinstance(x, ModelOutput):
+        data = {str(k): detach_tensors(v) for k, v in x.__dict__.items()}
+        return x.__class__(**data)
+
+    if isinstance(x, dict):
+        data = {k: detach_tensors(v) for k, v in x.items()}
+        return data
+
+    if isinstance(x, str):
+        return x
+
+    if isinstance(x, Iterable):
+        data = (detach_tensors(i) for i in x)
+        # For iterables like lists/tuples, we need to convert the generator to the appropriate type
+        if hasattr(x, "__class__"):
+            try:
+                return x.__class__(data)  # type: ignore[call-arg]
+            except TypeError:
+                # If the constructor doesn't accept a generator, convert to list first
+                return x.__class__(list(data))  # type: ignore[call-arg]
+        return list(data)
+
+    return x
+
+
+def model_output_to_serializable(
+    x: ModuleOutput,
+    include_tensor_content: bool = False,
+    include_type: bool = True,
+) -> str | Number | dict[str, Any]:
+    """
+    Convert a module output to a JSON-serializable format.
+
+    Recursively converts tensors, ModelOutput objects, named tuples,
+    dicts, and iterables to dictionaries with type information.
+
+    Args:
+        x: The output value to convert.
+        include_tensor_content: If True, include actual tensor elements
+            (for small tensors or "interesting" modules).
+        include_type: If True, include 'type' field in the output dictionary.
+
+    Returns:
+        A JSON-serializable representation of the output.
+    """
+    data: dict[str, Any] = {}
+    if include_type:
+        data["type"] = x.__class__.__name__
+
+    if isinstance(x, torch.Tensor):
+        data["dtype"] = str(x.dtype)
+        data["shape"] = str(x.shape)
+        if x.numel() > 1:
+            data["statistics"] = get_tensor_statistics(x)._asdict()
+        if x.numel() <= 1 or include_tensor_content:
+            data["value"] = x.tolist()
+        return data
+
+    if isinstance(x, ModelOutput):
+        data.update(
+            {
+                k: model_output_to_serializable(
+                    v,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                )
+                for k, v in x.__dict__.items()
+            }
+        )
+        return data
+
+    # NamedTuple
+    if hasattr(x, "_asdict"):
+        data.update(
+            {
+                str(k): model_output_to_serializable(
+                    v,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                )
+                for k, v in x._asdict().items()
+            }
+        )
+        return data
+
+    if isinstance(x, dict):
+        data.update(
+            {
+                str(k): model_output_to_serializable(
+                    v,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                )
+                for k, v in x.items()
+            }
+        )
+        return data
+
+    if isinstance(x, str) or isinstance(x, Number):
+        return x
+
+    if isinstance(x, Iterable):
+        data.update(
+            {
+                str(i): model_output_to_serializable(
+                    v,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                )
+                for i, v in enumerate(x)
+            }
+        )
+        return data
+
+    return str(x)
 
 
 def build_fqn_map(root: torch.nn.Module) -> dict[torch.nn.Module, str]:
@@ -26,6 +284,334 @@ def build_fqn_map(root: torch.nn.Module) -> dict[torch.nn.Module, str]:
     Return {module_object: full_qualified_name} without touching the modules.
     """
     return {m: n for n, m in root.named_modules()}
+
+
+@contextmanager
+def module_hook(
+    hook: Callable[
+        [torch.nn.Module, tuple[torch.Tensor, ...], dict[str, Any], Any], Any
+    ]
+):
+    """
+    Context manager for registering a global forward hook on all modules.
+
+    Args:
+        hook: Callback function to be called for each module's forward pass.
+
+    Yields:
+        None. The hook is automatically removed when exiting the context.
+    """
+    handle: torch.utils.hooks.RemovableHandle
+    if package_version_is_at_least(package_name="torch", required_version="2.6"):
+        handle = torch.nn.modules.module.register_module_forward_hook(
+            hook, with_kwargs=True, always_call=True
+        )
+    else:
+
+        def fallback_hook(
+            module: torch.nn.Module,
+            inputs: tuple[torch.Tensor, ...],
+            output: ModuleOutput,
+        ) -> Any:
+            return hook(module, inputs, {}, output)
+
+        handle = torch.nn.modules.module.register_module_forward_hook(
+            fallback_hook, always_call=True
+        )
+
+    yield
+    handle.remove()
+
+
+@contextmanager
+def full_tensor_printing():
+    """
+    Context manager for enabling full tensor printing.
+
+    Sets torch print options to 'full' profile to show all tensor elements,
+    then restores previous settings on exit.
+    """
+    prev_options = torch._tensor_str.PRINT_OPTS.__dict__.copy()
+    try:
+        torch.set_printoptions(profile="full")
+        yield
+    finally:
+        torch.set_printoptions(**prev_options)
+
+
+def create_tracing_hook(
+    print_input_output: bool,
+    module_outputs: MutableMapping[ModuleName, ModuleOutput] | None,
+    interesting_modules: Iterable[str] = [],
+    breakpoint_on_interesting_modules: bool = False,
+) -> Callable[[ModuleInputOutput], None]:
+    """
+    Create a hook function for tracing module inputs/outputs.
+
+    Args:
+        print_input_output: If True, print module input/output data.
+        module_outputs: Dictionary to store module outputs (keyed by module name).
+        interesting_modules: List of module names to inspect in detail.
+        breakpoint_on_interesting_modules: If True, break into debugger for interesting modules.
+
+    Returns:
+        A hook function suitable for use with trace_model_input_output.
+    """
+
+    def hook(data: ModuleInputOutput):
+        this_module_is_interesting = data.module_name in interesting_modules
+        if print_input_output:
+            print(f"\n{'='*80}")
+            print(
+                json.dumps(
+                    data.as_serializable(
+                        include_tensor_content=this_module_is_interesting
+                    ),
+                    indent=4,
+                )
+            )
+            print(f"{'='*80}")
+
+        if module_outputs is not None:
+            module_outputs[data.module_name] = data.output
+
+        if this_module_is_interesting and breakpoint_on_interesting_modules:
+            breakpoint()
+
+    return hook
+
+
+def trace_model_input_output(
+    model: torch.nn.Module,
+    model_inputs: dict[ArgName, torch.Tensor],
+    hook: Callable[[ModuleInputOutput], Any],
+    skip_ptqwrappers: bool = True,
+):
+    """
+    Run model forward pass and trace all module inputs/outputs.
+
+    Registers a forward hook on all modules, runs the model, and calls
+    the provided hook function for each module's execution.
+
+    Args:
+        model: The model to trace.
+        model_inputs: Input data for the model forward pass.
+        hook: Callback function called for each module with ModuleInputOutput data.
+        skip_ptqwrappers: If True, skip PTQWrapper modules (default: True).
+    """
+    module_to_name: dict[torch.nn.Module, ModuleName] | None
+    if isinstance(model, QuantModuleBase):
+        module_to_name = None
+    else:
+        module_to_name = build_fqn_map(model)
+
+    def trim_prefix_up_to(s: str, char: str) -> str:
+        """
+        Remove prefix from a string up to and including the first occurrence of a character.
+
+        Args:
+            s: Input string.
+            char: Character to search for.
+
+        Returns:
+            String with prefix removed, or original string if character not found.
+        """
+        char_index: int = s.find(char)
+        if char_index >= 0:
+            return s[char_index + 1 :]
+        else:
+            return s
+
+    def _hook(
+        module: torch.nn.Module,
+        inputs: tuple[torch.Tensor, ...],
+        kwargs: dict[str, Any],
+        output: ModuleOutput,
+    ):
+        if isinstance(module, PTQWrapper) and skip_ptqwrappers:
+            return
+
+        if not module_to_name and not hasattr(module, "fp_name"):
+            return
+
+        module_name: ModuleName
+        if module_to_name:
+            module_name = module_to_name[module]
+        else:
+            module_name = module.fp_name
+            # PTQWrapper adds an fp_name "model" to the top-level model,
+            # which is why every submodule obtains an additional "model."
+            # prefix in its fp_name. We trim that prefix in order to be
+            # consistent with usual (unquantized, unwrapped) models.
+            module_name = trim_prefix_up_to(module_name, char=".")
+
+        data = ModuleInputOutput(
+            module=module,
+            module_name=module_name,
+            inputs=inputs,
+            kwargs=kwargs,
+            output=detach_tensors(output),
+        )
+        hook(data)
+
+    with module_hook(_hook):
+        with torch.no_grad():
+            _ = model(**model_inputs)
+
+
+class DataMismatchError(Exception):
+    ...
+
+
+def compare_outputs(
+    lhs: ModuleOutput,
+    rhs: ModuleOutput,
+    full_tensor_diff: bool = False,
+) -> Number | torch.Tensor | DifferenceStatistics | dict[str, Any] | Exception | None:
+    """
+    Compare two module outputs and compute their difference.
+
+    Recursively compares outputs of various types (tensors, numbers, dicts,
+    lists, named tuples, ModelOutput objects) and returns the difference.
+
+    Args:
+        lhs: Left-hand side output (from unquantized model).
+        rhs: Right-hand side output (from quantized model).
+        full_tensor_diff: If True, return full tensor difference instead of statistics.
+
+    Returns:
+        The difference between outputs. For tensors, returns statistics or full tensor.
+        For containers, returns a dict of differences. Returns None if both are None.
+
+    Raises:
+        DataMismatchError: If the types or structure of lhs and rhs don't match.
+    """
+    if type(lhs) != type(rhs):
+        raise DataMismatchError(f"Type mismatch: {type(lhs)} != {type(rhs)}")
+
+    # None
+    if lhs is None:
+        return None
+
+    # Tensor
+    if isinstance(lhs, torch.Tensor):
+        if full_tensor_diff:
+            return lhs.to(torch.float) - rhs.to(torch.float)
+        else:
+            abs_delta: torch.Tensor = (lhs - rhs).abs().to(torch.float)
+            delta_stats: TensorStatistics = get_tensor_statistics(abs_delta)
+            interval = (lhs.max() - lhs.min()).item()
+            if interval != 0.0:
+                peir = delta_stats.max / interval
+                return DifferenceStatistics(**delta_stats._asdict(), peir=peir)
+            return delta_stats
+
+    # Number
+    if isinstance(lhs, Number):
+        return abs(lhs - rhs)
+
+    diff: dict[str, Any] = {}
+
+    # List, Tuple: compare element-wise
+    if isinstance(lhs, Sequence):
+        if len(lhs) != len(rhs):
+            raise DataMismatchError(f"Length mismatch: {len(lhs)} != {len(rhs)}")
+        for i, (lhs_val, rhs_val) in enumerate(zip(lhs, rhs)):
+            try:
+                diff[str(i)] = compare_outputs(lhs_val, rhs_val)
+            except Exception as ex:
+                diff[str(i)] = ex
+        return diff
+
+    # Dict
+    if isinstance(lhs, dict):
+        lhs_keys = set(lhs.keys())
+        rhs_keys = set(rhs.keys())
+
+        if lhs_keys != rhs_keys:
+            raise DataMismatchError(
+                "Dict key mismatch: "
+                f"lhs_keys={sorted(lhs_keys)}, "
+                f"rhs_keys={sorted(rhs_keys)}"
+            )
+
+        for key in lhs_keys:
+            lhs_val = lhs[key]
+            rhs_val = rhs[key]
+            try:
+                diff[key] = compare_outputs(lhs_val, rhs_val)
+            except Exception as ex:
+                diff[key] = ex
+        return diff
+
+    # Arbitrary type: compare by fields
+    attr_names = lhs.__dict__.keys()
+    for attr_name in attr_names:
+        lhs_val = lhs.__dict__[attr_name]
+        rhs_val = rhs.__dict__[attr_name]
+        try:
+            diff[attr_name] = compare_outputs(lhs_val, rhs_val)
+        except Exception as ex:
+            diff[attr_name] = ex
+    return diff
+
+
+def compare_side_by_side(
+    model_outputs_a: Mapping[str, ModuleOutput],
+    model_outputs_b: Mapping[str, ModuleOutput],
+    interesting_modules: Iterable[str] = [],
+    breakpoint_on_interesting_modules: bool = False,
+) -> None:
+    """
+    Compare outputs from two models side-by-side and print differences.
+
+    For similarly named submodules that are present in both models, computes and prints the difference
+    between outputs. Useful for comparing quantized vs unquantized model outputs.
+
+    Args:
+        model_outputs_a: First model's outputs (keyed by module name).
+        model_outputs_b: Second model's outputs (keyed by module name).
+        interesting_modules: Modules to inspect in detail (full tensor diff).
+        breakpoint_on_interesting_modules: If True, break into debugger for interesting modules.
+    """
+    common_module_names: set[ModuleName] = (
+        model_outputs_a.keys() & model_outputs_b.keys()
+    )
+    max_module_name_len = (
+        max(len(name) for name in common_module_names) if common_module_names else 0
+    )
+    format_str = f"{{: <{max_module_name_len}}} {{:}}"
+
+    print("-" * 80)
+    print(format_str.format("MODULE NAME", "DIFFERENCE"))
+    print("-" * 80)
+
+    for module_name in model_outputs_a.keys():
+        if module_name not in model_outputs_b:
+            continue
+        output_a = model_outputs_a[module_name]
+        output_b = model_outputs_b[module_name]
+        diff: Number | torch.Tensor | dict[str, Any] | Exception | None
+        this_module_is_interesting = module_name in interesting_modules
+        try:
+            diff = compare_outputs(
+                output_a, output_b, full_tensor_diff=this_module_is_interesting
+            )
+        except Exception as ex:
+            diff = ex
+        print(
+            format_str.format(
+                module_name,
+                model_output_to_serializable(
+                    diff,
+                    include_tensor_content=this_module_is_interesting,
+                    include_type=False,
+                ),
+            )
+        )
+
+        if this_module_is_interesting and breakpoint_on_interesting_modules:
+            breakpoint()
 
 
 def extract_tensor(output: Any) -> Optional[torch.Tensor]:

--- a/tico/quantization/wrapq/utils/version.py
+++ b/tico/quantization/wrapq/utils/version.py
@@ -1,7 +1,4 @@
-import importlib.metadata
-import importlib.util
-
-from packaging import version
+from tico.utils.version import package_version_is_at_least
 
 MIN_VERSIONS = {
     "llama": "4.36.0",  # transformers==4.31.0 supports llama but without layer_idx and position_embeddings feature
@@ -10,16 +7,10 @@ MIN_VERSIONS = {
 
 
 def has_transformers_for(model_type: str) -> bool:
-    if importlib.util.find_spec("transformers") is None:
-        return False
-
-    current_version = importlib.metadata.version("transformers")
     required_version = MIN_VERSIONS.get(model_type)
-
     if not required_version:
         raise ValueError(f"Invalid model_type {model_type}")
 
-    if version.parse(current_version) >= version.parse(required_version):
-        return True
-
-    return False
+    return package_version_is_at_least(
+        package_name="transformers", required_version=required_version
+    )

--- a/tico/utils/version.py
+++ b/tico/utils/version.py
@@ -1,0 +1,16 @@
+import importlib.metadata
+import importlib.util
+
+from packaging import version
+
+
+def package_version_is_at_least(
+    package_name: str,
+    required_version: str,
+) -> bool:
+    if importlib.util.find_spec(package_name) is None:
+        return False
+
+    current_version = importlib.metadata.version(package_name)
+
+    return version.parse(current_version) >= version.parse(required_version)


### PR DESCRIPTION
# What

This PR:
- moves reusable functionality from `tico/quantization/wrapq/examples/qwen/trace_qwen.py` to `tico/quantization/wrapq/utils/introspection.py`
- adds unit tests to `test/quantization/wrapq/utils/test_introspection.py`.

# Why

The detailed motivation for this PR is provided in [\[quantization\] Refactor tracing/debugging utilities to share common core between introspection and trace_qwen](https://github.com/Samsung/TICO/issues/627).

# Note For Reviewers

- Existing functionality in `introspection.py` (`extract_tensor`, `save_fp_outputs`, `compare_layer_outputs`) left intact.
- A utility function `package_version_is_at_least` is created in `tico/utils/version.py` for checking the version of a package. `torch.nn.modules.module.register_module_forward_hook` requires at least torch version 2.6 for `with_kwargs` argument.

# Unit Tests

```bash
$ coverage run -m pytest test/quantization/wrapq/utils/test_introspection.py -v
================================================================================= test session starts =================================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 82 items                                                                                                                                                                    

test/quantization/wrapq/utils/test_introspection.py::TestBuildFqnMap::test_bidirectional_consistency PASSED                                                                     [  1%]
test/quantization/wrapq/utils/test_introspection.py::TestBuildFqnMap::test_direct_child_name PASSED                                                                             [  2%]
test/quantization/wrapq/utils/test_introspection.py::TestBuildFqnMap::test_root_included PASSED                                                                                 [  3%]
test/quantization/wrapq/utils/test_introspection.py::TestBuildFqnMap::test_sequential_children PASSED                                                                           [  4%]
test/quantization/wrapq/utils/test_introspection.py::TestBuildFqnMap::test_total_entries PASSED                                                                                 [  6%]
test/quantization/wrapq/utils/test_introspection.py::TestSmoothQuantPTQDiff::test_custom_metric SKIPPED (Internal test — run only if --include-internal is set)                 [  7%]
test/quantization/wrapq/utils/test_introspection.py::TestSmoothQuantPTQDiff::test_layerwise_diff SKIPPED (Internal test — run only if --include-internal is set)                [  8%]
test/quantization/wrapq/utils/test_introspection.py::TestSmoothQuantPTQDiff::test_layerwise_peir SKIPPED (Internal test — run only if --include-internal is set)                [  9%]
test/quantization/wrapq/utils/test_introspection.py::TestSmoothQuantPTQDiff::test_metric_subset_selection SKIPPED (Internal test — run only if --include-internal is set)       [ 10%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_difference_statistics_asdict PASSED                                                             [ 12%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_difference_statistics_creation PASSED                                                           [ 13%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_difference_statistics_inheritance PASSED                                                        [ 14%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_get_tensor_statistics PASSED                                                                    [ 15%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_tensor_statistics_asdict PASSED                                                                 [ 17%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_tensor_statistics_creation PASSED                                                               [ 18%]
test/quantization/wrapq/utils/test_introspection.py::TestTensorStatistics::test_tensor_statistics_frozen PASSED                                                                 [ 19%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_dict PASSED                                                                                 [ 20%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_list PASSED                                                                                 [ 21%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_model_output PASSED                                                                         [ 23%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_nested_structure PASSED                                                                     [ 24%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_non_tensor_scalar PASSED                                                                    [ 25%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_plain_tensor PASSED                                                                         [ 26%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_tensor_no_grad PASSED                                                                       [ 28%]
test/quantization/wrapq/utils/test_introspection.py::TestDetachTensors::test_detach_tuple PASSED                                                                                [ 29%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_dict_serialization PASSED                                                              [ 30%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_list_serialization PASSED                                                              [ 31%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_model_output_serialization PASSED                                                      [ 32%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_namedtuple_serialization PASSED                                                        [ 34%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_nested_dict_with_tensors PASSED                                                        [ 35%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_non_tensor_primitive PASSED                                                            [ 36%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_none_serialization PASSED                                                              [ 37%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_scalar_tensor PASSED                                                                   [ 39%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_single_element_tensor PASSED                                                           [ 40%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_tensor_with_content PASSED                                                             [ 41%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_tensor_with_type PASSED                                                                [ 42%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_tensor_without_type PASSED                                                             [ 43%]
test/quantization/wrapq/utils/test_introspection.py::TestModelOutputToSerializable::test_tuple_serialization PASSED                                                             [ 45%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_as_serializable_empty_kwargs PASSED                                                            [ 46%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_as_serializable_keys PASSED                                                                    [ 47%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_as_serializable_tensor_output PASSED                                                           [ 48%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_as_serializable_with_tensor_content PASSED                                                     [ 50%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_as_serializable_with_type PASSED                                                               [ 51%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_as_serializable_without_type PASSED                                                            [ 52%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_field_access PASSED                                                                            [ 53%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleInputOutput::test_is_named_tuple PASSED                                                                          [ 54%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleHook::test_hook_called_during_context PASSED                                                                     [ 56%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleHook::test_hook_called_on_nested_modules PASSED                                                                  [ 57%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleHook::test_hook_not_called_after_context PASSED                                                                  [ 58%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleHook::test_hook_receives_inputs_and_output PASSED                                                                [ 59%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleHook::test_hook_receives_kwargs PASSED                                                                           [ 60%]
test/quantization/wrapq/utils/test_introspection.py::TestModuleHook::test_multiple_contexts_stacked PASSED                                                                      [ 62%]
test/quantization/wrapq/utils/test_introspection.py::TestFullTensorPrinting::test_large_tensor_printing PASSED                                                                  [ 63%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_interesting_modules_include_tensor_content PASSED                                              [ 64%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_multiple_modules_stored PASSED                                                                 [ 65%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_no_print_when_print_input_output_false PASSED                                                  [ 67%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_no_store_when_module_outputs_is_none PASSED                                                    [ 68%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_non_interesting_modules_exclude_tensor_content PASSED                                          [ 69%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_print_input_output PASSED                                                                      [ 70%]
test/quantization/wrapq/utils/test_introspection.py::TestCreateTracingHook::test_stores_output_in_module_outputs PASSED                                                         [ 71%]
test/quantization/wrapq/utils/test_introspection.py::TestTraceModelInputOutput::test_hook_called_for_each_module PASSED                                                         [ 73%]
test/quantization/wrapq/utils/test_introspection.py::TestTraceModelInputOutput::test_hook_receives_correct_module_names PASSED                                                  [ 74%]
test/quantization/wrapq/utils/test_introspection.py::TestTraceModelInputOutput::test_module_input_output_fields PASSED                                                          [ 75%]
test/quantization/wrapq/utils/test_introspection.py::TestTraceModelInputOutput::test_module_output_is_detached PASSED                                                           [ 76%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_dict_difference PASSED                                                                            [ 78%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_identical_tensors PASSED                                                                          [ 79%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_list_difference PASSED                                                                            [ 80%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_list_length_mismatch_raises PASSED                                                                [ 81%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_nested_dict_difference PASSED                                                                     [ 82%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_none_outputs PASSED                                                                               [ 84%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_number_difference PASSED                                                                          [ 85%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_tensor_difference_returns_difference_statistics PASSED                                            [ 86%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_tensor_difference_zero_interval PASSED                                                            [ 87%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_tensor_full_diff PASSED                                                                           [ 89%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_tensor_in_list_difference PASSED                                                                  [ 90%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_tuple_difference PASSED                                                                           [ 91%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareOutputs::test_type_mismatch_raises PASSED                                                                       [ 92%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareSideBySide::test_empty_outputs PASSED                                                                           [ 93%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareSideBySide::test_identical_outputs PASSED                                                                       [ 95%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareSideBySide::test_interesting_module_gets_full_tensor_diff PASSED                                                [ 96%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareSideBySide::test_number_outputs PASSED                                                                          [ 97%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareSideBySide::test_prints_common_modules PASSED                                                                   [ 98%]
test/quantization/wrapq/utils/test_introspection.py::TestCompareSideBySide::test_skips_modules_only_in_a PASSED                                                                 [100%]

====================================================================== 78 passed, 4 skipped, 1 warning in 3.09s =======================================================================
```