### PR TITLE
[quantization] Fix model save

### DIFF
--- a/test/quantization/wrapq/wrappers/llama/test_quant_model_for_casual_lm.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_model_for_casual_lm.py
@@ -24,6 +24,9 @@ import torch
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.version import has_transformers_for
+from tico.quantization.wrapq.wrappers.llama.export_adapters import (
+    QuantLlamaForCausalLMPrefillExportAdapter,
+)
 from tico.quantization.wrapq.wrappers.llama.quant_model_for_causal_lm import (
     QuantLlamaForCausalLM,
 )
@@ -58,6 +61,7 @@ class TestQuantLlamaForCausalLM(unittest.TestCase):
             num_hidden_layers=2,
             max_position_embeddings=cls.seq_len,
             use_cache=False,
+            vocab_size=cls.vocab_size,
             return_dict=True,  # 명시적으로 설정
         )
 
@@ -110,3 +114,21 @@ class TestQuantLlamaForCausalLM(unittest.TestCase):
         self.assertGreater(diff, 0.0)
         self.assertLess(diff, 0.4)
         self.assertEqual(fp_out.shape, q_out.shape)
+
+    def test_export_adapter_without_cache_return_logits_only(self):
+        qmodel = QuantLlamaForCausalLM(self.fp_model, qcfg=PTQConfig())
+        prefill_adapter = QuantLlamaForCausalLMPrefillExportAdapter(qmodel)
+
+        batch_size = 1
+        inp = torch.randint(
+            0,
+            self.vocab_size,
+            (1, self.seq_len),
+        )
+
+        with torch.no_grad():
+            logits = prefill_adapter(
+                input_ids=inp,
+            )
+
+        self.assertEqual(logits.shape, (batch_size, self.seq_len, self.vocab_size))

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -138,8 +138,9 @@ def save_model_to(q_m, calib_inputs, save_circle_to_folder):
     print(f"saving the whole model to {save_path.resolve()}")
     with torch.no_grad():
         with SuppressWarning(UserWarning, ".*"):
-            cm = tico.convert(q_m, (calib_inputs[0],), strict=False)
-
+            cm = tico.convert(
+                q_m.wrapped.as_export_module().eval(), (calib_inputs[0],), strict=False
+            )
             cm.save(save_path)
 
 

--- a/tico/quantization/wrapq/wrappers/llama/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/llama/export_adapters.py
@@ -227,3 +227,33 @@ class LlamaDecoderLayerDecodeExportAdapter(nn.Module):
 
         new_k, new_v = outputs[1]
         return hidden, new_k, new_v
+
+
+class QuantLlamaForCausalLMPrefillExportAdapter(nn.Module):
+    """
+    Export adapter for prefill QuantLLamaForCausalLM.
+
+    This adapter keeps a minimal accelerator-friendly signature while reusing the
+    wrapper unchanged.
+    """
+
+    def __init__(self, wrapped):
+        super().__init__()
+        self.wrapped = wrapped
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        **kwargs,
+    ):
+        outputs = self.wrapped(
+            input_ids=input_ids,
+            past_key_values=None,
+            use_cache=False,
+            return_dict=True,
+            **kwargs,
+        )
+
+        logits = outputs.logits
+
+        return logits

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -21,7 +21,10 @@ from transformers.cache_utils import Cache
 from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.ptq import ExportMode, PTQConfig
+from tico.quantization.wrapq.wrappers.llama.export_adapters import (
+    QuantLlamaForCausalLMPrefillExportAdapter,
+)
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -283,3 +286,8 @@ class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
             yield from m._all_observers()
         if self.rotate_lm_head is not None:
             yield from self.rotate_lm_head._all_observers()
+
+    def as_export_module(self, mode: ExportMode = "prefill") -> nn.Module:
+        if mode == "prefill":
+            return QuantLlamaForCausalLMPrefillExportAdapter(self)
+        raise ValueError(f"Unsupported export mode: {mode!r}")


### PR DESCRIPTION
This PR adds and uses `QuantLlamaForCausalLMPrefillExportAdapter` to fix the whole model saving with relevant tests.

<details> <summary> ./ccex test -k quantization.wrapq.wrappers.llama.test_quant_model_for_casual_lm.TestQuantLlamaForCausalLM </summary>

```
RUN unit tests with -k quantization.wrapq.wrappers.llama.test_quant_model_for_casual_lm.TestQuantLlamaForCausalLM ...
test_export_adapter_without_cache_return_logits_only (quantization.wrapq.wrappers.llama.test_quant_model_for_casual_lm.TestQuantLlamaForCausalLM) ... ok
test_forward_diff (quantization.wrapq.wrappers.llama.test_quant_model_for_casual_lm.TestQuantLlamaForCausalLM) ... ok
test_mode_transitions (quantization.wrapq.wrappers.llama.test_quant_model_for_casual_lm.TestQuantLlamaForCausalLM) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.196s

OK
```

</details>

<details> <summary> sample run on `Maykeye/TinyLLama-v0` </summary>

```
Namespace(model='Maykeye/TinyLLama-v0', device='cuda', dtype='float32', seed=42, trust_remote_code=False, hf_token=None, no_tqdm=False, no_GPTQ=False, no_spinquant=True, no_PTQ=False, output_dir='.', save=['ptq_checkpoint', 'circle_full'], cache_dir='/mnt/storage/transformers_cache', nsamples_for_qcalibration=128, linear_weight_bits=4, gptq_mse='mse', max_seq_len=2048, calibrate_seq_len=2048, decode_calibration_steps=0, embedding_weight_bits=8, lm_head_weight_bits=4, eval_tasks=None, sensitivity_path='/mnt/storage/slow_repos/llm-compression-framework/Fisher_info_for_HuggingFaceTB_SmolLM2-135M-Instruct_wikitext2_128_0.pt', verbose=False)
=== Config ===
Model            : Maykeye/TinyLLama-v0
Device           : cuda
DType            : float32

Loading FP model …
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 4705.30it/s]
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Skipping SpinQuant preprocessing …

Calculating original perplexities …
Token indices sequence length is longer than the specified maximum sequence length for this model (324381 > 2048). Running this sequence through the model will result in indexing errors
PPL:  99%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊ | 158/159 [00:04<00:00, 34.77it/s]

┌── Wikitext-2 test perplexity ─────────────
│ FP32 :  7584.31
└───────────────────────────────────────────
Applying GPTQ …
Quantizing layers: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:12<00:00,  1.58s/layer]
Wrapping layers with PTQWrapper …                                                                                                                                                                                                              
Calibrating PTQ observers…
PTQ calibration:   0%|                                                                                                                                                                                                 | 0/128 [00:00<?, ?it/s]`use_return_dict` is deprecated! Use `return_dict` instead!
PTQ calibration: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:55<00:00,  2.32it/s]
Saving PTQ model to PTQ_Maykeye_TinyLLama-v0_GPTQ_mse_128_42.pt

Calculating perplexities …
PPL:  99%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊ | 158/159 [00:43<00:00,  3.64it/s]

┌── Wikitext-2 test perplexity ─────────────
│ int16 :  7357.76
└───────────────────────────────────────────
saving the whole model to /mnt/storage/slow_repos/TICO/model.q.circle
```

</details>

Right now it crashes on model saving. Later the whole prefill-decode models/layers saving can be added.

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>