### PR TITLE
[quantization] Copy k_proj before scale fusion

### DIFF
--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from typing import List, Literal, Optional, Tuple
 
 import torch
@@ -88,6 +89,10 @@ class QuantLlamaAttention(QuantModuleBase):
         self.num_kv_heads = cfg.num_key_value_heads
         self.kv_rep = cfg.num_attention_heads // cfg.num_key_value_heads
         self.max_seq = cfg.max_position_embeddings
+        # Constant scale (1/√d)
+        scale_t = torch.tensor(
+            float(getattr(fp_attn, "scaling", self.head_dim**-0.5))
+        )
 
         q_cfg = qcfg.child("q_proj") if qcfg else None
         k_cfg = qcfg.child("k_proj") if qcfg else None
@@ -109,9 +114,6 @@ class QuantLlamaAttention(QuantModuleBase):
         self.q_proj = PTQWrapper(
             fp_attn.q_proj, qcfg=q_cfg, fp_name=join_name(fp_name, "q_proj")
         )
-        self.k_proj = PTQWrapper(
-            fp_attn.k_proj, qcfg=k_cfg, fp_name=join_name(fp_name, "k_proj")
-        )
         self.v_proj = PTQWrapper(
             fp_attn.v_proj, qcfg=v_cfg, fp_name=join_name(fp_name, "v_proj")
         )
@@ -119,17 +121,18 @@ class QuantLlamaAttention(QuantModuleBase):
             fp_attn.o_proj, qcfg=o_cfg, fp_name=join_name(fp_name, "o_proj")
         )
 
-        # Constant scale (1/√d)
-        scale_t = torch.tensor(
-            float(getattr(fp_attn, "scaling", self.head_dim**-0.5))
-        )
-
+        k_proj_fp = copy.deepcopy(fp_attn.k_proj)
         # merge scale_t to k_proj, (otherwise merge it to q_proj)
         with torch.no_grad():
-            lin = self.k_proj.wrapped.module
-            lin.weight.mul_(scale_t)
-            if lin.bias is not None:
-                lin.bias.mul_(scale_t)
+            k_proj_fp.weight.mul_(scale_t)
+            if k_proj_fp.bias is not None:
+                k_proj_fp.bias.mul_(scale_t)
+
+        self.k_proj = PTQWrapper(
+            k_proj_fp,
+            qcfg=k_cfg,
+            fp_name=join_name(fp_name, "k_proj"),
+        )
 
         mk = self._make_obs
         self.obs_hidden = mk("hidden")


### PR DESCRIPTION
This commit copies k_proj before scale fusion.

I found a potentially unsafe behavior in `QuantLlamaAttention`.

Right now, the constructor applies the attention scaling factor directly to `k_proj` using an in-place mutation. However, PTQWrapper / QuantLinear still keep references to the original FP module, so this can modify the source HF model weights themselves.

This may cause several issues:

- the reference model used for verification can unintentionally change after wrapping
- creating multiple wrappers from the same FP module may repeatedly apply the scaling factor
- wrapper construction becomes stateful and order-dependent

This is especially risky for the static prefill/decode runtime validation flow, because the runtime compares wrapper outputs against the original reference model.

```bash
python tico/quantization/wrapq/examples/static_llama_layer_runtime.py --model ~/hd/model/Llama-3.2-1B-Instruct --padding-side left
====================================================================================================
Step 0: prefill last-token logits
padding_side = left
prefill input shape = (1, 256)
valid lengths = [6]
mean|diff| = 0.00425058
 max|diff| = 0.03206921
PEIR    = 0.120310 %
----------------------------------------------------------------------------------------------------
Step 1: decode logits
sequence lengths = [7]
mean|diff| = 0.00311836
 max|diff| = 0.02931690
PEIR       = 0.101352 %
----------------------------------------------------------------------------------------------------
Step 2: decode logits
sequence lengths = [8]
mean|diff| = 0.00596676
 max|diff| = 0.02971554
PEIR       = 0.125985 %
----------------------------------------------------------------------------------------------------
Step 3: decode logits
sequence lengths = [9]
mean|diff| = 0.00562517
 max|diff| = 0.03532219
PEIR       = 0.150258 %
----------------------------------------------------------------------------------------------------
Step 4: decode logits
sequence lengths = [10]
mean|diff| = 0.00721914
 max|diff| = 0.04369521
PEIR       = 0.129629 %
----------------------------------------------------------------------------------------------------
Step 5: decode logits
sequence lengths = [11]
mean|diff| = 0.03119562
 max|diff| = 0.09716809
PEIR       = 0.227088 %
----------------------------------------------------------------------------------------------------
Step 6: decode logits
sequence lengths = [12]
mean|diff| = 0.02791960
 max|diff| = 0.08413744
PEIR       = 0.233558 %
====================================================================================================
Verification finished.
====================================================================================================
Generated text:
The capital of France is Paris. The Eiffel Tower is located in Paris. The Louvre Museum
```

Related: https://github.com/Samsung/TICO/pull/686#issuecomment-4404735767

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>