### PR TITLE
[quantization] Support Evaluation of Qwen3-VL With MMLU Dataset

### DIFF
--- a/tico/quantization/evaluation/mmlu_eval_utils.py
+++ b/tico/quantization/evaluation/mmlu_eval_utils.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+import torch
+
+from lm_eval import evaluator
+from lm_eval.models.huggingface import HFLM
+from lm_eval.utils import make_table
+
+
+def _normalize_subject(subject: str) -> str:
+    if subject is None:
+        return None
+
+    if subject.startswith("mmlu"):
+        return subject
+
+    return f"mmlu_{subject}"
+
+
+def evaluate_mmlu(
+    model,
+    tokenizer,
+    subjects: list[str] | None = None,
+    device: str | torch.device = "cuda",
+    n_shots: int = 5,
+    n_samples: int = -1,
+    batch_size: int = 1,
+    max_seq_len: int | None = None,
+) -> dict[str, Any]:
+    """
+    Evaluate a model on the MMLU benchmark using lm_eval.
+
+    This function uses the lm_eval framework for standardized MMLU evaluation.
+    The model can be a standard HuggingFace model or a wrapped quantized model
+    (e.g., QuantQwen3VLForConditionalGeneration).
+
+    Args:
+        model: Language model with generation capability. Can be a wrapped model.
+        tokenizer: Matching tokenizer for the model.
+        subjects: list of subjects to evaluate (e.g. 'stem', 'humanities', 'social_sciences', 'astronomy', etc.). Use None for all subjects.
+        device: Device for inference.
+        n_shots: Number of few-shot examples per subject.
+        n_samples: Number of test samples per subject. Use -1 for full test sets.
+        batch_size: Batch size for evaluation.
+        max_seq_len: Maximal sequence length to be generated.
+
+    Returns:
+        Aggregated results dictionary with per-subject, per-domain, and overall accuracy.
+    """
+    # Unwrap if needed (handles PTQWrapper)
+    if hasattr(model, "wrapped"):
+        model = model.wrapped
+
+    lm = HFLM(
+        pretrained=model,
+        backend="causal",
+        tokenizer=tokenizer,
+        batch_size=batch_size,
+        device=device,
+        max_length=max_seq_len,
+        truncation=True,
+    )
+
+    # Convert subjects to lm_eval task names
+    tasks: list[str] = (
+        [_normalize_subject(subject) for subject in subjects] if subjects else ["mmlu"]
+    )
+
+    # Run lm_eval evaluation
+    results: dict[str, Any] = evaluator.simple_evaluate(
+        model=lm,
+        tasks=tasks,
+        num_fewshot=n_shots,
+        batch_size=batch_size,
+        limit=n_samples if n_samples > 0 else None,
+        device=str(device) if device else None,
+    )
+    return results
+
+
+def print_mmlu_results(results: dict[str, Any]) -> None:
+    print(make_table(results))

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -25,6 +25,10 @@ from tico.quantization import convert, prepare
 from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
 from tico.quantization.config.builders import build_qwen3_vl_ptq_config
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
+from tico.quantization.evaluation.mmlu_eval_utils import (
+    evaluate_mmlu,
+    print_mmlu_results,
+)
 from tico.quantization.evaluation.vlm_eval_utils import (
     get_accuracy_on_dataset,
     get_calib_inputs,
@@ -254,6 +258,38 @@ def parse_args():
         type=int,
         default=2,
         help="Spatial merge size for vision tokens.",
+    )
+
+    # MMLU evaluation arguments
+    parser.add_argument(
+        "--mmlu_subjects",
+        type=str,
+        default=None,
+        nargs="+",
+        help=(
+            "Space-separated list of MMLU subjects to evaluate. Use 'mmlu' for all subjects."
+            "Use 'stem', 'humanities', 'social_sciences', or 'other' for the broader domains of knowledge."
+            "Or use narrower subjects like 'college_physics', 'abstract_algebra', etc."
+            "See https://huggingface.co/datasets/cais/mmlu for the full list."
+        ),
+    )
+    parser.add_argument(
+        "--mmlu_n_shots",
+        type=int,
+        default=5,
+        help="Number of few-shot examples for MMLU evaluation.",
+    )
+    parser.add_argument(
+        "--mmlu_n_samples",
+        type=int,
+        default=-1,
+        help="Number of samples per MMLU subject. Use -1 for full test set.",
+    )
+    parser.add_argument(
+        "--mmlu_batch_size",
+        type=int,
+        default=1,
+        help="Number of samples in a batch for MMLU evaluation.",
     )
 
     return parser.parse_args()
