### PR TITLE
[quantization] Increase precision

### DIFF
--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -294,7 +294,8 @@ class GPTQ:
                 inp.shape[0] * inp.shape[1], inp.shape[2] * inp.shape[3]
             ).T  # inp.shape =(C_in * krn_size[0] * krn_size[1] * krn_size[2], N * num_patches)
 
-        self.H += inp.double().matmul(inp.double().t()).float().to(self.H.device)  # type: ignore[union-attr]
+        inp = inp.double()
+        self.H += inp.matmul(inp.t()).to(device=self.H.device, dtype=self.H.dtype)  # type: ignore[union-attr]
 
     def fasterquant(
         self,

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -294,10 +294,7 @@ class GPTQ:
                 inp.shape[0] * inp.shape[1], inp.shape[2] * inp.shape[3]
             ).T  # inp.shape =(C_in * krn_size[0] * krn_size[1] * krn_size[2], N * num_patches)
 
-        self.H *= self.nsamples / (self.nsamples + tmp)
-        self.nsamples += tmp
-        inp = math.sqrt(2 / self.nsamples) * inp.float()
-        self.H += inp.matmul(inp.t()).to(self.H.device)
+        self.H += inp.double().matmul(inp.double().t()).float().to(self.H.device)  # type: ignore[union-attr]
 
     def fasterquant(
         self,
@@ -356,10 +353,10 @@ class GPTQ:
         damp = percdamp * torch.mean(torch.diag(H))
         diag = torch.arange(self.columns, device=self.dev)
         H[diag, diag] += damp
-        H = torch.linalg.cholesky(H)
+        H = torch.linalg.cholesky(H.double()).float()
         assert isinstance(H, torch.Tensor)
-        H = torch.cholesky_inverse(H)
-        H = torch.linalg.cholesky(H, upper=True)
+        H = torch.cholesky_inverse(H.double()).float()
+        H = torch.linalg.cholesky(H.double(), upper=True).float()
         Hinv = H
 
         assert isinstance(Hinv, torch.Tensor)

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -18,7 +18,6 @@
 
 # https://github.com/IST-DASLab/gptq/blob/2d65066/gptq.py
 
-import math
 import time
 from typing import Optional
 
@@ -294,6 +293,7 @@ class GPTQ:
                 inp.shape[0] * inp.shape[1], inp.shape[2] * inp.shape[3]
             ).T  # inp.shape =(C_in * krn_size[0] * krn_size[1] * krn_size[2], N * num_patches)
 
+        self.nsamples += tmp
         inp = inp.double()
         self.H += inp.matmul(inp.t()).to(device=self.H.device, dtype=self.H.dtype)  # type: ignore[union-attr]
 
@@ -351,13 +351,14 @@ class GPTQ:
         Losses = torch.zeros_like(W)
         Q = torch.zeros_like(W)
 
+        H = H.double()
         damp = percdamp * torch.mean(torch.diag(H))
         diag = torch.arange(self.columns, device=self.dev)
         H[diag, diag] += damp
-        H = torch.linalg.cholesky(H.double()).float()
+        H = torch.linalg.cholesky(H)
         assert isinstance(H, torch.Tensor)
-        H = torch.cholesky_inverse(H.double()).float()
-        H = torch.linalg.cholesky(H.double(), upper=True).float()
+        H = torch.cholesky_inverse(H)
+        H = torch.linalg.cholesky(H, upper=True).float()
         Hinv = H
 
         assert isinstance(Hinv, torch.Tensor)


### PR DESCRIPTION
This PR increases precision for GPTQ quantization:
1. replaces moving average in Hessian with just a sum
2. increases precision to double in Cholesky and its inversion to improve reproducibility.

Draft: https://github.com/Samsung/TICO/pull/670
Related: https://github.com/Samsung/TICO/issues/656

GPTQ quantization for `HuggingFaceTB/SmolLM2-135M-Instruct` provides the same 

```

┌── Wikitext-2 test perplexity ─────────────
│ int16 :    22.95
└───────────────────────────────────────────
```
ppl as in https://github.com/Samsung/TICO/pull/702#issue-4437609355

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>