### PR TITLE
[quantization] Introduction of mixed calibration dataset

### DIFF
--- a/tico/quantization/algorithm/gptq/utils.py
+++ b/tico/quantization/algorithm/gptq/utils.py
@@ -190,6 +190,10 @@ class SensitivityCalibrator:
             # update second order information as current weights gradients are ready
             for name in modules_to_process:
                 cur_module = modules_to_process[name]
+                # Skip modules that didn't participate in the forward pass
+                # (e.g., vision modules when processing text-only inputs)
+                if cur_module.weight.grad is None:
+                    continue
                 cur_grad = cur_module.weight.grad.detach().clone()
                 if torch.isnan(cur_grad).any().item():
                     print("WARNING NaN detected")

--- a/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
@@ -78,6 +78,12 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         self._orig_model_forward: Optional[Callable[..., Any]] = None
         self._quantizers: dict[str, Any] = {}
 
+        # Separate caches for vision batches (batches with pixel_values)
+        # This is needed because vision batches have different kwargs than text batches
+        self._vision_cache_args: list[list[Any]] = []
+        self._vision_cache_kwargs: dict[str, list[Any]] = {}
+        self._num_vision_batches: int = 0
+
     def _resolve_weight_bits(
         self,
         gptq_conf: Qwen3VLGPTQConfig,
@@ -150,6 +156,26 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 **cache_kwargs,
             )
 
+            # Track whether this batch has vision inputs (pixel_values)
+            # Vision inputs have 'pixel_values' or 'pixel_values_videos' in kwargs
+            # Store vision batches separately for vision stage quantization
+            has_vision_input = (
+                "pixel_values" in m_kwargs and m_kwargs["pixel_values"] is not None
+            ) or (
+                "pixel_values_videos" in m_kwargs
+                and m_kwargs["pixel_values_videos"] is not None
+            )
+
+            if has_vision_input:
+                # Also store in separate vision cache
+                append_batch_to_cache(
+                    self._vision_cache_args,
+                    self._vision_cache_kwargs,
+                    *cache_args,
+                    **cache_kwargs,
+                )
+                self._num_vision_batches += 1
+
             self.num_batches += 1
             return None
 
@@ -185,6 +211,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 stage_module=components.visual_patch_embed,
                 module_name=module_name,
                 stage_desc="vision.patch_embed",
+                vision_only=True,  # Only use vision inputs for vision stages
             )
 
         if should_quantize_vision_stage(gptq_conf, stage="blocks"):
@@ -200,6 +227,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 stage_module=components.visual_merger,
                 module_name=module_name,
                 stage_desc="vision.merger",
+                vision_only=True,  # Only use vision inputs for vision stages
             )
 
         if should_quantize_vision_stage(gptq_conf, stage="deepstack_mergers"):
@@ -209,6 +237,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                     stage_module=merger,
                     module_name=module_name,
                     stage_desc=f"vision.deepstack_merger[{idx}]",
+                    vision_only=True,  # Only use vision inputs for vision stages
                 )
 
         if should_quantize_text_stage(gptq_conf, stage="layers"):
@@ -231,6 +260,10 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         self.cache_args.clear()
         self.cache_kwargs.clear()
         self.num_batches = 0
+        # Clear vision cache
+        self._vision_cache_args.clear()
+        self._vision_cache_kwargs.clear()
+        self._num_vision_batches = 0
         model.quantizers = self._quantizers
         return model
 