@@ -695,6 +731,21 @@ def main() -> None:
         )
         print_eval_results("Evaluating original model", original_results)
 
+    # MMLU evaluation on original model
+    if args.mmlu_subjects is not None:
+        print("\n=== MMLU Evaluation (Original Model) ===")
+        original_mmlu_results = evaluate_mmlu(
+            model=model,
+            tokenizer=processor.tokenizer,
+            subjects=args.mmlu_subjects,
+            device=args.device,
+            n_shots=args.mmlu_n_shots,
+            n_samples=args.mmlu_n_samples,
+            batch_size=args.mmlu_batch_size,
+            max_seq_len=args.max_seq_len,
+        )
+        print_mmlu_results(original_mmlu_results)
+
     calib_inputs = get_calib_inputs(
         "vqav2",
         processor,
@@ -782,6 +833,21 @@ def main() -> None:
         )
         print_eval_results("Evaluating quantized model", quantized_results)
         print_markdown_comparison(original_results, quantized_results)
+
+    # MMLU evaluation on quantized model
+    if args.mmlu_subjects is not None:
+        print("\n=== MMLU Evaluation (Quantized Model) ===")
+        quantized_mmlu_results = evaluate_mmlu(
+            model=q_m,
+            tokenizer=processor.tokenizer,
+            subjects=args.mmlu_subjects,
+            device=args.device,
+            n_shots=args.mmlu_n_shots,
+            n_samples=args.mmlu_n_samples,
+            batch_size=args.mmlu_batch_size,
+            max_seq_len=args.max_seq_len,
+        )
+        print_mmlu_results(quantized_mmlu_results)
 
 
 if __name__ == "__main__":

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -202,3 +202,6 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
             video_grid_thw=video_grid_thw,
             **kwargs,
         )
+
+    def tie_weights(self):
+        pass


### PR DESCRIPTION
# What

