### PR TITLE
[quantization] Apply unified fp_name for Qwen-vl wrappers

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -436,13 +436,7 @@ def inject_gptq_qparams(
         if m.fp_name is None:
             continue
 
-        gptq_key = m.fp_name
-        if gptq_key.startswith("model."):
-            gptq_key = gptq_key[
-                len("model.") :
-            ]  # Remove "model." prefix which comes from `QuantQwen3VLForConditionalGeneration` wrapper
-
-        quantizer = gptq_quantizers.get(gptq_key)
+        quantizer = gptq_quantizers.get(m.fp_name)
         if quantizer is None:
             continue
         obs = m.get_observer(weight_obs_name)

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -59,14 +60,14 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
         self.model = PTQWrapper(
             fp_model.model,
             qcfg=qcfg.child("model") if qcfg else None,
-            fp_name=f"{fp_name}.model",
+            fp_name=join_name(fp_name, "model"),
         )
 
         # Wrap the language modeling head
         self.lm_head = PTQWrapper(
             fp_model.lm_head,
             qcfg=qcfg.child("lm_head") if qcfg else None,
-            fp_name=f"{fp_name}.lm_head",
+            fp_name=join_name(fp_name, "lm_head"),
         )
 
     def forward(

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
@@ -19,7 +19,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
-from tico.quantization.wrapq.utils.utils import get_model_arg
+from tico.quantization.wrapq.utils.utils import get_model_arg, join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -66,14 +66,14 @@ class QuantQwen3VLModel(QuantModuleBase):
         self.visual = PTQWrapper(
             fp_model.visual,
             qcfg=qcfg.child("visual") if qcfg else None,
-            fp_name=f"{fp_name}.visual",
+            fp_name=join_name(fp_name, "visual"),
         )
 
         # Wrap language model
         self.language_model = PTQWrapper(
             fp_model.language_model,
             qcfg=qcfg.child("language_model") if qcfg else None,
-            fp_name=f"{fp_name}.language_model",
+            fp_name=join_name(fp_name, "language_model"),
         )
 
         # Cache for rope_deltas - register as buffer for proper export handling

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attn.py
@@ -19,6 +19,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -65,22 +66,24 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         assert hasattr(fp_attn, "k_norm") and isinstance(fp_attn.k_norm, nn.Module)
 
         self.q_proj = PTQWrapper(
-            fp_attn.q_proj, qcfg=q_cfg, fp_name=f"{fp_name}.q_proj"
+            fp_attn.q_proj, qcfg=q_cfg, fp_name=join_name(fp_name, "q_proj")
         )
         self.k_proj = PTQWrapper(
-            fp_attn.k_proj, qcfg=k_cfg, fp_name=f"{fp_name}.k_proj"
+            fp_attn.k_proj, qcfg=k_cfg, fp_name=join_name(fp_name, "k_proj")
         )
         self.v_proj = PTQWrapper(
-            fp_attn.v_proj, qcfg=v_cfg, fp_name=f"{fp_name}.v_proj"
+            fp_attn.v_proj, qcfg=v_cfg, fp_name=join_name(fp_name, "v_proj")
         )
         self.o_proj = PTQWrapper(
-            fp_attn.o_proj, qcfg=o_cfg, fp_name=f"{fp_name}.o_proj"
+            fp_attn.o_proj, qcfg=o_cfg, fp_name=join_name(fp_name, "o_proj")
         )
         self.q_norm = PTQWrapper(
-            fp_attn.q_norm, qcfg=qn_cfg, fp_name=f"{fp_name}.q_norm"
+            fp_attn.q_norm, qcfg=qn_cfg, fp_name=join_name(fp_name, "q_norm")
         )
         self.k_norm = PTQWrapper(
-            copy.deepcopy(fp_attn.k_norm), qcfg=kn_cfg, fp_name=f"{fp_name}.k_norm"
+            copy.deepcopy(fp_attn.k_norm),
+            qcfg=kn_cfg,
+            fp_name=join_name(fp_name, "k_norm"),
         )
 
         # Constant scale (1/√d)

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -62,25 +63,25 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         self.self_attn = PTQWrapper(
             fp_layer.self_attn,
             qcfg=self_attn_cfg,
-            fp_name=f"{fp_name}.self_attn",
+            fp_name=join_name(fp_name, "self_attn"),
         )
 
         self.mlp = PTQWrapper(
             fp_layer.mlp,
             qcfg=mlp_cfg,
-            fp_name=f"{fp_name}.mlp",
+            fp_name=join_name(fp_name, "mlp"),
         )
 
         self.input_layernorm = PTQWrapper(
             fp_layer.input_layernorm,
             qcfg=input_layernorm_cfg,
-            fp_name=f"{fp_name}.input_layernorm",
+            fp_name=join_name(fp_name, "input_layernorm"),
         )
 
         self.post_attention_layernorm = PTQWrapper(
             fp_layer.post_attention_layernorm,
             qcfg=post_attention_layernorm_cfg,
-            fp_name=f"{fp_name}.post_attention_layernorm",
+            fp_name=join_name(fp_name, "post_attention_layernorm"),
         )
 
         # --- Observers for residual additions ----------------------------------

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -48,19 +49,23 @@ class QuantQwen3VLTextMLP(QuantModuleBase):
         assert hasattr(mlp_fp, "down_proj") and isinstance(mlp_fp.down_proj, nn.Module)
 
         self.gate_proj = PTQWrapper(
-            mlp_fp.gate_proj, qcfg=gate_proj_cfg, fp_name=f"{fp_name}.gate_proj"
+            mlp_fp.gate_proj,
+            qcfg=gate_proj_cfg,
+            fp_name=join_name(fp_name, "gate_proj"),
         )
         self.up_proj = PTQWrapper(
-            mlp_fp.up_proj, qcfg=up_proj_cfg, fp_name=f"{fp_name}.up_proj"
+            mlp_fp.up_proj, qcfg=up_proj_cfg, fp_name=join_name(fp_name, "up_proj")
         )
         self.down_proj = PTQWrapper(
-            mlp_fp.down_proj, qcfg=down_proj_cfg, fp_name=f"{fp_name}.down_proj"
+            mlp_fp.down_proj,
+            qcfg=down_proj_cfg,
+            fp_name=join_name(fp_name, "down_proj"),
         )
 
         # ----- activation function ---------------------------------------------
         assert hasattr(mlp_fp, "act_fn") and isinstance(mlp_fp.act_fn, nn.Module)
         self.act_fn = PTQWrapper(
-            mlp_fp.act_fn, qcfg=act_fn_cfg, fp_name=f"{fp_name}.act_fn"
+            mlp_fp.act_fn, qcfg=act_fn_cfg, fp_name=join_name(fp_name, "act_fn")
         )
 
         # ----- local observers for intermediate activations --------------------

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -19,7 +19,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
-from tico.quantization.wrapq.utils.utils import get_model_arg
+from tico.quantization.wrapq.utils.utils import get_model_arg, join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -69,7 +69,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         self.embed_tokens = PTQWrapper(
             fp_model.embed_tokens,
             qcfg=embed_tokens_cfg,
-            fp_name=f"{fp_name}.embed_tokens",
+            fp_name=join_name(fp_name, "embed_tokens"),
         )
 
         # Wrap each decoder layer
@@ -79,14 +79,14 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             wrapped_layer = PTQWrapper(
                 layer,
                 qcfg=layer_cfg,
-                fp_name=f"{fp_name}.layers.{idx}",
+                fp_name=join_name(fp_name, f"layers.{idx}"),
             )
             self.layers.append(wrapped_layer)
 
         self.norm = PTQWrapper(
             fp_model.norm,
             qcfg=norm_cfg,
-            fp_name=f"{fp_name}.norm",
+            fp_name=join_name(fp_name, "norm"),
         )
 
         # rotary_emb

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attn.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attn.py
@@ -19,6 +19,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -49,9 +50,13 @@ class QuantQwen3VLVisionAttention(QuantModuleBase):
         assert hasattr(attn_fp, "proj") and isinstance(attn_fp.proj, torch.nn.Module)
 
         self.qkv = PTQWrapper(
-            copy.deepcopy(attn_fp.qkv), qcfg=qkv_cfg, fp_name=f"{fp_name}.qkv_cfg"
+            copy.deepcopy(attn_fp.qkv),
+            qcfg=qkv_cfg,
+            fp_name=join_name(fp_name, "qkv"),
         )
-        self.proj = PTQWrapper(attn_fp.proj, qcfg=proj_cfg, fp_name=f"{fp_name}.proj")
+        self.proj = PTQWrapper(
+            attn_fp.proj, qcfg=proj_cfg, fp_name=join_name(fp_name, "proj")
+        )
 
         # Let's fold constant scale (1/√d) to k_proj
         scale_t = torch.tensor(

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_block.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -60,25 +61,25 @@ class QuantQwen3VLVisionBlock(QuantModuleBase):
         self.norm1 = PTQWrapper(
             fp_block.norm1,
             qcfg=norm1_cfg,
-            fp_name=f"{fp_name}.norm1",
+            fp_name=join_name(fp_name, "norm1"),
         )
 
         self.norm2 = PTQWrapper(
             fp_block.norm2,
             qcfg=norm2_cfg,
-            fp_name=f"{fp_name}.norm2",
+            fp_name=join_name(fp_name, "norm2"),
         )
 
         self.attn = PTQWrapper(
             fp_block.attn,
             qcfg=attn_cfg,
-            fp_name=f"{fp_name}.attn",
+            fp_name=join_name(fp_name, "attn"),
         )
 
         self.mlp = PTQWrapper(
             fp_block.mlp,
             qcfg=mlp_cfg,
-            fp_name=f"{fp_name}.mlp",
+            fp_name=join_name(fp_name, "mlp"),
         )
 
         # --- Observers for residual additions ----------------------------------

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_mlp.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_mlp.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -48,16 +49,20 @@ class QuantQwen3VLVisionMLP(QuantModuleBase):
         )
 
         self.linear_fc1 = PTQWrapper(
-            mlp_fp.linear_fc1, qcfg=linear_fc1_cfg, fp_name=f"{fp_name}.linear_fc1"
+            mlp_fp.linear_fc1,
+            qcfg=linear_fc1_cfg,
+            fp_name=join_name(fp_name, "linear_fc1"),
         )
         self.linear_fc2 = PTQWrapper(
-            mlp_fp.linear_fc2, qcfg=linear_fc2_cfg, fp_name=f"{fp_name}.linear_fc2"
+            mlp_fp.linear_fc2,
+            qcfg=linear_fc2_cfg,
+            fp_name=join_name(fp_name, "linear_fc2"),
         )
 
         # ----- activation ---------------------------------------------
         assert hasattr(mlp_fp, "act_fn") and isinstance(mlp_fp.act_fn, torch.nn.Module)
         self.act_fn = PTQWrapper(
-            mlp_fp.act_fn, qcfg=act_cfg, fp_name=f"{fp_name}.act_fn"
+            mlp_fp.act_fn, qcfg=act_cfg, fp_name=join_name(fp_name, "act_fn")
         )
 
         # ----- local observers ----------------------------------------

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_model.py
@@ -19,7 +19,7 @@ import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.mode import Mode
-from tico.quantization.wrapq.utils.utils import get_model_arg
+from tico.quantization.wrapq.utils.utils import get_model_arg, join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -102,7 +102,7 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
         self.patch_embed = PTQWrapper(
             fp_model.patch_embed,
             qcfg=qcfg.child("patch_embed") if qcfg else None,
-            fp_name=f"{fp_name}.patch_embed",
+            fp_name=join_name(fp_name, "patch_embed"),
         )
 
         # Wrap transformer blocks
@@ -113,7 +113,7 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
                 PTQWrapper(
                     blk,
                     qcfg=blocks_cfg.child(str(i)) if blocks_cfg else None,
-                    fp_name=f"{fp_name}.blocks.{i}",
+                    fp_name=join_name(fp_name, f"blocks.{i}"),
                 )
             )
 
@@ -121,7 +121,7 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
         self.merger = PTQWrapper(
             fp_model.merger,
             qcfg=qcfg.child("merger") if qcfg else None,
-            fp_name=f"{fp_name}.merger",
+            fp_name=join_name(fp_name, "merger"),
         )
 
         # Wrap deepstack merger list
@@ -134,7 +134,7 @@ class QuantQwen3VLVisionModel(QuantModuleBase):
                     qcfg=deepstack_merger_cfg.child(str(i))
                     if deepstack_merger_cfg
                     else None,
-                    fp_name=f"{fp_name}.deepstack_merger_list.{i}",
+                    fp_name=join_name(fp_name, f"deepstack_merger_list.{i}"),
                 )
             )
 

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_embed.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_embed.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -58,7 +59,7 @@ class QuantQwen3VLVisionPatchEmbed(QuantModuleBase):
         self.proj = PTQWrapper(
             fp_patch_embed.proj,
             qcfg=proj_cfg,
-            fp_name=f"{fp_name}.proj",
+            fp_name=join_name(fp_name, "proj"),
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -64,25 +65,25 @@ class QuantQwen3VLVisionPatchMerger(QuantModuleBase):
         self.norm = PTQWrapper(
             fp_merger.norm,
             qcfg=norm_cfg,
-            fp_name=f"{fp_name}.norm",
+            fp_name=join_name(fp_name, "norm"),
         )
 
         self.linear_fc1 = PTQWrapper(
             fp_merger.linear_fc1,
             qcfg=fc1_cfg,
-            fp_name=f"{fp_name}.linear_fc1",
+            fp_name=join_name(fp_name, "linear_fc1"),
         )
 
         self.act_fn = PTQWrapper(
             fp_merger.act_fn,
             qcfg=act_cfg,
-            fp_name=f"{fp_name}.act_fn",
+            fp_name=join_name(fp_name, "act_fn"),
         )
 
         self.linear_fc2 = PTQWrapper(
             fp_merger.linear_fc2,
             qcfg=fc2_cfg,
-            fp_name=f"{fp_name}.linear_fc2",
+            fp_name=join_name(fp_name, "linear_fc2"),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This commit unifies the `fp_name` across all Qwen-vl quantization wrappers to use full hierarchical paths (using `join_name`), and removes redundant code related to GPTQ key in `quantize_qwen3_vl_with_gptq.py`


Related commit: 
- #658

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>