### PR TITLE
[quantization] Disable `use_cache` in GPTQ

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -589,6 +589,10 @@ def main():
     if not args.no_GPTQ:
         print("Applying GPTQ …")
 
+        # use_cache increases vram usage significantly, but we don't use decoding in GPTQ
+        prev_use_cache = model.config.use_cache
+        model.config.use_cache = False
+
         sens = None
         if args.gptq_mse is not None and args.gptq_mse == "smse":
             if args.sensitivity_path is not None:
@@ -616,6 +620,8 @@ def main():
                 q_m(inp.to(args.device))
 
         q_m = convert(q_m, inplace=True)  # materialize INT-weight tensors
+
+        model.config.use_cache = prev_use_cache  # restore use-cache
     else:
         q_m = model
 


### PR DESCRIPTION
This PR disables `use_cache` in GPTQ due to large vram overhead which is not needed.

Background: could not run quantization on A100 for Llama3B. :cry: 

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>