@@ -249,11 +282,21 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         Quantize Qwen3-VL vision blocks in layerwise order using first-block entry
         caches and progressive re-forward.
         """
-        block_args, block_kwargs = self._collect_stage_entry_inputs(
+        # Only use vision inputs for vision block quantization
+        block_args, block_kwargs, num_vision_batches = self._collect_stage_entry_inputs(
             model=model,
             target_module=components.visual_blocks[0],
             desc="vision block entry capture",
+            vision_only=True,
         )
+
+        if num_vision_batches == 0:
+            print(
+                "Warning: No vision inputs found in calibration data. "
+                "Skipping vision block quantization."
+            )
+            return
+
         assert isinstance(self.config, Qwen3VLGPTQConfig)
         for block_idx, block in enumerate(
             tqdm(
@@ -271,10 +314,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 cached_args=block_args,
                 cached_kwargs=block_kwargs,
                 stage_desc=stage_name,
+                num_batches=num_vision_batches,
             )
 
             for batch_idx in tqdm(
-                range(self.num_batches),
+                range(num_vision_batches),
                 desc=f"[vision block {block_idx}] re-forward",
                 leave=False,
                 unit="batch",
@@ -309,10 +353,12 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         Quantize text decoder layers in layerwise order using first-layer entry
         caches and progressive re-forward.
         """
-        layer_args, layer_kwargs = self._collect_stage_entry_inputs(
+        # Text layers process all batches (both vision and text-only)
+        layer_args, layer_kwargs, num_batches = self._collect_stage_entry_inputs(
             model=model,
             target_module=components.text_layers[0],
             desc="text layer entry capture",
+            vision_only=False,  # Text layers process all inputs
         )
         assert isinstance(self.config, Qwen3VLGPTQConfig)
         for layer_idx, layer in enumerate(
@@ -331,10 +377,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 cached_args=layer_args,
                 cached_kwargs=layer_kwargs,
                 stage_desc=stage_name,
+                num_batches=num_batches,
             )
 
             for batch_idx in tqdm(
-                range(self.num_batches),
+                range(num_batches),
                 desc=f"[text layer {layer_idx}] re-forward",
                 leave=False,
                 unit="batch",
@@ -403,10 +450,20 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         stage_module: nn.Module,
         module_name: dict[nn.Module, str],
         stage_desc: str,
+        vision_only: bool = False,
     ) -> None:
         """
         Quantize a stage by replaying raw model inputs and collecting statistics
         only for that stage's quantizable submodules.
+
+        Args:
+            model: The full model.
+            stage_module: The specific module being quantized.
+            module_name: Mapping from module to name.
+            stage_desc: Description for logging.
+            vision_only: If True, only replay batches that have vision inputs
+                (pixel_values). This is needed for vision stages to avoid errors
+                when text-only inputs lack image tokens.
         """
         subset = get_quantizable_layers(stage_module)
         if not subset:
@@ -425,18 +482,35 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 )
             )
         assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # Use separate vision cache for vision-only quantization
+        if vision_only:
+            if self._num_vision_batches == 0:
+                print(
+                    f"[{stage_desc}] Warning: No vision inputs found in calibration data. "
+                    f"Skipping vision stage quantization."
+                )
+                for handle in handles:
+                    handle.remove()
+                return
+            cache_args = self._vision_cache_args
+            cache_kwargs = self._vision_cache_kwargs
+            num_batches = self._num_vision_batches
+        else:
+            cache_args = self.cache_args
+            cache_kwargs = self.cache_kwargs
+            num_batches = self.num_batches
+
         try:
             for batch_idx in tqdm(
-                range(self.num_batches),
+                range(num_batches),
                 desc=f"[{stage_desc}] collecting",
                 leave=False,
                 unit="batch",
                 disable=not self.config.show_progress,
             ):
-                args_batch = gather_single_batch_from_list(self.cache_args, batch_idx)
-                kwargs_batch = gather_single_batch_from_dict(
-                    self.cache_kwargs, batch_idx
-                )
+                args_batch = gather_single_batch_from_list(cache_args, batch_idx)
+                kwargs_batch = gather_single_batch_from_dict(cache_kwargs, batch_idx)
                 args_batch = self._move_batch_to_model_device(model, args_batch)
                 kwargs_batch = self._move_batch_to_model_device(model, kwargs_batch)
                 model(*args_batch, **kwargs_batch)
@@ -459,13 +533,25 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         cached_args: list[list[Any]],
         cached_kwargs: dict[str, list[Any]],
         stage_desc: str,
