### PR TITLE
[quantization] Unify fp_name to full hierarchical path and fix GPTQ key mismatch

### DIFF
--- a/test/quantization/algorithm/test_gptq.py
+++ b/test/quantization/algorithm/test_gptq.py
@@ -373,9 +373,9 @@ class GPTQTest(unittest.TestCase):
         convert(q_m, inplace=True)
 
         self.assertTrue(hasattr(q_m, "quantizers"))
-        self.assertEqual(q_m.quantizers["0.m.0"].maxq.item(), 15)
-        self.assertEqual(q_m.quantizers["0.m.1"].maxq.item(), 255)
-        self.assertEqual(q_m.quantizers["0.m.2"].maxq.item(), 15)
+        self.assertEqual(q_m.quantizers["m.0"].maxq.item(), 15)
+        self.assertEqual(q_m.quantizers["m.1"].maxq.item(), 255)
+        self.assertEqual(q_m.quantizers["m.2"].maxq.item(), 15)
 
     @unittest.skipIf(
         not IS_INTERNAL_TEST, "Internal test — run only if --include-internal is set"
@@ -467,10 +467,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # Enable after Conv2D quantization support
@@ -530,10 +530,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
     @unittest.skipIf(
@@ -554,7 +554,7 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
 
     @unittest.skipIf(
@@ -608,10 +608,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.conv" in q_m.quantizers  # type: ignore[operator]
+            "conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization (right now it can't be evaluated on backend)
@@ -634,10 +634,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.conv" in q_m.quantizers  # type: ignore[operator]
+            "conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -660,10 +660,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.conv" in q_m.quantizers  # type: ignore[operator]
+            "conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization (right now it can't be evaluated on backend)
@@ -700,10 +700,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.conv" in q_m.quantizers  # type: ignore[operator]
+            "conv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.conv2" in q_m.quantizers  # type: ignore[operator]
+            "conv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -726,10 +726,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.tconv" in q_m.quantizers  # type: ignore[operator]
+            "tconv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.tconv2" in q_m.quantizers  # type: ignore[operator]
+            "tconv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -766,10 +766,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.tconv" in q_m.quantizers  # type: ignore[operator]
+            "tconv" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.tconv2" in q_m.quantizers  # type: ignore[operator]
+            "tconv2" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
         # TODO add quantization
@@ -792,10 +792,10 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"
 
     @unittest.skipIf(
@@ -832,7 +832,7 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
 
     @unittest.skipIf(
@@ -867,8 +867,8 @@ class GPTQTest(unittest.TestCase):
         # check that all convolution nodes are quantized
         assert hasattr(q_m, "quantizers"), "quantized model does not have quantizers"
         assert (
-            "0.m.0" in q_m.quantizers  # type: ignore[operator]
+            "m.0" in q_m.quantizers  # type: ignore[operator]
         ), "first conv node is not quantized"
         assert (
-            "0.m.1" in q_m.quantizers  # type: ignore[operator]
+            "m.1" in q_m.quantizers  # type: ignore[operator]
         ), "second conv node is not quantized"

--- a/test/quantization/wrapq/utils/test_utils.py
+++ b/test/quantization/wrapq/utils/test_utils.py
@@ -15,7 +15,7 @@
 import unittest
 from types import SimpleNamespace
 
-from tico.quantization.wrapq.utils.utils import get_model_arg
+from tico.quantization.wrapq.utils.utils import get_model_arg, join_name
 
 
 class TestGetModelArg(unittest.TestCase):
@@ -113,3 +113,29 @@ class TestGetModelArg(unittest.TestCase):
 
         value = get_model_arg(qcfg, default=None)  # type: ignore[arg-type]
         self.assertEqual(value, {"vision": {"spatial_merge_size": 2}})
+
+
+class TestJoinName(unittest.TestCase):
+    """Tests for hierarchical fp_name construction."""
+
+    def test_returns_child_when_parent_is_none(self):
+        """join_name should return the child name for root-level modules."""
+        self.assertEqual(join_name(None, "model"), "model")
+
+    def test_returns_child_when_parent_is_empty(self):
+        """join_name should treat an empty parent as the root scope."""
+        self.assertEqual(join_name("", "model"), "model")
+
+    def test_joins_parent_and_child_with_dot(self):
+        """join_name should build a dot-delimited hierarchical name."""
+        self.assertEqual(
+            join_name("model", "layers.0"),
+            "model.layers.0",
+        )
+
+    def test_joins_nested_parent_and_child(self):
+        """join_name should preserve an existing nested parent scope."""
+        self.assertEqual(
+            join_name("model.layers.0", "self_attn.q_proj"),
+            "model.layers.0.self_attn.q_proj",
+        )

--- a/tico/quantization/algorithm/fpi_gptq/quantizer.py
+++ b/tico/quantization/algorithm/fpi_gptq/quantizer.py
@@ -75,6 +75,9 @@ class FPIGPTQQuantizer(GPTQQuantizer):
                 disable=not gptq_conf.show_progress,
             )
         ):
+            layer_prefix = (
+                f"model.layers.{l_idx}" if hasattr(model, "model") else str(l_idx)
+            )
             # 1) Identify quantizable submodules within the layer
             full = find_layers(
                 layer,
@@ -132,13 +135,16 @@ class FPIGPTQQuantizer(GPTQQuantizer):
 
                 # 3) Quantize each submodule
                 for name in subset:
+                    full_module_name = f"{layer_prefix}.{name}"
+
                     if gptq_conf.verbose:
-                        print(f"[Layer {l_idx}] {name} -> Quantizing ...")
+                        print(f"[{full_module_name}] -> Quantizing ...")
+
                     gptq[name].fasterquant(
                         percdamp=0.01,
                         verbose=gptq_conf.verbose,
                     )
-                    quantizers[f"{l_idx}.{name}"] = gptq[name].quantizer
+                    quantizers[full_module_name] = gptq[name].quantizer
                     gptq[name].free()
 
             # 4) After quantization, re-run the layer to produce outputs for the next layer

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -311,8 +311,11 @@ class GPTQQuantizer(BaseQuantizer):
 
                 # 3) Quantize each submodule
                 for name in subset:
+                    full_module_name = module_name[subset[name]]
+
                     if gptq_conf.verbose:
                         print(f"[Layer {l_idx}] {name} -> Quantizing ...")
+
                     gptq[name].fasterquant(
                         percdamp=gptq_conf.percdamp,
                         groupsize=gptq_conf.groupsize,
@@ -320,7 +323,7 @@ class GPTQQuantizer(BaseQuantizer):
                         static_groups=gptq_conf.static_groups,
                         verbose=gptq_conf.verbose,
                     )
-                    quantizers[f"{l_idx}.{name}"] = gptq[name].quantizer
+                    quantizers[full_module_name] = gptq[name].quantizer
                     gptq[name].free()
 
             # 4) After quantization, re-run the layer to produce outputs for the next layer

--- a/tico/quantization/wrapq/utils/utils.py
+++ b/tico/quantization/wrapq/utils/utils.py
@@ -55,3 +55,33 @@ def get_model_arg(
         value = value[key]
 
     return value
+
+
+def join_name(parent: Optional[str], child: str) -> str:
+    """
+    Join a parent scope and a child name into a dot-delimited hierarchical name.
+
+    This utility is used to construct a globally unique `fp_name` for each
+    quantized module, while keeping `qcfg` scope resolution independent.
+    It safely handles the root case where `parent` may be ``None``.
+
+    Examples:
+        >>> join_name(None, "model")
+        "model"
+        >>> join_name("model", "layers.0")
+        "model.layers.0"
+        >>> join_name("model.layers.0", "self_attn.q_proj")
+        "model.layers.0.self_attn.q_proj"
+
+    Args:
+        parent (Optional[str]):
+            The parent scope or prefix. If ``None`` or empty, the child name
+            is returned as-is.
+        child (str):
+            The child scope or name to append.
+
+    Returns:
+        str:
+            A dot-separated hierarchical name suitable for use as `fp_name`.
+    """
+    return f"{parent}.{child}" if parent else child

--- a/tico/quantization/wrapq/wrap_helper.py
+++ b/tico/quantization/wrapq/wrap_helper.py
@@ -17,6 +17,7 @@ from typing import Optional
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 
@@ -37,14 +38,19 @@ class PTQWrapHelper:
         self,
         root: nn.Module,
         qcfg: PTQConfig,
+        *,
+        fp_name: Optional[str] = None,
     ) -> nn.Module:
         """
         Recursively attempt to wrap boundaries. Strictness is applied at every boundary.
+
+        `qcfg.child(...)` always uses a local child scope.
+        `fp_name` always carries the full floating-point module path.
         """
         assert not isinstance(root, QuantModuleBase), "The module is already wrapped."
 
         try:
-            return PTQWrapper(root, qcfg=qcfg, fp_name="model")
+            return PTQWrapper(root, qcfg=qcfg, fp_name=fp_name)
         except NotImplementedError:
             print(
                 f"No specialized wrapper found for {type(root).__name__}; applying recursive wrapping."
@@ -52,29 +58,35 @@ class PTQWrapHelper:
 
         # Case A: HuggingFace-style transformers: model.model.layers
         lm = getattr(root, "model", None)
+        lm_cfg = qcfg.child("model")
+        lm_fp_name = join_name(fp_name, "model")
 
         embeddings = (
             getattr(lm, "embed_tokens", None) if isinstance(lm, nn.Module) else None
         )
         if isinstance(embeddings, nn.Module):
-            child_scope = "model.embeddings"
-            child_cfg = qcfg.child(child_scope)
+            child_scope = "embed_tokens"
+            child_cfg = lm_cfg.child(child_scope)
+            child_fp_name = join_name(lm_fp_name, child_scope)
+
             wrapped = self.try_wrap(
                 embeddings,
                 child_cfg,
-                fp_name=child_scope,
+                fp_name=child_fp_name,
                 raise_on_fail=self.strict_wrap,
             )
             lm.embed_tokens = wrapped  # type: ignore[union-attr]
 
         model_norm = getattr(lm, "norm", None) if isinstance(lm, nn.Module) else None
         if isinstance(model_norm, nn.Module):
-            child_scope = "model.norm"
-            child_cfg = qcfg.child(child_scope)
+            child_scope = "norm"
+            child_cfg = lm_cfg.child(child_scope)
+            child_fp_name = join_name(lm_fp_name, child_scope)
+
             wrapped = self.try_wrap(
                 model_norm,
                 child_cfg,
-                fp_name=child_scope,
+                fp_name=child_fp_name,
                 raise_on_fail=self.strict_wrap,
             )
             lm.norm = wrapped  # type: ignore[union-attr]
@@ -83,72 +95,88 @@ class PTQWrapHelper:
         if isinstance(lm_head, nn.Module):
             child_scope = "lm_head"
             child_cfg = qcfg.child(child_scope)
+            child_fp_name = join_name(fp_name, child_scope)
+
             wrapped = self.try_wrap(
                 lm_head,
                 child_cfg,
-                fp_name=child_scope,
+                fp_name=child_fp_name,
                 raise_on_fail=self.strict_wrap,
             )
             root.lm_head = wrapped  # type: ignore[attr-defined]
 
         layers = getattr(lm, "layers", None) if isinstance(lm, nn.Module) else None
         if isinstance(layers, nn.ModuleList):
+            layers_scope = "layers"
+            layers_cfg = lm_cfg.child(layers_scope)
+            layers_fp_name = join_name(lm_fp_name, layers_scope)
+
             new_list = nn.ModuleList()
             for idx, layer in enumerate(layers):
-                child_scope = f"layer{idx}"
-                child_cfg = qcfg.child(child_scope)
+                child_scope = str(idx)
+                child_cfg = layers_cfg.child(child_scope)
+                child_fp_name = join_name(layers_fp_name, child_scope)
 
                 wrapped = self.try_wrap(
                     layer,
                     child_cfg,
-                    fp_name=child_scope,
+                    fp_name=child_fp_name,
                     raise_on_fail=self.strict_wrap,
                 )
                 new_list.append(wrapped)
+
             lm.layers = new_list  # type: ignore[union-attr]
             return root
 
         # Case B: Containers
         if isinstance(root, (nn.Sequential, nn.ModuleList)):
             for i, child in enumerate(list(root)):
-                name = str(i)
-                child_cfg = qcfg.child(name)
+                child_scope = str(i)
+                child_cfg = qcfg.child(child_scope)
+                child_fp_name = join_name(fp_name, child_scope)
 
                 wrapped = self.try_wrap(
                     child,
                     child_cfg,
-                    fp_name=name,
+                    fp_name=child_fp_name,
                     raise_on_fail=self.strict_wrap,
                 )
                 if wrapped is child:
                     assert not self.strict_wrap
-                    wrapped = self.wrap_supported(wrapped, child_cfg)
+                    wrapped = self.wrap_supported(
+                        wrapped,
+                        child_cfg,
+                        fp_name=child_fp_name,
+                    )
                 root[i] = wrapped  # type: ignore[index]
             return root
 
         if isinstance(root, nn.ModuleDict):
-            for k, child in list(root.items()):
-                name = k
-                child_cfg = qcfg.child(name)
+            for child_scope, child in list(root.items()):
+                child_cfg = qcfg.child(child_scope)
+                child_fp_name = join_name(fp_name, child_scope)
 
                 wrapped = self.try_wrap(
                     child,
                     child_cfg,
-                    fp_name=name,
+                    fp_name=child_fp_name,
                     raise_on_fail=self.strict_wrap,
                 )
                 if wrapped is child:
                     assert not self.strict_wrap
-                    wrapped = self.wrap_supported(wrapped, child_cfg)
-                root[k] = wrapped  # type: ignore[index]
+                    wrapped = self.wrap_supported(
+                        wrapped,
+                        child_cfg,
+                        fp_name=child_fp_name,
+                    )
+                root[child_scope] = wrapped  # type: ignore[index]
             return root
 
         # Case C: Leaf node
-        root_name = getattr(root, "_get_name", lambda: None)()
         wrapped = self.try_wrap(
             root,
             qcfg,
-            fp_name=root_name,
+            fp_name=fp_name,
             raise_on_fail=self.strict_wrap,
         )
         if wrapped is not root:
@@ -156,19 +184,24 @@ class PTQWrapHelper:
 
         assert not self.strict_wrap
 
-        # Case D: Named children
-        for name, child in list(root.named_children()):
-            child_cfg = qcfg.child(name)
+        # Case D: Generic named children
+        for child_scope, child in list(root.named_children()):
+            child_cfg = qcfg.child(child_scope)
+            child_fp_name = join_name(fp_name, child_scope)
 
             wrapped = self.try_wrap(
                 child,
                 child_cfg,
-                fp_name=name,
+                fp_name=child_fp_name,
                 raise_on_fail=self.strict_wrap,
             )
             if wrapped is child:
-                wrapped = self.wrap_supported(wrapped, child_cfg)
-            setattr(root, name, wrapped)
+                wrapped = self.wrap_supported(
+                    wrapped,
+                    child_cfg,
+                    fp_name=child_fp_name,
+                )
+            setattr(root, child_scope, wrapped)
 
         return root
 

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -20,6 +20,7 @@ import torch.nn as nn
 from transformers.cache_utils import Cache
 
 from tico.quantization.config.ptq import ExportMode, PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
     LlamaAttentionDecodeExportAdapter,
     LlamaAttentionPrefillExportAdapter,
@@ -106,16 +107,16 @@ class QuantLlamaAttention(QuantModuleBase):
             fp_attn.o_proj, torch.nn.Module
         )
         self.q_proj = PTQWrapper(
-            fp_attn.q_proj, qcfg=q_cfg, fp_name=f"{fp_name}.q_proj" if fp_name else None
+            fp_attn.q_proj, qcfg=q_cfg, fp_name=join_name(fp_name, "q_proj")
         )
         self.k_proj = PTQWrapper(
-            fp_attn.k_proj, qcfg=k_cfg, fp_name=f"{fp_name}.k_proj" if fp_name else None
+            fp_attn.k_proj, qcfg=k_cfg, fp_name=join_name(fp_name, "k_proj")
         )
         self.v_proj = PTQWrapper(
-            fp_attn.v_proj, qcfg=v_cfg, fp_name=f"{fp_name}.v_proj" if fp_name else None
+            fp_attn.v_proj, qcfg=v_cfg, fp_name=join_name(fp_name, "v_proj")
         )
         self.o_proj = PTQWrapper(
-            fp_attn.o_proj, qcfg=o_cfg, fp_name=f"{fp_name}.o_proj" if fp_name else None
+            fp_attn.o_proj, qcfg=o_cfg, fp_name=join_name(fp_name, "o_proj")
         )
 
         # Constant scale (1/√d)

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -20,6 +20,7 @@ import torch.nn as nn
 from transformers.cache_utils import Cache
 
 from tico.quantization.config.ptq import ExportMode, PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
     LlamaDecoderLayerDecodeExportAdapter,
     LlamaDecoderLayerPrefillExportAdapter,
@@ -86,7 +87,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         self.self_attn = PTQWrapper(
             fp_layer.self_attn,
             qcfg=attn_cfg,
-            fp_name=f"{fp_name}.self_attn" if fp_name else None,
+            fp_name=join_name(fp_name, "self_attn"),
         )
         if hasattr(self.self_attn, "wrapped") and hasattr(
             self.self_attn.wrapped, "layer_idx"
@@ -95,17 +96,17 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         self.mlp = PTQWrapper(
             fp_layer.mlp,
             qcfg=mlp_cfg,
-            fp_name=f"{fp_name}.mlp" if fp_name else None,
+            fp_name=join_name(fp_name, "mlp"),
         )
         self.input_layernorm = PTQWrapper(
             fp_layer.input_layernorm,
             qcfg=input_ln_cfg,
-            fp_name=f"{fp_name}.input_layernorm" if fp_name else None,
+            fp_name=join_name(fp_name, "input_layernorm"),
         )
         self.post_attention_layernorm = PTQWrapper(
             fp_layer.post_attention_layernorm,
             qcfg=post_ln_cfg,
-            fp_name=f"{fp_name}.post_attention_layernorm" if fp_name else None,
+            fp_name=join_name(fp_name, "post_attention_layernorm"),
         )
 
         self.obs_mlp_residual_out = self._make_obs("mlp_residual_out")

--- a/tico/quantization/wrapq/wrappers/llama/quant_mlp.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_mlp.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -51,19 +52,19 @@ class QuantLlamaMLP(QuantModuleBase):
             mlp_fp.down_proj, torch.nn.Module
         )
         self.gate_proj = PTQWrapper(
-            mlp_fp.gate_proj, qcfg=gate_cfg, fp_name=f"{fp_name}.gate_proj"
+            mlp_fp.gate_proj, qcfg=gate_cfg, fp_name=join_name(fp_name, "gate_proj")
         )
         self.up_proj = PTQWrapper(
-            mlp_fp.up_proj, qcfg=up_cfg, fp_name=f"{fp_name}.up_proj"
+            mlp_fp.up_proj, qcfg=up_cfg, fp_name=join_name(fp_name, "up_proj")
         )
         self.down_proj = PTQWrapper(
-            mlp_fp.down_proj, qcfg=down_cfg, fp_name=f"{fp_name}.down_proj"
+            mlp_fp.down_proj, qcfg=down_cfg, fp_name=join_name(fp_name, "down_proj")
         )
 
         # ----- activation ---------------------------------------------
         assert hasattr(mlp_fp, "act_fn") and isinstance(mlp_fp.act_fn, torch.nn.Module)
         self.act_fn = PTQWrapper(
-            mlp_fp.act_fn, qcfg=act_cfg, fp_name=f"{fp_name}.act_fn"
+            mlp_fp.act_fn, qcfg=act_cfg, fp_name=join_name(fp_name, "act_fn")
         )
 
         # ----- local observers ----------------------------------------

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -23,6 +23,7 @@ from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.processing_utils import Unpack
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -61,10 +62,12 @@ class QuantLlamaModel(QuantModuleBase):
         )
 
         self.embed_tokens = PTQWrapper(
-            model_fp.embed_tokens, embed_cfg, fp_name=f"{fp_name}.embed_tokens"
+            model_fp.embed_tokens, embed_cfg, fp_name=join_name(fp_name, "embed_tokens")
         )
 
-        self.norm = PTQWrapper(model_fp.norm, norm_cfg, fp_name=f"{fp_name}.norm")
+        self.norm = PTQWrapper(
+            model_fp.norm, norm_cfg, fp_name=join_name(fp_name, "norm")
+        )
 
         # `rotate_embedding` exists only for SpinQuant-style custom models.
         # For a standard LlamaModel, skip creating the wrapper and bypass it
@@ -76,17 +79,18 @@ class QuantLlamaModel(QuantModuleBase):
             self.rotate_embedding = PTQWrapper(
                 model_fp.rotate_embedding,
                 rotate_embed_cfg,
-                fp_name=f"{fp_name}.rotate_embedding",
+                fp_name=join_name(fp_name, "rotate_embedding"),
             )
 
         new_list = nn.ModuleList()
         for idx, layer in enumerate(model_fp.layers):
-            child_scope = f"{idx}"
+            child_scope = f"{idx}"  # qcfg scope
+            child_fp_name = join_name(fp_name, f"layers.{idx}")
             child_cfg = layers_cfg.child(child_scope) if layers_cfg is not None else None  # type: ignore[union-attr]
             wrapped_layer = PTQWrapper(
                 layer,
                 child_cfg,
-                fp_name=child_scope,
+                fp_name=child_fp_name,
             )
 
             # Generation/cache path needs tuple outputs from decoder layers.

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -22,6 +22,7 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from tico.quantization.config.ptq import ExportMode, PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
     QuantLlamaForCausalLMPrefillExportAdapter,
 )
@@ -63,10 +64,12 @@ class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
             model_fp.lm_head, torch.nn.Module
         )
 
-        self.model = PTQWrapper(model_fp.model, qcfg=model_cfg, fp_name=f"model")
+        self.model = PTQWrapper(
+            model_fp.model, qcfg=model_cfg, fp_name=join_name(fp_name, "model")
+        )
 
         self.lm_head = PTQWrapper(
-            model_fp.lm_head, qcfg=lm_head_cfg, fp_name=f"lm_head"
+            model_fp.lm_head, qcfg=lm_head_cfg, fp_name=join_name(fp_name, "lm_head")
         )
 
         # `rotate_lm_head` exists only for SpinQuant-style custom models.
@@ -79,7 +82,7 @@ class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
             self.rotate_lm_head = PTQWrapper(
                 model_fp.rotate_lm_head,
                 rotate_lm_head_cfg,
-                fp_name=f"{fp_name}.rotate_lm_head",
+                fp_name=join_name(fp_name, "rotate_lm_head"),
             )
 
         self.config = model_fp.config


### PR DESCRIPTION
- Standardize fp_name as full module path (e.g. model.layers.0.self_attn.q_proj)
- Decouple qcfg scope (local) from fp_name (global path)
- Update PTQ WrapHelper to propagate hierarchical fp_name correctly
- Fix GPTQ quantizer key generation to use full module names
- Resolve mismatch between GPTQ quantizers and PTQWrapper fp_name

Related: #654
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>