### PR TITLE
[quantization] Support SpinQuant rotation PTQ overrides

### DIFF
--- a/test/quantization/config/test_builders.py
+++ b/test/quantization/config/test_builders.py
@@ -85,6 +85,18 @@ class TestBuilderHelpers(unittest.TestCase):
         )
         self.assertEqual(_build_weight_override(None), {})
 
+    def test_build_weight_override_signed_dtype_uses_symmetric_qscheme(self):
+        override = _build_weight_override(DType.int(16))
+        self.assertEqual(
+            override,
+            {
+                "weight": {
+                    "dtype": DType.int(16),
+                    "qscheme": QScheme.PER_TENSOR_SYMM,
+                }
+            },
+        )
+
     def test_build_norm_override_includes_module_and_weight_qscheme(self):
         override = _build_norm_override(
             norm_dtype=DType.uint(8),
@@ -137,6 +149,7 @@ class TestLlamaOverrideBuilders(unittest.TestCase):
             linear_weight_dtype=DType.uint(8),
             embedding_weight_dtype=DType.uint(4),
             lm_head_weight_dtype=DType.uint(8),
+            spin_rotation_weight_dtype=None,
             norm_dtype=DType.int(16),
             norm_weight_dtype=DType.uint(4),
         )
@@ -152,6 +165,8 @@ class TestLlamaOverrideBuilders(unittest.TestCase):
             overrides["lm_head"]["weight"]["qscheme"],
             QScheme.PER_CHANNEL_ASYMM,
         )
+        self.assertNotIn("rotate_embedding", overrides["model"])
+        self.assertNotIn("rotate_lm_head", overrides)
         self.assertEqual(
             overrides["model"]["norm"]["qscheme"],
             QScheme.PER_TENSOR_SYMM,
@@ -163,12 +178,41 @@ class TestLlamaOverrideBuilders(unittest.TestCase):
             QScheme.PER_CHANNEL_ASYMM,
         )
 
+    def test_build_llama_overrides_with_spin_rotation_weights(self):
+        overrides = _build_llama_overrides(
+            num_hidden_layers=1,
+            linear_weight_dtype=None,
+            embedding_weight_dtype=None,
+            lm_head_weight_dtype=None,
+            spin_rotation_weight_dtype=DType.int(16),
+            norm_dtype=None,
+            norm_weight_dtype=None,
+        )
+
+        self.assertEqual(
+            overrides["model"]["rotate_embedding"]["weight"]["dtype"],
+            DType.int(16),
+        )
+        self.assertEqual(
+            overrides["model"]["rotate_embedding"]["weight"]["qscheme"],
+            QScheme.PER_TENSOR_SYMM,
+        )
+        self.assertEqual(
+            overrides["rotate_lm_head"]["weight"]["dtype"],
+            DType.int(16),
+        )
+        self.assertEqual(
+            overrides["rotate_lm_head"]["weight"]["qscheme"],
+            QScheme.PER_TENSOR_SYMM,
+        )
+
     def test_build_llama_overrides_without_optional_weights(self):
         overrides = _build_llama_overrides(
             num_hidden_layers=1,
             linear_weight_dtype=None,
             embedding_weight_dtype=None,
             lm_head_weight_dtype=None,
+            spin_rotation_weight_dtype=None,
             norm_dtype=None,
             norm_weight_dtype=None,
         )
@@ -177,8 +221,10 @@ class TestLlamaOverrideBuilders(unittest.TestCase):
         self.assertIn("layers", overrides["model"])
         self.assertEqual(len(overrides["model"]["layers"]), 1)
         self.assertNotIn("embed_tokens", overrides["model"])
+        self.assertNotIn("rotate_embedding", overrides["model"])
         self.assertNotIn("norm", overrides["model"])
         self.assertNotIn("lm_head", overrides)
+        self.assertNotIn("rotate_lm_head", overrides)
         self.assertEqual(overrides["model"]["layers"]["0"], {})
 
 
@@ -192,6 +238,7 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
             linear_weight_dtype=DType.uint(8),
             embedding_weight_dtype=DType.uint(4),
             lm_head_weight_dtype=DType.uint(8),
+            spin_rotation_weight_dtype=DType.int(16),
             norm_dtype=DType.int(16),
             norm_weight_dtype=DType.uint(4),
             strict_wrap=False,
