### PR TITLE
[quantization] Support Evaluation of Qwen3-VL With MMMU Dataset

### DIFF
--- a/tico/quantization/evaluation/mmmu_eval_utils.py
+++ b/tico/quantization/evaluation/mmmu_eval_utils.py
@@ -1,0 +1,411 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import re
+from typing import Any, Iterable
+
+import torch
+from datasets import load_dataset
+
+from tico.quantization.evaluation.vlm_eval_utils import generate_answer
+
+
+MMMU_DATASET = "MMMU/MMMU"
+
+MMMU_SUBJECTS: list[str] = [
+    "Accounting",
+    "Agriculture",
+    "Architecture_and_Engineering",
+    "Art",
+    "Art_Theory",
+    "Basic_Medical_Science",
+    "Biology",
+    "Chemistry",
+    "Clinical_Medicine",
+    "Computer_Science",
+    "Design",
+    "Diagnostics_and_Laboratory_Medicine",
+    "Economics",
+    "Electronics",
+    "Energy_and_Power",
+    "Finance",
+    "Geography",
+    "History",
+    "Literature",
+    "Manage",
+    "Marketing",
+    "Materials",
+    "Math",
+    "Mechanical_Engineering",
+    "Music",
+    "Pharmacy",
+    "Physics",
+    "Psychology",
+    "Public_Health",
+    "Sociology",
+]
+
+MMMU_SPLITS: list[str] = [
+    "dev",
+    "validation",
+    "test",
+]
+
+
+def take_from_dataset(ds, start: int, n: int) -> Iterable[dict[str, Any]]:
+    assert start >= 0
+    i = 0
+    for ex in ds:
+        if n >= 0 and i >= start + n:
+            break
+        if i >= start:
+            yield ex
+        i += 1
+
+
+def load_data(
+    subject: str,
+    split: str = "validation",
+    start: int = 0,
+    n_samples: int = -1,
+    streaming: bool = True,
+) -> Iterable[dict[str, Any]]:
+    if subject not in MMMU_SUBJECTS:
+        raise ValueError(f"Invalid subject '{subject}'")
+
+    if split not in MMMU_SPLITS:
+        raise ValueError(f"Invalid split '{split}'")
+
+    ds: Iterable[dict[str, Any]] = load_dataset(
+        path=MMMU_DATASET,
+        name=subject,
+        split=split,
+        streaming=streaming,
+    )
+
+    if n_samples > 0:
+        ds = take_from_dataset(ds, start=start, n=n_samples)
+
+    return ds
+
+
+def get_item_mmmu(ex: dict[str, Any]) -> dict[str, Any]:
+    choices = ex["options"]
+    if isinstance(choices, str):
+        # Convert string "['choice1', 'choice2']" to a list ['choice1', 'choice2']
+        choices = ast.literal_eval(choices)
+
+    return {
+        "id": ex["id"],
+        "image": ex["image_1"],
+        "question": ex["question"],
+        "choices": choices,
+        "answer": ex["answer"],
+    }
+
+
+def format_multichoice_question(
+    question: str,
+    choices: list[str],
+    answer: str | None = None,
+) -> str:
+    """
+    Format a single multichoice question.
+
+    Args:
+        question: The question text.
+        choices: List of 4 answer choices.
+        answer: The correct answer letter (A/B/C/D), or None for target questions.
+
+    Returns:
+        Formatted question string.
+    """
+    lines = [question]
+    for i, choice in enumerate(choices):
+        letter = chr(ord("A") + i)
+        lines.append(f"{letter}. {choice}")
+    if answer is not None:
+        lines.append(f"Answer: {answer}")
+    return "\n".join(lines)
+
+
+def build_few_shot_prompt(
+    question: str,
+    choices: list[str],
+    subject: str,
+    few_shot_examples: list[dict[str, Any]],
+) -> str:
+    """
+    Build a few-shot prompt.
+
+    The prompt includes:
+    - A header indicating the subject
+    - Few-shot examples with answers
+    - The target question without an answer
+
+    Args:
+        question: The target question text.
+        choices: List of 4 answer choices for the target question.
+        subject: The subject name for context.
+        few_shot_examples: List of few-shot example dictionaries with
+            'question', 'choices', and 'answer' keys.
+
+    Returns:
+        A formatted prompt string ready for model input.
+    """
+    # Format subject name for display
+    subject_display = subject.replace("_", " ").title()
+
+    prompt_parts = [
+        f"The following are multiple choice questions about {subject_display}."
+    ]
+
+    # Add few-shot examples
+    for ex in few_shot_examples:
+        prompt_parts.append("")
+        prompt_parts.append(
+            format_multichoice_question(
+                ex["question"],
+                ex["choices"],
+                ex["answer"],
+            )
+        )
+
+    # Add target question
+    prompt_parts.append("")
+    prompt_parts.append(format_multichoice_question(question, choices, answer=None))
+    prompt_parts.append("Answer:")
+
+    return "\n".join(prompt_parts)
+
+
+def extract_answer(generated_text: str) -> str | None:
+    """
+    Extract the answer letter (A/B/C/D/E/F/G/H) from model output.
+
+    Args:
+        generated_text: The raw text generated by the model.
+
+    Returns:
+        The extracted letter (A/B/C/D/E/F/G/H), or generated_text if no valid answer found.
+    """
+    text = generated_text.strip()
+
+    # Look for standalone letter [A-H] at the beginning, e.g. "A", "a", "A.", "a.", "A. Answer", "A Answer"
+    first_char_match = re.match(r"^([A-H])([.\s]+[^\s]+)?\.?$", text, re.IGNORECASE)
+    if first_char_match:
+        return first_char_match.group(1).upper()
+
+    return text
+
+
+def load_few_shot_examples(
+    subject: str,
+    n_shots: int = 5,
+) -> list[dict[str, Any]]:
+    """
+    Load few-shot examples for a given MMMU subject from the 'dev' split.
+
+    Args:
+        subject: The subject name.
+        n_shots: Number of few-shot examples to load.
+
+    Returns:
+        List of example dictionaries with 'question', 'choices', and 'answer'.
+    """
+    if n_shots <= 0:
+        return []
+
+    ds = load_data(
+        subject=subject,
+        split="dev",
+        n_samples=n_shots,
+        streaming=True,
+    )
+
+    return [get_item_mmmu(ex) for ex in ds]
+
+
+def evaluate_subject(
+    model,
+    processor,
+    subject: str,
+    device: str | torch.device,
+    max_new_tokens: int,
+    n_shots: int = 5,
+    n_samples: int = -1,
+    max_seq_len: int | None = None,
+    temperature: float = 0.0,
+    verbose: bool = True,
+) -> tuple[int, int, int]:
+    """
+    Evaluate model accuracy on a single MMMU subject.
+
+    Args:
+        model: Language model with generation capability.
+        tokenizer: Matching tokenizer for the model.
+        subject: The MMMU subject to evaluate.
+        device: Device for inference.
+        n_shots: Number of few-shot examples.
+        n_samples: Number of test samples. Use -1 for full test set.
+        max_new_tokens: Maximum tokens to generate.
+        temperature: Sampling temperature.
+        verbose: Whether to print detailed logs.
+
+    Returns:
+        A tuple of (correct_count, total_count, skipped_count).
+    """
+    few_shot_examples = load_few_shot_examples(subject=subject, n_shots=n_shots)
+
+    test_data = load_data(
+        subject=subject,
+        split="validation",
+        n_samples=n_samples,
+        streaming=True,
+    )
+
+    correct = 0
+    total = 0
+    skipped = 0
+
+    ex: dict[str, Any]
+    for ex in test_data:
+        # Skip questions with multiple images
+        if ex["image_2"] is not None:
+            skipped += 1
+            if verbose:
+                question: str = ex["question"]
+                print(f"\n[WARNING]: Skipped question '{question[:100]}...'")
+            continue
+
+        item = get_item_mmmu(ex)
+
+        prompt = build_few_shot_prompt(
+            question=item["question"],
+            choices=item["choices"],
+            subject=subject,
+            few_shot_examples=few_shot_examples,
+        )
+
+        generated = generate_answer(
+            model=model,
+            processor=processor,
+            question=prompt,
+            image=item["image"],
+            device=device,
+            max_new_tokens=max_new_tokens,
+            max_seq_len=max_seq_len,
+            temperature=temperature,
+        )
+
+        predicted = extract_answer(generated)
+        gold = item["answer"].upper()
+
+        is_correct = predicted == gold
+        correct += int(is_correct)
+        total += 1
+
+        if verbose:
+            print(f"\n[Sample {total}] Subject: {subject}")
+            print(f"Q: {item['question'][:100]}...")
+            print(f"Choices: {item['choices']}")
+            print(
+                f"Generated: {generated}, Predicted: {predicted}, Gold: {gold}, Correct: {is_correct}"
+            )
+
+    return correct, total, skipped
+
+
+def evaluate_mmmu(
+    model,
+    processor,
+    subjects: list[str] | None = None,
+    device: str | torch.device = "cuda",
+    n_shots: int = 5,
+    n_samples: int = -1,
+    max_new_tokens: int = 16,
+    max_seq_len: int | None = None,
+    temperature: float = 0.0,
+    verbose: bool = True,
+) -> dict[str, tuple[int, int, int]]:
+    """
+    Evaluate a model on the MMMU benchmark.
+
+    Args:
+        model: Language model with generation capability.
+        tokenizer: Matching tokenizer for the model.
+        subjects: List of subjects to evaluate. Use None for all subjects.
+        device: Device for inference.
+        n_shots: Number of few-shot examples per subject.
+        n_samples: Number of test samples per subject. Use -1 for full test sets.
+        max_new_tokens: Maximum tokens to generate per question.
+        temperature: Sampling temperature. Use 0.0 for greedy decoding.
+        verbose: Whether to print progress.
+
+    Returns:
+        Aggregated results dictionary in '{ subject: (correct, total, skipped) }' format.
+    """
+    if subjects is None:
+        subjects = MMMU_SUBJECTS
+
+    # { subject: (correct, total) }
+    results: dict[str, tuple[int, int, int]] = {}
+
+    for i, subject in enumerate(subjects, 1):
+        if verbose:
+            print(f"\n[{i}/{len(subjects)}] Evaluating {subject}...")
+
+        correct, total, skipped = evaluate_subject(
+            model=model,
+            processor=processor,
+            subject=subject,
+            device=device,
+            n_shots=n_shots,
+            n_samples=n_samples,
+            max_new_tokens=max_new_tokens,
+            max_seq_len=max_seq_len,
+            temperature=temperature,
+            verbose=verbose,
+        )
+        results[subject] = (correct, total, skipped)
+
+        if verbose:
+            accuracy = correct / total if total > 0 else 0.0
+            skipped_str = f", skipped: {skipped}" if skipped > 0 else ""
+            print(f"  {subject}: {accuracy:.4f} ({correct}/{total}){skipped_str}")
+
+    return results
+
+
+def print_mmmu_results(results: dict[str, Any]) -> None:
+    """
+    Print MMMU evaluation results in a formatted table.
+
+    Args:
+        results: Per-subject results in '{ subject: (correct, total) }' format.
+    """
+    subject: str
+    correct: int
+    total: int
+    skipped: int
+    print(
+        f"| {'subject':<50} | {'correct':<10} | {'total':<10} | {'skipped':<10} | {'accuracy':<10} |"
+    )
+    print(f"| {'-'*50} | {'-'*10} | {'-'*10} | {'-'*10} | {'-'*10} |")
+    for subject, (correct, total, skipped) in results.items():
+        accuracy = correct / total
+        print(
+            f"| {subject:<50} | {correct:<10} | {total:<10} | {skipped:<10} | {accuracy:<10.4f} |"
+        )

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -30,6 +30,10 @@ from tico.quantization.evaluation.mmlu_eval_utils import (
     evaluate_mmlu,
     print_mmlu_results,
 )
