### PR TITLE
[quantization] Fix qscheme propagation issue caused by naming

### DIFF
--- a/test/quantization/algorithm/test_fpi_gptq.py
+++ b/test/quantization/algorithm/test_fpi_gptq.py
@@ -195,10 +195,10 @@ class FPIGPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "0.m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # Enable after Conv2D quantization support
@@ -277,10 +277,10 @@ class FPIGPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization (currently it can't be evaluated on backend)
@@ -303,10 +303,10 @@ class FPIGPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
         # TODO add quantization
 
@@ -328,10 +328,10 @@ class FPIGPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization (right now it can't be evaluated on backend)
@@ -354,10 +354,10 @@ class FPIGPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.tconv" in q_m.quantizers  # type: ignore[operator]
+            "0.tconv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.tconv2" in q_m.quantizers  # type: ignore[operator]
+            "0.tconv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization

--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -373,9 +373,9 @@ class GPTQTest(unittest.TestCase):
         convert(q_m, inplace=True)
 
         self.assertTrue(hasattr(q_m, "quantizers"))
-        self.assertEqual(q_m.quantizers["model.layers.0.m.0"].maxq.item(), 15)
-        self.assertEqual(q_m.quantizers["model.layers.0.m.1"].maxq.item(), 255)
-        self.assertEqual(q_m.quantizers["model.layers.0.m.2"].maxq.item(), 15)
+        self.assertEqual(q_m.quantizers["0.m.0"].maxq.item(), 15)
+        self.assertEqual(q_m.quantizers["0.m.1"].maxq.item(), 255)
+        self.assertEqual(q_m.quantizers["0.m.2"].maxq.item(), 15)
 
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -467,10 +467,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "0.m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # Enable after Conv2D quantization support
@@ -530,10 +530,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "0.m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
     @unittest.skipIf(
@@ -554,7 +554,7 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
 
     @unittest.skipIf(
@@ -608,10 +608,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization (right now it can't be evaluated on backend)
@@ -634,10 +634,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -660,10 +660,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization (right now it can't be evaluated on backend)
@@ -700,10 +700,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.conv" in q_m.quantizers  # type: ignore[operator]
+            "0.conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "0.conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -726,10 +726,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.tconv" in q_m.quantizers  # type: ignore[operator]
+            "0.tconv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.tconv2" in q_m.quantizers  # type: ignore[operator]
+            "0.tconv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -766,10 +766,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.tconv" in q_m.quantizers  # type: ignore[operator]
+            "0.tconv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.tconv2" in q_m.quantizers  # type: ignore[operator]
+            "0.tconv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -792,10 +792,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "0.m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
     @unittest.skipIf(
@@ -832,7 +832,7 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
 
     @unittest.skipIf(
@@ -867,8 +867,8 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "model.layers.0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "0.m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "model.layers.0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "0.m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"

--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -138,7 +138,7 @@ class FPIGPTQQuantizer(GPTQQuantizer):
                         percdamp=0.01,
                         verbose=gptq_conf.verbose,
                     )
-                    quantizers[f"model.layers.{l_idx}.{name}"] = gptq[name].quantizer
+                    quantizers[f"{l_idx}.{name}"] = gptq[name].quantizer
                     gptq[name].free()
 
             # 4) After quantization, re-run the layer to produce outputs for the next layer

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -320,7 +320,7 @@ class GPTQQuantizer(BaseQuantizer):
                         static_groups=gptq_conf.static_groups,
                         verbose=gptq_conf.verbose,
                     )
-                    quantizers[f"model.layers.{l_idx}.{name}"] = gptq[name].quantizer
+                    quantizers[f"{l_idx}.{name}"] = gptq[name].quantizer
                     gptq[name].free()
 
             # 4) After quantization, re-run the layer to produce outputs for the next layer

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -81,7 +81,7 @@ class QuantLlamaModel(QuantModuleBase):
 
         new_list = nn.ModuleList()
         for idx, layer in enumerate(model_fp.layers):
-            child_scope = f"{fp_name}.layers.{idx}"
+            child_scope = f"{idx}"
             child_cfg = layers_cfg.child(child_scope) if layers_cfg is not None else None  # type: ignore[union-attr]
             wrapped_layer = PTQWrapper(
                 layer,


### PR DESCRIPTION
This commit fixes qscheme propagation issue caused by naming and update GPTQ quantizer accordingly.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>