+        num_batches: Optional[int] = None,
     ) -> None:
         """
         Quantize a stage by replaying cached stage-entry inputs.
+
+        Args:
+            stage_module: The module to quantize.
+            module_name: Mapping from module to name.
+            cached_args: Cached positional arguments.
+            cached_kwargs: Cached keyword arguments.
+            stage_desc: Description for logging.
+            num_batches: Number of batches to use. If None, uses self.num_batches.
         """
         subset = get_quantizable_layers(stage_module)
         if not subset:
             return
+
+        if num_batches is None:
+            num_batches = self.num_batches
 
         gptq_objs = self._build_gptq_objects(
             subset=subset,
@@ -482,7 +568,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         assert isinstance(self.config, Qwen3VLGPTQConfig)
         try:
             for args_batch, kwargs_batch in tqdm(
-                iter_cached_batches(cached_args, cached_kwargs, self.num_batches),
+                iter_cached_batches(cached_args, cached_kwargs, num_batches),
                 desc=f"[{stage_desc}] collecting",
                 leave=False,
                 unit="batch",
@@ -613,10 +699,22 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         model: nn.Module,
         target_module: nn.Module,
         desc: str,
-    ) -> tuple[list[list[Any]], dict[str, list[Any]]]:
+        vision_only: bool = False,
+    ) -> tuple[list[list[Any]], dict[str, list[Any]], int]:
         """
         Capture the per-batch inputs fed into a specific stage module by replaying
         raw model inputs and stopping at the stage boundary.
+
+        Args:
+            model: The full model.
+            target_module: The module whose inputs to capture.
+            desc: Description for logging.
+            vision_only: If True, only capture inputs from batches with vision data.
+
+        Returns:
+            Tuple of (stage_args, stage_kwargs, num_batches) where num_batches is the
+            number of batches captured (may be less than self.num_batches if
+            vision_only=True).
         """
         stage_args: list[list[Any]] = []
         stage_kwargs: dict[str, list[Any]] = {}
@@ -660,19 +758,27 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
 
         target_module.forward = types.MethodType(capture_forward, target_module)
 
+        # Use separate vision cache for vision-only quantization
+        if vision_only:
+            cache_args = self._vision_cache_args
+            cache_kwargs = self._vision_cache_kwargs
+            num_batches = self._num_vision_batches
+        else:
+            cache_args = self.cache_args
+            cache_kwargs = self.cache_kwargs
+            num_batches = self.num_batches
+
         assert isinstance(self.config, Qwen3VLGPTQConfig)
         try:
             for batch_idx in tqdm(
-                range(self.num_batches),
+                range(num_batches),
                 desc=desc,
                 leave=False,
                 unit="batch",
                 disable=not self.config.show_progress,
             ):
-                args_batch = gather_single_batch_from_list(self.cache_args, batch_idx)
-                kwargs_batch = gather_single_batch_from_dict(
-                    self.cache_kwargs, batch_idx
-                )
+                args_batch = gather_single_batch_from_list(cache_args, batch_idx)
+                kwargs_batch = gather_single_batch_from_dict(cache_kwargs, batch_idx)
                 args_batch = self._move_batch_to_model_device(model, args_batch)
                 kwargs_batch = self._move_batch_to_model_device(model, kwargs_batch)
 
@@ -683,7 +789,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         finally:
             target_module.forward = orig_forward
 
-        return stage_args, stage_kwargs
+        return stage_args, stage_kwargs, num_batches
 
     # ------------------------------------------------------------------
     # Device / dtype helpers

--- a/tico/quantization/algorithm/qwen3_vl_gptq/utils.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/utils.py
@@ -501,6 +501,15 @@ def split_model_inputs(
     )
 
 