+from tico.quantization.evaluation.mmmu_eval_utils import (
+    evaluate_mmmu,
+    print_mmmu_results,
+)
 from tico.quantization.evaluation.vlm_eval_utils import (
     evaluate_ppl,
     get_accuracy_on_dataset,
@@ -320,6 +324,31 @@ def parse_args():
         type=int,
         default=1,
         help="Number of samples in a batch for MMLU evaluation.",
+    )
+
+    # MMMU evaluation arguments
+    parser.add_argument(
+        "--mmmu_subjects",
+        type=str,
+        default=None,
+        nargs="+",
+        help=(
+            "Space-separated list of MMMU subjects to evaluate. Use 'mmmu' for all subjects."
+            "Use 'Accounting', 'Agriculture', 'Art', etc. for specific subjects."
+            "See https://huggingface.co/datasets/MMMU/MMMU for the full list."
+        ),
+    )
+    parser.add_argument(
+        "--mmmu_n_shots",
+        type=int,
+        default=5,
+        help="Number of few-shot examples for MMMU evaluation.",
+    )
+    parser.add_argument(
+        "--mmmu_n_samples",
+        type=int,
+        default=-1,
+        help="Number of samples per MMMU subject. Use -1 for full test set.",
     )
 
     # PPL evaluation arguments