@@ -210,6 +257,22 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
         self.assertEqual(
             cfg.overrides["lm_head"]["weight"]["qscheme"],
             QScheme.PER_CHANNEL_ASYMM,
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["rotate_embedding"]["weight"]["dtype"],
+            DType.int(16),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["rotate_embedding"]["weight"]["qscheme"],
+            QScheme.PER_TENSOR_SYMM,
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["dtype"],
+            DType.int(16),
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["qscheme"],
+            QScheme.PER_TENSOR_SYMM,
         )
         self.assertEqual(
             cfg.overrides["model"]["layers"]["1"]["mlp"]["up_proj"]["weight"][
@@ -269,6 +332,31 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
             QScheme.PER_CHANNEL_ASYMM,
         )
 
+    def test_spin_rotation_explicit_dtype_takes_precedence_over_bits(self):
+        cfg = build_llm_ptq_config(
+            model_type="llama",
+            num_hidden_layers=1,
+            spin_rotation_weight_bits=16,
+            spin_rotation_weight_dtype=DType.uint(8),
+        )
+
+        self.assertEqual(
+            cfg.overrides["model"]["rotate_embedding"]["weight"]["dtype"],
+            DType.uint(8),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["rotate_embedding"]["weight"]["qscheme"],
+            QScheme.PER_CHANNEL_ASYMM,
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["dtype"],
+            DType.uint(8),
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["qscheme"],
+            QScheme.PER_CHANNEL_ASYMM,
+        )
+
     def test_build_llm_ptq_config_unsupported_model_type_raises(self):
         with self.assertRaises(NotImplementedError):
             build_llm_ptq_config(
@@ -292,6 +380,7 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
             linear_weight_bits=8,
             embedding_weight_bits=4,
             lm_head_weight_bits=8,
+            spin_rotation_weight_bits=16,
             norm_weight_bits=4,
             norm_dtype=DType.uint(8),
         )
@@ -311,6 +400,22 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
             DType.uint(8),
         )
         self.assertEqual(
+            cfg.overrides["model"]["rotate_embedding"]["weight"]["dtype"],
+            DType.int(16),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["rotate_embedding"]["weight"]["qscheme"],
+            QScheme.PER_TENSOR_SYMM,
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["dtype"],
+            DType.int(16),
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["qscheme"],
+            QScheme.PER_TENSOR_SYMM,
+        )
+        self.assertEqual(
             cfg.overrides["model"]["norm"]["weight"]["dtype"],
             DType.uint(4),
         )
@@ -328,4 +433,6 @@ class TestBuildLlmPtqConfig(unittest.TestCase):
         self.assertEqual(cfg.model_args, {"profile": DEFAULT_EXECUTION_PROFILE})
         self.assertIn("model", cfg.overrides)
         self.assertIn("layers", cfg.overrides["model"])
+        self.assertNotIn("rotate_embedding", cfg.overrides["model"])
+        self.assertNotIn("rotate_lm_head", cfg.overrides)
         self.assertEqual(cfg.overrides["model"]["layers"]["0"], {})

--- a/tico/quantization/config/builders.py
+++ b/tico/quantization/config/builders.py
@@ -257,6 +257,7 @@ def _build_llama_overrides(
     linear_weight_dtype: Optional[DType],
     embedding_weight_dtype: Optional[DType],
     lm_head_weight_dtype: Optional[DType],
+    spin_rotation_weight_dtype: Optional[DType],
     norm_dtype: Optional[DType],
     norm_weight_dtype: Optional[DType],
 ) -> Dict[str, Any]:
