### PR TITLE
[quantization] Add `gptq_percdamp`

### DIFF
--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -285,6 +285,13 @@ def parse_args():
         default=False,
         help="Run inputs for the next layer on original model to stabilize GPTQ",
     )
+    parser.add_argument(
+        "--gptq_percdamp",
+        type=float,
+        default=0.01,
+        help="Dampening parameter to be used in GPTQ. It helps to avoid degenerate,"
+        "ill-conditioned matrices and serve as a tradeoff between GPTQ and ordinary min-max quantizer.",
+    )
     return parser.parse_args()
 
 
@@ -444,6 +451,7 @@ def build_gptq_config(
         sensitivity=sensitivity,
         quantize_lm_head=args.gptq_lm_head,
         use_orig_model_inference=args.gptq_use_orig_model_inference,
+        percdamp=args.gptq_percdamp,
     )
 
 


### PR DESCRIPTION
This PR adds `gptq_percdamp` to example script for probable use in stabilizing GPTQ.

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>