### PR TITLE
[quantization] Make Attention Mask Fill Value Configurable

### DIFF
--- a/tico/quantization/config/ptq.py
+++ b/tico/quantization/config/ptq.py
@@ -167,6 +167,10 @@ class PTQConfig(BaseConfig):
         It is propagated as-is to child configurations.
     strict_wrap : bool
         If ``True``, any module that cannot be wrapped will raise an error.
+    attention_mask_fill_value : float
+        Value used to fill masked positions in attention masks before softmax.
+        This affects softmax suppression strength for masked positions and
+        numerical range before quantization/fake-quant. Default: -120.0.
 
     Example
     -------
@@ -199,6 +203,8 @@ class PTQConfig(BaseConfig):
     model_args: Mapping[str, Any] = field(default_factory=dict)
     # If True, any module that cannot be wrapped will raise.
     strict_wrap: bool = True
+    # Value used to fill masked positions in attention masks before softmax.
+    attention_mask_fill_value: float = -120.0
 
     def __post_init__(self) -> None:
         """
@@ -328,6 +334,7 @@ class PTQConfig(BaseConfig):
           • same `default_observer`
           • same `default_qscheme`
           • same `model_args`
+          • same `attention_mask_fill_value`
           • overrides under `self.overrides.get(scope, {})`
 
         Other scopes remain invisible to the child.
@@ -340,6 +347,7 @@ class PTQConfig(BaseConfig):
             overrides=sub_overrides,
             model_args=self.model_args,
             strict_wrap=self.strict_wrap,
+            attention_mask_fill_value=self.attention_mask_fill_value,
         )
 
     def __repr__(self):

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_decoder.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_decoder.py
@@ -129,8 +129,8 @@ class QuantFairseqDecoder(QuantModuleBase):
             self.layers.append(wrapped)
         self.num_layers = len(self.layers)
 
-        # choose a generous upper-bound; you can wire this from cfg if you like
-        self.mask_fill_value: float = -120.0
+        # Use the configurable attention mask fill value from PTQConfig
+        self.mask_fill_value: float = self.qcfg.attention_mask_fill_value
         max_tgt = int(getattr(self.cfg, "max_target_positions", 2048))  # fallback: 2048
 
         mask = torch.full((1, 1, max_tgt, max_tgt), float(self.mask_fill_value))

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_mha.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_mha.py
@@ -61,13 +61,18 @@ class QuantFairseqMultiheadAttention(QuantModuleBase):
         fp_name: Optional[str] = None,
         max_seq: int = 4096,
         use_static_causal: bool = False,
-        mask_fill_value: float = -120.0,
+        mask_fill_value: Optional[float] = None,
         assume_additive_key_padding: bool = False,
     ):
         super().__init__(qcfg, fp_name=fp_name)
 
         self.use_static_causal = use_static_causal
-        self.mask_fill_value = mask_fill_value
+        # Use provided mask_fill_value or fall back to PTQConfig's attention_mask_fill_value
+        self.mask_fill_value: float = (
+            mask_fill_value
+            if mask_fill_value is not None
+            else self.qcfg.attention_mask_fill_value
+        )
         self.assume_additive_key_padding = assume_additive_key_padding
         self.embed_dim: int = int(fp_attn.embed_dim)  # type: ignore[arg-type]
         self.num_heads: int = int(fp_attn.num_heads)  # type: ignore[arg-type]

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -178,7 +178,10 @@ class QuantLlamaAttention(QuantModuleBase):
         self.obs_present_value = mk("present_value")  # (B, max_seq, H)
 
         # Static causal mask template
-        mask = torch.full((1, 1, self.max_seq, self.max_seq), float("-120"))
+        mask = torch.full(
+            (1, 1, self.max_seq, self.max_seq),
+            float(self.qcfg.attention_mask_fill_value),
+        )
         mask.triu_(1)
         self.register_buffer("causal_mask_template", mask, persistent=False)
 
@@ -425,11 +428,12 @@ class QuantLlamaAttention(QuantModuleBase):
                 ..., past_len : past_len + q_len, :k_len
             ].to(device)
 
+            fill_val = self.qcfg.attention_mask_fill_value
             additive = torch.zeros_like(attention_mask, dtype=torch.float32)
-            additive = additive.masked_fill(~attention_mask, float("-120"))
+            additive = additive.masked_fill(~attention_mask, float(fill_val))
 
             # Combine causal mask and padding mask.
-            mask = torch.clamp(causal_mask + additive, min=-120.0)
+            mask = torch.clamp(causal_mask + additive, min=fill_val)
             return self._fq(mask.squeeze(0), self.obs_attn_mask)
 
         return self._fq(attention_mask, self.obs_attn_mask)

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -119,7 +119,10 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         assert isinstance(cfg.max_position_embeddings, int)
         self.max_seq = cfg.max_position_embeddings
         # Static causal mask template
-        mask = torch.full((1, 1, self.max_seq, self.max_seq), float("-120"))
+        mask = torch.full(
+            (1, 1, self.max_seq, self.max_seq),
+            float(self.qcfg.attention_mask_fill_value),
+        )
         mask.triu_(1)
         self.register_buffer("causal_mask_template", mask, persistent=False)
 
@@ -248,10 +251,11 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
                 ..., past_len : past_len + q_len, :k_len
             ].to(device)
 
+            fill_val = self.qcfg.attention_mask_fill_value
             additive = torch.zeros_like(attention_mask, dtype=torch.float32)
-            additive = additive.masked_fill(~attention_mask, float("-120"))
+            additive = additive.masked_fill(~attention_mask, float(fill_val))
 
-            mask = torch.clamp(causal_mask + additive, min=-120.0)
+            mask = torch.clamp(causal_mask + additive, min=fill_val)
             return self._fq(mask.squeeze(0), self.obs_attn_mask)
 
         return self._fq(attention_mask, self.obs_attn_mask)

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -119,7 +119,9 @@ class QuantLlamaModel(QuantModuleBase):
         # Static causal mask template ---------------------------------------
         assert isinstance(self.config.max_position_embeddings, int)
         max_seq = self.config.max_position_embeddings
-        mask = torch.full((1, 1, max_seq, max_seq), float("-120"))
+        mask = torch.full(
+            (1, 1, max_seq, max_seq), float(self.qcfg.attention_mask_fill_value)
+        )
         mask.triu_(1)
         self.register_buffer("causal_mask_template", mask, persistent=False)
 
@@ -460,9 +462,10 @@ class QuantLlamaModel(QuantModuleBase):
                 device=device,
             )
 
+            fill_val = self.qcfg.attention_mask_fill_value
             additive = torch.zeros_like(attention_mask, dtype=torch.float32)
-            additive = additive.masked_fill(~attention_mask, float("-120"))
-            mask = torch.clamp(causal_mask + additive, min=-120.0)
+            additive = additive.masked_fill(~attention_mask, float(fill_val))
+            mask = torch.clamp(causal_mask + additive, min=fill_val)
             return self._fq(mask.squeeze(0), self.obs_causal_mask)
 
         return self._fq(attention_mask, self.obs_causal_mask)

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py
@@ -130,7 +130,9 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         # Static causal mask template
         assert hasattr(cfg, "max_position_embeddings")
         max_seq = cfg.max_position_embeddings
-        mask = torch.full((1, 1, max_seq, max_seq), float("-120"))  # type: ignore[arg-type]
+        mask = torch.full(
+            (1, 1, max_seq, max_seq), float(self.qcfg.attention_mask_fill_value)
+        )
         mask.triu_(1)
         self.register_buffer("causal_mask_template", mask, persistent=False)
 

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -97,7 +97,9 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         # ----- static buffers: causal mask template ---------------------------
         assert isinstance(self.config.max_position_embeddings, int)
         max_seq = self.config.max_position_embeddings
-        mask = torch.full((1, 1, max_seq, max_seq), float("-120"))
+        mask = torch.full(
+            (1, 1, max_seq, max_seq), float(self.qcfg.attention_mask_fill_value)
+        )
         mask.triu_(1)
         self.register_buffer("causal_mask_template", mask, persistent=False)
 
@@ -264,6 +266,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             else:
                 padding_keep = attention_mask.to(torch.long) != 0
 
+            fill_val = self.qcfg.attention_mask_fill_value
             padding_mask = torch.zeros(
                 batch_size,
                 1,
@@ -274,10 +277,10 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             )
             padding_mask = padding_mask.masked_fill(
                 ~padding_keep[:, None, None, :].to(device=input_embeds.device),
-                float("-120"),
+                float(fill_val),
             )
 
-            return torch.clamp(causal_mask + padding_mask, min=-120.0, max=0.0)
+            return torch.clamp(causal_mask + padding_mask, min=fill_val, max=0.0)
 
         if attention_mask.ndim == 4:
             if attention_mask.shape[-2] != q_len or attention_mask.shape[-1] != kv_len:
@@ -292,6 +295,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
                     dtype=input_embeds.dtype,
                 )
 
+            fill_val = self.qcfg.attention_mask_fill_value
             if attention_mask.dtype == torch.bool:
                 additive_mask = torch.zeros_like(
                     attention_mask,
@@ -300,7 +304,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
                 )
                 additive_mask = additive_mask.masked_fill(
                     ~attention_mask.to(device=input_embeds.device),
-                    float("-120"),
+                    float(fill_val),
                 )
                 return additive_mask
 
@@ -312,7 +316,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             )
             additive_mask = additive_mask.masked_fill(
                 ~bool_mask.to(device=input_embeds.device),
-                float("-120"),
+                float(fill_val),
             )
             return additive_mask
 


### PR DESCRIPTION
# What

This change introduces a global configuration parameter attention_mask_fill_value to PTQConfig in order to make the attention mask fill value configurable across the TICO codebase.

# Why

The detailed motivation behind this change is described in issue [\[quantization\] Make Attention Mask Fill Value Configurable & Run Ablation Study](https://github.com/Samsung/TICO/issues/643).

# Implementation Details

### 1. Added `attention_mask_fill_value` to `PTQConfig` (`tico/quantization/config/ptq.py`)
- Added new field `attention_mask_fill_value: float = -120.0` with documentation
- Updated `child()` method to propagate this value to child configurations

### 2. Updated Wrapper Classes to Use Configurable Value

**Llama Wrappers:**
- `QuantLlamaAttention` (`tico/quantization/wrapq/wrappers/llama/quant_attention.py`):
  - Causal mask template creation
  - Boolean/int mask to additive mask conversion
  - Clamp operations

- `QuantLlamaDecoderLayer` (`tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py`):
  - Causal mask template creation
  - Boolean mask to additive mask conversion
  - Clamp operations

- `QuantLlamaModel` (`tico/quantization/wrapq/wrappers/llama/quant_model.py`):
  - Causal mask template creation
  - Boolean/int mask to additive mask conversion
  - Clamp operations

**Qwen VL Wrappers:**
- `QuantQwen3VLTextAttention` (`tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py`):
  - Causal mask template creation

- `QuantQwen3VLTextModel` (`tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py`):
  - Causal mask template creation
  - 2D and 4D mask handling with clamp operations

**Fairseq Wrappers:**
- `QuantFairseqDecoder` (`tico/quantization/wrapq/wrappers/fairseq/quant_decoder.py`):
  - Now uses `self.qcfg.attention_mask_fill_value` instead of hardcoded value

- `QuantFairseqMultiheadAttention` (`tico/quantization/wrapq/wrappers/fairseq/quant_mha.py`):
  - Updated to use PTQConfig's value as default, with option to override via constructor parameter

# Usage Example

```python
from tico.quantization.config.ptq import PTQConfig
from tico.quantization.wrapq.dtypes import DType

# Use default value (-120.0)
cfg = PTQConfig(default_dtype=DType.uint(8))

# Or specify a custom value
cfg = PTQConfig(
    default_dtype=DType.uint(8),
    attention_mask_fill_value=-100.0  # Custom value
)
```

The value is automatically propagated to all child configurations via the `child()` method, ensuring consistent behavior across the entire model hierarchy.