### PR TITLE
[quantization] Fix crash on empty `save`

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -600,7 +600,11 @@ def main():
             else:
                 calibrator = SensitivityCalibrator(model, calib_inputs)
                 sens = calibrator.compute_sensitivity_info()
-                if args.output_dir is not None and "sensitivity" in args.save:
+                if (
+                    args.output_dir is not None
+                    and args.save is not None
+                    and "sensitivity" in args.save
+                ):
                     save_name = get_sensitivities_info_name(
                         model, "wikitext", args.seed, len(calib_inputs)
                     )
@@ -631,7 +635,11 @@ def main():
     if not args.no_PTQ:
         q_m = quantize_using_PTQ(q_m, calib_inputs, args)
 
-        if args.output_dir is not None and "ptq_checkpoint" in args.save:
+        if (
+            args.output_dir is not None
+            and args.save is not None
+            and "ptq_checkpoint" in args.save
+        ):
             save_name = get_ptq_model_name(model, args)
             save_path = pathlib.Path(args.output_dir, save_name)
             print(f"Saving PTQ model to {save_path}")
@@ -640,10 +648,18 @@ def main():
     # after PTQ quantizer only fixed-length input sequences are valid
     evaluate(q_m, tokenizer, dataset_test, args)
 
-    if args.output_dir is not None and "circle_per_layer" in args.save:
+    if (
+        args.output_dir is not None
+        and args.save is not None
+        and "circle_per_layer" in args.save
+    ):
         save_layers_to(q_m, args.max_seq_len, args.output_dir)
 
-    if args.output_dir is not None and "circle_full" in args.save:
+    if (
+        args.output_dir is not None
+        and args.save is not None
+        and "circle_full" in args.save
+    ):
         calib_inputs = list(torch.stack(calib_inputs).reshape(-1, 1, args.max_seq_len))
         save_model_to(q_m, calib_inputs, args.output_dir)
 


### PR DESCRIPTION
This PR fixes crash on empty `save` with non-empty `output_dir`.

Output of `python ... --output_dir "." ...`

```
Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_spinquant=True, no_PTQ=False, output_dir='.', save=None, cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse='mse', max_seq_len=2048, calibrate_seq_len=2048, decode_calibration_steps=0, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks=None, sensitivity_path='/mnt/storage/slow_repos/llm-compression-framework/Fisher_info_for_HuggingFaceTB_SmolLM2-135M-Instruct_wikitext2_128_0.pt', verbose=False)
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Loading weights: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 4177.48it/s]
Skipping SpinQuant preprocessing …

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL:  99%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋ | 158/159 [00:03<00:00, 43.16it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  7584.31
└───────────────────────────────────────────
Applying GPTQ …
Quantizing layers: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:11<00:00,  1.48s/layer]
Wrapping layers with PTQWrapper …                                                                                                                                                                                                                       
Calibrating PTQ observers…
PTQ calibration:   0%|                                                                                                                                                                                                          | 0/128 [00:00<?, ?it/s]`use_return_dict` is deprecated! Use `return_dict` instead!
PTQ calibration: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:49<00:00,  2.58it/s]

Calculating perplexities …
PPL:  99%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▋ | 158/159 [00:33<00:00,  4.74it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  7357.76
└───────────────────────────────────────────
```
TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>