### PR TITLE
[quantization] SmoothQuant support for vision components of Qwen3-vl

### DIFF
--- a/test/quantization/algorithm/test_smooth_quant.py
+++ b/test/quantization/algorithm/test_smooth_quant.py
@@ -25,6 +25,12 @@ import torch.nn.functional as F
 from tico.quantization import convert, prepare
 from tico.quantization.config.smoothquant import SmoothQuantConfig
 
+# Initialize the registry with real transformer classes before any faux classes are installed.
+# This prevents the registry from registering wrappers for faux/mock classes.
+from tico.quantization.wrapq.wrappers.registry import _lazy_init
+
+_lazy_init()
+
 IS_INTERNAL_TEST = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
 
 
@@ -253,4 +259,299 @@ class SmoothQuantOutputHookTest(unittest.TestCase):
         #    so weights shouldn't blow up or vanish.
         self.assertTrue(
             torch.isfinite(new_fc1_w).all() and torch.isfinite(new_fc2_w).all()
+        )
+
+
+# ────────────────────────────────────────────────────────────
+# Faux Qwen3-VL vision components injection
+# ────────────────────────────────────────────────────────────
+
+# Store original classes for restoration
+_ORIGINAL_QWEN3VL_CLASSES = {}
+
+
+class FauxQwen3VLVisionAttention(nn.Module):
+    """Minimal faux Qwen3VLVisionAttention with combined qkv projection."""
+
+    def __init__(self, hidden_size: int = 64):
+        super().__init__()
+        self.qkv = nn.Linear(hidden_size, hidden_size * 3, bias=True)
+        self.proj = nn.Linear(hidden_size, hidden_size)
+
+
+class FauxQwen3VLVisionMLP(nn.Module):
+    """Minimal faux Qwen3VLVisionMLP."""
+
+    def __init__(self, hidden_size: int = 64, intermediate_size: int = 128):
+        super().__init__()
+        self.linear_fc1 = nn.Linear(hidden_size, intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(intermediate_size, hidden_size, bias=True)
+
+
+class FauxQwen3VLVisionBlock(nn.Module):
+    """
+    Minimal faux Qwen3VLVisionBlock:
+      - norm1 (LayerNorm) -> attn (attention with qkv)
+      - norm2 (LayerNorm) -> mlp
+    """
+
+    def __init__(self, hidden_size: int = 64, intermediate_size: int = 128):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(hidden_size, eps=1e-6)
+        self.norm2 = nn.LayerNorm(hidden_size, eps=1e-6)
+        self.attn = FauxQwen3VLVisionAttention(hidden_size)
+        self.mlp = FauxQwen3VLVisionMLP(hidden_size, intermediate_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Simplified forward (not used in tests)
+        return x + self.attn(self.norm1(x)) + self.mlp(self.norm2(x))
+
+
+class FauxQwen3VLVisionPatchMerger(nn.Module):
+    """
+    Minimal faux Qwen3VLVisionPatchMerger:
+      - norm (LayerNorm) -> linear_fc1 -> act_fn -> linear_fc2
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 64,
+        out_hidden_size: int = 128,
+        use_postshuffle_norm: bool = False,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.use_postshuffle_norm = use_postshuffle_norm
+        # norm.weight shape matches hidden_size for standard case
+        norm_size = hidden_size if not use_postshuffle_norm else hidden_size * 4
+        self.norm = nn.LayerNorm(norm_size, eps=1e-6)
+        self.linear_fc1 = nn.Linear(hidden_size, hidden_size, bias=True)
+        self.linear_fc2 = nn.Linear(hidden_size, out_hidden_size, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Simplified forward (not used in tests)
+        return self.linear_fc2(self.linear_fc1(self.norm(x)))
+
+
+def _install_faux_qwen3vl():
+    """
+    Install minimal fake 'transformers.models.qwen3_vl.modeling_qwen3_vl' into sys.modules
+    with Qwen3VLVisionBlock and Qwen3VLVisionPatchMerger.
+    """
+    global _ORIGINAL_QWEN3VL_CLASSES
+
+    # Build the module hierarchy
+    transformers_mod = sys.modules.get("transformers", types.ModuleType("transformers"))
+    models_mod = sys.modules.get(
+        "transformers.models", types.ModuleType("transformers.models")
+    )
+    qwen3_vl_mod = sys.modules.get(
+        "transformers.models.qwen3_vl", types.ModuleType("transformers.models.qwen3_vl")
+    )
+    modeling_mod = sys.modules.get(
+        "transformers.models.qwen3_vl.modeling_qwen3_vl",
+        types.ModuleType("transformers.models.qwen3_vl.modeling_qwen3_vl"),
+    )
+
+    # Store original classes if they exist (for restoration)
+    if hasattr(modeling_mod, "Qwen3VLVisionBlock"):
+        _ORIGINAL_QWEN3VL_CLASSES[
+            "Qwen3VLVisionBlock"
+        ] = modeling_mod.Qwen3VLVisionBlock
+    if hasattr(modeling_mod, "Qwen3VLVisionPatchMerger"):
+        _ORIGINAL_QWEN3VL_CLASSES[
+            "Qwen3VLVisionPatchMerger"
+        ] = modeling_mod.Qwen3VLVisionPatchMerger
+
+    # Override with faux classes
+    modeling_mod.Qwen3VLVisionBlock = FauxQwen3VLVisionBlock  # type: ignore[attr-defined]
+    modeling_mod.Qwen3VLVisionPatchMerger = FauxQwen3VLVisionPatchMerger  # type: ignore[attr-defined]
+    modeling_mod.FauxQwen3VLVisionAttention = FauxQwen3VLVisionAttention  # type: ignore[attr-defined]
+    modeling_mod.FauxQwen3VLVisionMLP = FauxQwen3VLVisionMLP  # type: ignore[attr-defined]
+
+    sys.modules["transformers"] = transformers_mod
+    sys.modules["transformers.models"] = models_mod
+    sys.modules["transformers.models.qwen3_vl"] = qwen3_vl_mod
+    sys.modules["transformers.models.qwen3_vl.modeling_qwen3_vl"] = modeling_mod
+
+
+def _uninstall_faux_qwen3vl():
+    """
+    Restore original classes in the modeling module instead of deleting modules.
+
+    Deleting modules from sys.modules causes subsequent imports to create NEW class
+    objects that don't match the ones registered in the wrapper registry, leading to
+    'No quant wrapper for X' errors in subsequent tests.
+    """
+    global _ORIGINAL_QWEN3VL_CLASSES
+
+    modeling_mod = sys.modules.get("transformers.models.qwen3_vl.modeling_qwen3_vl")
+    if modeling_mod is not None:
+        # Restore original classes if they were stored
+        if "Qwen3VLVisionBlock" in _ORIGINAL_QWEN3VL_CLASSES:
+            modeling_mod.Qwen3VLVisionBlock = _ORIGINAL_QWEN3VL_CLASSES["Qwen3VLVisionBlock"]  # type: ignore[attr-defined]
+        if "Qwen3VLVisionPatchMerger" in _ORIGINAL_QWEN3VL_CLASSES:
+            modeling_mod.Qwen3VLVisionPatchMerger = _ORIGINAL_QWEN3VL_CLASSES["Qwen3VLVisionPatchMerger"]  # type: ignore[attr-defined]
+
+        # Remove faux classes that we added
+        if hasattr(modeling_mod, "FauxQwen3VLVisionAttention"):
+            delattr(modeling_mod, "FauxQwen3VLVisionAttention")
+        if hasattr(modeling_mod, "FauxQwen3VLVisionMLP"):
+            delattr(modeling_mod, "FauxQwen3VLVisionMLP")
+
+    # Clear the stored original classes
+    _ORIGINAL_QWEN3VL_CLASSES = {}
+
+
+# ────────────────────────────────────────────────────────────
+# Tests for _apply_if_qwen3vl_vision_block
+# ────────────────────────────────────────────────────────────
+class ApplyIfQwen3VLVisionBlockTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+        np.random.seed(0)
+        _install_faux_qwen3vl()
+        # Get the faux classes from sys.modules
+        cls.Qwen3VLVisionBlock = sys.modules[  # type: ignore[attr-defined]
+            "transformers.models.qwen3_vl.modeling_qwen3_vl"
+        ].Qwen3VLVisionBlock
+
+    @classmethod
+    def tearDownClass(cls):
+        _uninstall_faux_qwen3vl()
+
+    def setUp(self):
+        # Import the function after faux module is installed
+        from tico.quantization.algorithm.smoothquant.smooth_quant import (
+            _apply_if_qwen3vl_vision_block,
+        )
+
+        self._apply_if_qwen3vl_vision_block = _apply_if_qwen3vl_vision_block
+
+    @torch.inference_mode()
+    def test_returns_true_for_valid_block_with_qkv(self):
+        """Test that the function returns True for a valid Qwen3VLVisionBlock with qkv."""
+        block = self.Qwen3VLVisionBlock(hidden_size=64, intermediate_size=128)  # type: ignore[attr-defined]
+
+        # Store original weights
+        orig_norm1_weight = block.norm1.weight.clone()
+        orig_norm2_weight = block.norm2.weight.clone()
+        orig_qkv_weight = block.attn.qkv.weight.clone()
+        orig_mlp_weight = block.mlp.linear_fc1.weight.clone()
+
+        # Create activation_max with correct keys
+        activation_max = {
+            "test.attn.qkv": torch.abs(torch.randn(64)) + 0.1,
+            "test.mlp.linear_fc1": torch.abs(torch.randn(64)) + 0.1,
+        }
+
+        result = self._apply_if_qwen3vl_vision_block("test", block, activation_max, 0.5)
+
+        self.assertTrue(result)
+        # Verify weights were modified
+        self.assertFalse(torch.allclose(orig_norm1_weight, block.norm1.weight))
+        self.assertFalse(torch.allclose(orig_norm2_weight, block.norm2.weight))
+        self.assertFalse(torch.allclose(orig_qkv_weight, block.attn.qkv.weight))
+        self.assertFalse(torch.allclose(orig_mlp_weight, block.mlp.linear_fc1.weight))
+
+
+# ────────────────────────────────────────────────────────────
+# Tests for _apply_if_qwen3vl_vision_patch_merger
+# ────────────────────────────────────────────────────────────
+class ApplyIfQwen3VLVisionPatchMergerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+        np.random.seed(0)
+        _install_faux_qwen3vl()
+        # Get the faux classes from sys.modules
+        cls.Qwen3VLVisionPatchMerger = sys.modules[  # type: ignore[attr-defined]
+            "transformers.models.qwen3_vl.modeling_qwen3_vl"
+        ].Qwen3VLVisionPatchMerger
+
+    @classmethod
+    def tearDownClass(cls):
+        _uninstall_faux_qwen3vl()
+
+    def setUp(self):
+        from tico.quantization.algorithm.smoothquant.smooth_quant import (
+            _apply_if_qwen3vl_vision_patch_merger,
+        )
+
+        self._apply_if_qwen3vl_vision_patch_merger = (
+            _apply_if_qwen3vl_vision_patch_merger
+        )
+
+    @torch.inference_mode()
+    def test_returns_true_and_applies_smoothing_for_valid_merger(self):
+        """Test that function returns True and applies smoothing for valid merger."""
+        # Create merger with matching dimensions (default case)
+        merger = self.Qwen3VLVisionPatchMerger(hidden_size=64, out_hidden_size=128)  # type: ignore[attr-defined]
+
+        # Verify dimensions match
+        norm_numel = merger.norm.weight.numel()  # 64
+        linear_in = merger.linear_fc1.in_features  # 64
+        self.assertEqual(norm_numel, linear_in)
+
+        # Store original weights
+        orig_norm_weight = merger.norm.weight.clone()
+        orig_fc1_weight = merger.linear_fc1.weight.clone()
+
+        # Create activation_max with correct key
+        activation_max = {
+            "test.linear_fc1": torch.abs(torch.randn(64)) + 0.1,
+        }
+
+        result = self._apply_if_qwen3vl_vision_patch_merger(
+            "test", merger, activation_max, 0.5
+        )
+
+        self.assertTrue(result)
+        # Verify weights were modified
+        self.assertFalse(torch.allclose(orig_norm_weight, merger.norm.weight))
+        self.assertFalse(torch.allclose(orig_fc1_weight, merger.linear_fc1.weight))
+
+    @torch.inference_mode()
+    def test_smoothing_preserves_numerical_equivalence(self):
+        """Test that smoothing preserves numerical equivalence of forward pass."""
+        merger = self.Qwen3VLVisionPatchMerger(hidden_size=64, out_hidden_size=128)  # type: ignore[attr-defined]
+        merger.eval()
+
+        # Create sample input
+        x = torch.randn(2, 10, 64)
+
+        # Get baseline output
+        with torch.no_grad():
+            base_output = merger(x)
+
+        # Store original weights
+        orig_norm_weight = merger.norm.weight.clone()
+        orig_fc1_weight = merger.linear_fc1.weight.clone()
+
+        # Apply smoothing
+        activation_max = {
+            "test.linear_fc1": torch.abs(torch.randn(64)) + 0.1,
+        }
+        result = self._apply_if_qwen3vl_vision_patch_merger(
+            "test", merger, activation_max, 0.5
+        )
+
+        self.assertTrue(result)
+
+        # Verify weights changed
+        self.assertFalse(torch.allclose(orig_norm_weight, merger.norm.weight))
+        self.assertFalse(torch.allclose(orig_fc1_weight, merger.linear_fc1.weight))
+
+        # Get output after smoothing
+        with torch.no_grad():
+            new_output = merger(x)
+
+        # Outputs should be close (smoothquant preserves equivalence)
+        np.testing.assert_allclose(
+            actual=new_output.numpy(),
+            desired=base_output.numpy(),
+            rtol=1e-4,
+            atol=1e-4,
+            err_msg="Output mismatch after SmoothQuant on PatchMerger.",
         )

--- a/tico/quantization/algorithm/smoothquant/smooth_quant.py
+++ b/tico/quantization/algorithm/smoothquant/smooth_quant.py
@@ -69,6 +69,8 @@ def smooth_weights(
     # Check shapes
     if isinstance(front_module, LlamaRMSNorm):
         front_numel = front_module.weight.numel()
+    elif isinstance(front_module, torch.nn.LayerNorm):
+        front_numel = front_module.weight.numel()
     else:
         raise NotImplementedError(
             f"Unsupported module type: {type(front_module).__name__}"
@@ -280,11 +282,193 @@ def _apply_if_fairseq_relu_bridge(
     return True
 
 
-# Registry of appliers (order matters: try LLaMA first, then fairseq)
+# ────────────────────────────────────────────────────────────
+# Qwen3-VL Vision Components (LayerNorm-based)
+# ────────────────────────────────────────────────────────────
+
+
+@torch.no_grad()
+def _apply_if_qwen3vl_vision_block(
+    name: str,
+    module: torch.nn.Module,
+    activation_max: Dict[str, torch.Tensor],
+    alpha_to_apply: float,
+) -> bool:
+    """
+    Apply SmoothQuant smoothing to Qwen3VLVisionBlock (LayerNorm-based).
+
+    Qwen3VLVisionBlock structure:
+        - norm1 (LayerNorm) → attn (attention)
+        - norm2 (LayerNorm) → mlp (feed-forward)
+
+    Returns True if this handler applied smoothing to `module`.
+    """
+    try:
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLVisionBlock
+    except Exception:
+        return False
+
+    if not isinstance(module, Qwen3VLVisionBlock):
+        return False
+
+    # Check for required attributes
+    if not hasattr(module, "norm1") or not hasattr(module, "norm2"):
+        return False
+    if not hasattr(module, "attn") or not hasattr(module, "mlp"):
+        return False
+
+    # Get attention input projections (qkv is typically combined or separate)
+    attn = module.attn
+    if hasattr(attn, "qkv"):
+        # Combined qkv projection
+        back_modules_attn = [attn.qkv]
+    elif (
+        hasattr(attn, "q_proj") and hasattr(attn, "k_proj") and hasattr(attn, "v_proj")
+    ):
+        # Separate q, k, v projections
+        back_modules_attn = [attn.q_proj, attn.k_proj, attn.v_proj]
+    else:
+        # Try to find any linear layers in attention
+        back_modules_attn = []
+        for attr_name in ["q", "k", "v", "query", "key", "value"]:
+            if hasattr(attn, attr_name):
+                attr = getattr(attn, attr_name)
+                if isinstance(attr, torch.nn.Linear):
+                    back_modules_attn.append(attr)
+        if not back_modules_attn:
+            return False
+
+    # Smooth norm1 → attention
+    applied_attn = False
+    attn_key = f"{name}.attn"
+    for key_suffix in ["", ".qkv", ".q_proj", ".q", ".query"]:
+        potential_key = f"{attn_key}{key_suffix}"
+        if potential_key in activation_max:
+            smooth_weights(
+                module.norm1,
+                back_modules_attn,
+                activation_max[potential_key],
+                alpha_to_apply,
+            )
+            applied_attn = True
+            break
+
+    if not applied_attn:
+        print(
+            f"[SmoothQuant] Warning: activation stats not found for "
+            f"{name} attention input."
+        )
+
+    # Get MLP input projections
+    mlp = module.mlp
+    back_modules_mlp = []
+    for attr_name in ["linear_fc1", "fc1", "up_proj", "gate_proj", "w1"]:
+        if hasattr(mlp, attr_name):
+            attr = getattr(mlp, attr_name)
+            if isinstance(attr, torch.nn.Linear):
+                back_modules_mlp.append(attr)
+
+    if not back_modules_mlp:
+        return True  # Already applied attention smoothing
+
+    # Smooth norm2 → mlp
+    applied_mlp = False
+    mlp_key = f"{name}.mlp"
+    for key_suffix in [".linear_fc1", ".fc1", ".up_proj", ".gate_proj", ".w1", ""]:
+        potential_key = f"{mlp_key}{key_suffix}"
+        if potential_key in activation_max:
+            smooth_weights(
+                module.norm2,
+                back_modules_mlp,
+                activation_max[potential_key],
+                alpha_to_apply,
+            )
+            applied_mlp = True
+            break
+
+    if not applied_mlp:
+        print(
+            f"[SmoothQuant] Warning: activation stats not found for "
+            f"{name} mlp input."
+        )
+
+    return True
+
+
+@torch.no_grad()
+def _apply_if_qwen3vl_vision_patch_merger(
+    name: str,
+    module: torch.nn.Module,
+    activation_max: Dict[str, torch.Tensor],
+    alpha_to_apply: float,
+) -> bool:
+    """
+    Apply SmoothQuant smoothing to Qwen3VLVisionPatchMerger (LayerNorm-based).
+
+    Qwen3VLVisionPatchMerger structure:
+        - norm (LayerNorm) → linear_fc1 → act_fn → linear_fc2
+
+    NOTE: In Qwen3-VL, the PatchMerger has a special structure where:
+        - norm.weight shape: [1024] (normalized_shape)
+        - linear_fc1.in_features: 4096 (hidden_size)
+
+    This means the LayerNorm is applied to a smaller dimension, then reshaped
+    before the linear layer. SmoothQuant cannot be directly applied here
+    because the dimensions don't match. We skip smoothing for this module.
+
+    Returns True if this handler applied smoothing to `module`, False otherwise.
+    """
+    try:
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+            Qwen3VLVisionPatchMerger,
+        )
+    except Exception:
+        return False
+
+    if not isinstance(module, Qwen3VLVisionPatchMerger):
+        return False
+
+    # Check for required attributes
+    if not hasattr(module, "norm"):
+        return False
+    if not hasattr(module, "linear_fc1"):
+        return False
+
+    # Check if dimensions are compatible for SmoothQuant
+    # LayerNorm weight shape = normalized_shape
+    # Linear in_features must match normalized_shape for smoothing
+    norm_numel = module.norm.weight.numel()
+    linear_in_features = module.linear_fc1.in_features
+
+    if norm_numel != linear_in_features:
+        # Dimensions don't match - PatchMerger reshapes between norm and linear
+        # SmoothQuant cannot be applied here
+        return False
+
+    # Smooth norm → linear_fc1
+    fc1_key = f"{name}.linear_fc1"
+    if fc1_key in activation_max:
+        fc1_input_scales = activation_max[fc1_key]
+        smooth_weights(
+            module.norm, [module.linear_fc1], fc1_input_scales, alpha_to_apply
+        )
+        return True
+    else:
+        print(
+            f"[SmoothQuant] Warning: activation stats not found for "
+            f"{name} linear_fc1 input."
+        )
+
+    return False
+
+
+# Registry of appliers (order matters: try LLaMA first, then Qwen3-VL vision, then fairseq)
 _APPLIERS: List[
     Callable[[str, torch.nn.Module, Dict[str, torch.Tensor], float], bool]
 ] = [
     _apply_if_llama_decoder,
+    _apply_if_qwen3vl_vision_block,
+    _apply_if_qwen3vl_vision_patch_merger,
     _apply_if_fairseq_relu_bridge,
 ]
 

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -23,6 +23,7 @@ from transformers import AutoProcessor
 
 from tico.quantization import convert, prepare
 from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
+from tico.quantization.algorithm.smoothquant.smooth_quant import apply_smoothing
 from tico.quantization.config.builders import build_qwen3_vl_ptq_config
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
 from tico.quantization.evaluation.mmlu_eval_utils import (
@@ -258,6 +259,26 @@ def parse_args():
         type=int,
         default=2,
         help="Spatial merge size for vision tokens.",
+    )
+    # SmoothQuant arguments (for LayerNorm-based vision components and RMSNorm-based text components)
+    parser.add_argument(
+        "--smoothquant",
+        action="store_true",
+        default=False,
+        help="Apply SmoothQuant smoothing for vision and text layers.",
+    )
+    parser.add_argument(
+        "--smoothquant_alpha",
+        type=float,
+        default=0.5,
+        help="SmoothQuant alpha for vision components (Qwen3VLVisionBlock, Qwen3VLVisionPatchMerger). "
+        "Range: 0.0-1.0. Higher = more weight smoothing.",
+    )
+    parser.add_argument(
+        "--print_quantized_model",
+        action="store_true",
+        default=False,
+        help="Print model after quantization",
     )
 
     # MMLU evaluation arguments
@@ -667,6 +688,9 @@ def main() -> None:
     print(f"Quantize lm_head : {quantize_lm_head}")
     print(f"Use GPTQ         : {not args.no_GPTQ}")
     print(f"Use PTQ          : {not args.no_PTQ}")
+    print(f"Use SmoothQuant  : {args.smoothquant}")
+    if args.smoothquant:
+        print(f"SmoothQuant alpha: {args.smoothquant_alpha}")
     print(f"grid_thw         : {grid_thw}")
     print(f"spatial_merge_size: {args.spatial_merge_size}")
     print(f"visual_start_idx : {args.visual_start_idx}")
@@ -753,6 +777,63 @@ def main() -> None:
         max_seq_len=args.calib_seq_len,
     )
 
+    # -------------------------------------------------------------------------
+    # Apply SmoothQuant transformation (for LayerNorm-based vision components)
+    # -------------------------------------------------------------------------
+    if args.smoothquant:
+        print("Applying SmoothQuant smoothing for vision LayerNorm layers …")
+
+        # Compute activation maximum values from calibration data
+        print("Computing activation maximum values for SmoothQuant …")
+        activation_max = {}
+
+        # Hook to capture activation maximums
+        hooks = []
+
+        def make_hook(name):
+            def hook(module, input, output):
+                if isinstance(input, tuple):
+                    x = input[0]
+                else:
+                    x = input
+                # Compute per-channel maximum
+                if x.dim() >= 2:
+                    # Reshape to (batch * seq, hidden)
+                    x_flat = x.view(-1, x.shape[-1])
+                    amax = x_flat.abs().max(dim=0)[0]
+                    if name not in activation_max:
+                        activation_max[name] = amax
+                    else:
+                        activation_max[name] = torch.maximum(activation_max[name], amax)
+
+            return hook
+
+        # Register hooks on Linear layers that follow LayerNorm
+        for name, module in model.named_modules():
+            if isinstance(module, torch.nn.Linear):
+                hook = module.register_forward_hook(make_hook(name))
+                hooks.append(hook)
+
+        # Run calibration pass
+        with torch.no_grad():
+            for inp in calib_inputs:
+                dev_inp = move_batch_to_device(inp, args.device)
+                model(**dev_inp)
+
+        # Remove hooks
+        for hook in hooks:
+            hook.remove()
+
+        print(f"Computed activation_max for {len(activation_max)} layers")
+
+        # Apply smoothing
+        apply_smoothing(
+            model,
+            activation_max,
+            alpha=args.smoothquant_alpha,
+        )
+        print("SmoothQuant smoothing complete.")
+
     if not args.no_GPTQ:
         print("Applying Qwen3-VL GPTQ …")
 
@@ -821,6 +902,10 @@ def main() -> None:
             num_text_layers=num_text_layers,
             num_deepstack_mergers=num_deepstack_mergers,
         )
+
+    # Print model
+    if args.print_quantized_model:
+        print(q_m)
 
     if args.eval_tasks is not None:
         quantized_results = evaluate_model(


### PR DESCRIPTION
This PR supports SmoothQuant for vision components of Qwen3-vl

It allows to reduce accuracy degradation by 3%. Tested for `vqav2` dataset.

SmoothQuant is appllied for `vision_block` and for `vision_patch_merger`


|model|vqav2| accuracy degradation|
|--|--|--|
|original|0.895| - |
|quantized W4A16 + GPTQ + SMSE |0.695| 20%|
|quantized W4A16 + GPTQ + SMSE + smoothquant (alpha=0.8)|0.721| 17% |


Run command:
```
python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py --model=Qwen/Qwen3-VL-4B-Instruct --cache_dir=<YOUR_CACHE_DIR> --sensitivity_path=<YOUR_PATH> --trust-remote-code --eval_tasks=vqav2 --gptq_mse=smse --nsamples_for_evaluation=1000 --embedding_weight_bits=8 --vision_patch_embed_weight_bits=4 --linear_weight_bits=4 --lm_head_weight_bits=4 --nsamples_for_qcalibration=128 --smoothquant --smoothquant_alpha=0.8
```


TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>