### PR TITLE
[quantization] Show quantization observers in introspection debugging utility

### DIFF
--- a/test/quantization/wrapq/utils/test_introspection.py
+++ b/test/quantization/wrapq/utils/test_introspection.py
@@ -725,12 +725,14 @@ class TestModuleInputOutput(unittest.TestCase):
         self.inputs = (torch.tensor([1.0, 2.0, 3.0, 4.0]),)
         self.kwargs = {"mask": None}
         self.output = torch.tensor([5.0, 6.0, 7.0, 8.0])
+        self.quantization: list = []
         self.mio = ModuleInputOutput(
             module=self.module,
             module_name="linear1",
             inputs=self.inputs,
             kwargs=self.kwargs,
             output=self.output,
+            quantization=self.quantization,
         )
 
     def test_field_access(self):
@@ -740,6 +742,7 @@ class TestModuleInputOutput(unittest.TestCase):
         self.assertEqual(self.mio.inputs, self.inputs)
         self.assertEqual(self.mio.kwargs, self.kwargs)
         self.assertIs(self.mio.output, self.output)
+        self.assertIs(self.mio.quantization, self.quantization)
 
     def test_is_named_tuple(self):
         """Test that ModuleInputOutput is a NamedTuple."""
@@ -748,7 +751,7 @@ class TestModuleInputOutput(unittest.TestCase):
         self.assertTrue(hasattr(ModuleInputOutput, "_fields"))
         self.assertEqual(
             ModuleInputOutput._fields,
-            ("module", "module_name", "inputs", "kwargs", "output"),
+            ("module", "module_name", "inputs", "kwargs", "output", "quantization"),
         )
         self.assertIsInstance(self.mio, tuple)
 
@@ -762,6 +765,7 @@ class TestModuleInputOutput(unittest.TestCase):
         self.assertIn("inputs", result)
         self.assertIn("kwargs", result)
         self.assertIn("output", result)
+        self.assertIn("quantization", result)
         self.assertEqual(result["module_name"], "linear1")
         self.assertEqual(result["module_type"], "Linear")
 

--- a/tico/quantization/wrapq/examples/qwen/trace_qwen.py
+++ b/tico/quantization/wrapq/examples/qwen/trace_qwen.py
@@ -246,7 +246,7 @@ def prepare_inputs(
     processor = AutoProcessor.from_pretrained(
         model_name,
         cache_dir=cache_dir,
-        local_files_only=cache_dir is not None,
+        local_files_only=os.path.isdir(model_name),
         trust_remote_code=True,
         token=hf_token,
     )
@@ -475,6 +475,12 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "--no-skip-ptqwrappers",
+        action="store_true",
+        help="Don't skip PTQ wrappers when tracing.",
+    )
+
+    parser.add_argument(
         "--no-side-by-side",
         action="store_true",
         help="Don't do side-by-side validation between quantized and unquantized models.",
@@ -526,6 +532,11 @@ def parse_arguments():
             f"[ERROR] --dtype {args.dtype} requires --enable-quantization flag to be specified."
         )
         sys.exit(1)
+
+    if args.no_trace_quantized and args.no_skip_ptqwrappers:
+        print(
+            f"[WARNING] --no-skip-ptqwrappers has no effect when --no-trace-quantized flag is specified."
+        )
 
     if args.dtype is None:
         args.dtype = "uint8"
@@ -603,6 +614,7 @@ def main():
                 interesting_modules=args.interesting_modules,
                 breakpoint_on_interesting_modules=args.breakpoint_on_interesting_modules,
             ),
+            skip_ptqwrappers=not args.no_skip_ptqwrappers,
         )
 
     if not args.no_side_by_side:

--- a/tico/quantization/wrapq/utils/introspection.py
+++ b/tico/quantization/wrapq/utils/introspection.py
@@ -23,6 +23,8 @@ import torch
 from transformers.modeling_outputs import ModelOutput
 
 from tico.quantization.evaluation.metric import MetricCalculator
+from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
+from tico.quantization.wrapq.observers.base import ObserverBase
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.utils.version import package_version_is_at_least
@@ -71,8 +73,8 @@ class ModuleInputOutput(NamedTuple):
     module: torch.nn.Module
     """The module instance that was executed."""
 
