### PR TITLE
Support exporting shared weight

### DIFF
--- a/test/unit_test/serialize_test/test_circle_serializer.py
+++ b/test/unit_test/serialize_test/test_circle_serializer.py
@@ -68,7 +68,7 @@ class CircleSerializerSharedTensorTest(unittest.TestCase):
     @staticmethod
     def _get_tied_weight_placeholders(exported_program):
         """Return placeholders for the canonicalized tied embedding weight."""
-        placeholders_by_target = {}
+        placeholders_by_target = {}  # type: ignore[var-annotated]
 
         for (
             placeholder_name,

--- a/test/unit_test/serialize_test/test_circle_serializer.py
+++ b/test/unit_test/serialize_test/test_circle_serializer.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from tico.serialize.circle_serializer import _export_tensors, _initialize_model
+
+
+_TIED_WEIGHT_NAMES = {"embed.weight", "lm_head.weight"}
+
+
+class TiedEmbeddingModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(8, 4)
+        self.lm_head = nn.Linear(4, 8, bias=False)
+        self.lm_head.weight = self.embed.weight
+
+    def forward(self, tokens):
+        hidden = self.embed(tokens)
+        return F.linear(hidden, self.lm_head.weight)
+
+
+class UntiedEmbeddingModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(8, 4)
+        self.lm_head = nn.Linear(4, 8, bias=False)
+
+        with torch.no_grad():
+            self.lm_head.weight.copy_(self.embed.weight)
+
+    def forward(self, tokens):
+        hidden = self.embed(tokens)
+        return F.linear(hidden, self.lm_head.weight)
+
+
+class CircleSerializerSharedTensorTest(unittest.TestCase):
+    @staticmethod
+    def _export_model(model):
+        """Export a model with a fixed token input."""
+        model.eval()
+        tokens = torch.tensor([[1, 2, 3]], dtype=torch.long)
+        return torch.export.export(model, (tokens,))
+
+    @staticmethod
+    def _export_graph(exported_program):
+        """Export tensors from an exported program and return the Circle graph."""
+        _, graph = _initialize_model()
+        _export_tensors(graph, exported_program)
+        return graph
+
+    @staticmethod
+    def _get_tied_weight_placeholders(exported_program):
+        """Return placeholders for the canonicalized tied embedding weight."""
+        placeholders_by_target = {}
+
+        for (
+            placeholder_name,
+            target_name,
+        ) in exported_program.graph_signature.inputs_to_parameters.items():
+            if target_name in _TIED_WEIGHT_NAMES:
+                placeholders_by_target.setdefault(target_name, []).append(
+                    placeholder_name
+                )
+
+        if len(placeholders_by_target) != 1:
+            raise AssertionError(
+                "Expected tied embedding weights to be canonicalized to one "
+                f"target name, but got {placeholders_by_target}."
+            )
+
+        target_name, placeholder_names = next(iter(placeholders_by_target.items()))
+
+        if len(placeholder_names) != 2:
+            raise AssertionError(
+                "Expected two placeholders for the tied embedding weight, but got "
+                f"{placeholder_names} for target {target_name}."
+            )
+
+        return target_name, placeholder_names
+
+    @staticmethod
+    def _get_single_parameter_placeholder(exported_program, parameter_name):
+        """Return the only placeholder mapped to the given parameter name."""
+        placeholder_names = [
+            placeholder_name
+            for placeholder_name, target_name in (
+                exported_program.graph_signature.inputs_to_parameters.items()
+            )
+            if target_name == parameter_name
+        ]
+
+        if len(placeholder_names) != 1:
+            raise AssertionError(
+                f"Expected one placeholder for {parameter_name}, but got "
+                f"{placeholder_names}."
+            )
+
+        return placeholder_names[0]
+
+    @staticmethod
+    def _materialized_tensor_names(graph, placeholder_names):
+        """Return placeholder names that were materialized as Circle tensors."""
+        actual_tensor_names = {tensor.name for tensor in graph.tensors}
+        return set(placeholder_names) & actual_tensor_names
+
+    def test_tied_embedding_parameter_placeholders_share_one_circle_tensor(self):
+        model = TiedEmbeddingModel()
+
+        self.assertEqual(
+            model.embed.weight.data_ptr(),
+            model.lm_head.weight.data_ptr(),
+        )
+
+        exported_program = self._export_model(model)
+        target_name, placeholder_names = self._get_tied_weight_placeholders(
+            exported_program
+        )
+
+        self.assertIn(target_name, _TIED_WEIGHT_NAMES)
+
+        graph = self._export_graph(exported_program)
+
+        for placeholder_name in placeholder_names:
+            self.assertTrue(graph.has_tensor(placeholder_name))
+
+        tensor_ids = {
+            graph.name_to_tid[placeholder_name]
+            for placeholder_name in placeholder_names
+        }
+        self.assertEqual(1, len(tensor_ids))
+
+        self.assertEqual(
+            1,
+            len(self._materialized_tensor_names(graph, placeholder_names)),
+        )
+
+    def test_same_value_parameter_tensors_are_not_shared(self):
+        model = UntiedEmbeddingModel()
+
+        self.assertNotEqual(
+            model.embed.weight.data_ptr(),
+            model.lm_head.weight.data_ptr(),
+        )
+        self.assertTrue(torch.equal(model.embed.weight, model.lm_head.weight))
+
+        exported_program = self._export_model(model)
+        graph = self._export_graph(exported_program)
+
+        embed_placeholder = self._get_single_parameter_placeholder(
+            exported_program, "embed.weight"
+        )
+        lm_head_placeholder = self._get_single_parameter_placeholder(
+            exported_program, "lm_head.weight"
+        )
+        placeholder_names = [embed_placeholder, lm_head_placeholder]
+
+        for placeholder_name in placeholder_names:
+            self.assertTrue(graph.has_tensor(placeholder_name))
+
+        self.assertNotEqual(
+            graph.name_to_tid[embed_placeholder],
+            graph.name_to_tid[lm_head_placeholder],
+        )
+
+        self.assertEqual(
+            2,
+            len(self._materialized_tensor_names(graph, placeholder_names)),
+        )

--- a/test/unit_test/serialize_test/test_circle_serializer.py
+++ b/test/unit_test/serialize_test/test_circle_serializer.py
@@ -67,33 +67,43 @@ class CircleSerializerSharedTensorTest(unittest.TestCase):
 
     @staticmethod
     def _get_tied_weight_placeholders(exported_program):
-        """Return placeholders for the canonicalized tied embedding weight."""
-        placeholders_by_target = {}  # type: ignore[var-annotated]
+        """Return placeholders whose target parameters share tied embedding storage."""
+        pairs = [
+            (placeholder_name, target_name)
+            for placeholder_name, target_name in (
+                exported_program.graph_signature.inputs_to_parameters.items()
+            )
+            if target_name in _TIED_WEIGHT_NAMES
+        ]
 
-        for (
-            placeholder_name,
-            target_name,
-        ) in exported_program.graph_signature.inputs_to_parameters.items():
-            if target_name in _TIED_WEIGHT_NAMES:
-                placeholders_by_target.setdefault(target_name, []).append(
-                    placeholder_name
+        if len(pairs) != 2:
+            raise AssertionError(
+                "Expected two placeholders for tied embedding weights, but got "
+                f"{pairs}."
+            )
+
+        alias_keys = set()
+        for _, target_name in pairs:
+            tensor = exported_program.state_dict[target_name]
+            alias_keys.add(
+                (
+                    str(tensor.device),
+                    tensor.data_ptr(),
+                    tensor.storage_offset(),
+                    tuple(tensor.shape),
+                    tuple(tensor.stride()),
+                    tensor.dtype,
+                    tensor.layout,
                 )
-
-        if len(placeholders_by_target) != 1:
-            raise AssertionError(
-                "Expected tied embedding weights to be canonicalized to one "
-                f"target name, but got {placeholders_by_target}."
             )
 
-        target_name, placeholder_names = next(iter(placeholders_by_target.items()))
-
-        if len(placeholder_names) != 2:
+        if len(alias_keys) != 1:
             raise AssertionError(
-                "Expected two placeholders for the tied embedding weight, but got "
-                f"{placeholder_names} for target {target_name}."
+                "Expected tied embedding parameters to share storage, but got "
+                f"{pairs} with alias keys {alias_keys}."
             )
 
-        return target_name, placeholder_names
+        return [placeholder_name for placeholder_name, _ in pairs]
 
     @staticmethod
     def _get_single_parameter_placeholder(exported_program, parameter_name):
@@ -129,11 +139,7 @@ class CircleSerializerSharedTensorTest(unittest.TestCase):
         )
 
         exported_program = self._export_model(model)
-        target_name, placeholder_names = self._get_tied_weight_placeholders(
-            exported_program
-        )
-
-        self.assertIn(target_name, _TIED_WEIGHT_NAMES)
+        placeholder_names = self._get_tied_weight_placeholders(exported_program)
 
         graph = self._export_graph(exported_program)
 

--- a/tico/passes/const_prop_pass.py
+++ b/tico/passes/const_prop_pass.py
@@ -19,7 +19,7 @@
 # https://github.com/pytorch/executorch/blob/61ddee5/exir/passes/constant_prop_pass.py
 
 from collections import OrderedDict
-from typing import List, Mapping, Optional, TYPE_CHECKING
+from typing import Any, List, Mapping, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import torch.fx
@@ -47,12 +47,266 @@ from tico.utils.trace_decorators import (
 from tico.utils.utils import get_fake_mode
 
 
+_MISSING = object()
+
+TensorStorageIdentityKey = tuple[
+    str,
+    int,
+    int,
+    tuple[int, ...],
+    tuple[int, ...],
+    torch.dtype,
+    torch.layout,
+]
+QuantizedTensorCacheKey = tuple[Any, ...]
+
+
+def _get_quantized_decomposed_default_op(op_name: str) -> Any | None:
+    """Return a quantized_decomposed default op if it is registered.
+
+    Quantized decomposed ops may not be registered when this module is imported.
+    Therefore, all access to torch.ops.quantized_decomposed must be lazy.
+    """
+    try:
+        namespace = torch.ops.quantized_decomposed
+    except AttributeError:
+        return None
+
+    try:
+        overload_packet = getattr(namespace, op_name)
+    except AttributeError:
+        return None
+
+    try:
+        return overload_packet.default
+    except AttributeError:
+        return None
+
+
+def _get_dequantize_ops() -> tuple[Any, ...]:
+    """Return registered quantized_decomposed dequantize ops."""
+    return tuple(
+        op
+        for op in (
+            _get_quantized_decomposed_default_op("dequantize_per_channel"),
+            _get_quantized_decomposed_default_op("dequantize_per_tensor"),
+        )
+        if op is not None
+    )
+
+
+def _get_quantize_ops() -> tuple[Any, ...]:
+    """Return registered quantized_decomposed quantize ops."""
+    return tuple(
+        op
+        for op in (
+            _get_quantized_decomposed_default_op("quantize_per_channel"),
+            _get_quantized_decomposed_default_op("quantize_per_tensor"),
+        )
+        if op is not None
+    )
+
+
+def _get_tensor_storage_identity_key(
+    tensor: torch.Tensor,
+) -> Optional[TensorStorageIdentityKey]:
+    """Return a hashable key that identifies the logical storage of a tensor.
+
+    The key is based on storage identity, not tensor contents. This avoids
+    accidentally merging cloned tensors that happen to have the same values,
+    while still detecting tied weights that share the same tensor storage.
+    """
+    if tensor.layout != torch.strided:
+        return None
+
+    if tensor.numel() == 0:
+        # Empty tensors often have a zero data pointer, so unrelated empty
+        # tensors may look identical.
+        return None
+
+    try:
+        data_ptr = tensor.data_ptr()
+    except RuntimeError:
+        return None
+
+    if data_ptr == 0:
+        return None
+
+    return (
+        str(tensor.device),
+        data_ptr,
+        tensor.storage_offset(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.layout,
+    )
+
+
+def _make_hashable_constant(value: Any) -> Any:
+    """Convert constant values into hashable values for cache keys.
+
+    Quantization parameters are part of the operation semantics, so tensor
+    values used as quantization parameters are compared by value. The quantized
+    weight input itself is handled separately by storage identity.
+    """
+    if isinstance(value, torch.Tensor):
+        tensor = value.detach()
+        if tensor.layout != torch.strided:
+            return ("tensor", str(tensor.layout), repr(tensor))
+
+        cpu_tensor = tensor.cpu().contiguous()
+        return (
+            "tensor",
+            cpu_tensor.dtype,
+            tuple(cpu_tensor.shape),
+            tuple(cpu_tensor.reshape(-1).tolist()),
+        )
+
+    if isinstance(value, (tuple, list)):
+        return tuple(_make_hashable_constant(v) for v in value)
+
+    if isinstance(value, dict):
+        return tuple(sorted((k, _make_hashable_constant(v)) for k, v in value.items()))
+
+    if isinstance(value, torch.dtype):
+        return ("torch.dtype", str(value))
+
+    if isinstance(value, torch.device):
+        return ("torch.device", str(value))
+
+    if isinstance(value, torch.layout):
+        return ("torch.layout", str(value))
+
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+
+    try:
+        hash(value)
+        return value
+    except TypeError:
+        return repr(value)
+
+
+def _get_argument_value(
+    args: tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+    position: int,
+    names: tuple[str, ...],
+) -> Any:
+    """Return an argument value by position or by one of its possible names."""
+    if len(args) > position:
+        return args[position]
+
+    for name in names:
+        if name in kwargs:
+            return kwargs[name]
+
+    return _MISSING
+
+
+def _get_quantized_tensor_cache_key(
+    node: torch.fx.Node,
+    args_data: tuple[Any, ...],
+    kwargs_data: Mapping[str, Any],
+) -> Optional[QuantizedTensorCacheKey]:
+    """Return a cache key for quantizing tied constant tensors.
+
+    The source tensor is keyed by storage identity, while quantization
+    parameters are keyed by value. This lets tied weights reuse a single
+    propagated quantized tensor only when the quantization operation is
+    semantically identical.
+    """
+    quantize_per_tensor = _get_quantized_decomposed_default_op("quantize_per_tensor")
+    quantize_per_channel = _get_quantized_decomposed_default_op("quantize_per_channel")
+
+    if quantize_per_tensor is not None and node.target == quantize_per_tensor:
+        input_tensor = _get_argument_value(
+            args_data, kwargs_data, 0, ("input", "tensor")
+        )
+        scale = _get_argument_value(args_data, kwargs_data, 1, ("scale",))
+        zero_point = _get_argument_value(
+            args_data, kwargs_data, 2, ("zero_point", "zero_p")
+        )
+        quant_min = _get_argument_value(args_data, kwargs_data, 3, ("quant_min",))
+        quant_max = _get_argument_value(args_data, kwargs_data, 4, ("quant_max",))
+        dtype = _get_argument_value(args_data, kwargs_data, 5, ("dtype",))
+
+        if any(
+            x is _MISSING
+            for x in (input_tensor, scale, zero_point, quant_min, quant_max, dtype)
+        ):
+            return None
+
+        if not isinstance(input_tensor, torch.Tensor):
+            return None
+
+        input_key = _get_tensor_storage_identity_key(input_tensor)
+        if input_key is None:
+            return None
+
+        return (
+            str(node.target),
+            input_key,
+            _make_hashable_constant(scale),
+            _make_hashable_constant(zero_point),
+            _make_hashable_constant(quant_min),
+            _make_hashable_constant(quant_max),
+            _make_hashable_constant(dtype),
+        )
+
+    if quantize_per_channel is not None and node.target == quantize_per_channel:
+        input_tensor = _get_argument_value(
+            args_data, kwargs_data, 0, ("input", "tensor")
+        )
+        scales = _get_argument_value(args_data, kwargs_data, 1, ("scales", "scale"))
+        zero_points = _get_argument_value(
+            args_data, kwargs_data, 2, ("zero_points", "zero_point", "zero_p")
+        )
+        axis = _get_argument_value(args_data, kwargs_data, 3, ("axis",))
+        quant_min = _get_argument_value(args_data, kwargs_data, 4, ("quant_min",))
+        quant_max = _get_argument_value(args_data, kwargs_data, 5, ("quant_max",))
+        dtype = _get_argument_value(args_data, kwargs_data, 6, ("dtype",))
+
+        if any(
+            x is _MISSING
+            for x in (
+                input_tensor,
+                scales,
+                zero_points,
+                axis,
+                quant_min,
+                quant_max,
+                dtype,
+            )
+        ):
+            return None
+
+        if not isinstance(input_tensor, torch.Tensor):
+            return None
+
+        input_key = _get_tensor_storage_identity_key(input_tensor)
+        if input_key is None:
+            return None
+
+        return (
+            str(node.target),
+            input_key,
+            _make_hashable_constant(scales),
+            _make_hashable_constant(zero_points),
+            _make_hashable_constant(axis),
+            _make_hashable_constant(quant_min),
+            _make_hashable_constant(quant_max),
+            _make_hashable_constant(dtype),
+        )
+
+    return None
+
+
 def get_constant_placeholder_to_tensor_dict(
     exported_program: ExportedProgram,
 ) -> OrderedDict[torch.fx.Node, torch.Tensor]:
-    """
-    Returns a dictionary of constant placeholder node to constant tensor.
-    """
+    """Return a dictionary from constant placeholder nodes to constant tensors."""
     const_node_to_tensor: OrderedDict[torch.fx.Node, torch.Tensor] = OrderedDict()
     graph_module = exported_program.graph_module
     graph: torch.fx.Graph = graph_module.graph
@@ -75,11 +329,11 @@ def get_constant_placeholder_to_tensor_dict(
 
 
 def has_constant_data(arg, const_node_to_tensor=None) -> bool:
-    """
-    Check if `arg` has constant data.
+    """Check whether an argument has constant data.
 
-    Assume that `const_node_to_tensor` is retrived from exported program.
-    When a node is a placeholder, only method to check if it is constant is to check the exported program.
+    Placeholder nodes are checked against the exported program's constant
+    placeholder mapping because placeholders do not carry enough information by
+    themselves to distinguish constants from user inputs.
     """
     if isinstance(arg, (tuple, list)):
         return all(has_constant_data(a, const_node_to_tensor) for a in arg)
@@ -103,6 +357,7 @@ def get_data(
     exported_program: ExportedProgram,
     const_node_to_tensor: Mapping[torch.fx.Node, torch.Tensor],
 ):
+    """Return concrete constant data for a constant argument."""
     if isinstance(arg, (tuple, list)):
         return (get_data(x, exported_program, const_node_to_tensor) for x in arg)
     elif isinstance(arg, _PRIMITIVE_TYPES):
@@ -115,20 +370,25 @@ def get_data(
 def propagate_constants(
     exported_program: ExportedProgram,
 ) -> OrderedDict[torch.fx.Node, torch.Tensor]:
-    """
-    Propagates constants and returns a dictionary of node to constant tensors of the graph.
+    """Propagate constants and return node-to-constant tensor mappings.
+
+    Quantize ops are cached by tied source tensor identity and quantization
+    parameters. This preserves tied weight sharing through constant propagation:
+    two quantize nodes that quantize the same tied weight with the same
+    quantization parameters reuse the same propagated quantized tensor object.
     """
     const_node_to_tensor = get_constant_placeholder_to_tensor_dict(exported_program)
+    quantized_tensor_cache: dict[QuantizedTensorCacheKey, torch.Tensor] = {}
+
+    dequantize_ops = _get_dequantize_ops()
+    quantize_ops = _get_quantize_ops()
 
     graph_module = exported_program.graph_module
     graph: torch.fx.Graph = graph_module.graph
     for node in graph.nodes:
         if node.op != "call_function":
             continue
-        if node.target in [
-            torch.ops.quantized_decomposed.dequantize_per_channel.default,
-            torch.ops.quantized_decomposed.dequantize_per_tensor.default,
-        ]:
+        if node.target in dequantize_ops:
             continue
         if not has_constant_data(
             [node.args, node.kwargs],
@@ -141,9 +401,27 @@ def propagate_constants(
             (node.args, node.kwargs),
         )
 
-        # propagate constant because all of its args are constant tensors.
+        quantized_tensor_cache_key = None
+        if node.target in quantize_ops:
+            quantized_tensor_cache_key = _get_quantized_tensor_cache_key(
+                node, args_data, kwargs_data
+            )
+            if (
+                quantized_tensor_cache_key is not None
+                and quantized_tensor_cache_key in quantized_tensor_cache
+            ):
+                const_node_to_tensor[node] = quantized_tensor_cache[
+                    quantized_tensor_cache_key
+                ]
+                continue
+
+        # Propagate constant because all of its args are constant tensors.
         with torch.no_grad():
             prop_constant_tensor = node.target(*args_data, **kwargs_data)
+
+        if quantized_tensor_cache_key is not None:
+            quantized_tensor_cache[quantized_tensor_cache_key] = prop_constant_tensor
+
         const_node_to_tensor[node] = prop_constant_tensor
 
     return const_node_to_tensor
@@ -153,13 +431,10 @@ def erase_constant_node(
     exported_program: ExportedProgram,
     node: torch.fx.Node,
 ) -> None:
-    """
-    Remove corresponding tensor from param/constants dict.
+    """Remove the corresponding tensor from parameter or constant dictionaries.
 
-    Q) Isn't it necessary to remove a node from `inputs_to_parameters`, `inputs_to_lifted_tensor_constants`
-      and `inputs_to_buffers` as well? Why do they just call `get`?
-    A) They internally uses `exported_program.graph_signature.input_specs` and the `input_specs` are updated
-      at the end of the const_prop_pass.
+    The input signature maps do not need to be updated here because the final
+    input specs are rebuilt at the end of this pass.
     """
     signature = exported_program.graph_signature
     if name := signature.inputs_to_parameters.get(node.name, None):
@@ -178,10 +453,15 @@ def create_constant_placeholder(
     const_node_to_tensor: Mapping[torch.fx.Node, torch.Tensor],
     exported_program: ExportedProgram,
 ) -> List[torch.fx.Node]:
-    """
-    This function creates constant placeholder nodes according to the given constant nodes (`const_node_to_tensor`) and replace it with the original node.
+    """Create constant placeholder nodes for propagated constant tensors.
+
+    If multiple propagated nodes share the same tensor object, only one
+    placeholder is created and the other nodes are replaced by that placeholder.
+    This is used for tied weights whose quantize ops are cached by
+    `propagate_constants`.
     """
     placeholders = []
+    tensor_id_to_placeholder: dict[int, torch.fx.Node] = {}
 
     fake_mode = get_fake_mode(exported_program)
     first_user_input = get_first_user_input(exported_program)
@@ -200,6 +480,13 @@ def create_constant_placeholder(
             continue
 
         if node.op == "placeholder":
+            continue
+
+        tensor_id = id(prop_constant_tensor)
+        if tensor_id in tensor_id_to_placeholder:
+            const_placeholder_node = tensor_id_to_placeholder[tensor_id]
+            node.replace_all_uses_with(const_placeholder_node, propagate_meta=False)
+            exported_program.graph.erase_node(node)
             continue
 
         # Add `prop_constant_tensor` to program.state_dict.
@@ -226,6 +513,7 @@ def create_constant_placeholder(
         )
         const_placeholder_node.meta["val"].constant = prop_constant_tensor
 
+        tensor_id_to_placeholder[tensor_id] = const_placeholder_node
         placeholders.append(const_placeholder_node)
 
     return placeholders
@@ -234,6 +522,7 @@ def create_constant_placeholder(
 def create_input_specs(
     placeholders: List[torch.fx.Node],
 ) -> dict[str, InputSpec]:
+    """Create input specs for newly created constant placeholders."""
     name_to_spec: dict[str, InputSpec] = {}
 
     # https://pytorch.org/docs/stable/export.ir_spec.html#placeholder
@@ -247,12 +536,11 @@ def create_input_specs(
 @trace_graph_diff_on_pass
 @trace_const_diff_on_pass
 class ConstPropPass(PassBase):
-    """
-    Performs constant folding and constant propagation.
+    """Perform constant folding and constant propagation.
 
-    NOTE The exported program gurantees that parameters, buffers, and constant tensors are lifted out of the graph as inputs.
-    It means that the pass need to update input specs after folding the constant nodes.
-    # ref: https://pytorch.org/docs/stable/export.html#torch.export.ExportGraphSignature
+    The exported program guarantees that parameters, buffers, and constant
+    tensors are lifted out of the graph as inputs. Therefore, this pass updates
+    input specs after folding constant nodes.
 
     [WHAT IT DOES]
     [1] Propagate the constants.

--- a/tico/quantization/passes/remove_weight_dequant_op.py
+++ b/tico/quantization/passes/remove_weight_dequant_op.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import Any, List, Optional, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import torch.fx
@@ -36,7 +36,42 @@ from tico.utils.validate_args_kwargs import (
 )
 
 
+def _get_quantized_decomposed_default_op(op_name: str) -> Any | None:
+    """Return a quantized_decomposed default op if it is registered.
+
+    Quantized decomposed ops may not be registered when this module is imported.
+    Therefore, all access to torch.ops.quantized_decomposed must be lazy.
+    """
+    try:
+        namespace = torch.ops.quantized_decomposed
+    except AttributeError:
+        return None
+
+    try:
+        overload_packet = getattr(namespace, op_name)
+    except AttributeError:
+        return None
+
+    try:
+        return overload_packet.default
+    except AttributeError:
+        return None
+
+
+def _get_dequantize_ops() -> tuple[Any, ...]:
+    """Return registered quantized_decomposed dequantize ops."""
+    return tuple(
+        op
+        for op in (
+            _get_quantized_decomposed_default_op("dequantize_per_channel"),
+            _get_quantized_decomposed_default_op("dequantize_per_tensor"),
+        )
+        if op is not None
+    )
+
+
 def get_constant(exported_program: ExportedProgram, node: torch.fx.Node):
+    """Return constant tensor data represented by a placeholder node."""
     assert isinstance(node, torch.fx.Node)
     if node.name in exported_program.constants:
         return exported_program.constants[node.name]
@@ -49,6 +84,8 @@ def get_constant(exported_program: ExportedProgram, node: torch.fx.Node):
 
 
 class ValRange:
+    """Represent the minimum and maximum values of tensor or list data."""
+
     def __init__(self, val: Union[torch.Tensor, List[int]]):
         if isinstance(val, torch.Tensor):
             self.max = torch.max(val).item()
@@ -60,11 +97,12 @@ class ValRange:
             raise RuntimeError("Wrong dtype (val)")
 
     def within(self, min_val, max_val):
+        """Return whether the represented range is within the given bounds."""
         return self.min >= min_val and self.max <= max_val
 
 
-# Infer dtype using weight, zero point, and dtype
 def infer_dtype(weight: torch.Tensor, zerop: List[int], dtype: torch.dtype) -> str:
+    """Infer quantization dtype using weight values, zero points, and dtype."""
     weight_val = ValRange(weight)
     zp_val = ValRange(zerop)
 
@@ -74,17 +112,121 @@ def infer_dtype(weight: torch.Tensor, zerop: List[int], dtype: torch.dtype) -> s
         return to_qparam_dtype(dtype)
 
 
+def _same_optional_float_list(
+    lhs: Optional[List[float]],
+    rhs: Optional[List[float]],
+) -> bool:
+    """Return whether two optional float lists have identical values."""
+    if lhs is None or rhs is None:
+        return lhs is rhs
+
+    if len(lhs) != len(rhs):
+        return False
+
+    return all(l == r for l, r in zip(lhs, rhs))
+
+
+def _same_optional_int_list(
+    lhs: Optional[List[int]],
+    rhs: Optional[List[int]],
+) -> bool:
+    """Return whether two optional integer lists have identical values."""
+    if lhs is None or rhs is None:
+        return lhs is rhs
+
+    if len(lhs) != len(rhs):
+        return False
+
+    return all(l == r for l, r in zip(lhs, rhs))
+
+
+def _same_quant_param(lhs: QuantParam, rhs: QuantParam) -> bool:
+    """Return whether two quantization parameter objects are equivalent."""
+    return (
+        _same_optional_float_list(lhs.scale, rhs.scale)
+        and _same_optional_int_list(lhs.zero_point, rhs.zero_point)
+        and lhs.quantized_dimension == rhs.quantized_dimension
+        and _same_optional_float_list(lhs.min, rhs.min)
+        and _same_optional_float_list(lhs.max, rhs.max)
+        and lhs.dtype == rhs.dtype
+    )
+
+
+def _extract_dequantize_args(
+    dq: torch.fx.Node,
+) -> Optional[DequantizePerChannelArgs | DequantizePerTensorArgs]:
+    """Extract typed arguments from a dequantize node."""
+    dequantize_per_channel = _get_quantized_decomposed_default_op(
+        "dequantize_per_channel"
+    )
+    dequantize_per_tensor = _get_quantized_decomposed_default_op(
+        "dequantize_per_tensor"
+    )
+
+    if dequantize_per_channel is not None and dq.target == dequantize_per_channel:
+        return DequantizePerChannelArgs(*dq.args, **dq.kwargs)
+
+    if dequantize_per_tensor is not None and dq.target == dequantize_per_tensor:
+        return DequantizePerTensorArgs(*dq.args, **dq.kwargs)
+
+    return None
+
+
+def _build_quant_param(
+    exported_program: ExportedProgram,
+    dq: torch.fx.Node,
+    dq_args: DequantizePerChannelArgs | DequantizePerTensorArgs,
+    q_weight: torch.fx.Node,
+) -> QuantParam:
+    """Build quantization parameters from a dequantize node."""
+    q_weight_meta = q_weight.meta["val"]
+    assert isinstance(q_weight_meta, FakeTensor)
+    # Weight should have quantized values.
+    assert q_weight_meta.dtype != torch.float
+
+    q_weight_val = get_constant(exported_program, q_weight)
+    assert isinstance(q_weight_val, torch.Tensor)
+
+    quant_param = QuantParam()
+    if isinstance(dq_args, DequantizePerChannelArgs):
+        scales = get_constant(exported_program, dq_args.scales)
+        zero_ps = get_constant(exported_program, dq_args.zero_points)
+
+        # Sometimes users can give fp32 zero point. Let's update dtype here.
+        zero_ps = zero_ps.to(torch.int64)
+        quant_param.scale = scales.tolist()
+        quant_param.zero_point = zero_ps.tolist()
+        assert quant_param.zero_point is not None  # To avoid mypy error
+        quant_param.quantized_dimension = dq_args.axis
+        quant_param.dtype = infer_dtype(
+            q_weight_val, quant_param.zero_point, q_weight_meta.dtype
+        )
+    elif isinstance(dq_args, DequantizePerTensorArgs):
+        quant_param.scale = [dq_args.scale]
+        quant_param.zero_point = [dq_args.zero_point]
+        assert quant_param.zero_point is not None  # To avoid mypy error
+        quant_param.dtype = infer_dtype(
+            q_weight_val, quant_param.zero_point, q_weight_meta.dtype
+        )
+    else:
+        raise RuntimeError(f"Invalid DQ target: {dq.target}")
+
+    return quant_param
+
+
 @trace_graph_diff_on_pass
 class RemoveWeightDequantOp(PassBase):
-    """
-    This pass identifies and removes any remaining Dequantize ops associated with
-     quantized weights.
+    """Remove dequantize ops associated with quantized weights.
 
-    Since weights already quantized earlier (and possibly kept in float by
-     attaching a DQ), the final stage of the quantization pipeline typically
-    does not require those DQ ops anymore.
+    Since weights are already quantized earlier, the final stage of the
+    quantization pipeline typically does not require weight dequantize ops.
 
-    NOTE Removing 'DQ' causes a sementic change: f32 -> quantized
+    If tied weights share a single quantized placeholder, multiple dequantize
+    nodes can point to the same placeholder. In that case, the first dequantize
+    node attaches quantization metadata to the weight, and later dequantize
+    nodes are removed after verifying that their quantization parameters match.
+
+    NOTE Removing a DQ causes a semantic change: f32 -> quantized.
 
     [BEFORE]
       W (quantized) - Dequantize (float)
@@ -101,69 +243,42 @@ class RemoveWeightDequantOp(PassBase):
 
         graph_module = exported_program.graph_module
         graph: torch.fx.Graph = graph_module.graph
+        dequantize_ops = _get_dequantize_ops()
+
         for dq in graph.nodes:
             if not dq.op == "call_function":
                 continue
 
-            if dq.target not in [
-                torch.ops.quantized_decomposed.dequantize_per_channel.default,
-                torch.ops.quantized_decomposed.dequantize_per_tensor.default,
-            ]:
+            if dq.target not in dequantize_ops:
                 continue
-            dq_args: Optional[DequantizePerChannelArgs | DequantizePerTensorArgs] = None
 
-            if (
-                dq.target
-                == torch.ops.quantized_decomposed.dequantize_per_channel.default
-            ):
-                dq_args = DequantizePerChannelArgs(*dq.args, **dq.kwargs)
-            elif (
-                dq.target
-                == torch.ops.quantized_decomposed.dequantize_per_tensor.default
-            ):
-                dq_args = DequantizePerTensorArgs(*dq.args, **dq.kwargs)
-            else:
+            dq_args = _extract_dequantize_args(dq)
+            if dq_args is None:
                 raise RuntimeError(f"Invalid DQ target: {dq.target}")
 
             q_weight = dq_args.input
-            # All weights are placehoders.
+            # All weights are placeholders.
             if q_weight.op != "placeholder":
                 continue
-            # Check if DQ already has quant param because DQ can be shared.
+
+            quant_param = _build_quant_param(exported_program, dq, dq_args, q_weight)
+
             if QPARAM_KEY in q_weight.meta:
+                existing_quant_param = q_weight.meta[QPARAM_KEY]
+                if not isinstance(existing_quant_param, QuantParam):
+                    raise RuntimeError(
+                        f"{q_weight.name} has invalid quantization metadata."
+                    )
+
+                if not _same_quant_param(existing_quant_param, quant_param):
+                    raise RuntimeError(
+                        f"{dq.name} cannot be removed because {q_weight.name} "
+                        "is already annotated with different quantization parameters."
+                    )
+
+                dq.replace_all_uses_with(q_weight, propagate_meta=False)
+                logger.debug(f"{dq.name} is removed.")
                 continue
-
-            q_weight_meta = q_weight.meta["val"]
-            assert isinstance(q_weight_meta, FakeTensor)
-            # Weight should have quantized values.
-            assert q_weight_meta.dtype != torch.float
-
-            q_weight_val = get_constant(exported_program, q_weight)
-            assert isinstance(q_weight_val, torch.Tensor)
-
-            quant_param = QuantParam()
-            if isinstance(dq_args, DequantizePerChannelArgs):
-                scales = get_constant(exported_program, dq_args.scales)
-                zero_ps = get_constant(exported_program, dq_args.zero_points)
-
-                # Sometimes users can give fp32 zero point. Let's update dtype here.
-                zero_ps = zero_ps.to(torch.int64)
-                quant_param.scale = scales.tolist()
-                quant_param.zero_point = zero_ps.tolist()
-                assert quant_param.zero_point is not None  # To avoid mypy error
-                quant_param.quantized_dimension = dq_args.axis
-                quant_param.dtype = infer_dtype(
-                    q_weight_val, quant_param.zero_point, q_weight_meta.dtype
-                )
-            elif isinstance(dq_args, DequantizePerTensorArgs):
-                quant_param.scale = [dq_args.scale]
-                quant_param.zero_point = [dq_args.zero_point]
-                assert quant_param.zero_point is not None  # To avoid mypy error
-                quant_param.dtype = infer_dtype(
-                    q_weight_val, quant_param.zero_point, q_weight_meta.dtype
-                )
-            else:
-                raise RuntimeError(f"Invalid DQ target: {dq.target}")
 
             q_weight.meta[QPARAM_KEY] = quant_param
             dq.replace_all_uses_with(q_weight, propagate_meta=False)

--- a/tico/quantization/wrapq/examples/nn/quantize_tied_embedding.py
+++ b/tico/quantization/wrapq/examples/nn/quantize_tied_embedding.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+PTQ export smoke test for tied embedding weights.
+
+This script builds a tiny language-model-like module whose token embedding
+weight and LM-head weight are tied. It then quantizes both modules with TICO
+WrapQ, exports the quantized model through tico.convert(), and checks that the
+serialized Circle model has only one data-backed tensor for the tied weight
+shape.
+"""
+
+import argparse
+import copy
+import os
+import pathlib
+from typing import Any, Sequence
+
+import torch
+import torch.nn as nn
+from circle_schema import circle
+
+import tico
+from tico.quantization import convert as qconvert, prepare
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.nn.quant_embedding import QuantEmbedding
+from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
+from tico.utils.utils import SuppressWarning
+
+
+class TiedEmbeddingLM(nn.Module):
+    """A tiny model with tied token embedding and LM-head weights."""
+
+    def __init__(self, vocab_size: int = 16, hidden_size: int = 8) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, hidden_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+
+        # This is the same pattern used by many language models.
+        self.lm_head.weight = self.embed.weight
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Run embedding lookup followed by the tied LM head."""
+        hidden = self.embed(token_ids)
+        return self.lm_head(hidden)
+
+
+def _unwrap_weight(module: nn.Module) -> torch.Tensor:
+    """Return the wrapped floating-point module weight when WrapQ is applied."""
+    if hasattr(module, "wrapped") and hasattr(module.wrapped, "module"):
+        return module.wrapped.module.weight
+    return module.weight  # type: ignore[attr-defined]
+
+
+def _assert_tied_weight(model: TiedEmbeddingLM, stage: str) -> None:
+    """Assert that embedding and LM-head weights share the same tensor storage."""
+    embed_weight = _unwrap_weight(model.embed)
+    lm_head_weight = _unwrap_weight(model.lm_head)
+
+    assert (
+        embed_weight is lm_head_weight
+    ), f"{stage}: embedding and LM-head do not reference the same Parameter object."
+    assert (
+        embed_weight.data_ptr() == lm_head_weight.data_ptr()
+    ), f"{stage}: embedding and LM-head do not share the same data_ptr."
+
+    print(
+        f"[OK] {stage}: tied weight data_ptr={embed_weight.data_ptr()}, "
+        f"shape={tuple(embed_weight.shape)}"
+    )
+
+
+def _storage_key(tensor: torch.Tensor) -> tuple[Any, ...]:
+    """Return a storage-identity key for debug printing."""
+    return (
+        str(tensor.device),
+        tensor.data_ptr(),
+        tensor.storage_offset(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.layout,
+    )
+
+
+def _print_exported_weight_placeholders(
+    exported_program: torch.export.ExportedProgram,
+) -> None:
+    """Print exported placeholders that point to module weights."""
+    print("\n[ExportedProgram parameter placeholders]")
+
+    found = False
+    for (
+        placeholder_name,
+        param_name,
+    ) in exported_program.graph_signature.inputs_to_parameters.items():
+        if not param_name.endswith("module.weight"):
+            continue
+
+        tensor = exported_program.state_dict[param_name]
+        if not isinstance(tensor, torch.Tensor):
+            continue
+
+        found = True
+        print(
+            f"  {placeholder_name:<32s} -> {param_name:<40s} "
+            f"data_ptr={tensor.data_ptr()} shape={tuple(tensor.shape)}"
+        )
+
+    if not found:
+        print("  No module.weight placeholders were found.")
+
+
+def _circle_tensor_shape(tensor) -> list[int]:
+    """Return a Circle tensor shape as a Python list."""
+    return [tensor.Shape(i) for i in range(tensor.ShapeLength())]
+
+
+def _circle_tensor_name(tensor) -> str:
+    """Return a Circle tensor name as a Python string."""
+    raw_name = tensor.Name()
+    if raw_name is None:
+        return ""
+    return raw_name.decode("utf-8")
+
+
+def _circle_data_tensors_with_shape(
+    circle_binary: bytes,
+    shape: Sequence[int],
+) -> list[tuple[int, str, int, int, int]]:
+    """Return data-backed Circle tensors with the requested shape.
+
+    Each tuple is:
+        tensor_id, tensor_name, buffer_id, buffer_data_size, tensor_type
+    """
+    model = circle.Model.Model.GetRootAsModel(bytearray(circle_binary), 0)
+    subgraph = model.Subgraphs(0)
+
+    matched = []
+    expected_shape = list(shape)
+
+    for tensor_id in range(subgraph.TensorsLength()):
+        tensor = subgraph.Tensors(tensor_id)
+        tensor_shape = _circle_tensor_shape(tensor)
+        if tensor_shape != expected_shape:
+            continue
+
+        buffer_id = tensor.Buffer()
+        buffer = model.Buffers(buffer_id)
+        buffer_data_size = buffer.DataLength()
+
+        if buffer_data_size == 0:
+            continue
+
+        matched.append(
+            (
+                tensor_id,
+                _circle_tensor_name(tensor),
+                buffer_id,
+                buffer_data_size,
+                tensor.Type(),
+            )
+        )
+
+    return matched
+
+
+def _quantize_model(model: TiedEmbeddingLM) -> TiedEmbeddingLM:
+    """Apply WrapQ PTQ to the embedding and LM-head modules."""
+    qcfg = PTQConfig()
+
+    model.embed = prepare(model.embed, qcfg)  # type: ignore[assignment]
+    model.lm_head = prepare(model.lm_head, qcfg)  # type: ignore[assignment]
+
+    assert isinstance(model.embed.wrapped, QuantEmbedding)  # type: ignore[attr-defined]
+    assert isinstance(model.lm_head.wrapped, QuantLinear)  # type: ignore[attr-defined]
+
+    _assert_tied_weight(model, "after prepare()")
+
+    return model
+
+
+def _calibrate(
+    model: TiedEmbeddingLM, vocab_size: int, batch: int, seq: int, iters: int
+):
+    """Run a small calibration loop."""
+    model.eval()
+
+    with torch.no_grad():
+        for _ in range(iters):
+            token_ids = torch.randint(0, vocab_size, (batch, seq), dtype=torch.long)
+            _ = model(token_ids)
+
+
+def _freeze_quantized_model(model: TiedEmbeddingLM) -> TiedEmbeddingLM:
+    """Freeze WrapQ observers and switch modules to quantized simulation mode."""
+    model.embed = qconvert(model.embed)  # type: ignore[assignment]
+    model.lm_head = qconvert(model.lm_head)  # type: ignore[assignment]
+
+    assert model.embed._mode is Mode.QUANT  # type: ignore[attr-defined]
+    assert model.lm_head._mode is Mode.QUANT  # type: ignore[attr-defined]
+
+    _assert_tied_weight(model, "after quantization convert()")
+
+    return model
+
+
+def main() -> None:
+    """Run the tied-weight quantization and Circle export smoke test."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--vocab-size", type=int, default=16)
+    parser.add_argument("--hidden-size", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=5)
+    parser.add_argument("--calib-iters", type=int, default=16)
+    parser.add_argument(
+        "--save-path",
+        type=pathlib.Path,
+        default=pathlib.Path("tied_embedding_lm.q.circle"),
+    )
+    parser.add_argument(
+        "--dump-graphs",
+        action="store_true",
+        help="Set TICO_GRAPH_DUMP=1 before running tico.convert().",
+    )
+    parser.add_argument(
+        "--skip-circle-sharing-check",
+        action="store_true",
+        help="Skip the final Circle tensor sharing assertion.",
+    )
+    args = parser.parse_args()
+
+    if args.dump_graphs:
+        os.environ["TICO_GRAPH_DUMP"] = "1"
+
+    torch.manual_seed(2026)
+
+    model = TiedEmbeddingLM(
+        vocab_size=args.vocab_size,
+        hidden_size=args.hidden_size,
+    ).eval()
+    fp32_ref = copy.deepcopy(model).eval()
+
+    _assert_tied_weight(model, "initial model")
+    _assert_tied_weight(fp32_ref, "FP32 reference")
+
+    model = _quantize_model(model)
+    _calibrate(
+        model,
+        vocab_size=args.vocab_size,
+        batch=args.batch_size,
+        seq=args.seq_len,
+        iters=args.calib_iters,
+    )
+    model = _freeze_quantized_model(model)
+
+    check_tokens = torch.randint(
+        0,
+        args.vocab_size,
+        (args.batch_size, args.seq_len),
+        dtype=torch.long,
+    )
+
+    with torch.no_grad():
+        fp32_out = fp32_ref(check_tokens)
+        quant_out = model(check_tokens)
+
+    print("\n[Quantization sanity check]")
+    print(f"  Mean |diff|: {(quant_out - fp32_out).abs().mean().item():.6f}")
+
+    # Export once directly with torch.export so the placeholder sharing state is
+    # easy to inspect before the full TICO conversion pipeline runs.
+    with torch.no_grad():
+        exported_program = torch.export.export(model, (check_tokens,))
+
+    _print_exported_weight_placeholders(exported_program)
+
+    embed_weight = _unwrap_weight(model.embed)
+    lm_head_weight = _unwrap_weight(model.lm_head)
+    print("\n[Tied weight storage keys]")
+    print(f"  embedding: {_storage_key(embed_weight)}")
+    print(f"  lm_head  : {_storage_key(lm_head_weight)}")
+
+    # Run the full TICO conversion. This is the path that exercises:
+    #   ConstPropPass -> FoldQuantOps -> RemoveWeightDequantOp -> serializer
+    with SuppressWarning(UserWarning, ".*"):
+        circle_model = tico.convert(model, (check_tokens,))
+
+    circle_model.save(args.save_path)
+    print(f"\n[OK] Quantized Circle model saved to {args.save_path.resolve()}")
+
+    tied_weight_shape = [args.vocab_size, args.hidden_size]
+    matched_tensors = _circle_data_tensors_with_shape(
+        circle_model.circle_binary,
+        tied_weight_shape,
+    )
+
+    print("\n[Circle data-backed tensors with tied weight shape]")
+    print(f"  expected shape: {tied_weight_shape}")
+    for tensor_id, name, buffer_id, buffer_data_size, tensor_type in matched_tensors:
+        print(
+            f"  tensor_id={tensor_id:<4d} buffer_id={buffer_id:<4d} "
+            f"bytes={buffer_data_size:<6d} type={tensor_type:<3d} name={name}"
+        )
+
+    if not args.skip_circle_sharing_check:
+        assert len(matched_tensors) == 1, (
+            "Expected exactly one data-backed Circle tensor for the tied weight "
+            f"shape {tied_weight_shape}, but found {len(matched_tensors)}. "
+            "This usually means tied Q propagation or serializer tensor sharing "
+            "is still broken."
+        )
+        print("\n[OK] Circle export has one shared tied-weight tensor.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/serialize/circle_serializer.py
+++ b/tico/serialize/circle_serializer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import operator
-from typing import Dict
+from typing import Dict, Optional
 
 import flatbuffers
 import torch
@@ -26,6 +26,7 @@ from tico.serialize.operators import *
 from tico.serialize.circle_graph import CircleModel, CircleSubgraph
 from tico.serialize.operators.hashable_opcode import OpCode
 from tico.serialize.operators.node_visitor import get_node_visitors
+from tico.serialize.quant_param import QPARAM_KEY
 from tico.utils import logging
 from tico.utils.serialize import finalise_tensor_names, validate_tensor_shapes
 
@@ -34,6 +35,27 @@ multiple_output_ops = [
     torch.ops.aten.split_with_sizes.default,
     torch.ops.aten.max.dim,
 ]
+
+
+QuantizationAliasKey = tuple[
+    tuple[float, ...] | None,
+    tuple[int, ...] | None,
+    int | None,
+    tuple[float, ...] | None,
+    tuple[float, ...] | None,
+    str,
+]
+TensorAliasKey = tuple[
+    str,
+    int,
+    int,
+    tuple[int, ...],
+    tuple[int, ...],
+    torch.dtype,
+    torch.layout,
+    QuantizationAliasKey | None,
+]
+SharedTensorRegistry = Dict[TensorAliasKey, str]
 
 
 def _initialize_model() -> tuple[CircleModel, CircleSubgraph]:
@@ -133,6 +155,119 @@ def build_circle(
     return bytes(buf)
 
 
+def _get_quantization_alias_key(node: torch.fx.Node) -> QuantizationAliasKey | None:
+    """Return a hashable representation of a node's quantization metadata."""
+    qparam = node.meta.get(QPARAM_KEY)
+    if qparam is None:
+        return None
+
+    return (
+        tuple(qparam.scale) if qparam.scale is not None else None,
+        tuple(qparam.zero_point) if qparam.zero_point is not None else None,
+        qparam.quantized_dimension,
+        tuple(qparam.min) if qparam.min is not None else None,
+        tuple(qparam.max) if qparam.max is not None else None,
+        qparam.dtype,
+    )
+
+
+def _get_tensor_alias_key(
+    tensor: torch.Tensor,
+    node: torch.fx.Node,
+) -> Optional[TensorAliasKey]:
+    """
+    Return a key that identifies shared logical tensor storage.
+
+    The key is based on tensor identity, not tensor contents. This lets tied
+    parameters, such as tied embeddings and LM-head weights, reuse the same
+    Circle tensor while avoiding accidental deduplication of cloned tensors that
+    merely contain equal values.
+    """
+    if tensor.layout != torch.strided:
+        return None
+
+    if tensor.numel() == 0:
+        # Empty tensors often have a zero data pointer, which can cause
+        # unrelated empty tensors to look identical.
+        return None
+
+    try:
+        data_ptr = tensor.data_ptr()
+    except RuntimeError:
+        return None
+
+    if data_ptr == 0:
+        return None
+
+    return (
+        str(tensor.device),
+        data_ptr,
+        tensor.storage_offset(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.layout,
+        _get_quantization_alias_key(node),
+    )
+
+
+def _register_tensor_alias(
+    graph: CircleSubgraph,
+    node: torch.fx.Node,
+    canonical_tensor_name: str,
+) -> None:
+    """Register an FX node name as an alias of an existing Circle tensor."""
+    if canonical_tensor_name not in graph.name_to_tid:
+        raise KeyError(f"{canonical_tensor_name} is not registered.")
+
+    canonical_tid = graph.name_to_tid[canonical_tensor_name]
+    existing_tid = graph.name_to_tid.get(node.name)
+
+    if existing_tid is not None:
+        if existing_tid != canonical_tid:
+            raise ValueError(
+                f"Cannot alias {node.name} to {canonical_tensor_name}: "
+                f"{node.name} is already registered to tensor id {existing_tid}."
+            )
+        return
+
+    graph.name_to_tid[node.name] = canonical_tid
+
+
+def _add_tensor_from_node_with_data_sharing(
+    graph: CircleSubgraph,
+    node: torch.fx.Node,
+    tensor_data: torch.Tensor,
+    shared_tensors: SharedTensorRegistry,
+) -> str | None:
+    """Add a data-backed tensor, reusing a Circle tensor for shared storage.
+
+    Args:
+        graph: CircleSubgraph to add tensor to
+        node: The FX node that represents the tensor
+        tensor_data: Tensor data associated with the node
+        shared_tensors: Mapping from tensor identity keys to Circle tensor names
+
+    Returns:
+        The reused Circle tensor name when the node is registered as an alias.
+        Returns None when a new Circle tensor is created.
+    """
+    alias_key = _get_tensor_alias_key(tensor_data, node)
+
+    if alias_key is not None and alias_key in shared_tensors:
+        canonical_tensor_name = shared_tensors[alias_key]
+        _register_tensor_alias(graph, node, canonical_tensor_name)
+        return canonical_tensor_name
+
+    tensor_value = tensor_data.detach().cpu().numpy()
+    graph.add_tensor_from_node(node, tensor_value)
+
+    if alias_key is not None:
+        shared_tensors[alias_key] = graph.tensors[-1].name
+
+    return None
+
+
 def _export_tensors(graph: CircleSubgraph, ep: ExportedProgram) -> None:
     """Export all tensors from the exported program to the circle graph.
 
@@ -143,6 +278,7 @@ def _export_tensors(graph: CircleSubgraph, ep: ExportedProgram) -> None:
     logger = logging.getLogger(__name__)
     logger.debug("---------------Export tensors--------------")
     buf_name_to_data = {name: buf for name, buf in ep.named_buffers()}
+    shared_tensors: SharedTensorRegistry = {}
 
     for node in ep.graph.nodes:
         if node.op == "call_function":
@@ -157,7 +293,7 @@ def _export_tensors(graph: CircleSubgraph, ep: ExportedProgram) -> None:
             logger.debug(f"call_function: {node.name} tensor exported.")
 
         elif node.op == "placeholder":
-            _handle_placeholder_node(graph, node, ep, buf_name_to_data)
+            _handle_placeholder_node(graph, node, ep, buf_name_to_data, shared_tensors)
 
         elif node.op == "get_attr":
             _handle_get_attr_node(graph, node)
@@ -183,17 +319,18 @@ def _handle_placeholder_node(
     node: torch.fx.Node,
     ep: ExportedProgram,
     buf_name_to_data: dict,
+    shared_tensors: SharedTensorRegistry,
 ) -> None:
     """Handle a placeholder node during tensor export."""
     # placeholder invariants
     assert node.args is None or len(node.args) == 0  # Not support default param
 
     if node.name in ep.graph_signature.inputs_to_parameters:
-        _handle_parameter_node(graph, node, ep)
+        _handle_parameter_node(graph, node, ep, shared_tensors)
     elif node.name in ep.graph_signature.inputs_to_buffers:
-        _handle_buffer_node(graph, node, ep, buf_name_to_data)
+        _handle_buffer_node(graph, node, ep, buf_name_to_data, shared_tensors)
     elif node.name in ep.graph_signature.inputs_to_lifted_tensor_constants:
-        _handle_constant_tensor_node(graph, node, ep)
+        _handle_constant_tensor_node(graph, node, ep, shared_tensors)
     else:
         _handle_user_input_node(graph, node, ep)
 
@@ -202,6 +339,7 @@ def _handle_parameter_node(
     graph: CircleSubgraph,
     node: torch.fx.Node,
     ep: ExportedProgram,
+    shared_tensors: SharedTensorRegistry,
 ) -> None:
     """Handle a parameter placeholder node by exporting its tensor data.
 
@@ -209,6 +347,7 @@ def _handle_parameter_node(
         graph: CircleSubgraph to add tensor to
         node: The parameter node to process
         ep: ExportedProgram containing parameter data
+        shared_tensors: Mapping used to reuse Circle tensors for shared data
     """
     param_name = ep.graph_signature.inputs_to_parameters[node.name]
     param_data = ep.state_dict[param_name]
@@ -216,11 +355,17 @@ def _handle_parameter_node(
     if not isinstance(param_data, torch.Tensor):
         raise ValueError(f"Parameter {param_name} is not a tensor")
 
-    tensor_value = param_data.cpu().detach().numpy()
-    graph.add_tensor_from_node(node, tensor_value)
+    reused_tensor_name = _add_tensor_from_node_with_data_sharing(
+        graph, node, param_data, shared_tensors
+    )
 
     logger = logging.getLogger(__name__)
-    logger.debug(f"Exported parameter tensor: {node.name}")
+    if reused_tensor_name is None:
+        logger.debug(f"Exported parameter tensor: {node.name}")
+    else:
+        logger.debug(
+            f"Reused shared parameter tensor: {node.name} -> {reused_tensor_name}"
+        )
 
 
 def _handle_buffer_node(
@@ -228,6 +373,7 @@ def _handle_buffer_node(
     node: torch.fx.Node,
     ep: ExportedProgram,
     buf_name_to_data: dict,
+    shared_tensors: SharedTensorRegistry,
 ) -> None:
     """Handle a buffer placeholder node by exporting its tensor data.
 
@@ -236,6 +382,7 @@ def _handle_buffer_node(
         node: The buffer node to process
         ep: ExportedProgram containing buffer info
         buf_name_to_data: Mapping of buffer names to data
+        shared_tensors: Mapping used to reuse Circle tensors for shared data
     """
     buffer_name = ep.graph_signature.inputs_to_buffers[node.name]
 
@@ -247,17 +394,24 @@ def _handle_buffer_node(
     if not isinstance(buffer_data, torch.Tensor):
         raise ValueError(f"Buffer {buffer_name} is not a tensor")
 
-    tensor_value = buffer_data.cpu().detach().numpy()
-    graph.add_tensor_from_node(node, tensor_value)
+    reused_tensor_name = _add_tensor_from_node_with_data_sharing(
+        graph, node, buffer_data, shared_tensors
+    )
 
     logger = logging.getLogger(__name__)
-    logger.debug(f"Exported buffer tensor: {node.name}")
+    if reused_tensor_name is None:
+        logger.debug(f"Exported buffer tensor: {node.name}")
+    else:
+        logger.debug(
+            f"Reused shared buffer tensor: {node.name} -> {reused_tensor_name}"
+        )
 
 
 def _handle_constant_tensor_node(
     graph: CircleSubgraph,
     node: torch.fx.Node,
     ep: ExportedProgram,
+    shared_tensors: SharedTensorRegistry,
 ) -> None:
     """Handle a constant tensor placeholder node by exporting its tensor data.
 
@@ -265,6 +419,7 @@ def _handle_constant_tensor_node(
         graph: CircleSubgraph to add tensor to
         node: The constant tensor node to process
         ep: ExportedProgram containing constant data
+        shared_tensors: Mapping used to reuse Circle tensors for shared data
     """
     ctensor_name = ep.graph_signature.inputs_to_lifted_tensor_constants[node.name]
 
@@ -276,11 +431,17 @@ def _handle_constant_tensor_node(
     if not isinstance(ctensor_data, torch.Tensor):
         raise ValueError(f"Constant tensor {ctensor_name} is not a tensor")
 
-    tensor_value = ctensor_data.cpu().detach().numpy()
-    graph.add_tensor_from_node(node, tensor_value)
+    reused_tensor_name = _add_tensor_from_node_with_data_sharing(
+        graph, node, ctensor_data, shared_tensors
+    )
 
     logger = logging.getLogger(__name__)
-    logger.debug(f"Exported constant tensor: {node.name}")
+    if reused_tensor_name is None:
+        logger.debug(f"Exported constant tensor: {node.name}")
+    else:
+        logger.debug(
+            f"Reused shared constant tensor: {node.name} -> {reused_tensor_name}"
+        )
 
 
 def _handle_user_input_node(


### PR DESCRIPTION
This comit supports exporting shared weight.

```bash
python tico/quantization/wrapq/examples/nn/quantize_tied_embedding.py
[OK] initial model: tied weight data_ptr=94343401886528, shape=(16, 8)
[OK] FP32 reference: tied weight data_ptr=94343401909056, shape=(16, 8)
[OK] after prepare(): tied weight data_ptr=94343401886528, shape=(16, 8)
[OK] after quantization convert(): tied weight data_ptr=94343401886528, shape=(16, 8)

[Quantization sanity check]
  Mean |diff|: 0.024324

[ExportedProgram parameter placeholders]
  p_embed_wrapped_module_weight    -> lm_head.wrapped.module.weight            data_ptr=94343401886528 shape=(16, 8)

[Tied weight storage keys]
  embedding: ('cpu', 94343401886528, 0, (16, 8), (8, 1), torch.float32, torch.strided)
  lm_head  : ('cpu', 94343401886528, 0, (16, 8), (8, 1), torch.float32, torch.strided)
[QuantCheck] WARNING: 1 nodes without qparam detected (see logs).

[OK] Quantized Circle model saved to /home/seongwoo/TICO/tied_embedding_lm.q.circle

[Circle data-backed tensors with tied weight shape]
  expected shape: [16, 8]
  tensor_id=0    buffer_id=1    bytes=128    type=3   name=tico.quantization.wrapq.wrappers.nn.quant_linear.QuantLinear::_prop_tensor_constant10

[OK] Circle export has one shared tied-weight tensor.
```

Related: #696
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>