@@ -839,6 +868,21 @@ def main() -> None:
         )
         print_mmlu_results(original_mmlu_results)
 
+    # MMMU evaluation on original model
+    if args.mmmu_subjects is not None:
+        print("\n=== MMMU Evaluation (Original Model) ===")
+        original_mmmu_results = evaluate_mmmu(
+            model=model,
+            processor=processor,
+            subjects=args.mmmu_subjects,
+            device=args.device,
+            n_shots=args.mmmu_n_shots,
+            n_samples=args.mmmu_n_samples,
+            max_seq_len=args.max_seq_len,
+            verbose=args.verbose,
+        )
+        print_mmmu_results(original_mmmu_results)
+
     # PPL evaluation on original model
     if args.ppl_dataset:
         print("\n=== PPL Evaluation (Original Model) ===")
@@ -1050,6 +1094,21 @@ def main() -> None:
             max_seq_len=args.max_seq_len,
         )
         print_mmlu_results(quantized_mmlu_results)
+
+    # MMMU evaluation on quantized model
+    if args.mmmu_subjects is not None:
+        print("\n=== MMMU Evaluation (Quantized Model) ===")
+        quantized_mmmu_results = evaluate_mmmu(
+            model=model,
+            processor=processor,
+            subjects=args.mmmu_subjects,
+            device=args.device,
+            n_shots=args.mmmu_n_shots,
+            n_samples=args.mmmu_n_samples,
+            max_seq_len=args.max_seq_len,
+            verbose=args.verbose,
+        )
+        print_mmmu_results(quantized_mmmu_results)
 
     # PPL evaluation on quantized model
     if args.ppl_dataset:


