### PR TITLE
[quantization] Support Evaluation of Qwen3-VL With COCO Dataset

### DIFF
--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 import re
 import string
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+import tempfile
+
+from collections.abc import Callable
+from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict
 
 import torch
 from datasets import load_dataset
@@ -154,6 +159,31 @@ def get_item_textvqa(ex: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def get_item_coco(ex: dict[str, Any]) -> dict[str, Any]:
+    """
+    Adapt a COCO Captioning-style sample to a common evaluation format.
+
+    COCO Captioning differs from VQA datasets:
+    - There is no question; the task is to describe the image.
+    - Each image has multiple reference captions (typically 5).
+
+    The returned schema is:
+
+    `{"image": image, "question": question, "golds": gold_answers}`
+
+    Args:
+        ex: Raw dataset example.
+
+    Returns:
+        A normalized evaluation item.
+    """
+    return {
+        "image": ex["image"],
+        "question": ex.get("question", ""),
+        "golds": _extract_golds(ex.get("answer")),
+    }
+
+
 DATASETS = {
     "vqav2": {
         "default_split": "validation",
@@ -164,6 +194,13 @@ DATASETS = {
         "default_split": "validation",
         "adapter": get_item_textvqa,
         "candidates": ["textvqa", "HuggingFaceM4/TextVQA", "lmms-lab/textvqa"],
+    },
+    "coco": {
+        "default_split": "val",
+        "adapter": get_item_coco,
+        "candidates": [
+            "lmms-lab/COCO-Caption2017",
+        ],
     },
 }
 
@@ -325,6 +362,148 @@ def generate_answer(
     gen_ids = out_ids[0, input_len:]
 
     return processor.tokenizer.decode(gen_ids, skip_special_tokens=True).strip()
+
+
+class CocoResult(TypedDict):
+    image_id: str
+    caption: str
+
+
+class CocoAnnotation(TypedDict):
+    id: int
+    image_id: str
+    caption: str
+
+
+class CocoImage(TypedDict):
+    id: str
+    file_name: str
+
+
+def get_coco_scores_on_dataset(
+    model,
+    processor,
+    ds: Iterable[dict[str, Any]],
+    device: str | torch.device,
+    max_new_tokens: int = 30,
+    temperature: float = 0.0,
+    max_seq_len: int | None = None,
+    verbose: bool = True,
+    log_first_n: int = 5,
+    log_every_n: int = 50,
+) -> dict[str, float]:
+    """
+    Compute CIDEr, BLEU, and other captioning metrics on a dataset iterator.
+
+    This function uses the pycocoevalcap package to compute standard captioning
+    metrics including CIDEr, BLEU-1 through BLEU-4, METEOR, ROUGE-L, and SPICE.
+
+    Args:
+        model: Vision-language generation model.
+        processor: Matching processor for the model.
+        ds: Iterable dataset yielding raw examples.
+        device: Device used for inference.
+        max_new_tokens: Maximum number of generated tokens.
+        temperature: Sampling temperature.
+        max_seq_len: Optional maximum text sequence length.
+        verbose: Whether to print sample predictions and progress logs.
+        log_first_n: Number of early examples to print.
+        log_every_n: Logging interval after the initial examples.
+
+    Returns:
+        A dictionary mapping metric names to scores (e.g., "CIDEr", "Bleu_4").
+    """
+    # Collect predictions and ground truth
+    results: list[CocoResult] = []
+    images: list[CocoImage] = []
+    annotations: list[CocoAnnotation] = []
+
+    for i, ex in enumerate(ds, 1):
+        image: Any = ex["image"]
+        question: str = ex["question"]
+        id: int = ex["id"]
+        image_id: str = ex["question_id"]
+        file_name: str = ex["file_name"]
+        gold_answers: list[str] = ex["answer"]
+
+        # Generate caption
+        pred = generate_answer(
+            model=model,
+            processor=processor,
+            image=image,
+            question=question,
+            device=device,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            max_seq_len=max_seq_len,
+        )
+
+        # Store result
+        result: CocoResult = {"image_id": image_id, "caption": pred}
+        results.append(result)
+
+        # Store ground truth
+        img: CocoImage = {"id": image_id, "file_name": file_name}
+        images.append(img)
+
+        for answer in gold_answers:
+            annotation: CocoAnnotation = {
+                "id": id,
+                "image_id": image_id,
+                "caption": answer,
+            }
+            annotations.append(annotation)
+
+        should_log = verbose and (
+            i <= log_first_n or (log_every_n > 0 and i % log_every_n == 0)
+        )
+        if should_log:
+            print("id:", id)
+            print("image_id:", image_id)
+            print("Q:", question)
+            print("pred:", repr(pred))
+            print("pred_norm:", repr(normalize_answer(pred)))
+            print("golds[:10]:", [repr(x) for x in gold_answers[:10]])
+            print("-" * 60)
+
+    assert results
+    assert images
+    assert annotations
+
+    # Create temporary files for COCO evaluation
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False
+    ) as annotations_file:
+        json.dump(
+            {
+                "images": images,
+                "annotations": annotations,
+            },
+            annotations_file,
+        )
+        annotations_file.flush()
+        annotation_path = annotations_file.name
+
+    # Run COCO evaluation
+    try:
+        from pycocoevalcap.eval import COCOEvalCap
+        from pycocotools.coco import COCO
+
+        coco = COCO(annotation_path)
+        coco_result = coco.loadRes(results)
+        coco_eval = COCOEvalCap(coco, coco_result)
+        coco_eval.params["id"] = coco_result.getImgIds()
+        coco_eval.evaluate()
+
+        metrics: dict[str, float] = {}
+        for metric, score in coco_eval.eval.items():
+            metrics[metric] = float(score)
+            if verbose:
+                print(f"{metric}: {score:.4f}")
+
+        return metrics
+    finally:
+        os.unlink(annotation_path)
 
 
 def get_accuracy_on_dataset(

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -32,6 +32,7 @@ from tico.quantization.evaluation.mmlu_eval_utils import (
 from tico.quantization.evaluation.vlm_eval_utils import (
     get_accuracy_on_dataset,
     get_calib_inputs,
+    get_coco_scores_on_dataset,
     get_dataset,
 )
 from tico.quantization.wrapq.dtypes import DType
@@ -52,6 +53,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Qwen3-VL GPTQ+PTQ pipeline (architecture-aware, stagewise)"
     )
+
     parser.add_argument(
         "--model",
         type=str,
@@ -369,6 +371,8 @@ def evaluate_model(
     results: dict[str, tuple[int, int]] = {}
 
     for task in tasks_list:
+        if "vqa" not in task:
+            continue
         with (
             io.StringIO() as buffer,
             contextlib.redirect_stdout(buffer),
@@ -386,6 +390,29 @@ def evaluate_model(
             results[task] = (em_cnt, total)
 
     return results
+
+
+def evaluate_model_coco(
+    model,
+    processor,
+    device: str,
+    nsamples: int = 50,
+    max_seq_len: Optional[int] = None,
+):
+    with (
+        io.StringIO() as buffer,
+        contextlib.redirect_stdout(buffer),
+        contextlib.redirect_stderr(buffer),
+    ):
+        ds, _ = get_dataset("coco", n=nsamples)
+        result = get_coco_scores_on_dataset(
+            model=model,
+            processor=processor,
+            ds=ds,
+            device=device,
+            max_seq_len=max_seq_len,
+        )
+        return result
 
 
 def move_batch_to_device(
@@ -721,15 +748,28 @@ def main() -> None:
             model.config.text_config.use_cache = False
 
     if args.eval_tasks is not None:
-        original_results = evaluate_model(
-            model,
-            processor,
-            args.eval_tasks,
-            args.device,
-            args.nsamples_for_evaluation,
-            max_seq_len=args.max_seq_len,
-        )
-        print_eval_results("Evaluating original model", original_results)
+        if "vqa" in args.eval_tasks:
+            original_results = evaluate_model(
+                model,
+                processor,
+                args.eval_tasks,
+                args.device,
+                args.nsamples_for_evaluation,
+                max_seq_len=args.max_seq_len,
+            )
+            print_eval_results("Evaluating original model", original_results)
+
+        if "coco" in args.eval_tasks:
+            print("\n=== COCO Evaluation (Original Model) ===")
+            results = evaluate_model_coco(
+                model=model,
+                processor=processor,
+                device=args.device,
+                nsamples=args.nsamples_for_evaluation,
+                max_seq_len=args.max_seq_len,
+            )
+            for metric, value in results.items():
+                print(f"{metric:<10} {value:.3f}")
 
     # MMLU evaluation on original model
     if args.mmlu_subjects is not None:
@@ -823,16 +863,29 @@ def main() -> None:
         )
 
     if args.eval_tasks is not None:
-        quantized_results = evaluate_model(
-            q_m,
-            processor,
-            args.eval_tasks,
-            args.device,
-            args.nsamples_for_evaluation,
-            max_seq_len=args.max_seq_len,
-        )
-        print_eval_results("Evaluating quantized model", quantized_results)
-        print_markdown_comparison(original_results, quantized_results)
+        if "vqa" in args.eval_tasks:
+            quantized_results = evaluate_model(
+                q_m,
+                processor,
+                args.eval_tasks,
+                args.device,
+                args.nsamples_for_evaluation,
+                max_seq_len=args.max_seq_len,
+            )
+            print_eval_results("Evaluating quantized model", quantized_results)
+            print_markdown_comparison(original_results, quantized_results)
+
+        if "coco" in args.eval_tasks:
+            print("\n=== COCO Evaluation (Quantized Model) ===")
+            results = evaluate_model_coco(
+                model=q_m,
+                processor=processor,
+                device=args.device,
+                nsamples=args.nsamples_for_evaluation,
+                max_seq_len=args.max_seq_len,
+            )
+            for metric, value in results.items():
+                print(f"{metric:<10} {value:.3f}")
 
     # MMLU evaluation on quantized model
     if args.mmlu_subjects is not None:


### PR DESCRIPTION
# What

This change adds support for [COCO dataset](https://cocodataset.org/) in `tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py` script.

# Why

COCO is listed among the target benchmarks in issue [PTQ Evaluation — Qwen3-VL](https://github.sec.samsung.net/one-project/TICO/issues/192).

# Implementation Details

## `vlm_eval_utils.py`

### 1. `get_item_coco(ex: dict[str, Any]) -> dict[str, Any]`
Adapts COCO Captioning samples to the unified format:
- Returns `image`, `question`, `gold` just like other adapters.
- Can be used for accuracy estimation only (`get_accuracy_on_dataset`)

### 2. New entry in `DATASETS` dictionary
```python
    "coco": {
        "default_split": "val",
        "adapter": get_item_coco,
        "candidates": [
            "lmms-lab/COCO-Caption2017",
            "sentence-transformers/coco-captions",
            "HuggingFaceM4/COCO",
        ],
    },
```

### 3. `get_coco_scores_on_dataset(model, processor, ds, device, ...) -> dict[str, float]`
Computes CIDEr, BLEU, and other captioning metrics:
- Collects predictions and ground truth
- Formats results in COCO format
- Uses `pycocotools.coco.COCO` and `pycocoevalcap.eval.COCOEvalCap` for evaluation
- Returns metrics: `CIDEr`, `Bleu_1`, `Bleu_2`, `Bleu_3`, `Bleu_4`, `METEOR`, `ROUGE_L`, `SPICE`

# Usage Example
```bash
$ python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
   --model=Qwen/Qwen3-VL-4B-Instruct \
   --cache_dir=/home/d.savchenkov/models/qwen3-vl-4b \
   --trust-remote-code \
   --gptq_mse=mse \              
   --no_GPTQ \
   --eval_tasks=coco \
   --nsamples_for_evaluation=1 \
   --embedding_weight_bits=16 \
   --vision_patch_embed_weight_bits=16 \
   --linear_weight_bits=16 \
   --lm_head_weight_bits=16 \
   --nsamples_for_qcalibration=10 \
   --verbose
```

# Example Output

```
=== COCO Evaluation (Originhal Model) ===
Bleu_1     0.800
Bleu_2     0.596
Bleu_3     0.354
Bleu_4     0.000
METEOR     0.338
ROUGE_L    0.600
CIDEr      0.000
SPICE      0.242

=== COCO Evaluation (Quantized Model) ===
Bleu_1     0.444
Bleu_2     0.333
Bleu_3     0.251
Bleu_4     0.000
METEOR     0.211
ROUGE_L    0.357
CIDEr      0.000
SPICE      0.061
```
```