-    module_name: ModuleName
-    """Fully qualified name of the module in the model hierarchy."""
+    module_name: ModuleName | None
+    """(Optional) Fully qualified name of the module in the model hierarchy."""
 
     inputs: tuple[torch.Tensor, ...]
     """Positional arguments passed to the module's forward method."""
@@ -82,6 +84,9 @@ class ModuleInputOutput(NamedTuple):
 
     output: ModuleOutput
     """Output returned by the module's forward method."""
+
+    quantization: Iterable[ObserverBase] | None = None
+    """(Optional) Quantization parameters associated with the module"""
 
     def as_serializable(
         self,
@@ -122,6 +127,12 @@ class ModuleInputOutput(NamedTuple):
                 include_type=include_type,
             ),
         }
+        if self.quantization is not None:
+            data["quantization"] = model_output_to_serializable(
+                self.quantization,
+                include_tensor_content=include_tensor_content,
+                include_type=include_type,
+            )
         return data
 
 
@@ -229,6 +240,37 @@ def model_output_to_serializable(
                     include_type=include_type,
                 )
                 for k, v in x.__dict__.items()
+            }
+        )
+        return data
+
+    if isinstance(x, AffineObserverBase):
+        data.update(
+            {
+                "name": x.name,
+                "dtype": str(x.dtype),
+                "qscheme": str(x.qscheme),
+                "channel_axis": str(x.channel_axis),
+                "min_val": model_output_to_serializable(
+                    x.min_val,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                ),
+                "max_val": model_output_to_serializable(
+                    x.max_val,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                ),
+                "scale": model_output_to_serializable(
+                    x._cached_scale,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                ),
+                "zp": model_output_to_serializable(
+                    x._cached_zp,
+                    include_tensor_content=include_tensor_content,
+                    include_type=include_type,
+                ),
             }
         )
         return data