+def _num_cached_batches(
+    cache_args: list[list[Any]],
+    cache_kwargs: dict[str, list[Any]],
+) -> int:
+    lengths = [len(v) for v in cache_args]
+    lengths.extend(len(v) for v in cache_kwargs.values())
+    return max(lengths, default=0)
+
+
 def append_batch_to_cache(
     cache_args: list[list[Any]],
     cache_kwargs: dict[str, list[Any]],
@@ -515,15 +524,26 @@ def append_batch_to_cache(
         cache_kwargs: Keyword cache storage.
         *args: Positional batch values.
         **kwargs: Keyword batch values.
+
+    Note:
+        The previous batch count is derived from the existing cache contents
+        and keys occurrences are aligned among cache_args and cache_kwargs.
+        This ensures index alignment across all batches.
     """
+    prev_batches = _num_cached_batches(cache_args, cache_kwargs)
+
     for idx, item in enumerate(args):
         if idx >= len(cache_args):
-            cache_args.append([])
+            cache_args.append([None] * prev_batches)
         cache_args[idx].append(detach_clone_tree(item))
+
+    for key in list(cache_kwargs.keys()):
+        if key not in kwargs:
+            cache_kwargs[key].append(None)
 
     for key, value in kwargs.items():
         if key not in cache_kwargs:
-            cache_kwargs[key] = []
+            cache_kwargs[key] = [None] * prev_batches
         cache_kwargs[key].append(detach_clone_tree(value))
 
 

--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -14,11 +14,11 @@
 
 import json
 import os
+import random
 import re
 import string
 import tempfile
 
-from collections.abc import Callable
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict
 
 import torch
@@ -184,16 +184,61 @@ def get_item_coco(ex: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def get_item_wikitext2(ex: dict[str, Any]) -> dict[str, Any]:
+    """
+    Adapt a Wikitext2 sample to a common format for text-only calibration.
+
+    The returned schema is:
+
+    `{"text": text}`
+
+    Args:
+        ex: Raw dataset example.
+
+    Returns:
+        A normalized text item.
+    """
+    return {"text": ex.get("text", "")}
+
+
+def get_item_alpaca(ex: dict[str, Any]) -> dict[str, Any]:
+    """
+    Adapt an Alpaca-style sample to a common format for text-only calibration.
+
+    Alpaca format has "instruction", "input", and "output" fields.
+    The instruction and input are combined for the text.
+
+    The returned schema is:
+
+    `{"text": text}`
+
+    Args:
+        ex: Raw dataset example.
+
+    Returns:
+        A normalized text item.
+    """
+    instruction = ex.get("instruction", "")
+    input_text = ex.get("input", "")
+    if input_text:
+        text = f"{instruction}\n{input_text}"
+    else:
+        text = instruction
+    return {"text": text}
+
+
 DATASETS: dict[str, dict[str, Any]] = {
     "vqav2": {
         "default_split": "validation",
         "adapter": get_item_vqav2,
         "candidates": ["HuggingFaceM4/VQAv2", "vqav2", "lmms-lab/VQAv2"],
+        "is_text_only": False,
     },
     "textvqa": {
         "default_split": "validation",
         "adapter": get_item_textvqa,
         "candidates": ["textvqa", "HuggingFaceM4/TextVQA", "lmms-lab/textvqa"],
+        "is_text_only": False,
     },
     "coco": {
         "default_split": "val",
@@ -201,12 +246,20 @@ DATASETS: dict[str, dict[str, Any]] = {
         "candidates": [
             "lmms-lab/COCO-Caption2017",
         ],
+        "is_text_only": False,
     },
     "wikitext2": {
         "default_split": "test",
-        "adapter": None,  # Text-only dataset, no adapter needed
+        "adapter": get_item_wikitext2,
         "candidates": ["wikitext"],
         "config": "wikitext-2-raw-v1",
+        "is_text_only": True,
+    },
+    "alpaca": {
+        "default_split": "train",
+        "adapter": get_item_alpaca,
+        "candidates": ["tatsu-lab/alpaca"],
+        "is_text_only": True,
     },
 }
 
@@ -855,4 +908,196 @@ def get_calib_inputs(
         )
         calib_inputs.append(inputs)
 
+    return calib_inputs
+
+
+def build_text_only_inputs(
+    processor,
+    text: str,
+    return_tensors: str = "pt",
+    max_seq_len: Optional[int] = None,
+):
+    """
+    Build processor inputs for text-only data (no image).
+
+    Args:
+        processor: Hugging Face processor.
+        text: Input text.
+        return_tensors: Tensor format requested from the processor.
+        max_seq_len: Optional maximum text sequence length. If provided,
+                     text inputs are truncated to this length.
+
+    Returns:
+        A processor output object containing model-ready text inputs.
+    """
+    processor_kwargs: Dict[str, Any] = {
+        "text": text,
+        "return_tensors": return_tensors,
+    }
+    if max_seq_len is not None and max_seq_len > 0:
+        processor_kwargs["truncation"] = True
+        processor_kwargs["max_length"] = max_seq_len
+
+    return processor(**processor_kwargs)
+
+
+def _build_text_calib_inputs(
+    processor,
+    text: str,
+    n_samples: int,
+    max_seq_len: int,
+    seed: int,
+) -> List[Dict[str, Any]]:
+    """
+    Build calibration inputs from text by sampling random fixed-length sequences.
+
+    Tokenize all text, then sample random fixed-length sequences.
+
+    Args:
+        processor: Hugging Face processor with tokenizer.
+        text: Full text to sample from.
+        n_samples: Number of calibration samples to generate.
+        max_seq_len: Sequence length for each sample.
+        seed: Random seed for reproducible sampling.
+
+    Returns:
+        A list of processor output objects, each containing input_ids.
+    """
+    # Tokenize the full text
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    input_ids = tokenizer(text, return_tensors="pt").input_ids
+
+    calib_inputs = []
+    rng = random.Random(seed)
+
+    for _ in range(n_samples):
+        # Sample a random starting position
+        max_start = input_ids.shape[1] - max_seq_len - 1
+        if max_start <= 0:
+            # If text is too short, use what we have
+            start = 0
+            end = input_ids.shape[1]
+        else:
+            start = rng.randint(0, max_start)
+            end = start + max_seq_len
+
+        sample_ids = input_ids[:, start:end]
+
+        # Build inputs dict similar to processor output
+        inputs = {"input_ids": sample_ids}
+        calib_inputs.append(inputs)
+
+    return calib_inputs
+
+
+def get_mixed_calib_inputs(
+    processor,
+    dataset_config: Dict[str, Dict[str, Any]],
+    max_seq_len: int,
+    seed: int = 42,
+) -> List[Dict[str, Any]]:
+    """
+    Build calibration inputs from multiple datasets
+
+    This function loads samples from multiple datasets and combines them into
+    a single calibration set. It handles both image-text datasets (e.g. VQAv2, COCO)
+    and text-only datasets (e.g. Wikitext2, Alpaca).
+
+    For text-only datasets, it concatenates all text and samples random
+    fixed-length sequences.
+
+    For image-text datasets, it takes the first n_samples directly.
+
+    Args:
+        processor: Hugging Face processor.
+        max_seq_len: maximum text sequence length.
+        dataset_config: Dictionary mapping dataset names (with optional split) to
+            number of samples. Format: {"dataset": {"n_samples": n_samples}} or
+                                       {"dataset": {"split":"split","n_samples": n_samples}}.
+            Example: {
+                      "wikitext2": {"n_samples": 128},
+                      "alpaca": {"split": "train", "n_samples": 32}
+                      }
+        seed: Random seed for reproducible sampling (used only for text-only
+            datasets).
+
+    Returns:
+        A list of processor output objects from all datasets.
+    """
+    calib_inputs = []
+
+    for dataset, config in dataset_config.items():
+        n_samples = config.get("n_samples", None)
+        split = config.get("split", None)
+        if n_samples is None or n_samples <= 0:
+            continue
+
+        if dataset not in DATASETS:
+            print(f"[warn] Unknown dataset '{dataset}', skipping")
+            continue
+
+        is_text_only = DATASETS[dataset].get("is_text_only", False)
+
+        if is_text_only:
+            # TODO: text only inputs should be changed with chat template
+
+            # Loading whole dataset
+            ds, adapter = get_dataset(dataset=dataset, n=-1, split=split)
+
+            # For text-only datasets: use adapter to extract text, then sample random sequences
+            if adapter is None:
+                print(f"[warn] No adapter for dataset '{dataset}', skipping")
+                continue
+
+            all_texts = []
+            for ex in ds:
+                item = adapter(ex)
+                text = item.get("text", "")
+                if text.strip():
+                    all_texts.append(text)
+
+            if not all_texts:
+                print(f"[warn] No text found in dataset '{dataset}', skipping")
+                continue
+
+            # Concatenate all text
+            full_text = "\n\n".join(all_texts)
+            print(f"[info] Tokenizing {len(full_text)} chars from '{dataset}'")
+
+            # Sample random fixed-length sequences
+            text_inputs = _build_text_calib_inputs(
+                processor=processor,
+                text=full_text,
+                n_samples=n_samples,
+                max_seq_len=max_seq_len,
+                seed=seed,
+            )
+            calib_inputs.extend(text_inputs)
+        else:
+            # Loading whole dataset
+            ds, adapter = get_dataset(dataset=dataset, n=n_samples, split=split)
+
+            # For image-text datasets: take first n_samples directly
+            if adapter is None:
+                print(f"[warn] No adapter for dataset '{dataset}', skipping")
+                continue
+
+            for ex in ds:
+                item = adapter(ex)
+                inputs = build_vlm_inputs(
+                    processor=processor,
+                    image=item["image"],
+                    question=item["question"],
+                    return_tensors="pt",
+                    max_seq_len=max_seq_len,
+                )
+                calib_inputs.append(inputs)
+
+    if not calib_inputs:
+        raise ValueError(
+            "No calibration inputs were loaded. "
+            "Please check --nsamples_for_qcalibration."
+        )
+
+    print(f"[info] Total calibration samples: {len(calib_inputs)}")
     return calib_inputs

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -15,7 +15,7 @@
 import argparse
 import contextlib
 import io
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 import tqdm
@@ -37,9 +37,9 @@ from tico.quantization.evaluation.mmmu_eval_utils import (
 from tico.quantization.evaluation.vlm_eval_utils import (
     evaluate_ppl,
     get_accuracy_on_dataset,
-    get_calib_inputs,
     get_coco_scores_on_dataset,
     get_dataset,
+    get_mixed_calib_inputs,
 )
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
@@ -124,9 +124,15 @@ def parse_args():
     )
     parser.add_argument(
         "--nsamples_for_qcalibration",
-        type=int,
-        default=128,
-        help="Number of samples to be used in GPTQ calibration.",
+        type=str,
+        default="vqav2:testdev:128,wikitext2:train:128",
+        help=(
+            "Just a number -> uses default dataset `vqav2` with `testdev` split and N samples. "
+            "Comma-separated list: "
+            "a) dataset:n_samples -> uses default split. "
+            "b) dataset:split:n_samples -> uses specified split. "
+            "c) Multiple datasets example: vqav2:testdev:128,wikitext2:train:128,coco:32"
+        ),
     )
     parser.add_argument(
         "--nsamples_for_evaluation",
@@ -1074,6 +1080,57 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
         print(f"Quantized PPL: {quantized_ppl:.2f}")
 
 
+def load_calib_inputs(processor, args) -> List[Dict[str, Any]]:
+    """
+    Load calibration inputs
+    Parse the nsamples_for_qcalibration argument
+
+    Formats supported:
+    - Just a number -> uses default dataset "vqav2" with N samples
+    - "dataset:n_samples" -> uses default split
+    - "dataset:split:n_samples" -> uses specified split
+    - Multiple datasets: "vqav2:32,coco:val:32,wikitext2:test:32"
+    """
+    dataset_config: Dict[str, Dict[str, Any]] = {}
+    raw_input = args.nsamples_for_qcalibration.strip()
+
+    # Check if the input is just a number
+    # In this case, use the default dataset "vqav2"
+    if raw_input.isdigit():
+        n_samples = int(raw_input)
+        dataset_config["vqav2"] = {"n_samples": n_samples, "split": "testdev"}
+        print(f"[info] Using default dataset 'vqav2' with {n_samples} samples")
+    else:
+        # Parse the full format
+        for item in raw_input.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            parts = item.split(":")
+            if len(parts) == 2:
+                # Format: "dataset:n_samples" (use default split)
+                name, n_samples = parts
+                dataset_config[name.strip()] = {"n_samples": int(n_samples)}
+            elif len(parts) == 3:
+                # Format: "dataset:split:n_samples"
+                name, split, n_samples = parts
+                dataset_config[name.strip()] = {
+                    "n_samples": int(n_samples),
+                    "split": split.strip(),
+                }
+            else:
+                print(
+                    f"[warn] Invalid format '{item}', expected 'dataset:n_samples' or 'dataset:split:n_samples'"
+                )
+
+    return get_mixed_calib_inputs(
+        processor=processor,
+        dataset_config=dataset_config,
+        max_seq_len=args.calib_seq_len,
+        seed=args.seed,
+    )
+
+
 def main() -> None:
     args = parse_args()
     print(args)
@@ -1158,12 +1215,7 @@ def main() -> None:
 
     original_results = evaluate_original_model(model, processor, args)
 
-    calib_inputs = get_calib_inputs(
-        "vqav2",
-        processor,
-        n_samples=args.nsamples_for_qcalibration,
-        max_seq_len=args.calib_seq_len,
-    )
+    calib_inputs = load_calib_inputs(processor, args)
 
     apply_smoothquant_if_requested(model, calib_inputs, args)
 


### PR DESCRIPTION
This PR introduces support for mixed calibration dataset that combines both image-text samples (e.g., VQAv2, COCO) and text-only samples (e.g., Wikitext2, Alpaca). This enables more comprehensive calibration for Qwen3-VL.

Text-only samples requires additional processing in `tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py`

Additionally `--nsamples_for_qcalibration` argument was extended to comma-separated list. 
Formats supported:
- Just a number N -> uses default dataset "vqav2" with N samples
- "dataset:n_samples" -> uses default split
- "dataset:split:n_samples" -> uses specified split
- Multiple datasets: "vqav2:testdev:128,wikitext2:train:128"

Related issue:
- https://github.com/Samsung/TICO/issues/645

---------------------
### Changes:

#### 1. __quantizer.py__ (qwen3_vl_gptq) 

- Added __separate caches for vision batches__: `_vision_cache_args`, `_vision_cache_kwargs`, `_num_vision_batches`
- Vision stages (patch_embed, blocks, merger) now __only process batches with vision inputs__ via `vision_only=True` flag
- Text decoder layers process __all batches__ (both image-text and text-only)
- Prevents errors when text-only inputs lack image tokens
- Added warning when no vision inputs are found in calibration data

#### 2. __utils.py__ (qwen3_vl_gptq) - Cache Handling

- Enhanced `append_batch_to_cache()` to maintain __index alignment__ across batches with different kwargs
- New keys are backfilled with `None` for previous batches
- Missing keys in current batch get `None` placeholder
- Ensures consistent batch indexing across heterogeneous samples

#### 3. __utils.py__ (gptq) - Gradient Safety

- Added check to __skip modules without gradients__ during sensitivity calibration
- Prevents errors when vision modules don't participate in forward pass (text-only inputs)

#### 4. __vlm_eval_utils.py__ - Dataset Support

- Added __text-only datasets__: `alpaca` and adapters

- New `is_text_only` flag in dataset registry to distinguish dataset types

- New functions:

  - `build_text_only_inputs()` - builds processor inputs for text-only data
  - `_build_text_calib_inputs()` - samples random fixed-length sequences from text
  - `get_mixed_calib_inputs()` - combines multiple datasets into single calibration set

#### 5. __quantize_qwen3_vl_with_gptq.py__ 

- Changed `--nsamples_for_qcalibration` from `int` to `str` type

- Supports multiple formats:

  - Just a number: `128` → uses default `vqav2:testdev:128`
  - `dataset:n_samples` → uses default split
  - `dataset:split:n_samples` → uses specified split
  - Multiple: `vqav2:testdev:128,wikitext2:train:128,coco:32`

- Added `load_calib_inputs()` function to parse and load multiple datasets


TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>