This change adds support for [MMLU benchmark](https://en.wikipedia.org/wiki/MMLU) in `tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py` script.

# Why

MMLU benchmark is listed among the target benchmarks in issue [PTQ Evaluation — Qwen3-VL](https://github.sec.samsung.net/one-project/TICO/issues/192).

# Implementation Details

**1. New File: `tico/quantization/evaluation/mmlu_eval_utils.py`** (78 lines)
- Created `evaluate_mmlu()` function using `lm_eval` framework
- Wraps model with `HFLM` (lm_eval's HuggingFace wrapper)
- Supports subject selection, few-shot prompting, sample limits
- Added `_normalize_subject()` helper for task name conversion
- Added `print_mmlu_results()` for formatted output

**2. Modified: `quantize_qwen3_vl_with_gptq.py`** (+64 lines)
- Added CLI arguments: `--mmlu_subjects`, `--mmlu_n_shots`, `--mmlu_n_samples`, `--mmlu_batch_size`
- Added MMLU evaluation for original model (before quantization)
- Added MMLU evaluation for quantized model (after GPTQ+PTQ)

**3. Modified: `quant_for_conditional_generation.py`** (+3 lines)
- Added `tie_weights()` method (pass) — required by `lm_eval`'s `HFLM` wrapper

## Key Design Decisions:
1. Using `lm_eval` framework for MMLU benchmarking.
2. Subjects specified as space-separated list (nargs="+").

# Usage Example:
```bash
$ python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
    --model=Qwen/Qwen3-VL-4B-Instruct \
    --cache_dir=/home/d.savchenkov/models/qwen3-vl-4b \
    --trust-remote-code \
    --mmlu_subjects=stem \
    --gptq_mse=mse \
    --no_GPTQ \
    --mmlu_n_samples=10 \
    --embedding_weight_bits=16 \
    --vision_patch_embed_weight_bits=16 \
    --linear_weight_bits=16 \
    --lm_head_weight_bits=16 \
    --nsamples_for_qcalibration=10 \
    --verbose
```

# Example Output

```
=== MMLU Evaluation (Original Model) ===
|             Tasks             |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-------------------------------|------:|------|-----:|------|---|-----:|---|-----:|
|stem                           |      2|none  |      |acc   |↑  |0.7211|±  |0.0288|
| - abstract_algebra            |      1|none  |     5|acc   |↑  |0.4000|±  |0.1633|
| - anatomy                     |      1|none  |     5|acc   |↑  |0.8000|±  |0.1333|
| - astronomy                   |      1|none  |     5|acc   |↑  |1.0000|±  |0.0000|
| - college_biology             |      1|none  |     5|acc   |↑  |1.0000|±  |0.0000|
| - college_chemistry           |      1|none  |     5|acc   |↑  |0.7000|±  |0.1528|
| - college_computer_science    |      1|none  |     5|acc   |↑  |0.6000|±  |0.1633|
| - college_mathematics         |      1|none  |     5|acc   |↑  |0.3000|±  |0.1528|
| - college_physics             |      1|none  |     5|acc   |↑  |0.6000|±  |0.1633|
| - computer_security           |      1|none  |     5|acc   |↑  |0.8000|±  |0.1333|
| - conceptual_physics          |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - electrical_engineering      |      1|none  |     5|acc   |↑  |0.7000|±  |0.1528|
| - elementary_mathematics      |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - high_school_biology         |      1|none  |     5|acc   |↑  |1.0000|±  |0.0000|
| - high_school_chemistry       |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - high_school_computer_science|      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - high_school_mathematics     |      1|none  |     5|acc   |↑  |0.1000|±  |0.1000|
| - high_school_physics         |      1|none  |     5|acc   |↑  |0.6000|±  |0.1633|
| - high_school_statistics      |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - machine_learning            |      1|none  |     5|acc   |↑  |0.6000|±  |0.1633|

=== MMLU Evaluation (Quantized Model) ===
|             Tasks             |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-------------------------------|------:|------|-----:|------|---|-----:|---|-----:|
|stem                           |      2|none  |      |acc   |↑  |0.6474|±  |0.0307|
| - abstract_algebra            |      1|none  |     5|acc   |↑  |0.2000|±  |0.1333|
| - anatomy                     |      1|none  |     5|acc   |↑  |0.7000|±  |0.1528|
| - astronomy                   |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - college_biology             |      1|none  |     5|acc   |↑  |1.0000|±  |0.0000|
| - college_chemistry           |      1|none  |     5|acc   |↑  |0.4000|±  |0.1633|
| - college_computer_science    |      1|none  |     5|acc   |↑  |0.5000|±  |0.1667|
| - college_mathematics         |      1|none  |     5|acc   |↑  |0.5000|±  |0.1667|
| - college_physics             |      1|none  |     5|acc   |↑  |0.7000|±  |0.1528|
| - computer_security           |      1|none  |     5|acc   |↑  |0.8000|±  |0.1333|
| - conceptual_physics          |      1|none  |     5|acc   |↑  |1.0000|±  |0.0000|
| - electrical_engineering      |      1|none  |     5|acc   |↑  |0.7000|±  |0.1528|
| - elementary_mathematics      |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - high_school_biology         |      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - high_school_chemistry       |      1|none  |     5|acc   |↑  |0.6000|±  |0.1633|
| - high_school_computer_science|      1|none  |     5|acc   |↑  |0.9000|±  |0.1000|
| - high_school_mathematics     |      1|none  |     5|acc   |↑  |0.1000|±  |0.1000|
| - high_school_physics         |      1|none  |     5|acc   |↑  |0.4000|±  |0.1633|
| - high_school_statistics      |      1|none  |     5|acc   |↑  |0.7000|±  |0.1528|
| - machine_learning            |      1|none  |     5|acc   |↑  |0.4000|±  |0.1633|
```