### PR TITLE
[quantization] Make LlamaAttention export configurable

### DIFF
--- a/test/quantization/config/test_builders.py
+++ b/test/quantization/config/test_builders.py
@@ -23,6 +23,7 @@ from tico.quantization.config.builders import (
     _weight_dtype_from_bits,
     build_llm_ptq_config,
 )
+from tico.quantization.config.llama_attention import DEFAULT_EXECUTION_PROFILE
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.config.utils import auto_qscheme_for
 from tico.quantization.wrapq.dtypes import DType
@@ -200,6 +201,7 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
         self.assertEqual(cfg.default_dtype, DType.uint(8))
         self.assertEqual(cfg.default_qscheme, QScheme.PER_TENSOR_ASYMM)
         self.assertFalse(cfg.strict_wrap)
+        self.assertEqual(cfg.model_args["profile"], DEFAULT_EXECUTION_PROFILE)
 
         self.assertEqual(
             cfg.overrides["model"]["embed_tokens"]["weight"]["qscheme"],
@@ -219,6 +221,32 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
             cfg.overrides["model"]["norm"]["qscheme"],
             QScheme.PER_TENSOR_SYMM,
         )
+
+    def test_build_llm_ptq_config_sets_reference_eval_profile(self):
+        cfg = build_llm_ptq_config(
+            model_type="llama",
+            num_hidden_layers=1,
+            profile="reference_eval",
+        )
+
+        self.assertEqual(cfg.model_args, {"profile": "reference_eval"})
+
+    def test_build_llm_ptq_config_sets_npu_export_profile(self):
+        cfg = build_llm_ptq_config(
+            model_type="llama",
+            num_hidden_layers=1,
+            profile="npu_export",
+        )
+
+        self.assertEqual(cfg.model_args, {"profile": "npu_export"})
+
+    def test_build_llm_ptq_config_invalid_profile_raises(self):
+        with self.assertRaises(ValueError):
+            build_llm_ptq_config(
+                model_type="llama",
+                num_hidden_layers=1,
+                profile="invalid_profile",  # type: ignore[arg-type]
+            )
 
     def test_explicit_dtype_takes_precedence_over_bits(self):
         cfg = build_llm_ptq_config(
@@ -297,6 +325,7 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
         self.assertEqual(cfg.default_dtype, DType.int(16))
         self.assertEqual(cfg.default_qscheme, QScheme.PER_TENSOR_SYMM)
         self.assertTrue(cfg.strict_wrap)
+        self.assertEqual(cfg.model_args, {"profile": DEFAULT_EXECUTION_PROFILE})
         self.assertIn("model", cfg.overrides)
         self.assertIn("layers", cfg.overrides["model"])
         self.assertEqual(cfg.overrides["model"]["layers"]["0"], {})

--- a/test/quantization/config/test_llama_attention.py
+++ b/test/quantization/config/test_llama_attention.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tico.quantization.config.llama_attention import (
+    DEFAULT_EXECUTION_PROFILE,
+    get_llama_attention_options,
+    is_npu_export_attention_options,
+    LlamaAttentionOptions,
+    normalize_execution_profile,
+)
+from tico.quantization.config.ptq import PTQConfig
+
+
+class TestExecutionProfileValidation(unittest.TestCase):
+    def test_normalize_execution_profile_accepts_supported_profiles(self):
+        self.assertEqual(
+            normalize_execution_profile("reference_eval"),
+            "reference_eval",
+        )
+        self.assertEqual(normalize_execution_profile("npu_export"), "npu_export")
+
+    def test_normalize_execution_profile_rejects_unknown_profile(self):
+        with self.assertRaises(ValueError):
+            normalize_execution_profile("debug")
+
+    def test_normalize_execution_profile_rejects_non_string_profile(self):
+        with self.assertRaises(TypeError):
+            normalize_execution_profile(123)
+
+
+class TestLlamaAttentionOptionsResolver(unittest.TestCase):
+    def test_default_options_preserve_npu_export_profile(self):
+        options = get_llama_attention_options(None)
+
+        self.assertEqual(DEFAULT_EXECUTION_PROFILE, "npu_export")
+        self.assertEqual(options.scale_fusion, "k_proj")
+        self.assertEqual(options.rope, "pre_negated_sin")
+        self.assertEqual(options.layout, "unrolled")
+        self.assertTrue(is_npu_export_attention_options(options))
+
+    def test_root_reference_eval_profile(self):
+        qcfg = PTQConfig(model_args={"profile": "reference_eval"})
+
+        options = get_llama_attention_options(qcfg)
+
+        self.assertEqual(options.scale_fusion, "none")
+        self.assertEqual(options.rope, "hf")
+        self.assertEqual(options.layout, "batched")
+        self.assertFalse(is_npu_export_attention_options(options))
+
+    def test_root_npu_export_profile(self):
+        qcfg = PTQConfig(model_args={"profile": "npu_export"})
+
+        options = get_llama_attention_options(qcfg)
+
+        self.assertEqual(options.scale_fusion, "k_proj")
+        self.assertEqual(options.rope, "pre_negated_sin")
+        self.assertEqual(options.layout, "unrolled")
+        self.assertTrue(is_npu_export_attention_options(options))
+
+    def test_attention_string_overrides_root_profile(self):
+        qcfg = PTQConfig(
+            model_args={
+                "profile": "reference_eval",
+                "attention": "npu_export",
+            }
+        )
+
+        options = get_llama_attention_options(qcfg)
+
+        self.assertEqual(options.scale_fusion, "k_proj")
+        self.assertEqual(options.rope, "pre_negated_sin")
+        self.assertEqual(options.layout, "unrolled")
+
+    def test_attention_mapping_profile_overrides_root_profile(self):
+        qcfg = PTQConfig(
+            model_args={
+                "profile": "reference_eval",
+                "attention": {
+                    "profile": "npu_export",
+                },
+            }
+        )
+
+        options = get_llama_attention_options(qcfg)
+
+        self.assertEqual(options.scale_fusion, "k_proj")
+        self.assertEqual(options.rope, "pre_negated_sin")
+        self.assertEqual(options.layout, "unrolled")
+
+    def test_attention_mapping_can_override_individual_fields(self):
+        qcfg = PTQConfig(
+            model_args={
+                "profile": "reference_eval",
+                "attention": {
+                    "layout": "unrolled",
+                    "scale_fusion": "q_proj",
+                },
+            }
+        )
+
+        options = get_llama_attention_options(qcfg)
+
+        self.assertEqual(options.scale_fusion, "q_proj")
+        self.assertEqual(options.rope, "hf")
+        self.assertEqual(options.layout, "unrolled")
+
+    def test_attention_none_uses_root_profile(self):
+        qcfg = PTQConfig(
+            model_args={
+                "profile": "reference_eval",
+                "attention": None,
+            }
+        )
+
+        options = get_llama_attention_options(qcfg)
+
+        self.assertEqual(options.scale_fusion, "none")
+        self.assertEqual(options.rope, "hf")
+        self.assertEqual(options.layout, "batched")
+
+    def test_unknown_attention_option_raises(self):
+        qcfg = PTQConfig(
+            model_args={
+                "attention": {
+                    "unknown": True,
+                }
+            }
+        )
+
+        with self.assertRaises(ValueError):
+            get_llama_attention_options(qcfg)
+
+    def test_invalid_attention_option_value_raises(self):
+        qcfg = PTQConfig(
+            model_args={
+                "attention": {
+                    "layout": "flat",
+                }
+            }
+        )
+
+        with self.assertRaises(ValueError):
+            get_llama_attention_options(qcfg)
+
+    def test_invalid_attention_payload_type_raises(self):
+        qcfg = PTQConfig(model_args={"attention": 1})
+
+        with self.assertRaises(TypeError):
+            get_llama_attention_options(qcfg)
+
+    def test_invalid_root_profile_raises(self):
+        qcfg = PTQConfig(model_args={"profile": "invalid"})
+
+        with self.assertRaises(ValueError):
+            get_llama_attention_options(qcfg)
+
+    def test_is_npu_export_attention_options_checks_exact_graph_contract(self):
+        self.assertTrue(
+            is_npu_export_attention_options(
+                LlamaAttentionOptions(
+                    scale_fusion="k_proj",
+                    rope="pre_negated_sin",
+                    layout="unrolled",
+                )
+            )
+        )
+        self.assertFalse(
+            is_npu_export_attention_options(
+                LlamaAttentionOptions(
+                    scale_fusion="none",
+                    rope="pre_negated_sin",
+                    layout="unrolled",
+                )
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/llama/test_quant_attention.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_attention.py
@@ -64,21 +64,45 @@ class TestQuantLlamaAttention(unittest.TestCase):
         cls.n_h = cfg.num_attention_heads
         cls.hidden_size = cfg.hidden_size
 
-    def _make_qattn(self) -> QuantLlamaAttention:
-        qattn = QuantLlamaAttention(self.fp_attn, layer_idx=0)
+    def _make_qattn(self, qcfg: PTQConfig | None = None) -> QuantLlamaAttention:
+        qattn = QuantLlamaAttention(self.fp_attn, qcfg=qcfg, layer_idx=0)
         qattn.enable_calibration()
 
         for _ in range(3):
             x = torch.randn(2, 4, self.hidden_size)
-            pos = self._rand_rope(2, 4)
+            pos = self._rand_rope_for(qattn, 2, 4)
             _ = qattn(x, pos)
 
         qattn.freeze_qparams()
         return qattn
 
-    def _rand_rope(self, batch_size: int, seq_len: int):
+    def _rand_rope(
+        self,
+        batch_size: int,
+        seq_len: int,
+        *,
+        pre_negated_sin: bool = False,
+    ):
         emb = torch.randn(batch_size, seq_len, self.head_dim)
-        return emb.cos(), emb.sin()
+        cos = emb.cos()
+        sin = emb.sin()
+        if pre_negated_sin:
+            half_dim = self.head_dim // 2
+            sin = sin.clone()
+            sin[..., :half_dim] = -sin[..., :half_dim]
+        return cos, sin
+
+    def _rand_rope_for(
+        self,
+        qattn: QuantLlamaAttention,
+        batch_size: int,
+        seq_len: int,
+    ):
+        return self._rand_rope(
+            batch_size,
+            seq_len,
+            pre_negated_sin=qattn.attn_options.rope == "pre_negated_sin",
+        )
 
     def _rand_additive_mask(self, batch_size: int, q_len: int, k_len: int):
         mask = torch.zeros(batch_size, q_len, k_len, dtype=torch.float32)
@@ -101,6 +125,123 @@ class TestQuantLlamaAttention(unittest.TestCase):
         past_v = torch.randn(batch_size, self.n_kv, past_len, self.head_dim)
         return past_k, past_v
 
+    def test_default_profile_preserves_npu_export_options(self):
+        qattn = QuantLlamaAttention(self.fp_attn)
+
+        self.assertEqual(qattn.attn_options.scale_fusion, "k_proj")
+        self.assertEqual(qattn.attn_options.rope, "pre_negated_sin")
+        self.assertEqual(qattn.attn_options.layout, "unrolled")
+
+    def test_reference_eval_profile_selects_batched_hf_like_path(self):
+        qcfg = PTQConfig(model_args={"profile": "reference_eval"})
+        qattn = QuantLlamaAttention(self.fp_attn, qcfg=qcfg)
+
+        self.assertEqual(qattn.attn_options.scale_fusion, "none")
+        self.assertEqual(qattn.attn_options.rope, "hf")
+        self.assertEqual(qattn.attn_options.layout, "batched")
+
+    def test_projection_scale_fusion_is_profile_controlled(self):
+        scale = float(getattr(self.fp_attn, "scaling", self.head_dim**-0.5))
+
+        qattn_npu = QuantLlamaAttention(self.fp_attn)
+        torch.testing.assert_close(
+            qattn_npu.q_proj.wrapped.module.weight,
+            self.fp_attn.q_proj.weight,
+        )
+        torch.testing.assert_close(
+            qattn_npu.k_proj.wrapped.module.weight,
+            self.fp_attn.k_proj.weight * scale,
+        )
+
+        qattn_ref = QuantLlamaAttention(
+            self.fp_attn,
+            qcfg=PTQConfig(model_args={"profile": "reference_eval"}),
+        )
+        torch.testing.assert_close(
+            qattn_ref.q_proj.wrapped.module.weight,
+            self.fp_attn.q_proj.weight,
+        )
+        torch.testing.assert_close(
+            qattn_ref.k_proj.wrapped.module.weight,
+            self.fp_attn.k_proj.weight,
+        )
+
+        qattn_q_fused = QuantLlamaAttention(
+            self.fp_attn,
+            qcfg=PTQConfig(
+                model_args={
+                    "attention": {
+                        "scale_fusion": "q_proj",
+                        "rope": "hf",
+                        "layout": "batched",
+                    }
+                }
+            ),
+        )
+        torch.testing.assert_close(
+            qattn_q_fused.q_proj.wrapped.module.weight,
+            self.fp_attn.q_proj.weight * scale,
+        )
+        torch.testing.assert_close(
+            qattn_q_fused.k_proj.wrapped.module.weight,
+            self.fp_attn.k_proj.weight,
+        )
+
+    def test_reference_eval_and_npu_export_profiles_are_float_equivalent(self):
+        torch.manual_seed(11)
+
+        qattn_ref = QuantLlamaAttention(
+            self.fp_attn,
+            qcfg=PTQConfig(model_args={"profile": "reference_eval"}),
+        )
+        qattn_npu = QuantLlamaAttention(
+            self.fp_attn,
+            qcfg=PTQConfig(model_args={"profile": "npu_export"}),
+        )
+
+        batch_size, seq_len = 2, 5
+        x = torch.randn(batch_size, seq_len, self.hidden_size)
+        cos, sin = self._rand_rope(batch_size, seq_len)
+        _, pre_negated_sin = self._rand_rope(
+            batch_size,
+            seq_len,
+            pre_negated_sin=True,
+        )
+        # Keep the same sine magnitudes for both profiles and only switch the
+        # convention-dependent sign.
+        pre_negated_sin = sin.clone()
+        pre_negated_sin[..., : self.head_dim // 2] = -pre_negated_sin[
+            ..., : self.head_dim // 2
+        ]
+        mask = torch.zeros(batch_size, seq_len, seq_len)
+
+        with torch.no_grad():
+            ref_out, ref_attn = qattn_ref(
+                x,
+                (cos, sin),
+                attention_mask=mask,
+            )
+            npu_out, npu_attn = qattn_npu(
+                x,
+                (cos, pre_negated_sin),
+                attention_mask=mask,
+            )
+
+        torch.testing.assert_close(ref_out, npu_out, rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(ref_attn, npu_attn, rtol=1e-5, atol=1e-5)
+
+    def test_as_export_module_can_require_npu_profile(self):
+        qattn_npu = QuantLlamaAttention(self.fp_attn)
+        adapter = qattn_npu.as_export_module("prefill", require_npu_profile=True)
+        self.assertIsInstance(adapter, LlamaAttentionPrefillExportAdapter)
+
+        qattn_ref = QuantLlamaAttention(
+            self.fp_attn,
+            qcfg=PTQConfig(model_args={"profile": "reference_eval"}),
+        )
+        with self.assertRaises(ValueError):
+            qattn_ref.as_export_module("prefill", require_npu_profile=True)
+
     def test_mode_transitions_prefill(self):
         qattn = QuantLlamaAttention(self.fp_attn)
         self.assertIs(qattn._mode, Mode.NO_QUANT)
@@ -109,7 +250,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         self.assertIs(qattn._mode, Mode.CALIB)
 
         x = torch.randn(2, 5, self.hidden_size)
-        pos = self._rand_rope(2, 5)
+        pos = self._rand_rope_for(qattn, 2, 5)
         _ = qattn(x, pos)
 
         qattn.freeze_qparams()
@@ -124,7 +265,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
 
         batch_size = 1
         x = torch.randn(batch_size, 1, self.hidden_size)
-        pos = self._rand_rope(batch_size, 1)
+        pos = self._rand_rope_for(qattn, batch_size, 1)
         past = self._rand_past(batch_size, self.max_seq - 1)
         mask = self._rand_additive_mask(batch_size, 1, self.max_seq)
 
@@ -140,19 +281,26 @@ class TestQuantLlamaAttention(unittest.TestCase):
         self.assertIs(qattn._mode, Mode.QUANT)
 
     def test_forward_diff_prefill(self):
-        qattn = QuantLlamaAttention(self.fp_attn)
+        qcfg = PTQConfig(model_args={"profile": "reference_eval"})
+        qattn = QuantLlamaAttention(self.fp_attn, qcfg=qcfg)
         qattn.enable_calibration()
         for _ in range(4):
             inp = torch.randn(2, 6, self.hidden_size)
-            pos = self._rand_rope(2, 6)
-            _ = qattn(inp, pos)
+            pos = self._rand_rope_for(qattn, 2, 6)
+            mask = torch.zeros(2, 6, 6)
+            _ = qattn(inp, pos, attention_mask=mask)
         qattn.freeze_qparams()
 
         x = torch.randn(2, 6, self.hidden_size)
-        pos = self._rand_rope(2, 6)
+        pos = self._rand_rope_for(qattn, 2, 6)
+        mask = torch.zeros(2, 6, 6)
         with torch.no_grad():
-            q_out, _ = qattn(x, pos)
-            fp_out = self.fp_attn(x, position_embeddings=pos, attention_mask=None)[0]
+            q_out, _ = qattn(x, pos, attention_mask=mask)
+            fp_out = self.fp_attn(
+                x,
+                position_embeddings=pos,
+                attention_mask=mask.unsqueeze(1),
+            )[0]
 
         diff = (fp_out - q_out).abs().mean().item()
         self.assertGreater(diff, 0.0)
@@ -162,19 +310,20 @@ class TestQuantLlamaAttention(unittest.TestCase):
     def test_forward_with_float_attention_mask_prefill(self):
         torch.manual_seed(123)
 
-        qattn = QuantLlamaAttention(self.fp_attn)
+        qcfg = PTQConfig(model_args={"profile": "reference_eval"})
+        qattn = QuantLlamaAttention(self.fp_attn, qcfg=qcfg)
         batch_size, seq_len = 2, 4
         float_mask = torch.zeros(batch_size, seq_len, seq_len)
 
         qattn.enable_calibration()
         for _ in range(2):
             x = torch.randn(batch_size, seq_len, self.hidden_size)
-            pos = self._rand_rope(batch_size, seq_len)
+            pos = self._rand_rope_for(qattn, batch_size, seq_len)
             _ = qattn(x, pos, attention_mask=float_mask)
         qattn.freeze_qparams()
 
         x = torch.randn(batch_size, seq_len, self.hidden_size)
-        pos = self._rand_rope(batch_size, seq_len)
+        pos = self._rand_rope_for(qattn, batch_size, seq_len)
         with torch.no_grad():
             q_out, attn_w = qattn(x, pos, attention_mask=float_mask)
             fp_out = self.fp_attn(
@@ -195,7 +344,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         batch_size = 2
         seq_len = 4
         x = torch.randn(batch_size, seq_len, self.hidden_size)
-        pos = self._rand_rope(batch_size, seq_len)
+        pos = self._rand_rope_for(qattn, batch_size, seq_len)
         bool_mask = self._rand_bool_mask(batch_size, seq_len, seq_len)
 
         with torch.no_grad():
@@ -212,7 +361,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         batch_size = 2
         seq_prefill = 4
         x0 = torch.randn(batch_size, seq_prefill, self.hidden_size)
-        pos0 = self._rand_rope(batch_size, seq_prefill)
+        pos0 = self._rand_rope_for(qattn, batch_size, seq_prefill)
 
         with torch.no_grad():
             out0, attn_w0, present0 = qattn(
@@ -233,7 +382,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
 
         seq_decode = 1
         x1 = torch.randn(batch_size, seq_decode, self.hidden_size)
-        pos1 = self._rand_rope(batch_size, seq_decode)
+        pos1 = self._rand_rope_for(qattn, batch_size, seq_decode)
         mask1 = self._rand_additive_mask(
             batch_size, seq_decode, seq_prefill + seq_decode
         )
@@ -271,7 +420,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
 
         batch_size = 1
         x = torch.randn(batch_size, 1, self.hidden_size)
-        pos = self._rand_rope(batch_size, 1)
+        pos = self._rand_rope_for(qattn, batch_size, 1)
         mask = self._rand_additive_mask(batch_size, 1, self.max_seq)
         past_k, past_v = self._rand_past(batch_size, self.max_seq - 1)
 
@@ -294,7 +443,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         qattn = self._make_qattn()
 
         x = torch.randn(1, 1, self.hidden_size)
-        pos = self._rand_rope(1, 1)
+        pos = self._rand_rope_for(qattn, 1, 1)
 
         with self.assertRaises(ValueError):
             _ = qattn(
@@ -311,7 +460,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         batch_size = 2
         seq_len = 4
         x = torch.randn(batch_size, seq_len, self.hidden_size)
-        pos = self._rand_rope(batch_size, seq_len)
+        pos = self._rand_rope_for(qattn, batch_size, seq_len)
 
         with torch.no_grad():
             hidden, new_k, new_v = adapter(
@@ -332,7 +481,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         q_len = 1
         past_len = self.max_seq - 1
         x = torch.randn(batch_size, q_len, self.hidden_size)
-        pos = self._rand_rope(batch_size, q_len)
+        pos = self._rand_rope_for(qattn, batch_size, q_len)
         past = self._rand_past(batch_size, past_len)
         mask = self._rand_additive_mask(batch_size, q_len, past_len + q_len)
 
@@ -357,7 +506,7 @@ class TestQuantLlamaAttention(unittest.TestCase):
         batch_size = 1
         q_len = 1
         x = torch.randn(batch_size, q_len, self.hidden_size)
-        pos = self._rand_rope(batch_size, q_len)
+        pos = self._rand_rope_for(qattn, batch_size, q_len)
         past = self._rand_past(batch_size, self.max_seq - 1)
         mask = self._rand_additive_mask(batch_size, q_len, self.max_seq)
 
@@ -402,13 +551,13 @@ class TestQuantLlamaAttention(unittest.TestCase):
 
         for _ in range(4):
             x = torch.randn(1, 1, self.hidden_size)
-            pos = self._rand_rope(1, 1)
+            pos = self._rand_rope_for(qattn, 1, 1)
             mask = self._rand_additive_mask(1, 1, self.max_seq)
             past = self._rand_past(1, self.max_seq - 1)
             _ = qattn(x, pos, mask, past, use_cache=True)
 
         x = torch.randn(1, 1, self.hidden_size)
-        pos = self._rand_rope(1, 1)
+        pos = self._rand_rope_for(qattn, 1, 1)
         mask = self._rand_additive_mask(1, 1, self.max_seq)
         past = self._rand_past(1, self.max_seq - 1)
 

--- a/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
@@ -82,6 +82,64 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         past_v = torch.randn(batch_size, self.n_kv, past_len, self.head_dim)
         return past_k, past_v
 
+    def test_reference_eval_profile_propagates_to_self_attention(self):
+        qcfg = PTQConfig(model_args={"profile": "reference_eval"})
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer, qcfg=qcfg, layer_idx=0)
+
+        self.assertEqual(qlayer.attn_options.scale_fusion, "none")
+        self.assertEqual(qlayer.attn_options.rope, "hf")
+        self.assertEqual(qlayer.attn_options.layout, "batched")
+
+        qattn = qlayer.self_attn.wrapped
+        self.assertEqual(qattn.attn_options.scale_fusion, "none")
+        self.assertEqual(qattn.attn_options.rope, "hf")
+        self.assertEqual(qattn.attn_options.layout, "batched")
+
+    def test_attention_specific_profile_override_propagates_to_self_attention(self):
+        qcfg = PTQConfig(
+            model_args={
+                "profile": "reference_eval",
+                "attention": "npu_export",
+            }
+        )
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer, qcfg=qcfg, layer_idx=0)
+
+        self.assertEqual(qlayer.attn_options.scale_fusion, "k_proj")
+        self.assertEqual(qlayer.attn_options.rope, "pre_negated_sin")
+        self.assertEqual(qlayer.attn_options.layout, "unrolled")
+
+        qattn = qlayer.self_attn.wrapped
+        self.assertEqual(qattn.attn_options.scale_fusion, "k_proj")
+        self.assertEqual(qattn.attn_options.rope, "pre_negated_sin")
+        self.assertEqual(qattn.attn_options.layout, "unrolled")
+
+    def test_rope_sin_template_convention_depends_on_profile(self):
+        qlayer_ref = QuantLlamaDecoderLayer(
+            self.fp_layer,
+            qcfg=PTQConfig(model_args={"profile": "reference_eval"}),
+            layer_idx=0,
+        )
+        qlayer_npu = QuantLlamaDecoderLayer(
+            self.fp_layer,
+            qcfg=PTQConfig(model_args={"profile": "npu_export"}),
+            layer_idx=0,
+        )
+
+        half_dim = self.head_dim // 2
+
+        torch.testing.assert_close(
+            qlayer_ref.rope_cos_template,
+            qlayer_npu.rope_cos_template,
+        )
+        torch.testing.assert_close(
+            qlayer_npu.rope_sin_template[..., :half_dim],
+            -qlayer_ref.rope_sin_template[..., :half_dim],
+        )
+        torch.testing.assert_close(
+            qlayer_npu.rope_sin_template[..., half_dim:],
+            qlayer_ref.rope_sin_template[..., half_dim:],
+        )
+
     def test_mode_transitions_prefill(self):
         qlayer = QuantLlamaDecoderLayer(self.fp_layer)
         self.assertIs(qlayer._mode, Mode.NO_QUANT)

--- a/test/quantization/wrapq/wrappers/llama/test_quant_model.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_model.py
@@ -36,6 +36,7 @@ class TestQuantLlamaModel(unittest.TestCase):
     seq_len: int
     vocab_size: int
     fp_model: torch.nn.Module
+    head_dim: int
 
     @classmethod
     def setUpClass(cls):
@@ -46,12 +47,13 @@ class TestQuantLlamaModel(unittest.TestCase):
 
         cls.seq_len = 16
         cls.vocab_size = 10000
+        cls.head_dim = 4
 
         cfg = LlamaConfig(
             hidden_size=8,
             num_attention_heads=2,
             num_key_value_heads=1,
-            head_dim=4,
+            head_dim=cls.head_dim,
             attention_bias=False,
             attention_dropout=0.0,
             attn_implementation="eager",
@@ -106,6 +108,70 @@ class TestQuantLlamaModel(unittest.TestCase):
         self.assertGreater(diff, 0.0)
         self.assertLess(diff, 0.4)
         self.assertEqual(fp_out.shape, q_out.shape)
+
+    def test_reference_eval_profile_propagates_to_layers_and_attention(self):
+        qcfg = PTQConfig(model_args={"profile": "reference_eval"})
+        qmodel = QuantLlamaModel(self.fp_model, qcfg=qcfg)
+
+        first_layer = qmodel.layers[0].wrapped
+        first_attn = first_layer.self_attn.wrapped
+
+        self.assertEqual(qmodel.attn_options.scale_fusion, "none")
+        self.assertEqual(qmodel.attn_options.rope, "hf")
+        self.assertEqual(qmodel.attn_options.layout, "batched")
+
+        self.assertEqual(first_layer.attn_options.scale_fusion, "none")
+        self.assertEqual(first_layer.attn_options.rope, "hf")
+        self.assertEqual(first_layer.attn_options.layout, "batched")
+
+        self.assertEqual(first_attn.attn_options.scale_fusion, "none")
+        self.assertEqual(first_attn.attn_options.rope, "hf")
+        self.assertEqual(first_attn.attn_options.layout, "batched")
+
+    def test_attention_specific_profile_override_propagates(self):
+        qcfg = PTQConfig(
+            model_args={
+                "profile": "reference_eval",
+                "attention": {
+                    "profile": "npu_export",
+                },
+            }
+        )
+        qmodel = QuantLlamaModel(self.fp_model, qcfg=qcfg)
+
+        first_attn = qmodel.layers[0].wrapped.self_attn.wrapped
+
+        self.assertEqual(qmodel.attn_options.scale_fusion, "k_proj")
+        self.assertEqual(qmodel.attn_options.rope, "pre_negated_sin")
+        self.assertEqual(qmodel.attn_options.layout, "unrolled")
+        self.assertEqual(first_attn.attn_options.scale_fusion, "k_proj")
+        self.assertEqual(first_attn.attn_options.rope, "pre_negated_sin")
+        self.assertEqual(first_attn.attn_options.layout, "unrolled")
+
+    def test_rope_sin_template_convention_depends_on_profile(self):
+        qmodel_ref = QuantLlamaModel(
+            self.fp_model,
+            qcfg=PTQConfig(model_args={"profile": "reference_eval"}),
+        )
+        qmodel_npu = QuantLlamaModel(
+            self.fp_model,
+            qcfg=PTQConfig(model_args={"profile": "npu_export"}),
+        )
+
+        half_dim = self.head_dim // 2
+
+        torch.testing.assert_close(
+            qmodel_ref.rope_cos_template,
+            qmodel_npu.rope_cos_template,
+        )
+        torch.testing.assert_close(
+            qmodel_npu.rope_sin_template[..., :half_dim],
+            -qmodel_ref.rope_sin_template[..., :half_dim],
+        )
+        torch.testing.assert_close(
+            qmodel_npu.rope_sin_template[..., half_dim:],
+            qmodel_ref.rope_sin_template[..., half_dim:],
+        )
 
     def test_layer_qscheme_override_propagates_to_projection_weight_observer(self):
         """

--- a/tico/quantization/config/builders.py
+++ b/tico/quantization/config/builders.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 import copy
-from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Optional, Tuple, Type
 
+from tico.quantization.config.llama_attention import (
+    DEFAULT_EXECUTION_PROFILE,
+    ExecutionProfile,
+    normalize_execution_profile,
+)
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.config.utils import auto_qscheme_for
 from tico.quantization.wrapq.dtypes import DType
@@ -336,6 +340,7 @@ def build_llm_ptq_config(
     norm_weight_bits: Optional[int] = None,
     norm_weight_dtype: Optional[DType] = None,
     strict_wrap: bool = True,
+    profile: ExecutionProfile = DEFAULT_EXECUTION_PROFILE,
 ) -> PTQConfig:
     """
     Build a PTQConfig for an LLM using model-family-aware override generation.
@@ -363,9 +368,7 @@ def build_llm_ptq_config(
         explicit override.
     default_observer : Type[ObserverBase], default=MinMaxObserver
         Observer class to instantiate when no explicit observer is provided
-        via overrides.
-        This should be a subclass of `ObserverBase` (e.g., MinMaxObserver,
-        EMAObserver). The class itself (not an instance) must be passed.
+        through overrides.
     linear_weight_bits : Optional[int], default=None
         Convenience bit-width for decoder-layer linear projection weights.
         Used only when `linear_weight_dtype` is not provided.
@@ -391,6 +394,12 @@ def build_llm_ptq_config(
     strict_wrap : bool, default=True
         If True, preparing a model will raise when a required module cannot be
         wrapped.
+    profile : ExecutionProfile, default="npu_export"
+        Execution profile stored as `PTQConfig.model_args["profile"]`.
+        "reference_eval" selects a GPU-friendly, Hugging Face-like path.
+        "npu_export" preserves the existing NPU-export-oriented graph.
+        Advanced users may override or extend `qcfg.model_args` directly
+        before calling `prepare()`.
 
     Returns
     -------
@@ -402,6 +411,11 @@ def build_llm_ptq_config(
     NotImplementedError
         If the requested `model_type` is not supported.
     """
+    profile = normalize_execution_profile(
+        profile,
+        context="build_llm_ptq_config.profile",
+    )
+
     resolved_linear_weight_dtype = _resolve_weight_dtype(
         dtype=linear_weight_dtype,
         bits=linear_weight_bits,
@@ -438,6 +452,7 @@ def build_llm_ptq_config(
         default_qscheme=default_qscheme,
         default_observer=default_observer,
         overrides=overrides,
+        model_args={"profile": profile},
         strict_wrap=strict_wrap,
     )
 
@@ -448,7 +463,10 @@ def _build_qwen3_vl_norm_override(
     norm_weight_dtype: Optional[DType],
 ) -> Dict[str, Any]:
     """
-    Build an override dictionary for Qwen3-VL norm modules (RMSNorm and LayerNorm).
+    Build an override dictionary for Qwen3-VL norm modules.
+
+    The generated override covers both RMSNorm-style observers used by text
+    modules and LayerNorm-style observers used by vision modules.
 
     Parameters
     ----------

--- a/tico/quantization/config/llama_attention.py
+++ b/tico/quantization/config/llama_attention.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, fields, replace
+from typing import Any, cast, Literal, Mapping, Optional
+
+from tico.quantization.config.ptq import PTQConfig
+
+
+ExecutionProfile = Literal["reference_eval", "npu_export"]
+ScaleFusion = Literal["none", "q_proj", "k_proj"]
+RopeConvention = Literal["hf", "pre_negated_sin"]
+AttentionLayout = Literal["batched", "unrolled"]
+
+DEFAULT_EXECUTION_PROFILE: ExecutionProfile = "npu_export"
+SUPPORTED_EXECUTION_PROFILES: tuple[ExecutionProfile, ...] = (
+    "reference_eval",
+    "npu_export",
+)
+
+
+@dataclass(frozen=True)
+class LlamaAttentionOptions:
+    """
+    Execution options for quantized Llama attention wrappers.
+
+    These options describe graph-level implementation choices, not quantization
+    policy. They are intentionally read from `PTQConfig.model_args` instead of
+    `PTQConfig.overrides`.
+
+    Attributes
+    ----------
+    scale_fusion : ScaleFusion
+        Where to apply the attention scale `1 / sqrt(head_dim)`.
+        "none" applies it to logits at runtime, while "q_proj" and
+        "k_proj" fold it into the corresponding projection weights.
+    rope : RopeConvention
+        Rotary embedding sign convention. "hf" uses `rotate_half` as
+        `(-x2, x1)` with normal sine values. "pre_negated_sin" expects the
+        first half of sine values to be pre-negated and uses `(x2, x1)` in the
+        rotate-half operation.
+    layout : AttentionLayout
+        Attention implementation layout. "batched" is closer to the
+        Hugging Face implementation and is preferable for GPU evaluation.
+        "unrolled" preserves the NPU-export-friendly per-head loop.
+    """
+
+    scale_fusion: ScaleFusion = "k_proj"
+    rope: RopeConvention = "pre_negated_sin"
+    layout: AttentionLayout = "unrolled"
+
+
+_PRESETS: dict[ExecutionProfile, LlamaAttentionOptions] = {
+    "reference_eval": LlamaAttentionOptions(
+        scale_fusion="none",
+        rope="hf",
+        layout="batched",
+    ),
+    "npu_export": LlamaAttentionOptions(
+        scale_fusion="k_proj",
+        rope="pre_negated_sin",
+        layout="unrolled",
+    ),
+}
+
+
+def normalize_execution_profile(
+    profile: Any,
+    *,
+    context: str = "profile",
+) -> ExecutionProfile:
+    """
+    Validate and return an execution profile string.
+
+    Parameters
+    ----------
+    profile : Any
+        User-provided profile value.
+    context : str
+        Human-readable location used in error messages.
+
+    Returns
+    -------
+    ExecutionProfile
+        Validated profile value.
+
+    Raises
+    ------
+    TypeError
+        If the profile value is not a string.
+    ValueError
+        If the profile string is not supported.
+    """
+    if not isinstance(profile, str):
+        raise TypeError(f"{context} must be a string, got {type(profile).__name__}.")
+    if profile not in SUPPORTED_EXECUTION_PROFILES:
+        raise ValueError(
+            f"Unsupported execution profile at {context}: {profile!r}. "
+            f"Supported profiles: {list(SUPPORTED_EXECUTION_PROFILES)}."
+        )
+    return cast(ExecutionProfile, profile)
+
+
+def get_llama_attention_options(
+    qcfg: Optional[PTQConfig],
+) -> LlamaAttentionOptions:
+    """
+    Resolve Llama attention implementation options from a PTQConfig.
+
+    The root-level `model_args["profile"]` selects the default execution
+    profile for all profile-aware wrappers. The attention wrapper may override
+    that default through `model_args["attention"]`.
+
+    Supported examples are::
+
+        PTQConfig(..., model_args={"profile": "reference_eval"})
+
+    and::
+
+        PTQConfig(
+            ...,
+            model_args={
+                "profile": "reference_eval",
+                "attention": {
+                    "layout": "unrolled",
+                },
+            },
+        )
+
+    `model_args["attention"]` may also be a plain profile string, for example
+    "npu_export". When no option is provided, the default profile is
+    "npu_export" to preserve the existing export-oriented graph.
+
+    Parameters
+    ----------
+    qcfg : Optional[PTQConfig]
+        PTQ configuration associated with the wrapper.
+
+    Returns
+    -------
+    LlamaAttentionOptions
+        Validated execution options.
+    """
+    if qcfg is None:
+        return _PRESETS[DEFAULT_EXECUTION_PROFILE]
+
+    root_profile = normalize_execution_profile(
+        qcfg.get_model_arg("profile", DEFAULT_EXECUTION_PROFILE),
+        context="PTQConfig.model_args['profile']",
+    )
+
+    raw_attention = qcfg.get_model_arg("attention", {})
+    if raw_attention is None:
+        raw_attention = {}
+    if isinstance(raw_attention, str):
+        raw_attention = {"profile": raw_attention}
+    if not isinstance(raw_attention, Mapping):
+        raise TypeError(
+            "PTQConfig.model_args['attention'] must be a mapping, a string, or None."
+        )
+
+    raw = dict(raw_attention)
+    profile = normalize_execution_profile(
+        raw.pop("profile", root_profile),
+        context="PTQConfig.model_args['attention']['profile']",
+    )
+
+    valid_keys = {field.name for field in fields(LlamaAttentionOptions)}
+    unknown_keys = sorted(set(raw) - valid_keys)
+    if unknown_keys:
+        raise ValueError(f"Unknown Llama attention option(s): {unknown_keys}.")
+
+    options = replace(_PRESETS[profile], **raw)
+    _validate_llama_attention_options(options)
+    return options
+
+
+def is_npu_export_attention_options(options: LlamaAttentionOptions) -> bool:
+    """
+    Return whether the options match the NPU-export-friendly attention graph.
+    """
+    return (
+        options.scale_fusion == "k_proj"
+        and options.rope == "pre_negated_sin"
+        and options.layout == "unrolled"
+    )
+
+
+def _validate_llama_attention_options(options: LlamaAttentionOptions) -> None:
+    """
+    Validate a fully resolved LlamaAttentionOptions instance.
+    """
+    if options.scale_fusion not in ("none", "q_proj", "k_proj"):
+        raise ValueError(f"Unsupported scale_fusion: {options.scale_fusion!r}.")
+    if options.rope not in ("hf", "pre_negated_sin"):
+        raise ValueError(f"Unsupported rope convention: {options.rope!r}.")
+    if options.layout not in ("batched", "unrolled"):
+        raise ValueError(f"Unsupported attention layout: {options.layout!r}.")

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -22,13 +22,23 @@
 #   4. Calibrate activations observers in a single pass over a text corpus.
 #   5. Inject GPTQ’s per-tensor weight scales / zero-points into the PTQ graph.
 #   6. Freeze all Q-params and compute Wikitext-2 perplexity.
-#   7. Save model/layers (optional)
+#   7. Save model/layers (optional).
+#
+# Llama attention execution profiles
+# -----------------------------------------------------------------------------
+#   --profile npu_export
+#       Preserves the current NPU-export-oriented attention graph.
+#
+#   --profile reference_eval
+#       Uses a Hugging Face-like attention path that is better suited for quick
+#       GPU evaluation and regression checks. Circle export is intentionally
+#       restricted to npu_export in this example.
 # =============================================================================
 
 import argparse
 import pathlib
 import random
-from typing import Any
+from typing import Any, Optional
 
 import torch
 import tqdm
@@ -42,6 +52,10 @@ from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
 from tico.quantization.config.builders import build_llm_ptq_config
 from tico.quantization.config.cle import CLEConfig
 from tico.quantization.config.gptq import GPTQConfig
+from tico.quantization.config.llama_attention import (
+    DEFAULT_EXECUTION_PROFILE,
+    SUPPORTED_EXECUTION_PROFILES,
+)
 from tico.quantization.config.spinquant import SpinQuantConfig
 from tico.quantization.evaluation.script.llm_tasks_eval import evaluate_llm_on_tasks
 from tico.quantization.wrapq.dtypes import DType
@@ -169,7 +183,7 @@ def parse_args():
     parser.add_argument(
         "--nsamples_for_qcalibration",
         type=int,
-        default="128",  # almost standard
+        default=128,  # almost standard
         help="number of samples to be used in GPTQ/PTQ calibration",
     )
     parser.add_argument(
@@ -217,6 +231,15 @@ def parse_args():
         type=int,
         default=4,
         help="Number of bits to be used to quantize lm_head",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=list(SUPPORTED_EXECUTION_PROFILES),
+        default=DEFAULT_EXECUTION_PROFILE,
+        help=(
+            "Use 'reference_eval' for a GPU-friendly, HF-like attention path. "
+            "Use 'npu_export' for the NPU-export-oriented attention graph."
+        ),
     )
     parser.add_argument(
         "--eval_tasks",
@@ -450,7 +473,7 @@ def save_model_to(
 
 
 def make_random_position_embeddings(B, head_dim, DEVICE):
-    # RoPE tables for the *current token* only.
+    """Create random RoPE tables for one decode step."""
     cos = torch.randn(B, 1, head_dim, device=DEVICE)
     sin = torch.randn(B, 1, head_dim, device=DEVICE)
     return (cos, sin)
@@ -470,6 +493,7 @@ def make_random_decode_attn_mask(B, MAX_SEQ, DEVICE):
 # copied from quantize_decoder_layer_decode.py
 # -----------------------------------------------------------------------------
 def make_random_decode_batch(model, B, DEVICE, MAX_SEQ):
+    """Create a synthetic decode batch for per-layer export."""
     # TODO reduce code duplication
     D = model.config.hidden_size
     head_dim = getattr(model.config, "head_dim", D // model.config.num_attention_heads)
@@ -625,6 +649,7 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
         return q_m
 
     print("Wrapping layers with PTQWrapper …")
+    print(f"Using PTQ execution profile: {args.profile}")
 
     qcfg = build_llm_ptq_config(
         model_type="llama",
@@ -636,6 +661,7 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
         lm_head_weight_bits=args.lm_head_weight_bits,
         norm_weight_dtype=DType.int(16),
         strict_wrap=True,
+        profile=args.profile,
     )
     q_m = prepare(q_m, qcfg)
 
@@ -741,6 +767,27 @@ def should_save(args, artifact: str) -> bool:
     )
 
 
+def circle_export_requested(args) -> bool:
+    """Return True if any Circle export artifact is requested."""
+    return should_save(args, "circle_full") or should_save(args, "circle_per_layer")
+
+
+def validate_export_profile(args) -> None:
+    """
+    Reject Circle export when the model was prepared with a non-export profile.
+    """
+    if not circle_export_requested(args):
+        return
+
+    if args.profile != "npu_export":
+        raise ValueError(
+            "Circle export in this example requires --profile npu_export. "
+            "Use --profile reference_eval for fast GPU evaluation without "
+            "circle_full/circle_per_layer saving, or rerun calibration with "
+            "--profile npu_export before exporting."
+        )
+
+
 def setup_runtime(args) -> tuple[torch.device, torch.dtype]:
     """
     Initialize deterministic settings and resolve runtime device / dtype.
@@ -759,6 +806,7 @@ def print_config(args, device: torch.device) -> None:
     print(f"Model            : {args.model}")
     print(f"Device           : {device.type}")
     print(f"DType            : {args.dtype}")
+    print(f"PTQ profile      : {args.profile}")
     print()
 
 
@@ -923,127 +971,142 @@ def compute_or_load_sensitivity(model, calib_inputs, args):
         return None
 
     if args.sensitivity_path is not None:
-        return torch.load(args.sensitivity_path)
+        path = pathlib.Path(args.sensitivity_path)
+        if path.exists():
+            print(f"Loading sensitivity information from {path.resolve()}")
+            return torch.load(path)
 
+    print("Computing sensitivity information for GPTQ SMSE ...")
     calibrator = SensitivityCalibrator(model, calib_inputs)
     sens = calibrator.compute_sensitivity_info()
 
     if should_save(args, "sensitivity"):
-        save_name = get_sensitivities_info_name(
-            model,
-            "wikitext",
-            args.seed,
-            len(calib_inputs),
+        default_path = pathlib.Path(
+            get_sensitivities_info_name(
+                model,
+                DATASET_NAME,
+                args.seed,
+                args.nsamples_for_qcalibration,
+            )
         )
-        save_path = pathlib.Path(args.output_dir, save_name)
-        print(f"Saving calibrated_sensitivities to {save_path}")
+        output_dir = pathlib.Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        save_path = output_dir / default_path.name
+        print(f"Saving sensitivity information to {save_path.resolve()}")
         torch.save(sens, save_path)
 
     return sens
 
 
-def quantize_using_GPTQ(model, calib_inputs, args):
+def apply_gptq(model, calib_inputs, args):
     """
-    Run the optional GPTQ weight-only quantization pass.
+    Optionally run GPTQ weight-only quantization.
     """
     if args.no_GPTQ:
+        print("Skipping GPTQ ...")
         return model
 
-    print("Applying GPTQ …")
-
-    # use_cache increases VRAM usage significantly, but GPTQ does not use decoding.
-    prev_use_cache = model.config.use_cache
-    model.config.use_cache = False
-
+    print("Applying GPTQ ...")
     sens = compute_or_load_sensitivity(model, calib_inputs, args)
+
     gptq_config = GPTQConfig(
         weight_bits=args.linear_weight_bits,
         perchannel=True,
         mse=args.gptq_mse,
         sensitivity=sens,
     )
-
     q_m = prepare(model, gptq_config, inplace=True)
+
+    iterator = calib_inputs
+    if not args.no_tqdm:
+        iterator = tqdm.tqdm(calib_inputs, desc="GPTQ calibration")
+
     with torch.no_grad():
-        for inp in calib_inputs:
+        for inp in iterator:
             q_m(inp.to(args.device))
 
-    q_m = convert(q_m, inplace=True)
-    model.config.use_cache = prev_use_cache
-    return q_m
+    return convert(q_m, inplace=True)
 
 
-def save_ptq_checkpoint(q_m, model, args) -> None:
+def get_pad_token_id(tokenizer) -> int:
     """
-    Save the PTQ checkpoint when requested by CLI flags.
+    Return a usable pad token id for export example inputs.
     """
-    if not should_save(args, "ptq_checkpoint"):
-        return
+    if tokenizer.pad_token_id is not None:
+        return int(tokenizer.pad_token_id)
+    if tokenizer.eos_token_id is not None:
+        return int(tokenizer.eos_token_id)
+    return 0
 
-    save_name = get_ptq_model_name(model, args)
-    save_path = pathlib.Path(args.output_dir, save_name)
-    print(f"Saving PTQ model to {save_path}")
-    torch.save(q_m, save_path)
+
+def get_export_input(calib_inputs, tokenizer, args) -> torch.Tensor:
+    """
+    Build the token tensor used for full-model export.
+    """
+    example = calib_inputs[0].cpu()
+    if args.max_seq_len is None:
+        return example
+    return pad_input(example, get_pad_token_id(tokenizer), args.max_seq_len).cpu()
 
 
 def save_requested_artifacts(q_m, tokenizer, calib_inputs, args) -> None:
     """
-    Save requested Circle artifacts after final evaluation.
+    Save requested artifacts after PTQ conversion.
     """
-    if should_save(args, "circle_per_layer"):
-        save_layers_to(
-            q_m,
-            args.max_seq_len,
-            args.output_dir,
-            prefill_decode=args.decode_calibration_steps != 0,
-        )
+    if args.output_dir is None or args.save is None:
+        return
+
+    output_dir = pathlib.Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if should_save(args, "ptq_checkpoint"):
+        save_path = output_dir / get_ptq_model_name(q_m.wrapped, args)
+        print(f"Saving PTQ checkpoint to {save_path.resolve()}")
+        torch.save(q_m, save_path)
 
     if should_save(args, "circle_full"):
-        pad_token_id = (
-            tokenizer.pad_token_id
-            if tokenizer.pad_token_id is not None
-            else tokenizer.eos_token_id
-        )
-        calib_input = pad_input(
-            calib_inputs[0], pad_token_id, max_seq_len=args.max_seq_len
-        )
+        export_input = get_export_input(calib_inputs, tokenizer, args)
         save_model_to(
             q_m,
-            calib_input,
-            args.output_dir,
-            prefill_decode=args.decode_calibration_steps != 0,
+            export_input,
+            output_dir,
+            prefill_decode=args.decode_calibration_steps > 0,
+        )
+
+    if should_save(args, "circle_per_layer"):
+        max_seq_len = args.max_seq_len or q_m.wrapped.config.max_position_embeddings
+        save_layers_to(
+            q_m,
+            max_seq_len,
+            output_dir,
+            prefill_decode=args.decode_calibration_steps > 0,
         )
 
 
-def run_pipeline(args) -> None:
-    """
-    Run the full Llama GPTQ + PTQ quantization pipeline.
-    """
+def main():
+    args = parse_args()
     print(args)
+    validate_export_profile(args)
 
     device, dtype = setup_runtime(args)
     print_config(args, device)
 
     model, tokenizer = load_model_and_tokenizer(args, dtype)
-    model = apply_spinquant(model, args)
-    model = apply_cle(model, args)
     configure_max_position_embeddings(model, args)
 
     dataset_test = load_eval_dataset(args)
     evaluate_original_model(model, tokenizer, dataset_test, args, device)
 
     calib_inputs = build_calibration_inputs(model, tokenizer, args, device)
-    q_m = quantize_using_GPTQ(model, calib_inputs, args)
-    q_m = quantize_using_PTQ(q_m, calib_inputs, args)
-    save_ptq_checkpoint(q_m, model, args)
+
+    model = apply_spinquant(model, args)
+    model = apply_cle(model, args)
+    model = apply_gptq(model, calib_inputs, args)
+
+    q_m = quantize_using_PTQ(model, calib_inputs, args)
 
     evaluate(q_m, tokenizer, dataset_test, args)
     save_requested_artifacts(q_m, tokenizer, calib_inputs, args)
-
-
-def main() -> None:
-    args = parse_args()
-    run_pipeline(args)
 
 
 if __name__ == "__main__":

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 
 import copy
-from typing import List, Literal, Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
 
 from transformers.cache_utils import Cache
 
+from tico.quantization.config.llama_attention import (
+    get_llama_attention_options,
+    is_npu_export_attention_options,
+)
 from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
@@ -35,6 +39,25 @@ CacheOutputMode = Literal["present", "delta"]
 LayerKV = Tuple[torch.Tensor, torch.Tensor]
 
 
+def _clone_projection_with_scale(module: nn.Module, scale: torch.Tensor) -> nn.Module:
+    """
+    Return a deep-copied projection module with its affine parameters scaled.
+
+    The helper is intentionally conservative and only touches `weight` and
+    `bias` attributes when they exist.
+    """
+    scaled = copy.deepcopy(module)
+    with torch.no_grad():
+        weight = getattr(scaled, "weight", None)
+        if weight is not None:
+            weight.mul_(scale.to(device=weight.device, dtype=weight.dtype))
+
+        bias = getattr(scaled, "bias", None)
+        if bias is not None:
+            bias.mul_(scale.to(device=bias.device, dtype=bias.dtype))
+    return scaled
+
+
 @try_register(
     "transformers.models.llama.modeling_llama.LlamaAttention",
     "transformers.models.llama.modeling_llama.LlamaSdpaAttention",
@@ -47,7 +70,9 @@ class QuantLlamaAttention(QuantModuleBase):
       - prefill: `past_key_value is None`
       - decode : `past_key_value is not None`
 
-    Export specialization is provided by thin adapter modules.
+    Export specialization is provided by thin adapter modules. Implementation
+    details such as projection scale fusion, RoPE sign convention, and attention
+    layout are controlled by `PTQConfig.model_args`.
 
     Behavior
     --------
@@ -69,6 +94,8 @@ class QuantLlamaAttention(QuantModuleBase):
     ):
         super().__init__(qcfg, fp_name=fp_name)
 
+        self.attn_options = get_llama_attention_options(self.qcfg)
+
         cfg = fp_attn.config
         self.config = cfg
         self.layer_idx = layer_idx
@@ -89,8 +116,9 @@ class QuantLlamaAttention(QuantModuleBase):
         self.num_kv_heads = cfg.num_key_value_heads
         self.kv_rep = cfg.num_attention_heads // cfg.num_key_value_heads
         self.max_seq = cfg.max_position_embeddings
+
         # Constant scale (1/√d)
-        scale_t = torch.tensor(
+        self.attn_scale = torch.tensor(
             float(getattr(fp_attn, "scaling", self.head_dim**-0.5))
         )
 
@@ -111,27 +139,31 @@ class QuantLlamaAttention(QuantModuleBase):
         assert hasattr(fp_attn, "o_proj") and isinstance(
             fp_attn.o_proj, torch.nn.Module
         )
+
+        q_proj_fp = fp_attn.q_proj
+        k_proj_fp = fp_attn.k_proj
+        if self.attn_options.scale_fusion == "q_proj":
+            q_proj_fp = _clone_projection_with_scale(fp_attn.q_proj, self.attn_scale)
+        elif self.attn_options.scale_fusion == "k_proj":
+            k_proj_fp = _clone_projection_with_scale(fp_attn.k_proj, self.attn_scale)
+        elif self.attn_options.scale_fusion != "none":
+            raise RuntimeError(
+                f"Invalid scale fusion option: {self.attn_options.scale_fusion!r}"
+            )
+
         self.q_proj = PTQWrapper(
-            fp_attn.q_proj, qcfg=q_cfg, fp_name=join_name(fp_name, "q_proj")
+            q_proj_fp, qcfg=q_cfg, fp_name=join_name(fp_name, "q_proj")
+        )
+        self.k_proj = PTQWrapper(
+            k_proj_fp,
+            qcfg=k_cfg,
+            fp_name=join_name(fp_name, "k_proj"),
         )
         self.v_proj = PTQWrapper(
             fp_attn.v_proj, qcfg=v_cfg, fp_name=join_name(fp_name, "v_proj")
         )
         self.o_proj = PTQWrapper(
             fp_attn.o_proj, qcfg=o_cfg, fp_name=join_name(fp_name, "o_proj")
-        )
-
-        k_proj_fp = copy.deepcopy(fp_attn.k_proj)
-        # merge scale_t to k_proj, (otherwise merge it to q_proj)
-        with torch.no_grad():
-            k_proj_fp.weight.mul_(scale_t)
-            if k_proj_fp.bias is not None:
-                k_proj_fp.bias.mul_(scale_t)
-
-        self.k_proj = PTQWrapper(
-            k_proj_fp,
-            qcfg=k_cfg,
-            fp_name=join_name(fp_name, "k_proj"),
         )
 
         mk = self._make_obs
@@ -167,14 +199,16 @@ class QuantLlamaAttention(QuantModuleBase):
         self.obs_attn_out = mk("attn_out")
         self.obs_attn_weights = mk("attn_weights")
         self.obs_attn_out_h = mk("attn_out_h")
+        self.obs_scale = mk("scale")
+        self.obs_logits_raw = mk("logits_raw")
 
         # kv cache
         self.obs_past_key = mk("past_key")
         self.obs_past_value = mk("past_value")
 
-        # New kv delta``
-        self.obs_new_k = mk("new_k")  # (B, n_kv, 1, H)
-        self.obs_new_v = mk("new_v")  # (B, n_kv, 1, H)
+        # New kv delta
+        self.obs_new_k = mk("new_k")  # (B, n_kv, S, H)
+        self.obs_new_v = mk("new_v")  # (B, n_kv, S, H)
 
         # Total KV after concat (used for matmul/attn)
         self.obs_present_key = mk("present_key")  # (B, max_seq, H)
@@ -189,10 +223,25 @@ class QuantLlamaAttention(QuantModuleBase):
         self.register_buffer("causal_mask_template", mask, persistent=False)
 
     def _rot(self, t: torch.Tensor, o_x1, o_x2, o_cat):
+        """
+        Apply the profile-selected rotate-half primitive.
+
+        `rope='hf'` computes `(-x2, x1)`. `rope='pre_negated_sin'` assumes
+        the first half of the sine table has already been negated and therefore
+        computes `(x2, x1)`.
+        """
         x1, x2 = torch.chunk(t, 2, dim=-1)
         x1 = self._fq(x1, o_x1)
         x2 = self._fq(x2, o_x2)
-        return self._fq(torch.cat((x2, x1), dim=-1), o_cat)
+
+        if self.attn_options.rope == "hf":
+            first = -x2
+        elif self.attn_options.rope == "pre_negated_sin":
+            first = x2
+        else:
+            raise RuntimeError(f"Invalid RoPE option: {self.attn_options.rope!r}")
+
+        return self._fq(torch.cat((first, x1), dim=-1), o_cat)
 
     def _apply_rope(
         self,
@@ -206,10 +255,43 @@ class QuantLlamaAttention(QuantModuleBase):
         obs_sin,
         obs_rot,
     ):
+        """
+        Apply rotary position embedding to a Q or K tensor.
+        """
         t_half = self._rot(t, obs_x1, obs_x2, obs_cat)
         t_cos = self._fq(t * cos, obs_cos)
         t_sin = self._fq(t_half * sin, obs_sin)
         return self._fq(t_cos + t_sin, obs_rot)
+
+    def _apply_attention_scale_if_needed(self, logits: torch.Tensor) -> torch.Tensor:
+        """
+        Apply runtime attention scaling when it was not fused into a projection.
+        """
+        if self.attn_options.scale_fusion == "none":
+            logits = self._fq(logits, self.obs_logits_raw)
+            scale = self._fq(self.attn_scale, self.obs_scale)
+            return logits * scale
+        return logits
+
+    @staticmethod
+    def _expand_rope_for_batched(t: torch.Tensor) -> torch.Tensor:
+        """
+        Convert a RoPE table to a shape broadcastable to `(B, heads, S, H)`.
+        """
+        if t.dim() == 2:
+            t = t.unsqueeze(0)
+        if t.dim() == 3:
+            t = t.unsqueeze(1)
+        return t
+
+    @staticmethod
+    def _expand_attention_mask_for_batched(t: torch.Tensor) -> torch.Tensor:
+        """
+        Convert an attention mask to a shape broadcastable to batched logits.
+        """
+        if t.dim() == 3:
+            t = t.unsqueeze(1)
+        return t
 
     def _get_layer_kv_from_cache(
         self,
@@ -452,7 +534,7 @@ class QuantLlamaAttention(QuantModuleBase):
 
         Supported cases:
         - None: build a causal mask slice.
-        - bool/int mask: convert to additive mask using 0 / -120.
+        - bool/int mask: convert to additive mask using 0 / configured fill value.
         - additive mask: use as-is.
 
         Args:
@@ -569,21 +651,7 @@ class QuantLlamaAttention(QuantModuleBase):
         cache_output_mode: CacheOutputMode,
     ) -> Cache | LayerKV:
         """
-        Finalize the cache object returned by forward.
-
-        Args:
-            past_key_value_in: Original input cache in HF `Cache` or legacy form.
-            new_k_parts: Per-head new key tensors of shape `(B, S, H)`.
-            new_v_parts: Per-head new value tensors of shape `(B, S, H)`.
-            present_k_parts: Per-head full key tensors of shape `(B, K, H)`.
-            present_v_parts: Per-head full value tensors of shape `(B, K, H)`.
-            cache_output_mode: Cache return policy.
-
-        Returns:
-            Cache object to return from forward:
-            - delta `(new_k, new_v)` if `cache_output_mode == "delta"`
-            - updated HF `Cache` if the input cache was an HF cache
-            - full present legacy tuple otherwise
+        Finalize the cache object returned by the unrolled forward path.
         """
         if cache_output_mode not in ("present", "delta"):
             raise ValueError(f"Unsupported cache_output_mode: {cache_output_mode!r}")
@@ -632,61 +700,77 @@ class QuantLlamaAttention(QuantModuleBase):
         )
         return present_k, present_v
 
-    def forward(
+    def _finalize_cache_output_batched(
         self,
-        hidden_states: torch.Tensor,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor],
-        attention_mask: Optional[torch.Tensor] = None,
-        past_key_value: Optional[Cache | LayerKV] = None,
-        use_cache: Optional[bool] = False,
-        cache_position: Optional[torch.LongTensor] = None,
-        cache_output_mode: CacheOutputMode = "present",
-        **kwargs,
+        *,
+        past_key_value_in: Optional[Cache | LayerKV],
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        present_k: torch.Tensor,
+        present_v: torch.Tensor,
+        cache_output_mode: CacheOutputMode,
+    ) -> Cache | LayerKV:
+        """
+        Finalize the cache object returned by the batched forward path.
+        """
+        if cache_output_mode not in ("present", "delta"):
+            raise ValueError(f"Unsupported cache_output_mode: {cache_output_mode!r}")
+
+        if cache_output_mode == "delta":
+            if torch.compiler.is_compiling() and isinstance(past_key_value_in, Cache):
+                if self.layer_idx is None:
+                    raise RuntimeError(
+                        "layer_idx must be set to update an HF Cache object."
+                    )
+                past_key_value_in.layers[self.layer_idx] = type(
+                    past_key_value_in.layers[self.layer_idx]
+                )()
+                past_key_value_in.update(
+                    new_k, new_v, self.layer_idx, cache_kwargs=None
+                )
+                self._get_layer_kv_from_cache(
+                    past_key_value_in,
+                    k_obs=self.obs_new_k,
+                    v_obs=self.obs_new_v,
+                    write_back=True,
+                )
+            return new_k, new_v
+
+        if isinstance(past_key_value_in, Cache):
+            if self.layer_idx is None:
+                raise RuntimeError(
+                    "layer_idx must be set to update an HF Cache object."
+                )
+            past_key_value_in.update(new_k, new_v, self.layer_idx, cache_kwargs=None)
+            if torch.compiler.is_compiling():
+                self._get_layer_kv_from_cache(
+                    past_key_value_in,
+                    k_obs=self.obs_past_key,
+                    v_obs=self.obs_past_value,
+                    write_back=True,
+                )
+            return past_key_value_in
+
+        return present_k, present_v
+
+    def _forward_unrolled(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        attn_mask: torch.Tensor,
+        past_key_value: Optional[LayerKV],
+        past_key_value_in: Optional[Cache | LayerKV],
+        use_cache: Optional[bool],
+        cache_output_mode: CacheOutputMode,
     ):
         """
-        Run quantized Llama attention.
-
-        Args:
-            hidden_states: Input hidden states with shape `(B, S, D)`.
-            position_embeddings: Rotary cosine and sine tensors.
-            attention_mask: Optional additive or boolean attention mask.
-            past_key_value: Optional cache in HF `Cache` or legacy tuple form.
-            use_cache: Whether to return cache output.
-            cache_position: Unused compatibility placeholder.
-            cache_output_mode: Cache return policy.
-                - "present": return the full present cache.
-                - "delta": return only the newly produced K/V.
-            **kwargs: Extra compatibility arguments ignored by this wrapper.
-
-        Returns:
-            A tuple of:
-                - attention output
-                - attention weights
-                - optional cache output when `use_cache=True`
+        Run the NPU-export-friendly per-head unrolled attention path.
         """
-        del cache_position, kwargs
-
-        past_key_value_in = past_key_value
-        past_key_value = self._normalize_past_key_value(past_key_value)
-
-        hidden = self._fq(hidden_states, self.obs_hidden)
-        B, S, _ = hidden.shape
-        H = self.head_dim
-
-        q = self.q_proj(hidden).view(B, S, self.num_heads, H)
-        k = self.k_proj(hidden).view(B, S, self.num_kv_heads, H)
-        v = self.v_proj(hidden).view(B, S, self.num_kv_heads, H)
-
-        cos, sin = position_embeddings
-        cos = self._fq(cos, self.obs_cos)
-        sin = self._fq(sin, self.obs_sin)
-
-        attn_mask = self._build_attention_mask(
-            hidden_states=hidden_states,
-            attention_mask=attention_mask,
-            past_key_value=past_key_value,
-            device=hidden.device,
-        )
+        B, S, _, _ = q.shape
 
         attn_weights_parts: list[torch.Tensor] = []
         attn_out_parts: list[torch.Tensor] = []
@@ -749,10 +833,9 @@ class QuantLlamaAttention(QuantModuleBase):
                     self.obs_q_rot,
                 )
 
-                logits_i = self._fq(
-                    q_i @ present_k_i.transpose(-2, -1),
-                    self.obs_logits,
-                )
+                logits_i = q_i @ present_k_i.transpose(-2, -1)
+                logits_i = self._apply_attention_scale_if_needed(logits_i)
+                logits_i = self._fq(logits_i, self.obs_logits)
 
                 assert attn_mask.shape[-2:] == logits_i.shape[-2:], (
                     attn_mask.shape,
@@ -798,6 +881,195 @@ class QuantLlamaAttention(QuantModuleBase):
 
         return outputs
 
+    def _forward_batched(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        attn_mask: torch.Tensor,
+        past_key_value: Optional[LayerKV],
+        past_key_value_in: Optional[Cache | LayerKV],
+        use_cache: Optional[bool],
+        cache_output_mode: CacheOutputMode,
+    ):
+        """
+        Run a HF-like batched attention path optimized for GPU evaluation.
+        """
+        B, S, _, _ = q.shape
+
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        cos = self._expand_rope_for_batched(cos)
+        sin = self._expand_rope_for_batched(sin)
+
+        q = self._apply_rope(
+            q,
+            cos,
+            sin,
+            self.obs_q_x1,
+            self.obs_q_x2,
+            self.obs_q_cat,
+            self.obs_q_cos,
+            self.obs_q_sin,
+            self.obs_q_rot,
+        )
+        k = self._apply_rope(
+            k,
+            cos,
+            sin,
+            self.obs_k_x1,
+            self.obs_k_x2,
+            self.obs_k_cat,
+            self.obs_k_cos,
+            self.obs_k_sin,
+            self.obs_k_rot,
+        )
+
+        new_k = self._fq(k, self.obs_new_k)
+        new_v = self._fq(v, self.obs_new_v)
+
+        if past_key_value is None:
+            present_k = self._fq(new_k, self.obs_present_key)
+            present_v = self._fq(new_v, self.obs_present_value)
+        else:
+            past_k, past_v = past_key_value
+            present_k = self._fq(
+                torch.cat([past_k, new_k], dim=2),
+                self.obs_present_key,
+            )
+            present_v = self._fq(
+                torch.cat([past_v, new_v], dim=2),
+                self.obs_present_value,
+            )
+
+        if self.kv_rep != 1:
+            present_k_for_attn = present_k.repeat_interleave(self.kv_rep, dim=1)
+            present_v_for_attn = present_v.repeat_interleave(self.kv_rep, dim=1)
+        else:
+            present_k_for_attn = present_k
+            present_v_for_attn = present_v
+
+        logits = q @ present_k_for_attn.transpose(-2, -1)
+        logits = self._apply_attention_scale_if_needed(logits)
+        logits = self._fq(logits, self.obs_logits)
+
+        attn_mask = self._expand_attention_mask_for_batched(attn_mask)
+        assert attn_mask.shape[-2:] == logits.shape[-2:], (
+            attn_mask.shape,
+            logits.shape,
+        )
+
+        logits = self._fq(logits + attn_mask, self.obs_mask_add)
+
+        attn_weights = torch.softmax(logits, dim=-1, dtype=torch.float32).to(q.dtype)
+        attn_weights = self._fq(attn_weights, self.obs_softmax)
+        attn_weights = self._fq(attn_weights, self.obs_attn_weights)
+
+        attn_out_h = self._fq(attn_weights @ present_v_for_attn, self.obs_attn_out)
+        attn_out_h = self._fq(attn_out_h, self.obs_attn_out_h)
+
+        attn_out = attn_out_h.transpose(1, 2).contiguous().reshape(B, S, -1)
+        out = self.o_proj(attn_out)
+
+        outputs = (out, attn_weights)
+
+        if use_cache:
+            cache_out = self._finalize_cache_output_batched(
+                past_key_value_in=past_key_value_in,
+                new_k=new_k,
+                new_v=new_v,
+                present_k=present_k,
+                present_v=present_v,
+                cache_output_mode=cache_output_mode,
+            )
+            outputs += (cache_out,)  # type: ignore[assignment]
+
+        return outputs
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_value: Optional[Cache | LayerKV] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        cache_output_mode: CacheOutputMode = "present",
+        **kwargs,
+    ):
+        """
+        Run quantized Llama attention.
+
+        Args:
+            cache_output_mode: Cache return policy.
+                - "present": return the full present cache.
+                - "delta": return only the newly produced K/V.
+
+        Returns:
+            A tuple of:
+                - attention output
+                - attention weights
+                - optional cache output when `use_cache=True`
+        """
+        del cache_position, kwargs
+
+        past_key_value_in = past_key_value
+        past_key_value = self._normalize_past_key_value(past_key_value)
+
+        hidden = self._fq(hidden_states, self.obs_hidden)
+        B, S, _ = hidden.shape
+        H = self.head_dim
+
+        q = self.q_proj(hidden).view(B, S, self.num_heads, H)
+        k = self.k_proj(hidden).view(B, S, self.num_kv_heads, H)
+        v = self.v_proj(hidden).view(B, S, self.num_kv_heads, H)
+
+        cos, sin = position_embeddings
+        cos = self._fq(cos, self.obs_cos)
+        sin = self._fq(sin, self.obs_sin)
+
+        attn_mask = self._build_attention_mask(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            past_key_value=past_key_value,
+            device=hidden.device,
+        )
+
+        if self.attn_options.layout == "batched":
+            return self._forward_batched(
+                q=q,
+                k=k,
+                v=v,
+                cos=cos,
+                sin=sin,
+                attn_mask=attn_mask,
+                past_key_value=past_key_value,
+                past_key_value_in=past_key_value_in,
+                use_cache=use_cache,
+                cache_output_mode=cache_output_mode,
+            )
+
+        if self.attn_options.layout == "unrolled":
+            return self._forward_unrolled(
+                q=q,
+                k=k,
+                v=v,
+                cos=cos,
+                sin=sin,
+                attn_mask=attn_mask,
+                past_key_value=past_key_value,
+                past_key_value_in=past_key_value_in,
+                use_cache=use_cache,
+                cache_output_mode=cache_output_mode,
+            )
+
+        raise RuntimeError(f"Invalid attention layout: {self.attn_options.layout!r}")
+
     def _all_observers(self):
         # local first
         yield from (
@@ -818,6 +1090,8 @@ class QuantLlamaAttention(QuantModuleBase):
             self.obs_k_rot,
             self.obs_attn_mask,
             self.obs_logits,
+            self.obs_logits_raw,
+            self.obs_scale,
             self.obs_mask_add,
             self.obs_softmax,
             self.obs_attn_out,
@@ -835,8 +1109,35 @@ class QuantLlamaAttention(QuantModuleBase):
             yield from m._all_observers()
 
     def as_export_module(
-        self, mode: ExportMode = "prefill", *, return_kv: bool = True
+        self,
+        mode: ExportMode = "prefill",
+        *,
+        return_kv: bool = True,
+        require_npu_profile: bool = False,
     ) -> nn.Module:
+        """
+        Return an export adapter for the requested attention mode.
+
+        Parameters
+        ----------
+        mode : ExportMode
+            Export mode, either ``"prefill"`` or ``"decode"``.
+        return_kv : bool
+            Whether the adapter should return the newly produced KV tensors.
+        require_npu_profile : bool
+            If True, reject configurations that do not match the NPU-export
+            profile. This protects export flows from accidentally using the
+            HF-like evaluation graph.
+        """
+        if require_npu_profile and not is_npu_export_attention_options(
+            self.attn_options
+        ):
+            raise ValueError(
+                "NPU export requires execution profile 'npu_export'. "
+                "Set PTQConfig.model_args['profile'] "
+                "to 'npu_export'."
+            )
+
         if mode == "prefill":
             return LlamaAttentionPrefillExportAdapter(self, return_kv=return_kv)
         if mode == "decode":

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 
 from transformers.cache_utils import Cache
 
+from tico.quantization.config.llama_attention import get_llama_attention_options
 from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
@@ -40,6 +41,8 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
     - Keep a single HF-compatible forward for both prefill and decode.
     - Preserve calibration/runtime semantics in the main wrapper.
     - Move export-specific static contracts to thin export adapters.
+    - Share the same Llama attention implementation profile used by
+      `QuantLlamaAttention` for RoPE table generation.
     """
 
     def __init__(
@@ -52,9 +55,11 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         layer_idx: Optional[int] = None,
     ):
         """
-        Q) Why do we need `return_type`?
-        A) Different versions of `transformers` wrap the decoder output in
-            different containers: a plain Tensor or a tuple.
+        Initialize the quantized decoder-layer wrapper.
+
+        `return_type` is needed because different versions of
+        `transformers` wrap decoder output in different containers: a plain
+        tensor or a tuple.
         """
         self.return_type = return_type
         if self.return_type is None:
@@ -66,6 +71,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
 
         super().__init__(qcfg, fp_name=fp_name)
 
+        self.attn_options = get_llama_attention_options(self.qcfg)
         self.layer_idx = layer_idx
 
         attn_cfg = qcfg.child("self_attn") if qcfg else None
@@ -157,7 +163,8 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         cos_t = emb.cos() * attn_scaling
         sin_t = emb.sin() * attn_scaling
         half_dim = head_dim // 2
-        sin_t[..., :half_dim] = -sin_t[..., :half_dim]
+        if self.attn_options.rope == "pre_negated_sin":
+            sin_t[..., :half_dim] = -sin_t[..., :half_dim]
         self.register_buffer(
             "rope_cos_template", cos_t.unsqueeze(0), persistent=False
         )  # [1, max_seq, head_dim]
@@ -173,6 +180,9 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         device: torch.device,
         dtype: torch.dtype,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Slice the static RoPE templates for the requested token range.
+        """
         assert isinstance(self.rope_cos_template, torch.Tensor)
         assert isinstance(self.rope_sin_template, torch.Tensor)
         end = start + seq_len
@@ -184,6 +194,9 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         self,
         past_key_value: Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
     ) -> int:
+        """
+        Return the cached sequence length for this layer.
+        """
         if past_key_value is None:
             return 0
         if isinstance(past_key_value, Cache):
@@ -202,6 +215,9 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]],
         past_key_value: Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Return position embeddings that match this wrapper's RoPE convention.
+        """
         if position_embeddings is None:
             q_len = hidden_states.size(1)
             past_len = self._get_past_len(past_key_value)
@@ -228,7 +244,7 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
 
         Supported cases:
         - None: build a causal mask slice.
-        - bool mask: convert to additive mask using 0 / -120.
+        - bool mask: convert to additive mask using 0 / configured fill value.
         - additive mask: use as-is.
         """
         q_len = hidden_states.size(1)
@@ -271,6 +287,9 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         Optional[torch.Tensor],
         Optional[Cache | Tuple[torch.Tensor, torch.Tensor]],
     ]:
+        """
+        Normalize attention outputs into hidden, attention, and cache values.
+        """
         if not isinstance(attn_out, tuple):
             return attn_out, None, None
 
@@ -301,6 +320,11 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
         **kwargs,
     ):
+        """
+        Run the quantized decoder layer.
+        """
+        del position_ids
+
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
@@ -358,6 +382,9 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         yield self.obs_mlp_residual_out
 
     def as_export_module(self, mode: ExportMode = "prefill", *, return_kv: bool = True):
+        """
+        Return a decoder-layer export adapter for the requested mode.
+        """
         if mode == "prefill":
             return LlamaDecoderLayerPrefillExportAdapter(self, return_kv=return_kv)
         if mode == "decode":

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -22,6 +22,7 @@ from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.processing_utils import Unpack
 
+from tico.quantization.config.llama_attention import get_llama_attention_options
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
@@ -37,6 +38,14 @@ LegacyCache = Tuple[Tuple[torch.Tensor, torch.Tensor], ...]
     "tico.quantization.algorithm.spinquant.spin_llama.SpinLlamaModel",
 )
 class QuantLlamaModel(QuantModuleBase):
+    """
+    Quantized wrapper for a Llama-style decoder-only model.
+
+    The wrapper owns model-level masks and RoPE templates shared across decoder
+    layers. RoPE sign convention is controlled by `PTQConfig.model_args` so it
+    stays consistent with `QuantLlamaAttention`.
+    """
+
     def __init__(
         self,
         model_fp: nn.Module,
@@ -45,6 +54,8 @@ class QuantLlamaModel(QuantModuleBase):
         fp_name: Optional[str] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)
+
+        self.attn_options = get_llama_attention_options(self.qcfg)
 
         # ----- child configs (hierarchical override) -------------------
         embed_cfg = qcfg.child("embed_tokens") if qcfg else None
@@ -161,7 +172,8 @@ class QuantLlamaModel(QuantModuleBase):
         cos_t = emb.cos() * attn_scaling
         sin_t = emb.sin() * attn_scaling
         half_dim = head_dim // 2
-        sin_t[..., :half_dim] = -sin_t[..., :half_dim]
+        if self.attn_options.rope == "pre_negated_sin":
+            sin_t[..., :half_dim] = -sin_t[..., :half_dim]
         cos_t = cos_t.unsqueeze(0)  # [1, max_seq, head_dim]
         sin_t = sin_t.unsqueeze(0)  # [1, max_seq, head_dim]
 
@@ -426,6 +438,9 @@ class QuantLlamaModel(QuantModuleBase):
         past_len: int,
         device: torch.device,
     ) -> torch.Tensor:
+        """
+        Slice the static causal mask template.
+        """
         assert isinstance(self.causal_mask_template, torch.Tensor)
         return self.causal_mask_template[..., past_len : past_len + q_len, :k_len].to(
             device
@@ -438,6 +453,9 @@ class QuantLlamaModel(QuantModuleBase):
         *,
         past_len: int,
     ) -> torch.Tensor:
+        """
+        Build an additive attention mask for the current model step.
+        """
         q_len = hidden_states.size(1)
         k_len = past_len + q_len
         device = hidden_states.device
@@ -476,6 +494,9 @@ class QuantLlamaModel(QuantModuleBase):
         *,
         start: int,
     ):
+        """
+        Return RoPE tables for the current model step.
+        """
         end = start + hidden_states.size(1)
         cos = self.rope_cos_template[:, start:end, :].to(
             dtype=hidden_states.dtype, device=hidden_states.device


### PR DESCRIPTION
Add configurable Llama attention execution profiles for wrapq.

The new profiles allow choosing between a reference-like GPU evaluation path and the existing NPU export-oriented path. The profile is stored in PTQConfig.model_args and can be set through build_llm_ptq_config().

Supported profiles:
- reference_eval: no scale fusion, HF RoPE convention, batched attention
- npu_export: k_proj scale fusion, pre-negated RoPE sine, head-unrolled attention

Also update Llama model and decoder-layer RoPE template generation to follow the selected profile.

Related: #690
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>