### PR TITLE
[quantization] Support PPL Evaluation of Qwen3-VL With Wikitext2 Dataset

### DIFF
--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict
 
 import torch
-from datasets import load_dataset
+from datasets import Dataset, IterableDataset, load_dataset
 
 
 def normalize_answer(s: str) -> str:
@@ -184,7 +184,7 @@ def get_item_coco(ex: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-DATASETS = {
+DATASETS: dict[str, dict[str, Any]] = {
     "vqav2": {
         "default_split": "validation",
         "adapter": get_item_vqav2,
@@ -201,6 +201,12 @@ DATASETS = {
         "candidates": [
             "lmms-lab/COCO-Caption2017",
         ],
+    },
+    "wikitext2": {
+        "default_split": "test",
+        "adapter": None,  # Text-only dataset, no adapter needed
+        "candidates": ["wikitext"],
+        "config": "wikitext-2-raw-v1",
     },
 }
 
@@ -612,10 +618,11 @@ def get_dataset(
             f"Unsupported dataset '{dataset}'. Available datasets: {list(DATASETS.keys())}"
         )
 
-    meta = DATASETS[dataset]
+    meta: dict[str, Any] = DATASETS[dataset]
     adapter = meta["adapter"]
     split = split or meta["default_split"]  # type: ignore[assignment]
     candidates = meta["candidates"]
+    config = meta.get("config")  # Optional config for datasets like wikitext
     assert isinstance(candidates, list)
 
     ds = None
@@ -623,14 +630,20 @@ def get_dataset(
 
     for name in candidates:
         try:
-            ds = load_dataset(name, split=split, streaming=streaming)
+            if config:
+                ds = load_dataset(
+                    path=name, name=config, split=split, streaming=streaming
+                )
+            else:
+                ds = load_dataset(path=name, split=split, streaming=streaming)
             if n >= 0:
                 ds = ds.take(n)
 
             size_str = str(n) if n >= 0 else "all"
             stream_str = "streaming" if streaming else "non-streaming"
+            config_str = f"config={config}, " if config else ""
             print(
-                f"[info] Loaded dataset: {name} ({split}, {stream_str}), size={size_str}"
+                f"[info] Loaded dataset: {name} ({config_str}{split}, {stream_str}), size={size_str}"
             )
             break
         except Exception as exc:
@@ -643,6 +656,53 @@ def get_dataset(
         )
 
     return ds, adapter
+
+
+def evaluate_ppl(
+    model,
+    tokenizer,
+    ds: Dataset | IterableDataset,
+    device: str | torch.device,
+    stride: int = 512,
+    max_seq_len: Optional[int] = None,
+    show_progress: bool = True,
+) -> float:
+    """
+    Evaluate perplexity on a text dataset.
+
+    This function computes perplexity using a strided sliding-window approach.
+    It expects a dataset that yields examples with a "text" field (e.g., wikitext2).
+
+    Args:
+        model: Language model to evaluate.
+        tokenizer: Tokenizer for encoding text.
+        ds: Iterable dataset yielding examples with a "text" field.
+        device: Device used for evaluation.
+        stride: Sliding window stride for perplexity calculation.
+        max_seq_len: Maximum sequence length. Defaults to model's max_position_embeddings.
+        show_progress: Whether to show progress bar.
+
+    Returns:
+        Perplexity score.
+    """
+    from tico.quantization.wrapq.utils.metrics import perplexity
+
+    # Concatenate all text from the dataset
+    full_text = "\n\n".join(ds["text"])
+
+    # Encode the full text
+    encodings = tokenizer(full_text, return_tensors="pt")
+
+    # Compute perplexity
+    ppl = perplexity(
+        model=model,
+        encodings=encodings,
+        device=device,
+        max_length=max_seq_len,
+        stride=stride,
+        show_progress=show_progress,
+    )
+    return ppl
 
 
 def get_calib_inputs(

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -31,6 +31,7 @@ from tico.quantization.evaluation.mmlu_eval_utils import (
     print_mmlu_results,
 )
 from tico.quantization.evaluation.vlm_eval_utils import (
+    evaluate_ppl,
     get_accuracy_on_dataset,
     get_calib_inputs,
     get_coco_scores_on_dataset,
@@ -313,6 +314,21 @@ def parse_args():
         type=int,
         default=1,
         help="Number of samples in a batch for MMLU evaluation.",
+    )
+
+    # PPL evaluation arguments
+    parser.add_argument(
+        "--ppl_dataset",
+        type=str,
+        default=None,
+        choices=["wikitext2"],
+        help="Text dataset for PPL (perplexity) evaluation.",
+    )
+    parser.add_argument(
+        "--ppl_stride",
+        type=int,
+        default=512,
+        help="Sliding window stride for perplexity calculation.",
     )
 
     return parser.parse_args()
@@ -810,6 +826,21 @@ def main() -> None:
         )
         print_mmlu_results(original_mmlu_results)
 
+    # PPL evaluation on original model
+    if args.ppl_dataset:
+        print("\n=== PPL Evaluation (Original Model) ===")
+        ds_ppl, _ = get_dataset(args.ppl_dataset, n=args.nsamples_for_evaluation)
+        original_ppl = evaluate_ppl(
+            model=model,
+            tokenizer=processor.tokenizer,
+            ds=ds_ppl,
+            device=args.device,
+            stride=args.ppl_stride,
+            max_seq_len=args.max_seq_len,
+            show_progress=not args.hide_progress,
+        )
+        print(f"Original PPL: {original_ppl:.2f}")
+
     calib_inputs = get_calib_inputs(
         "vqav2",
         processor,
@@ -986,6 +1017,21 @@ def main() -> None:
             max_seq_len=args.max_seq_len,
         )
         print_mmlu_results(quantized_mmlu_results)
+
+    # PPL evaluation on quantized model
+    if args.ppl_dataset:
+        print("\n=== PPL Evaluation (Quantized Model) ===")
+        ds_ppl, _ = get_dataset(args.ppl_dataset, n=args.nsamples_for_evaluation)
+        quantized_ppl = evaluate_ppl(
+            model=q_m,
+            tokenizer=processor.tokenizer,
+            ds=ds_ppl,
+            device=args.device,
+            stride=args.ppl_stride,
+            max_seq_len=args.max_seq_len,
+            show_progress=not args.hide_progress,
+        )
+        print(f"Quantized PPL: {quantized_ppl:.2f}")
 
 
 if __name__ == "__main__":

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -142,18 +142,28 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
             Qwen3VLCausalLMOutputWithPast,
         )
 
-        if return_dict:
-            output = Qwen3VLCausalLMOutputWithPast(
-                loss=None,
+        loss = None
+        if labels is not None:
+            loss = self.module.loss_function(
                 logits=logits,
-                past_key_values=outputs.past_key_values,
-                hidden_states=outputs.hidden_states,
-                attentions=outputs.attentions,
-                rope_deltas=outputs.rope_deltas,
+                labels=labels,
+                vocab_size=self.module.config.text_config.vocab_size,
+                **kwargs,
             )
-        else:
-            # (logits, past_key_values)
-            output = (logits,) if len(outputs) == 1 else (logits, outputs[1])
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        output = Qwen3VLCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=outputs.rope_deltas,
+        )
+
         return output
 
     def _all_observers(self) -> Iterable:


### PR DESCRIPTION
# What

This commit adds support for PPL (perplexity) evaluation on the wikitext2 dataset for Qwen3-VL models in `quantize_qwen3_vl_with_gptq.py`.

# Why

PPL metric is listed in issue [PTQ Evaluation — Qwen3-VL](https://github.sec.samsung.net/one-project/TICO/issues/192).

# Implementation Details

## `tico/quantization/evaluation/vlm_eval_utils.py`

1. **Added wikitext2 dataset record to DATASETS dictionary:**
   - `default_split`: "test"
   - `adapter`: None (text-only dataset)
   - `candidates`: ["wikitext"]
   - `config`: "wikitext-2-raw-v1"

2. **Updated `get_dataset()` function:**
   - Added support for optional `config` parameter for datasets requiring a config name
   - Updated dataset loading to use `load_dataset(path=name, name=config, ...)` when config is present
   - Updated log message to include config info

3. **Added `evaluate_ppl()` function:**
   - Accepts: model, tokenizer, dataset, device, stride, max_seq_len, show_progress
   - Concatenates all text from dataset using `"\n\n".join(ds["text"])`
   - Encodes text with tokenizer
   - Calls `perplexity()` from `tico/quantization/wrapq/utils/metrics.py`
   - Returns PPL score as float

## `tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py`

1. **Added import:** `evaluate_ppl` from vlm_eval_utils

2. **Added CLI arguments:**
   - `--ppl_dataset`: Text dataset for PPL evaluation (choices: ["wikitext2"])
   - `--ppl_stride`: Sliding window stride (default: 512)

3. **Added PPL evaluation for original model** (after MMLU evaluation):
   - Loads dataset via `get_dataset(args.ppl_dataset, n=args.nsamples_for_evaluation)`
   - Calls `evaluate_ppl()` with model, tokenizer, dataset, device, stride, max_seq_len
   - Prints "Original PPL: XX.XX"

4. **Added PPL evaluation for quantized model** (after MMLU evaluation):
   - Same process as original model evaluation
   - Prints "Quantized PPL: XX.XX"

## `tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py`

1. **Added loss computation in `forward()` method:**
   - When `labels` is provided and `return_dict` is True
   - Calls `self.module.loss_function(logits, labels, vocab_size)`
   - Returns loss in `Qwen3VLCausalLMOutputWithPast`
   - This is required for PPL calculation which uses the model's loss output


# Usage Example

```bash
$ python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
   --model=Qwen/Qwen3-VL-4B-Instruct \
   --cache_dir=/home/d.savchenkov/models/qwen3-vl-4b \
   --trust-remote-code \
   --gptq_mse=mse \
   --no_GPTQ \
   --ppl_dataset=wikitext2 \
   --nsamples_for_evaluation=50 \
   --embedding_weight_bits=16 \
   --vision_patch_embed_weight_bits=16 \
   --linear_weight_bits=16 \
   --lm_head_weight_bits=16 \
   --nsamples_for_qcalibration=10 \
   --verbose
```

# Example Output

```
=== PPL Evaluation (Original Model) ===
[info] Loaded dataset: wikitext (config=wikitext-2-raw-v1, test, streaming), size=50
Original PPL: 8.38

=== PPL Evaluation (Quantized Model) ===
[info] Loaded dataset: wikitext (config=wikitext-2-raw-v1, test, streaming), size=50
Quantized PPL: 9.40
```