@@ -359,7 +401,9 @@ def create_tracing_hook(
     """
 
     def hook(data: ModuleInputOutput):
-        this_module_is_interesting = data.module_name in interesting_modules
+        this_module_is_interesting = (
+            data.module_name is not None and data.module_name in interesting_modules
+        )
         if print_input_output:
             print(f"\n{'='*80}")
             print(
@@ -372,7 +416,7 @@ def create_tracing_hook(
             )
             print(f"{'='*80}")
 
-        if module_outputs is not None:
+        if module_outputs is not None and data.module_name is not None:
             module_outputs[data.module_name] = data.output
 
         if this_module_is_interesting and breakpoint_on_interesting_modules:
@@ -439,11 +483,14 @@ def trace_model_input_output(
             module_name = module_to_name[module]
         else:
             module_name = module.fp_name
-            # PTQWrapper adds an fp_name "model" to the top-level model,
-            # which is why every submodule obtains an additional "model."
-            # prefix in its fp_name. We trim that prefix in order to be
-            # consistent with usual (unquantized, unwrapped) models.
-            module_name = trim_prefix_up_to(module_name, char=".")
+            # fp_name attribute of PTQWrapper is usually None,
+            # fp_name is set to a meaningful string for wrapped modules only.
+            if module_name is not None:
+                # PTQWrapper adds an fp_name "model" to the top-level model,
+                # which is why every submodule obtains an additional "model."
+                # prefix in its fp_name. We trim that prefix in order to be
+                # consistent with usual (unquantized, unwrapped) models.
+                module_name = trim_prefix_up_to(module_name, char=".")
 
         data = ModuleInputOutput(
             module=module,
@@ -451,6 +498,9 @@ def trace_model_input_output(
             inputs=inputs,
             kwargs=kwargs,
             output=detach_tensors(output),
+            quantization=module._all_observers()
+            if isinstance(module, QuantModuleBase)
+            else None,
         )
         hook(data)
 


### PR DESCRIPTION
# What & Why

This PR implements a suggestion made by @Torrero in [this comment](https://github.com/Samsung/TICO/pull/648#issuecomment-4311927391).

The change enables printing of QuantModules' observers during the tracing of quantized models.
This is useful to check the *range (min, max)* of an observed variable as well as quntization parameters *scale* and *zero point* obtained from that range.

Changed files:
- **trace_qwen.py**: `--no-skip-ptqwrappers` flag added.
- **introspection.py**: added a new field `quantization` to `ModuleInputOutput` class that contains the collection of observers; added `AffineObserverBase` serialization in `model_output_to_serializable` function.
- **test_introspection.py**: added a few checks to `TestModuleInputOutput` unit test.

# Example of `trace_qwen.py` output

Below is a fragment of `trace_qwen.py` output showing the observer printing for a quantized model (look for `"quantization"` key):
```bash
$ python tico/quantization/wrapq/examples/qwen/trace_qwen.py \
    --model "Qwen/Qwen3-VL-2B-Instruct" \
    --cache-dir ~/models/qwen3-vl-2b \
    --no-trace-unquantized \
    --no-side-by-side \
    --enable-quantization

...
================================================================================
{
    "module_name": "model",
    "module_type": "QuantQwen3VLModel",
    "inputs": {
        "type": "tuple"
    },
    "kwargs": {
        "input_ids": {
            "type": "Tensor",
            "dtype": "torch.int64",
            "shape": "torch.Size([1, 84])",
            "statistics": {
                "mean": 907.6785888671875,
                "min": 13.0,
                "max": 998.0,
                "stddev": 238.7711181640625
            }
        },
        "pixel_values": {
            "type": "Tensor",
            "dtype": "torch.float32",
            "shape": "torch.Size([280, 1536])",
            "statistics": {
                "mean": -1.0,
                "min": -1.0,
                "max": -1.0,
                "stddev": 0.0
            }
        },
        "pixel_values_videos": "None",
        "image_grid_thw": {
            "type": "Tensor",
            "dtype": "torch.int64",
            "shape": "torch.Size([1, 3])",
            "statistics": {
                "mean": 11.666666984558105,
                "min": 1.0,
                "max": 20.0,
                "stddev": 7.930251598358154
            }
        },
        "video_grid_thw": "None",
        "position_ids": "None",
        "attention_mask": {
            "type": "Tensor",
            "dtype": "torch.int64",
            "shape": "torch.Size([1, 84])",
            "statistics": {
                "mean": 1.0,
                "min": 1.0,
                "max": 1.0,
                "stddev": 0.0
            }
        },
        "past_key_values": "None",
        "inputs_embeds": "None",
        "cache_position": "None",
        "return_dict": true
    },
    "output": {
        "type": "Qwen3VLModelOutputWithPast",
        "last_hidden_state": {
            "type": "Tensor",
            "dtype": "torch.float32",
            "shape": "torch.Size([1, 84, 64])",
            "statistics": {
                "mean": -0.023641211912035942,
                "min": -3.0294017791748047,
                "max": 2.912886381149292,
                "stddev": 0.9996187090873718
            }
        },
        "past_key_values": "None",
        "hidden_states": "None",
        "attentions": "None",
        "rope_deltas": {
            "type": "Tensor",
            "dtype": "torch.int64",
            "shape": "torch.Size([1, 1])",
            "value": [
                [
                    -60
                ]
            ]
        }
    },
    "quantization": {
        "type": "generator",
        "0": {
            "type": "MinMaxObserver",
            "name": "mm_fusion",
            "dtype": "uint8",
            "qscheme": "per_tensor_asymm",
            "channel_axis": "None",
            "min_val": {
                "type": "Tensor",
                "dtype": "torch.float32",
                "shape": "torch.Size([])",
                "value": -0.09763260185718536
            },
            "max_val": {
                "type": "Tensor",
                "dtype": "torch.float32",
                "shape": "torch.Size([])",
                "value": 0.13567161560058594
            },
            "scale": {
                "type": "Tensor",
                "dtype": "torch.float32",
                "shape": "torch.Size([])",
                "value": 0.0009149184916168451
            },
            "zp": {
                "type": "Tensor",
                "dtype": "torch.int32",
                "shape": "torch.Size([])",
                "value": 107
            }
        }
    }
}
================================================================================
...
```