### PR TITLE
[quantization][draft] [NO_MERGE] Fix instability

### DIFF
--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -164,7 +164,8 @@ def get_matmul_input_for_convtranspose2d(layer, inp):
 
 
 class GPTQ:
-    def __init__(self, layer):
+    def __init__(self, layer, stability_option):
+        self.stability_option = stability_option
         self.layer = layer
         self.dev = self.layer.weight.device
         W = layer.weight.data.clone()
@@ -177,7 +178,7 @@ class GPTQ:
         self.rows = W.shape[0]
         self.columns = W.shape[1]
         self.H: Optional[torch.Tensor] = torch.zeros(
-            (self.columns, self.columns), device=self.dev
+            (self.columns, self.columns), device=self.dev, dtype=torch.float64 if self.stability_option >= 2 else torch.float32
         )
         self.nsamples = 0
         self.quantizer: Quantizer = Quantizer()
@@ -294,11 +295,20 @@ class GPTQ:
                 inp.shape[0] * inp.shape[1], inp.shape[2] * inp.shape[3]
             ).T  # inp.shape =(C_in * krn_size[0] * krn_size[1] * krn_size[2], N * num_patches)
 
-        self.H *= self.nsamples / (self.nsamples + tmp)
-        self.nsamples += tmp
-        inp = math.sqrt(2 / self.nsamples) * inp.float()
-        self.H += inp.matmul(inp.t()).to(self.H.device)
-
+        if self.stability_option == 0:
+            self.H *= self.nsamples / (self.nsamples + tmp)
+            self.nsamples += tmp
+            inp = math.sqrt(2 / self.nsamples) * inp.float()
+            self.H += inp.matmul(inp.t()).to(self.H.device)
+        elif self.stability_option == 1:
+            self.H += inp.double().matmul(inp.double().t()).float().to(self.H.device)
+        elif self.stability_option == 2: #(2, 3) H in double 
+            inp = inp.double()
+            self.H = (self.H * self.nsamples + 2.0 * inp.matmul(inp.t())) / (self.nsamples + tmp) #.float().to(self.H.device)
+            self.nsamples += tmp
+        elif self.stability_option == 3:
+            self.H += inp.double().matmul(inp.double().t()).to(self.H.device)
+        
     def fasterquant(
         self,
         blocksize=128,
@@ -352,16 +362,44 @@ class GPTQ:
 
         Losses = torch.zeros_like(W)
         Q = torch.zeros_like(W)
-
-        damp = percdamp * torch.mean(torch.diag(H))
-        diag = torch.arange(self.columns, device=self.dev)
-        H[diag, diag] += damp
-        H = torch.linalg.cholesky(H)
-        assert isinstance(H, torch.Tensor)
-        H = torch.cholesky_inverse(H)
-        H = torch.linalg.cholesky(H, upper=True)
+        if verbose:
+            cond_initial = torch.linalg.cond(H)
+        #if cond_initial > 100:
+        #    percdamp = 0.1
+        #else:
+        #    percdamp = 0.0
+        if self.stability_option == 0:
+            damp = percdamp * torch.mean(torch.diag(torch.abs(H)))
+            diag = torch.arange(self.columns, device=self.dev)
+            H[diag, diag] += damp
+            if verbose:
+                cond_dampened = torch.linalg.cond(H)
+            H = torch.linalg.cholesky(H)
+            assert isinstance(H, torch.Tensor)
+            H = torch.cholesky_inverse(H)
+            H = torch.linalg.cholesky(H, upper=True)
+        elif self.stability_option == 1:
+            damp = percdamp * torch.mean(torch.diag(torch.abs(H)))
+            diag = torch.arange(self.columns, device=self.dev)
+            H[diag, diag] += damp
+            if verbose:
+                cond_dampened = torch.linalg.cond(H)
+            H = torch.linalg.cholesky(H.double()).float()
+            assert isinstance(H, torch.Tensor)
+            H = torch.cholesky_inverse(H.double()).float()
+            H = torch.linalg.cholesky(H.double(), upper=True).float()
+        else:
+            damp = percdamp * torch.mean(torch.diag(torch.abs(H)))
+            diag = torch.arange(self.columns, device=self.dev)
+            H[diag, diag] += damp
+            if verbose:
+                cond_dampened = torch.linalg.cond(H)
+            H = torch.linalg.cholesky(H)
+            assert isinstance(H, torch.Tensor)
+            H = torch.cholesky_inverse(H)
+            H = torch.linalg.cholesky(H, upper=True).float()
         Hinv = H
-
+        
         assert isinstance(Hinv, torch.Tensor)
         for i1 in range(0, self.columns, blocksize):
             i2 = min(i1 + blocksize, self.columns)
@@ -412,6 +450,8 @@ class GPTQ:
         if verbose:
             print("time %.2f" % (time.time() - tick))
             print("error", torch.sum(Losses).item())
+            print("condition_number_inital", cond_initial.item())
+            print("condition_number_dampened", cond_dampened.item())
 
         if actorder:
             Q = Q[:, invperm]

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -264,7 +264,7 @@ class GPTQQuantizer(BaseQuantizer):
 
                 gptq: Dict[str, GPTQ] = {}
                 for name in subset:
-                    gptq[name] = GPTQ(subset[name])
+                    gptq[name] = GPTQ(subset[name], stability_option=gptq_conf.stability_option)
                     full_module_name = module_name[subset[name]]
                     weight_bits = self._resolve_weight_bits(
                         gptq_conf,
@@ -440,7 +440,7 @@ class GPTQQuantizer(BaseQuantizer):
                 self.cache_args[0][batch_idx] = move_to_cpu(hidden_states)
 
         layer = model.lm_head
-        gptq = GPTQ(layer)
+        gptq = GPTQ(layer, stability_option=gptq_conf.stability_option)
         full_module_name = "lm_head"
         weight_bits = self._resolve_weight_bits(
             gptq_conf,

--- a/tico/quantization/config/gptq.py
+++ b/tico/quantization/config/gptq.py
@@ -65,6 +65,7 @@ class GPTQConfig(BaseConfig):
     groupsize: int = -1
     actorder: bool = True
     static_groups: bool = False
+    stability_option: int = 4
 
     # use this option to stabilize GPTQ for deep models
     use_orig_model_inference: bool = False

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -45,6 +45,8 @@ import tqdm
 from datasets import load_dataset
 from lm_eval.utils import make_table
 from transformers import AutoModelForCausalLM, AutoTokenizer
+import os
+import numpy as np
 
 import tico
 from tico.quantization import convert, prepare
@@ -86,6 +88,8 @@ DATASET_CONFIG = "wikitext-2-raw-v1"
 TRAIN_SPLIT = "train"
 TEST_SPLIT = "test"
 
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+#os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -274,6 +278,18 @@ def parse_args():
         help="Verbose logging for debugging (e.g., GPTQ injection coverage)",
     )
     parser.add_argument(
+        "--gptq_stability_option",
+        type=int,
+        default=0,
+        help="Stability_option",
+    )
+    parser.add_argument(
+        "--gptq_percdamp",
+        type=float,
+        default=0.01,
+        help="Dampening factor to be used in GPTQ",
+    )
+    parser.add_argument(
         "--gptq_use_orig_model_inference",
         action="store_true",
         default=False,
@@ -438,6 +454,8 @@ def build_gptq_config(
         sensitivity=sensitivity,
         quantize_lm_head=args.gptq_lm_head,
         use_orig_model_inference=args.gptq_use_orig_model_inference,
+        percdamp=args.gptq_percdamp,
+        stability_option=args.gptq_stability_option,
     )
 
 
@@ -891,7 +909,7 @@ def evaluate(q_m, tokenizer, dataset_test, args):
     )
 
     print("\n┌── Wikitext-2 test perplexity ─────────────")
-    print(f"│ int16 : {ppl_uint8:8.2f}")
+    print(f"│ int16 : {ppl_uint8:8.9f}")
     print("└───────────────────────────────────────────")
 
     if args.eval_tasks is not None:
@@ -978,6 +996,13 @@ def setup_runtime(args) -> tuple[torch.device, torch.dtype]:
     Initialize deterministic settings and resolve runtime device / dtype.
     """
     torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    random.seed(args.seed)
+    torch.backends.cudnn.benchmark = False
+    torch.use_deterministic_algorithms(True)
+    torch.utils.deterministic.fill_uninitialized_memory = True
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
     device = torch.device(args.device)
     dtype = DTYPE_MAP[args.dtype]
     return device, dtype
@@ -1114,7 +1139,7 @@ def evaluate_original_model(
     )
 
     print("\n┌── Wikitext-2 test perplexity ─────────────")
-    print(f"│ FP32 : {ppl_fp32:8.2f}")
+    print(f"│ FP32 : {ppl_fp32:8.9f}")
     print("└───────────────────────────────────────────")
 
     if args.eval_tasks is not None:


### PR DESCRIPTION
This PR tries to fix instability in llama quantization.


results of ppl evaluation for `LLama3.2-3B-Instruct` quantized using GPTQ only (smse) on 128 samples

torch and transformers packages were the same on all GPUs: 

```

torch 2.10.0
transformers 5.8.0

```

|environment| original| fix_stability==1  |fix_stability==2|fix_stability==3|
|--|-----------|------|--|-|
|GPU_0|12.023604393|11.953644753|12.002959251|12.002959251|
|GPU_1|11.913434029|12.059534073|11.875122070|11.875122070|
|GPU_2|12.054678917|12.145004272|11.989699364|11.989699364|

with `gptq_use_orig_model` enabled:

|environment| fix_stability==0| fix_stability==1  |fix_stability==2|
|--|-----------|------|--|
|GPU_0|11.892453194|11.894100189|11.898873329|
|GPU_1|11.902789116|11.898837090|11.893599510|
|GPU_2|11.905962944|11.892909050|11.891006470|

Relative error:
|parameters| fix_stability*==0 (%)| fix_stability==1  |fix_stability==2|
|--|-----------|------|--|
|NO_gptq_use_orig_model|1.27|1.73|1.16|
|gptq_use_orig_model|0.12|**0.05**|0.07|

Related: #656

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>