### PR DESCRIPTION
# What

Adds support for evaluating Qwen3-VL models on the MMMU (Massive Multi-discipline Multimodal Understanding) benchmark dataset.

# Why

Addresses [PTQ Evaluation — Qwen3-VL](https://github.sec.samsung.net/one-project/TICO/issues/192) issue which requested MMMU dataset support for comprehensive VLM evaluation.

# Implementation Details

**New File:**
- `tico/quantization/evaluation/mmmu_eval_utils.py` — MMMU evaluation utilities including:
  - Dataset loading and streaming for 30 MMMU subjects
  - Few-shot prompt construction with multichoice formatting
  - Answer extraction (A/B/C/D) from model output
  - Per-subject and aggregate evaluation functions
  - Reuses common utilities from `vlm_eval_utils.py`

**Modified File:**
- `tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py`:
  - Added CLI arguments: `--mmmu_subjects`, `--mmmu_n_shots`, `--mmmu_n_samples`
  - Integrated MMMU evaluation for both original and quantized models

# Example
```bash
python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
    --model=Qwen/Qwen3-VL-4B-Instruct \
    --cache_dir=/home/d.savchenkov/models/qwen3-vl-4b \
    --trust-remote-code \
    --mmmu_subjects Art Geography Biology \
    --gptq_mse=mse \
    --no_GPTQ \
    --mmmu_n_samples=10 \
    --embedding_weight_bits=16 \
    --vision_patch_embed_weight_bits=16 \
    --linear_weight_bits=16 \
    --lm_head_weight_bits=16 \
    --nsamples_for_qcalibration=10

=== MMMU Evaluation (Original Model) ===
| subject                                            | correct    | total      | accuracy   |
| -------------------------------------------------- | ---------- | ---------- | ---------- |
| Art                                                | 5          | 10         | 0.5000     |
| Geography                                          | 1          | 10         | 0.1000     |
| Biology                                            | 6          | 10         | 0.6000     |

=== MMMU Evaluation (Quantized Model) ===
| subject                                            | correct    | total      | accuracy   |
| -------------------------------------------------- | ---------- | ---------- | ---------- |
| Art                                                | 5          | 10         | 0.5000     |
| Geography                                          | 1          | 10         | 0.1000     |
| Biology                                            | 6          | 10         | 0.6000     |
```