@@ -265,12 +266,15 @@ def _build_llama_overrides(
 
     This helper generates overrides for:
       - input embedding: model.embed_tokens
+      - SpinLlama input rotation: model.rotate_embedding
       - all decoder layers: model.layers.{i}
       - final model norm: model.norm
+      - SpinLlama output rotation: rotate_lm_head
       - output projection: lm_head
 
     Modules that are not explicitly overridden continue to use PTQConfig
-    defaults.
+    defaults. SpinLlama rotation overrides are emitted only when
+    `spin_rotation_weight_dtype` is provided.
 
     Parameters
     ----------
@@ -282,6 +286,8 @@ def _build_llama_overrides(
         Weight dtype override for model.embed_tokens.weight.
     lm_head_weight_dtype : Optional[DType]
         Weight dtype override for lm_head.weight.
+    spin_rotation_weight_dtype : Optional[DType]
+        Weight dtype override for SpinLlama rotation weights.
     norm_dtype : Optional[DType]
         Module-level dtype override for norm modules.
     norm_weight_dtype : Optional[DType]
@@ -305,6 +311,13 @@ def _build_llama_overrides(
     lm_head_override = _build_weight_override(lm_head_weight_dtype)
     if lm_head_override:
         overrides["lm_head"] = lm_head_override
+
+    spin_rotation_override = _build_weight_override(spin_rotation_weight_dtype)
+    if spin_rotation_override:
+        _set_nested_override(
+            overrides, ("model", "rotate_embedding"), spin_rotation_override
+        )
+        _set_nested_override(overrides, ("rotate_lm_head",), spin_rotation_override)
 
     final_norm_override = _build_norm_override(
         norm_dtype=norm_dtype,
@@ -336,6 +349,8 @@ def build_llm_ptq_config(
     embedding_weight_dtype: Optional[DType] = None,
     lm_head_weight_bits: Optional[int] = None,
     lm_head_weight_dtype: Optional[DType] = None,
+    spin_rotation_weight_bits: Optional[int] = None,
+    spin_rotation_weight_dtype: Optional[DType] = None,
     norm_dtype: Optional[DType] = None,
     norm_weight_bits: Optional[int] = None,
     norm_weight_dtype: Optional[DType] = None,
@@ -384,6 +399,12 @@ def build_llm_ptq_config(
         Used only when `lm_head_weight_dtype` is not provided.
     lm_head_weight_dtype : Optional[DType], default=None
         Explicit dtype for the LM head weight.
+    spin_rotation_weight_bits : Optional[int], default=None
+        Convenience bit-width for SpinLlama rotation weights:
+        `model.rotate_embedding.weight` and `rotate_lm_head.weight`.
+        Used only when `spin_rotation_weight_dtype` is not provided.
+    spin_rotation_weight_dtype : Optional[DType], default=None
+        Explicit dtype for SpinLlama rotation weights.
     norm_dtype : Optional[DType], default=None
         Explicit module-level dtype override for norm modules.
     norm_weight_bits : Optional[int], default=None
@@ -428,6 +449,10 @@ def build_llm_ptq_config(
         dtype=lm_head_weight_dtype,
         bits=lm_head_weight_bits,
     )
+    resolved_spin_rotation_weight_dtype = _resolve_weight_dtype(
+        dtype=spin_rotation_weight_dtype,
+        bits=spin_rotation_weight_bits,
+    )
     resolved_norm_weight_dtype = _resolve_weight_dtype(
         dtype=norm_weight_dtype,
         bits=norm_weight_bits,
@@ -439,6 +464,7 @@ def build_llm_ptq_config(
             linear_weight_dtype=resolved_linear_weight_dtype,
             embedding_weight_dtype=resolved_embedding_weight_dtype,
             lm_head_weight_dtype=resolved_lm_head_weight_dtype,
+            spin_rotation_weight_dtype=resolved_spin_rotation_weight_dtype,
             norm_dtype=norm_dtype,
             norm_weight_dtype=resolved_norm_weight_dtype,
         )

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -255,6 +255,16 @@ def parse_args():
         help="Number of bits to be used to quantize lm_head",
     )
     parser.add_argument(
+        "--spin_rotation_weight_bits",
+        type=int,
+        default=16,
+        help=(
+            "Number of bits to be used to quantize SpinLlama rotation weights "
+            "created by SpinQuant, namely model.rotate_embedding.weight and "
+            "rotate_lm_head.weight. This option is used only when SpinQuant is enabled."
+        ),
+    )
+    parser.add_argument(
         "--profile",
         choices=list(SUPPORTED_EXECUTION_PROFILES),
         default=DEFAULT_EXECUTION_PROFILE,
@@ -850,6 +860,9 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
         linear_weight_bits=args.linear_weight_bits,
         embedding_weight_bits=args.embedding_weight_bits,
         lm_head_weight_bits=args.lm_head_weight_bits,
+        spin_rotation_weight_bits=(
+            None if args.no_spinquant else args.spin_rotation_weight_bits
+        ),
         norm_weight_dtype=DType.int(16),
         strict_wrap=True,
         profile=args.profile,
@@ -1013,6 +1026,10 @@ def print_config(args, device: torch.device) -> None:
     print(f"Linear weight bits     : {args.linear_weight_bits}")
     print(f"Embedding weight bits  : {args.embedding_weight_bits}")
     print(f"LM head weight bits    : {args.lm_head_weight_bits}")
+    print(
+        "Spin rotation bits     : "
+        f"{args.spin_rotation_weight_bits if not args.no_spinquant else 'disabled'}"
+    )
     print(f"Calibration samples    : {args.nsamples_for_qcalibration}")
     print(f"Calibration seq length : {args.calibrate_seq_len}")
     print(f"Max seq length         : {args.max_seq_len}")

--- a/tico/quantization/wrapq/wrappers/quant_module_base.py
+++ b/tico/quantization/wrapq/wrappers/quant_module_base.py
@@ -21,6 +21,20 @@ from tico.quantization.config.ptq import PTQConfig
 
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.observers.base import ObserverBase
+from tico.quantization.wrapq.qscheme import QScheme
+
+
+def _symmetric_qscheme_like(qscheme: QScheme) -> QScheme:
+    """
+    Return the symmetric qscheme with the same tensor/channel granularity.
+
+    This helper is used when a signed dtype is selected but the observer did
+    not receive an explicit user qscheme. It preserves the wrapper's preferred
+    granularity while avoiding signed asymmetric quantization by default.
+    """
+    if qscheme.is_per_channel():
+        return QScheme.PER_CHANNEL_SYMM
+    return QScheme.PER_TENSOR_SYMM
 
 
 class QuantModuleBase(nn.Module, ABC):
@@ -154,6 +168,13 @@ class QuantModuleBase(nn.Module, ABC):
         user_qscheme = user_cfg.pop("qscheme", _UNSPEC)
         wrapper_qscheme = wrapper_defaults.pop("qscheme", _UNSPEC)
         final_qscheme = pick3(user_qscheme, wrapper_qscheme, self.qcfg.default_qscheme)
+
+        if (
+            user_qscheme is _UNSPEC
+            and final_dtype.signed
+            and not final_qscheme.is_symmetric()
+        ):
+            final_qscheme = _symmetric_qscheme_like(final_qscheme)
 
         # 4) merge remaining kwargs: user_cfg wins
         final_kw = wrapper_defaults


### PR DESCRIPTION
This commit supports the overrides for SpinQuant rotation
 and signed weight qscheme auto-fix.

Related: #706
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>