### PR TITLE
[quantization] Support Evaluation of Qwen3-VL With HellaSwag Dataset

### DIFF
--- a/tico/quantization/evaluation/hellaswag_eval_utils.py
+++ b/tico/quantization/evaluation/hellaswag_eval_utils.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HellaSwag benchmark evaluation utilities.
+
+HellaSwag is a dataset for commonsense natural language inference (NLI).
+It evaluates an LLM's commonsense reasoning by requiring it to choose the
+most logical ending to a sentence describing an everyday situation.
+
+Dataset structure:
+- ctx_a, ctx_b: Context (short story or event description)
+- ending_a, ending_b, ending_c, ending_d: Four possible continuations
+- label: Index (0-3) of the correct ending
+
+Evaluation metric: Multiple-choice accuracy
+"""
+
+from typing import Any
+
+import torch
+
+from lm_eval import evaluator
+from lm_eval.models.huggingface import HFLM
+from lm_eval.utils import make_table
+
+
+def evaluate_hellaswag(
+    model,
+    tokenizer,
+    device: str | torch.device = "cuda",
+    n_shots: int = 10,
+    n_samples: int = -1,
+    batch_size: int = 1,
+    max_seq_len: int | None = None,
+) -> dict[str, Any]:
+    """
+    Evaluate a model on the HellaSwag benchmark using lm_eval.
+
+    This function uses the lm_eval framework for standardized HellaSwag evaluation.
+    The model can be a standard HuggingFace model or a wrapped quantized model
+    (e.g., QuantQwen3VLForConditionalGeneration).
+
+    Args:
+        model: Language model with generation capability. Can be a wrapped model.
+        tokenizer: Matching tokenizer for the model.
+        device: Device for inference.
+        n_shots: Number of few-shot examples (default: 10 for HellaSwag).
+        n_samples: Number of test samples. Use -1 for full test set.
+        batch_size: Batch size for evaluation.
+        max_seq_len: Maximal sequence length to be generated.
+
+    Returns:
+        Results dictionary with accuracy metrics including:
+        - acc: Accuracy
+        - acc_norm: Normalized accuracy (length-normalized)
+    """
+    # Unwrap if needed (handles PTQWrapper)
+    if hasattr(model, "wrapped"):
+        model = model.wrapped
+
+    lm = HFLM(
+        pretrained=model,
+        backend="causal",
+        tokenizer=tokenizer,
+        batch_size=batch_size,
+        device=device,
+        max_length=max_seq_len,
+        truncation=True,
+    )
+
+    # Run lm_eval evaluation on hellaswag task
+    results: dict[str, Any] = evaluator.simple_evaluate(
+        model=lm,
+        tasks=["hellaswag"],
+        num_fewshot=n_shots,
+        batch_size=batch_size,
+        limit=n_samples if n_samples > 0 else None,
+        device=str(device) if device else None,
+    )
+    return results
+
+
+def print_hellaswag_results(results: dict[str, Any]) -> None:
+    """
+    Print HellaSwag evaluation results in a formatted table.
+
+    Args:
+        results: Results dictionary from evaluate_hellaswag().
+    """
+    print(make_table(results))
+
+
+def get_hellaswag_accuracy(results: dict[str, Any]) -> dict[str, float]:
+    """
+    Extract accuracy metrics from HellaSwag evaluation results.
+
+    Args:
+        results: Results dictionary from evaluate_hellaswag().
+
+    Returns:
+        Dictionary with accuracy metrics:
+        - acc: Accuracy
+        - acc_norm: Normalized accuracy (length-normalized)
+    """
+    hellaswag_results = results.get("results", {}).get("hellaswag", {})
+    return {
+        "acc": hellaswag_results.get("acc", 0.0),
+        "acc_norm": hellaswag_results.get("acc_norm", 0.0),
+    }

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -26,6 +26,11 @@ from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
 from tico.quantization.algorithm.smoothquant.smooth_quant import apply_smoothing
 from tico.quantization.config.builders import build_qwen3_vl_ptq_config
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
+from tico.quantization.evaluation.hellaswag_eval_utils import (
+    evaluate_hellaswag,
+    get_hellaswag_accuracy,
+    print_hellaswag_results,
+)
 from tico.quantization.evaluation.mmlu_eval_utils import (
     evaluate_mmlu,
     print_mmlu_results,
@@ -359,6 +364,32 @@ def parse_args():
         type=int,
         default=-1,
         help="Number of samples per MMMU subject. Use -1 for full test set.",
+    )
+
+    # HellaSwag evaluation arguments
+    parser.add_argument(
+        "--hellaswag",
+        action="store_true",
+        default=False,
+        help="Evaluate on HellaSwag benchmark.",
+    )
+    parser.add_argument(
+        "--hellaswag_n_shots",
+        type=int,
+        default=10,
+        help="Number of few-shot examples for HellaSwag evaluation.",
+    )
+    parser.add_argument(
+        "--hellaswag_n_samples",
+        type=int,
+        default=-1,
+        help="Number of samples for HellaSwag evaluation. Use -1 for full test set.",
+    )
+    parser.add_argument(
+        "--hellaswag_batch_size",
+        type=int,
+        default=1,
+        help="Batch size for HellaSwag evaluation.",
     )
 
     # PPL evaluation arguments
@@ -967,6 +998,21 @@ def evaluate_original_model(model, processor, args):
         )
         print_mmlu_results(original_mmlu_results)
 
+    if args.hellaswag:
+        print("\n=== HellaSwag Evaluation (Original Model) ===")
+        original_hellaswag_results = evaluate_hellaswag(
+            model=model,
+            tokenizer=processor.tokenizer,
+            device=args.device,
+            n_shots=args.hellaswag_n_shots,
+            n_samples=args.hellaswag_n_samples,
+            batch_size=args.hellaswag_batch_size,
+            max_seq_len=args.max_seq_len,
+        )
+        print_hellaswag_results(original_hellaswag_results)
+        acc = get_hellaswag_accuracy(original_hellaswag_results)
+        print(f"Accuracy: {acc['acc']:.4f}, Accuracy (norm): {acc['acc_norm']:.4f}")
+
     if args.mmmu_subjects is not None:
         print("\n=== MMMU Evaluation (Original Model) ===")
         original_mmmu_results = evaluate_mmmu(
@@ -1044,6 +1090,21 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
             max_seq_len=args.max_seq_len,
         )
         print_mmlu_results(quantized_mmlu_results)
+
+    if args.hellaswag:
+        print("\n=== HellaSwag Evaluation (Quantized Model) ===")
+        quantized_hellaswag_results = evaluate_hellaswag(
+            model=model,
+            tokenizer=processor.tokenizer,
+            device=args.device,
+            n_shots=args.hellaswag_n_shots,
+            n_samples=args.hellaswag_n_samples,
+            batch_size=args.hellaswag_batch_size,
+            max_seq_len=args.max_seq_len,
+        )
+        print_hellaswag_results(quantized_hellaswag_results)
+        acc = get_hellaswag_accuracy(quantized_hellaswag_results)
+        print(f"Accuracy: {acc['acc']:.4f}, Accuracy (norm): {acc['acc_norm']:.4f}")
 
     if args.mmmu_subjects is not None:
         print("\n=== MMMU Evaluation (Quantized Model) ===")


### PR DESCRIPTION
### What
Adds support for evaluating Qwen3-VL models on the HellaSwag benchmark dataset.

### Why
HellaSwag evaluation support was requested in [PTQ Evaluation — Qwen3-VL](https://github.sec.samsung.net/one-project/TICO/issues/192). HellaSwag is a commonsense natural language inference benchmark that tests an LLM's ability to choose the most logical ending to a given context.

### Implementation Details

**New file:**
- `tico/quantization/evaluation/hellaswag_eval_utils.py` — Provides:
  - `evaluate_hellaswag()`: Evaluates a model using the `lm_eval` framework
  - `print_hellaswag_results()`: Prints results in formatted table
  - `get_hellaswag_accuracy()`: Extracts accuracy metrics (`acc`, `acc_norm`)

**Modified file:**
- `tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py`:
  - Added CLI arguments: `--hellaswag`, `--hellaswag_n_shots`, `--hellaswag_n_samples`, `--hellaswag_batch_size`
  - Integrated HellaSwag evaluation into `evaluate_original_model()` and `evaluate_quantized_model()` functions

### Example

```bash
python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
    --model=Qwen/Qwen3-VL-4B-Instruct \
    --cache_dir=/home/d.savchenkov/models/qwen3-vl-4b \
    --trust-remote-code \
    --no_GPTQ \
    --hellaswag \
    --hellaswag_n_shots=5 \
    --hellaswag_n_samples=100 \
    --embedding_weight_bits=16 \
    --vision_patch_embed_weight_bits=16 \
    --linear_weight_bits=16 \
    --lm_head_weight_bits=16 \
    --nsamples_for_qcalibration=10 \
    --verbose
```

```
=== HellaSwag Evaluation (Original Model) ===
|  Tasks  |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|---------|------:|------|-----:|--------|---|----:|---|-----:|
|hellaswag|      1|none  |     5|acc     |↑  |  0.2|±  |0.1333|
|         |       |none  |     5|acc_norm|↑  |  0.3|±  |0.1528|

=== HellaSwag Evaluation (Quantized Model) ===
|  Tasks  |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|---------|------:|------|-----:|--------|---|----:|---|-----:|
|hellaswag|      1|none  |     5|acc     |↑  |  0.3|±  |0.1528|
|         |       |none  |     5|acc_norm|↑  |  0.3|±  |0.1528|
```