### PR TITLE
[quantization] Apply SpinQuant to Qwen3-VL

### DIFF
--- a/test/quantization/algorithm/test_qwen3_vl_spinquant.py
+++ b/test/quantization/algorithm/test_qwen3_vl_spinquant.py
@@ -1,0 +1,716 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.qwen3_vl_spinquant import Qwen3VLSpinQuantConfig
+
+try:
+    from tico.quantization.algorithm.spinquant.qwen3_vl_quantizer import (
+        Qwen3VLSpinQuantQuantizer,
+    )
+    from tico.quantization.algorithm.spinquant.spin_qwen3_vl import (
+        SpinQwen3VLForConditionalGeneration,
+    )
+    from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
+    from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+        Qwen3VLForConditionalGeneration,
+    )
+
+    QWEN3_VL_AVAILABLE = True
+    QWEN3_VL_SKIP_REASON = ""
+except (AttributeError, ImportError, ModuleNotFoundError) as exc:
+    Qwen3VLConfig = None  # type: ignore[assignment]
+    Qwen3VLForConditionalGeneration = None  # type: ignore[assignment]
+    Qwen3VLSpinQuantQuantizer = None  # type: ignore[assignment, arg-type, misc]
+    SpinQwen3VLForConditionalGeneration = None  # type: ignore[assignment, arg-type, misc]
+    QWEN3_VL_AVAILABLE = False
+    QWEN3_VL_SKIP_REASON = f"Qwen3-VL transformers integration is unavailable: {exc}"
+
+
+class Qwen3VLSpinQuantConfigTest(unittest.TestCase):
+    def test_config_default_is_random(self):
+        cfg = Qwen3VLSpinQuantConfig()
+        self.assertEqual(cfg.init_method, "random")
+        self.assertEqual(cfg.name, "spinquant")
+
+    def test_config_accepts_hadamard(self):
+        cfg = Qwen3VLSpinQuantConfig(init_method="hadamard")
+        self.assertEqual(cfg.init_method, "hadamard")
+
+    def test_config_requires_r1_for_external(self):
+        with self.assertRaises(ValueError):
+            Qwen3VLSpinQuantConfig(init_method="external")
+
+    def test_config_rejects_non_tensor_r1(self):
+        with self.assertRaises(TypeError):
+            Qwen3VLSpinQuantConfig(
+                init_method="random",
+                r1="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_config_rejects_non_dict_r2_map(self):
+        with self.assertRaises(TypeError):
+            Qwen3VLSpinQuantConfig(
+                init_method="random",
+                r2_map="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_config_rejects_non_tensor_r2_value(self):
+        with self.assertRaises(TypeError):
+            Qwen3VLSpinQuantConfig(
+                init_method="random",
+                r2_map={"model.language_model.layers.0.self_attn.R2": "invalid"},  # type: ignore[dict-item]
+            )
+
+
+@unittest.skipUnless(QWEN3_VL_AVAILABLE, QWEN3_VL_SKIP_REASON)
+class Qwen3VLSpinQuantTest(unittest.TestCase):
+    def _build_qwen3_vl_model(
+        self,
+        *,
+        hidden_size: int = 32,
+        intermediate_size: int = 64,
+        num_hidden_layers: int = 2,
+        num_attention_heads: int = 4,
+        num_key_value_heads: int = 2,
+        head_dim: int = 8,
+        vocab_size: int = 80,
+        tie_word_embeddings: bool = True,
+        deepstack_visual_indexes: list[int] | None = None,
+    ) -> torch.nn.Module:
+        """
+        Build a tiny Qwen3-VL model for SpinQuant unit tests.
+
+        Parameters:
+            hidden_size: Text hidden dimension.
+            intermediate_size: Text MLP intermediate dimension.
+            num_hidden_layers: Number of text decoder layers.
+            num_attention_heads: Number of query attention heads.
+            num_key_value_heads: Number of key/value attention heads.
+            head_dim: Attention head dimension.
+            vocab_size: Text vocabulary size.
+            tie_word_embeddings: Whether input embedding and LM head share storage.
+            deepstack_visual_indexes: Vision layer indexes used for DeepStack outputs.
+
+        Returns:
+            A tiny Qwen3VLForConditionalGeneration instance.
+        """
+        assert Qwen3VLConfig is not None
+        assert Qwen3VLForConditionalGeneration is not None
+
+        if deepstack_visual_indexes is None:
+            deepstack_visual_indexes = [0]
+
+        text_config = {
+            "vocab_size": vocab_size,
+            "hidden_size": hidden_size,
+            "intermediate_size": intermediate_size,
+            "num_hidden_layers": num_hidden_layers,
+            "num_attention_heads": num_attention_heads,
+            "num_key_value_heads": num_key_value_heads,
+            "head_dim": head_dim,
+            "hidden_act": "silu",
+            "max_position_embeddings": 64,
+            "initializer_range": 0.02,
+            "rms_norm_eps": 1e-6,
+            "use_cache": False,
+            "rope_theta": 10000.0,
+            "rope_parameters": {
+                "rope_type": "default",
+                "rope_theta": 10000.0,
+                "mrope_section": [2, 1, 1],
+            },
+            "attention_bias": False,
+            "attention_dropout": 0.0,
+            "pad_token_id": 0,
+        }
+        vision_config = {
+            "depth": 1,
+            "hidden_size": 16,
+            "hidden_act": "gelu_pytorch_tanh",
+            "intermediate_size": 32,
+            "num_heads": 4,
+            "in_channels": 3,
+            "patch_size": 2,
+            "spatial_merge_size": 1,
+            "temporal_patch_size": 2,
+            "out_hidden_size": hidden_size,
+            "num_position_embeddings": 16,
+            "deepstack_visual_indexes": deepstack_visual_indexes,
+            "initializer_range": 0.02,
+        }
+        config = Qwen3VLConfig(
+            text_config=text_config,
+            vision_config=vision_config,
+            image_token_id=vocab_size - 4,
+            video_token_id=vocab_size - 3,
+            vision_start_token_id=vocab_size - 2,
+            vision_end_token_id=vocab_size - 1,
+            tie_word_embeddings=tie_word_embeddings,
+        )
+        self._patch_qwen3_vl_rope_config(config)
+        model = Qwen3VLForConditionalGeneration(config)
+        self._force_qwen3_vl_embedding_tie(
+            model, tie_word_embeddings=tie_word_embeddings
+        )
+        model.eval()
+        return model
+
+    def _force_qwen3_vl_embedding_tie(
+        self,
+        model: torch.nn.Module,
+        *,
+        tie_word_embeddings: bool,
+    ) -> None:
+        """
+        Force the synthetic Qwen3-VL model to match the requested tie setting.
+
+        Some transformers versions do not automatically tie ``lm_head`` to
+        ``model.language_model.embed_tokens`` when a model is constructed from a
+        tiny synthetic config. Real checkpoints can still be tied after loading,
+        but unit tests need the in-memory test model to expose the same storage
+        alias before SpinQuant validation runs.
+
+        Parameters:
+            model: Qwen3-VL model to update in-place.
+            tie_word_embeddings: Whether to tie or explicitly untie the weights.
+        """
+        model.config.tie_word_embeddings = tie_word_embeddings
+
+        if tie_word_embeddings:
+            try:
+                model.tie_weights()
+            except Exception:
+                pass
+
+            if (
+                model.model.language_model.embed_tokens.weight.data_ptr()
+                != model.lm_head.weight.data_ptr()
+            ):
+                model.lm_head.weight = model.model.language_model.embed_tokens.weight
+            return
+
+        if (
+            model.model.language_model.embed_tokens.weight.data_ptr()
+            == model.lm_head.weight.data_ptr()
+        ):
+            model.lm_head.weight = torch.nn.Parameter(
+                model.lm_head.weight.detach().clone()
+            )
+
+    def _patch_qwen3_vl_rope_config(self, config) -> None:
+        """
+        Patch tiny Qwen3-VL RoPE config fields for transformers version drift.
+
+        Some Qwen3-VL releases read ``text_config.rope_parameters`` while other
+        releases read ``text_config.rope_scaling`` directly. Unit tests construct
+        a tiny synthetic config, so both fields are populated to avoid depending
+        on one specific transformers minor version.
+
+        Parameters:
+            config: Qwen3-VL top-level configuration to patch in-place.
+        """
+        text_config = config.text_config
+        mrope_section = [2, 1, 1]
+
+        rope_parameters = {
+            "rope_type": "default",
+            "rope_theta": 10000.0,
+            "mrope_section": mrope_section,
+        }
+        rope_scaling = {
+            "type": "default",
+            "rope_type": "default",
+            "mrope_section": mrope_section,
+        }
+
+        if getattr(text_config, "rope_parameters", None) is None:
+            text_config.rope_parameters = dict(rope_parameters)
+
+        if getattr(text_config, "rope_scaling", None) is None:
+            text_config.rope_scaling = dict(rope_scaling)
+
+        if not hasattr(text_config, "rope_theta"):
+            text_config.rope_theta = 10000.0
+
+    def _force_tied_qwen3_vl_word_embeddings(self, model: torch.nn.Module) -> None:
+        """
+        Force Qwen3-VL input embeddings and LM head to share storage.
+
+        Some transformers releases do not tie synthetic Qwen3-VL models even
+        when ``tie_word_embeddings=True`` is passed to the tiny test config.
+        The production SpinQuant path assumes tied embeddings, so the test
+        helper explicitly creates the same storage alias used by real tied
+        checkpoints.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+        """
+        model.config.tie_word_embeddings = True
+        model.lm_head.weight = model.model.language_model.embed_tokens.weight
+
+    def _force_untied_qwen3_vl_word_embeddings(self, model: torch.nn.Module) -> None:
+        """
+        Force Qwen3-VL input embeddings and LM head to use separate storage.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+        """
+        model.config.tie_word_embeddings = False
+        model.lm_head.weight = torch.nn.Parameter(model.lm_head.weight.detach().clone())
+
+    def _clone_state_dict(self, model: torch.nn.Module) -> dict[str, torch.Tensor]:
+        """
+        Clone a model state_dict into detached tensors.
+
+        Parameters:
+            model: Source model.
+
+        Returns:
+            A copied state_dict.
+        """
+        return {
+            key: value.detach().clone() for key, value in model.state_dict().items()
+        }
+
+    def _assert_identity_linear(self, layer: torch.nn.Linear) -> None:
+        """
+        Assert that a Linear layer is initialized as identity.
+
+        Parameters:
+            layer: Target Linear layer.
+        """
+        self.assertEqual(layer.in_features, layer.out_features)
+        expected = torch.eye(
+            layer.in_features,
+            device=layer.weight.device,
+            dtype=layer.weight.dtype,
+        )
+        self.assertTrue(torch.allclose(layer.weight, expected))
+        if layer.bias is not None:
+            self.assertTrue(torch.allclose(layer.bias, torch.zeros_like(layer.bias)))
+
+    def _assert_tied_word_embedding(self, model: torch.nn.Module) -> None:
+        """
+        Assert that a Qwen3-VL model has tied input and output embeddings.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+        """
+        embed_weight = model.model.language_model.embed_tokens.weight
+        lm_head_weight = model.lm_head.weight
+        self.assertEqual(embed_weight.data_ptr(), lm_head_weight.data_ptr())
+
+    def _make_permutation_rotation(
+        self,
+        size: int,
+        *,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        """
+        Create a deterministic orthogonal permutation rotation.
+
+        Parameters:
+            size: Matrix size.
+            device: Optional target device.
+
+        Returns:
+            A square permutation matrix with dtype float64.
+        """
+        return torch.eye(size, device=device, dtype=torch.float64).roll(
+            shifts=1, dims=1
+        )
+
+    def _make_identity_r2_map(self, model: torch.nn.Module) -> dict[str, torch.Tensor]:
+        """
+        Build an identity R2 map for all Qwen3-VL text layers.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+
+        Returns:
+            Mapping from supported R2 keys to identity matrices.
+        """
+        text_config = model.config.text_config
+        head_dim = int(text_config.head_dim)
+        return {
+            f"model.language_model.layers.{idx}.self_attn.R2": torch.eye(
+                head_dim,
+                dtype=torch.float64,
+            )
+            for idx in range(int(text_config.num_hidden_layers))
+        }
+
+    def _make_external_config(
+        self,
+        model: torch.nn.Module,
+        r1: torch.Tensor,
+        *,
+        apply_r2: bool = True,
+    ) -> Qwen3VLSpinQuantConfig:
+        """
+        Build an external-rotation Qwen3-VL SpinQuant configuration.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+            r1: Global hidden-dimension rotation.
+            apply_r2: Whether to apply identity R2 rotations.
+
+        Returns:
+            A Qwen3VLSpinQuantConfig instance.
+        """
+        return Qwen3VLSpinQuantConfig(
+            init_method="external",
+            r1=r1,
+            r2_map=self._make_identity_r2_map(model) if apply_r2 else None,
+            apply_r2=apply_r2,
+            show_progress=False,
+        )
+
+    @torch.inference_mode()
+    def test_prepare_converts_qwen3_vl_to_spin_qwen3_vl(self):
+        model = self._build_qwen3_vl_model()
+        cfg = Qwen3VLSpinQuantConfig(show_progress=False)
+
+        q_m = prepare(model, cfg)
+
+        self.assertIsInstance(q_m, SpinQwen3VLForConditionalGeneration)
+        self.assertTrue(hasattr(q_m.model.language_model, "rotate_embedding"))
+        self.assertTrue(hasattr(q_m, "rotate_lm_head"))
+        self._assert_identity_linear(q_m.model.language_model.rotate_embedding)
+        self._assert_identity_linear(q_m.rotate_lm_head)
+
+    @torch.inference_mode()
+    def test_prepare_preserves_generation_related_attributes(self):
+        model = self._build_qwen3_vl_model()
+        model.name_or_path = "dummy-qwen3-vl"
+        model._keep_in_fp32_modules = {"lm_head"}
+        model.hf_device_map = {"": "cpu"}
+
+        q_m = prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+
+        self.assertEqual(q_m.name_or_path, "dummy-qwen3-vl")
+        self.assertEqual(q_m._keep_in_fp32_modules, {"lm_head"})
+        self.assertEqual(q_m.hf_device_map, {"": "cpu"})
+        self.assertIs(q_m.config, model.config)
+
+    @torch.inference_mode()
+    def test_prepare_preserves_original_weights_before_convert(self):
+        model = self._build_qwen3_vl_model()
+        original_state = self._clone_state_dict(model)
+
+        q_m = prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.language_model.embed_tokens.weight,
+                original_state["model.language_model.embed_tokens.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                q_m.lm_head.weight,
+                original_state["lm_head.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.language_model.layers[0].self_attn.q_proj.weight,
+                original_state["model.language_model.layers.0.self_attn.q_proj.weight"],
+            )
+        )
+
+    @torch.inference_mode()
+    def test_prepare_preserves_tied_embedding_sharing(self):
+        model = self._build_qwen3_vl_model(tie_word_embeddings=True)
+        self._assert_tied_word_embedding(model)
+
+        q_m = prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+
+        self._assert_tied_word_embedding(q_m)
+
+    @torch.inference_mode()
+    def test_prepare_rejects_untied_embedding(self):
+        model = self._build_qwen3_vl_model(tie_word_embeddings=False)
+        self.assertNotEqual(
+            model.model.language_model.embed_tokens.weight.data_ptr(),
+            model.lm_head.weight.data_ptr(),
+        )
+
+        with self.assertRaises(ValueError):
+            prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+
+    @torch.inference_mode()
+    def test_prepare_identity_forward_matches_original(self):
+        torch.manual_seed(0)
+        model = self._build_qwen3_vl_model()
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+
+        original_logits = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        ).logits
+
+        q_m = prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+        prepared_logits = q_m(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        ).logits
+
+        self.assertTrue(
+            torch.allclose(original_logits, prepared_logits, atol=1e-5, rtol=1e-5)
+        )
+
+    @torch.inference_mode()
+    def test_rotate_embedding_is_on_forward_path(self):
+        model = self._build_qwen3_vl_model()
+        q_m = prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+
+        q_m.model.language_model.rotate_embedding.weight.zero_()
+        logits = q_m(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        ).logits
+
+        self.assertTrue(
+            torch.allclose(logits, torch.zeros_like(logits), atol=1e-6, rtol=0.0)
+        )
+
+    @torch.inference_mode()
+    def test_rotate_lm_head_is_on_forward_path(self):
+        model = self._build_qwen3_vl_model()
+        q_m = prepare(model, Qwen3VLSpinQuantConfig(show_progress=False))
+
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+
+        q_m.rotate_lm_head.weight.zero_()
+        logits = q_m(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        ).logits
+
+        self.assertTrue(
+            torch.allclose(logits, torch.zeros_like(logits), atol=1e-6, rtol=0.0)
+        )
+
+    @torch.inference_mode()
+    def test_convert_with_external_r1_preserves_text_logits(self):
+        torch.manual_seed(0)
+        model = self._build_qwen3_vl_model()
+        hidden_size = int(model.config.text_config.hidden_size)
+        r1 = self._make_permutation_rotation(hidden_size)
+        cfg = self._make_external_config(model, r1, apply_r2=True)
+
+        input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+
+        original_logits = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        ).logits
+
+        q_m = prepare(model, cfg)
+        q_m = convert(q_m)
+        converted_logits = q_m(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+        ).logits
+
+        self.assertTrue(
+            torch.allclose(
+                original_logits,
+                converted_logits,
+                atol=1e-4,
+                rtol=1e-4,
+            )
+        )
+
+    @torch.inference_mode()
+    def test_convert_updates_runtime_boundary_layers(self):
+        model = self._build_qwen3_vl_model()
+        hidden_size = int(model.config.text_config.hidden_size)
+        r1 = self._make_permutation_rotation(hidden_size)
+        cfg = self._make_external_config(model, r1, apply_r2=False)
+
+        q_m = prepare(model, cfg)
+        final_norm_scale = q_m.model.language_model.norm.weight.detach().clone()
+
+        q_m = convert(q_m)
+
+        expected_rotate_embedding = r1.T.to(
+            device=q_m.model.language_model.rotate_embedding.weight.device,
+            dtype=q_m.model.language_model.rotate_embedding.weight.dtype,
+        )
+        expected_rotate_lm_head = (
+            final_norm_scale.to(device=r1.device, dtype=torch.float64).view(-1, 1) * r1
+        ).to(
+            device=q_m.rotate_lm_head.weight.device,
+            dtype=q_m.rotate_lm_head.weight.dtype,
+        )
+
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.language_model.rotate_embedding.weight,
+                expected_rotate_embedding,
+            )
+        )
+        self.assertTrue(
+            torch.allclose(q_m.rotate_lm_head.weight, expected_rotate_lm_head)
+        )
+
+    @torch.inference_mode()
+    def test_convert_resets_folded_text_norms_to_identity(self):
+        model = self._build_qwen3_vl_model()
+        hidden_size = int(model.config.text_config.hidden_size)
+        r1 = self._make_permutation_rotation(hidden_size)
+        cfg = self._make_external_config(model, r1, apply_r2=False)
+
+        q_m = prepare(model, cfg)
+        q_m = convert(q_m)
+
+        for layer in q_m.model.language_model.layers:
+            self.assertTrue(
+                torch.allclose(
+                    layer.input_layernorm.weight,
+                    torch.ones_like(layer.input_layernorm.weight),
+                )
+            )
+            self.assertTrue(
+                torch.allclose(
+                    layer.post_attention_layernorm.weight,
+                    torch.ones_like(layer.post_attention_layernorm.weight),
+                )
+            )
+
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.language_model.norm.weight,
+                torch.ones_like(q_m.model.language_model.norm.weight),
+            )
+        )
+
+    @torch.inference_mode()
+    def test_convert_changes_decoder_weights_but_keeps_tied_embedding(self):
+        model = self._build_qwen3_vl_model()
+        hidden_size = int(model.config.text_config.hidden_size)
+        r1 = self._make_permutation_rotation(hidden_size)
+        cfg = self._make_external_config(model, r1, apply_r2=False)
+
+        q_m = prepare(model, cfg)
+        before_q = (
+            q_m.model.language_model.layers[0].self_attn.q_proj.weight.detach().clone()
+        )
+        before_o = (
+            q_m.model.language_model.layers[0].self_attn.o_proj.weight.detach().clone()
+        )
+        before_gate = (
+            q_m.model.language_model.layers[0].mlp.gate_proj.weight.detach().clone()
+        )
+        before_down = (
+            q_m.model.language_model.layers[0].mlp.down_proj.weight.detach().clone()
+        )
+
+        q_m = convert(q_m)
+
+        self.assertFalse(
+            torch.allclose(
+                before_q, q_m.model.language_model.layers[0].self_attn.q_proj.weight
+            )
+        )
+        self.assertFalse(
+            torch.allclose(
+                before_o, q_m.model.language_model.layers[0].self_attn.o_proj.weight
+            )
+        )
+        self.assertFalse(
+            torch.allclose(
+                before_gate, q_m.model.language_model.layers[0].mlp.gate_proj.weight
+            )
+        )
+        self.assertFalse(
+            torch.allclose(
+                before_down, q_m.model.language_model.layers[0].mlp.down_proj.weight
+            )
+        )
+        self._assert_tied_word_embedding(q_m)
+
+    @torch.inference_mode()
+    def test_convert_fuses_deepstack_outputs_but_not_main_visual_merger(self):
+        model = self._build_qwen3_vl_model(deepstack_visual_indexes=[0])
+        hidden_size = int(model.config.text_config.hidden_size)
+        r1 = self._make_permutation_rotation(hidden_size)
+        cfg = self._make_external_config(model, r1, apply_r2=False)
+
+        q_m = prepare(model, cfg)
+        main_before = q_m.model.visual.merger.linear_fc2.weight.detach().clone()
+        deep_before = (
+            q_m.model.visual.deepstack_merger_list[0].linear_fc2.weight.detach().clone()
+        )
+
+        q_m = convert(q_m)
+
+        main_after = q_m.model.visual.merger.linear_fc2.weight
+        deep_after = q_m.model.visual.deepstack_merger_list[0].linear_fc2.weight
+        expected_deep = (
+            r1.T.to(device=deep_before.device, dtype=deep_before.dtype) @ deep_before
+        )
+
+        self.assertTrue(torch.allclose(main_after, main_before))
+        self.assertTrue(torch.allclose(deep_after, expected_deep))
+
+    @torch.inference_mode()
+    def test_quantizer_direct_prepare_and_convert_with_identity_external_rotation(self):
+        assert Qwen3VLSpinQuantQuantizer is not None
+
+        model = self._build_qwen3_vl_model()
+        hidden_size = int(model.config.text_config.hidden_size)
+        r1 = torch.eye(hidden_size, dtype=torch.float64)
+        cfg = self._make_external_config(model, r1, apply_r2=True)
+        quantizer = Qwen3VLSpinQuantQuantizer(cfg)
+
+        q_m = quantizer.prepare(model)
+        q_m = quantizer.convert(q_m)
+
+        expected_identity = torch.eye(
+            hidden_size,
+            device=q_m.model.language_model.rotate_embedding.weight.device,
+            dtype=q_m.model.language_model.rotate_embedding.weight.dtype,
+        )
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.language_model.rotate_embedding.weight, expected_identity
+            )
+        )
+        self._assert_tied_word_embedding(q_m)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/quantization/algorithm/spinquant/quantizer.py
+++ b/tico/quantization/algorithm/spinquant/quantizer.py
@@ -360,3 +360,9 @@ class SpinQuantQuantizer(BaseQuantizer):
 
         if hasattr(src, "config"):
             dst.config = src.config
+
+
+# Register additional SpinQuant variants.
+from tico.quantization.algorithm.spinquant.qwen3_vl_quantizer import (  # noqa: E402,F401
+    Qwen3VLSpinQuantQuantizer,
+)

--- a/tico/quantization/algorithm/spinquant/qwen3_vl_model_utils.py
+++ b/tico/quantization/algorithm/spinquant/qwen3_vl_model_utils.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch.nn as nn
+
+from tico.quantization.config.qwen3_vl_spinquant import Qwen3VLSpinQuantConfig
+
+
+@dataclass
+class Qwen3VLSpinQuantComponents:
+    """
+    Resolved Qwen3-VL module references required by SpinQuant.
+
+    Attributes:
+        language_model: Qwen3-VL text model.
+        text_layers: Text decoder layers.
+        lm_head: Final language modeling head.
+        visual_deepstack_mergers: DeepStack visual merger modules.
+    """
+
+    language_model: nn.Module
+    text_layers: nn.ModuleList
+    lm_head: nn.Linear
+    visual_deepstack_mergers: nn.ModuleList
+
+
+def get_module_by_path(root: nn.Module, path: str) -> Any:
+    """
+    Resolve a dotted attribute path from a root module.
+
+    Parameters:
+        root: Root module.
+        path: Dotted path such as ``"model.language_model.layers"``.
+
+    Returns:
+        The resolved object.
+
+    Raises:
+        AttributeError: If the path cannot be fully resolved.
+        ValueError: If the path is empty.
+    """
+    if not path:
+        raise ValueError("path must be a non-empty string.")
+
+    current: Any = root
+    for part in path.split("."):
+        if isinstance(current, (nn.ModuleList, list, tuple)) and part.isdigit():
+            index = int(part)
+            try:
+                current = current[index]
+            except IndexError as exc:
+                raise AttributeError(
+                    f"Failed to resolve path {path!r}. Index {index} is out of range."
+                ) from exc
+            continue
+
+        if not hasattr(current, part):
+            raise AttributeError(
+                f"Failed to resolve attribute path {path!r}. "
+                f"Missing attribute {part!r} on object of type {type(current).__name__}."
+            )
+        current = getattr(current, part)
+
+    return current
+
+
+def require_linear_attr(module: nn.Module, attr_name: str) -> nn.Linear:
+    """
+    Return a required Linear attribute from a module.
+
+    Parameters:
+        module: Parent module.
+        attr_name: Attribute name.
+
+    Returns:
+        The resolved Linear module.
+
+    Raises:
+        AttributeError: If the attribute is missing.
+        TypeError: If the attribute is not an nn.Linear.
+    """
+    if not hasattr(module, attr_name):
+        raise AttributeError(
+            f"Expected attribute {attr_name!r} on module {type(module).__name__}."
+        )
+
+    value = getattr(module, attr_name)
+    if not isinstance(value, nn.Linear):
+        raise TypeError(
+            f"Expected {attr_name!r} to be nn.Linear, got {type(value).__name__}."
+        )
+
+    return value
+
+
+def resolve_qwen3_vl_spinquant_components(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> Qwen3VLSpinQuantComponents:
+    """
+    Resolve Qwen3-VL modules required by SpinQuant.
+
+    Parameters:
+        model: Target model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        Resolved component references.
+
+    Raises:
+        TypeError: If a resolved module has an unexpected type.
+    """
+    language_model = get_module_by_path(model, config.language_model_attr)
+    text_layers = get_module_by_path(model, config.text_layers_attr)
+    lm_head = get_module_by_path(model, config.lm_head_attr)
+
+    if config.fuse_deepstack_visual_outputs:
+        visual_deepstack_mergers = get_module_by_path(
+            model,
+            config.visual_deepstack_mergers_attr,
+        )
+    else:
+        visual_deepstack_mergers = nn.ModuleList()
+
+    if not isinstance(language_model, nn.Module):
+        raise TypeError(
+            f"{config.language_model_attr!r} must resolve to nn.Module, "
+            f"got {type(language_model).__name__}."
+        )
+
+    if not isinstance(text_layers, nn.ModuleList):
+        raise TypeError(
+            f"{config.text_layers_attr!r} must resolve to nn.ModuleList, "
+            f"got {type(text_layers).__name__}."
+        )
+
+    if not isinstance(lm_head, nn.Linear):
+        raise TypeError(
+            f"{config.lm_head_attr!r} must resolve to nn.Linear, "
+            f"got {type(lm_head).__name__}."
+        )
+
+    if not isinstance(visual_deepstack_mergers, nn.ModuleList):
+        raise TypeError(
+            f"{config.visual_deepstack_mergers_attr!r} must resolve to nn.ModuleList, "
+            f"got {type(visual_deepstack_mergers).__name__}."
+        )
+
+    return Qwen3VLSpinQuantComponents(
+        language_model=language_model,
+        text_layers=text_layers,
+        lm_head=lm_head,
+        visual_deepstack_mergers=visual_deepstack_mergers,
+    )
+
+
+def is_tied_word_embedding(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> bool:
+    """
+    Return whether the Qwen3-VL input embedding and LM head share storage.
+
+    Parameters:
+        model: Target model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        True if the two weights share the same data pointer.
+    """
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+
+    if not hasattr(components.language_model, "embed_tokens"):
+        return False
+
+    embed_tokens = components.language_model.embed_tokens
+    if not isinstance(embed_tokens, nn.Embedding):
+        return False
+
+    return embed_tokens.weight.data_ptr() == components.lm_head.weight.data_ptr()
+
+
+def assert_tied_word_embedding(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> None:
+    """
+    Validate that Qwen3-VL input embedding and LM head are tied.
+
+    Parameters:
+        model: Target model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Raises:
+        ValueError: If the weights are not tied.
+    """
+    if not is_tied_word_embedding(model, config):
+        raise ValueError(
+            "Qwen3-VL SpinQuant assumes tied word embeddings, but "
+            "`model.language_model.embed_tokens.weight` and `lm_head.weight` "
+            "do not share storage."
+        )
+
+
+def validate_qwen3_vl_for_spinquant(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+    *,
+    require_spin_runtime: bool = False,
+) -> None:
+    """
+    Validate that a model exposes the modules required by Qwen3-VL SpinQuant.
+
+    Parameters:
+        model: Target model.
+        config: Qwen3-VL SpinQuant configuration.
+        require_spin_runtime: Whether to require added SpinQuant runtime layers.
+
+    Raises:
+        TypeError: If the input is not a module or a submodule has an invalid type.
+        ValueError: If the model type or tied embedding assumption is invalid.
+        AttributeError: If a required module is missing.
+    """
+    if not isinstance(model, nn.Module):
+        raise TypeError(f"Expected an nn.Module, got {type(model).__name__}.")
+
+    model_config = getattr(model, "config", None)
+    model_type = getattr(model_config, "model_type", None)
+    if model_type != "qwen3_vl":
+        raise ValueError(
+            "Qwen3-VL SpinQuant supports only Qwen3-VL dense models, "
+            f"but got model_type={model_type!r}."
+        )
+
+    if not hasattr(model_config, "text_config"):
+        raise ValueError("Qwen3-VL SpinQuant requires `model.config.text_config`.")
+
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+
+    if not hasattr(components.language_model, "embed_tokens"):
+        raise AttributeError("Expected language model to expose `embed_tokens`.")
+    if not isinstance(components.language_model.embed_tokens, nn.Embedding):
+        raise TypeError(
+            "Expected language_model.embed_tokens to be nn.Embedding, "
+            f"got {type(components.language_model.embed_tokens).__name__}."
+        )
+
+    if not hasattr(components.language_model, "norm"):
+        raise AttributeError("Expected language model to expose final `norm`.")
+
+    for layer_idx, layer in enumerate(components.text_layers):
+        if not hasattr(layer, "self_attn"):
+            raise AttributeError(f"Text layer {layer_idx} is missing `self_attn`.")
+        if not hasattr(layer, "mlp"):
+            raise AttributeError(f"Text layer {layer_idx} is missing `mlp`.")
+        if not hasattr(layer, "input_layernorm"):
+            raise AttributeError(
+                f"Text layer {layer_idx} is missing `input_layernorm`."
+            )
+        if not hasattr(layer, "post_attention_layernorm"):
+            raise AttributeError(
+                f"Text layer {layer_idx} is missing `post_attention_layernorm`."
+            )
+
+        for attr_name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            require_linear_attr(layer.self_attn, attr_name)
+
+        for attr_name in ("gate_proj", "up_proj", "down_proj"):
+            require_linear_attr(layer.mlp, attr_name)
+
+    if config.fuse_deepstack_visual_outputs:
+        for merger_idx, merger in enumerate(components.visual_deepstack_mergers):
+            try:
+                require_linear_attr(merger, "linear_fc2")
+            except Exception as exc:
+                raise type(exc)(
+                    f"Invalid DeepStack merger {merger_idx}: {exc}"
+                ) from exc
+
+    assert_tied_word_embedding(model, config)
+
+    if require_spin_runtime:
+        require_linear_attr(components.language_model, "rotate_embedding")
+        require_linear_attr(model, "rotate_lm_head")

--- a/tico/quantization/algorithm/spinquant/qwen3_vl_quantizer.py
+++ b/tico/quantization/algorithm/spinquant/qwen3_vl_quantizer.py
@@ -1,0 +1,370 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+
+from tico.quantization.algorithm.spinquant.qwen3_vl_model_utils import (
+    assert_tied_word_embedding,
+    resolve_qwen3_vl_spinquant_components,
+    validate_qwen3_vl_for_spinquant,
+)
+from tico.quantization.algorithm.spinquant.qwen3_vl_rotation_utils import (
+    apply_qwen3_vl_embedding_side_rotation,
+    apply_qwen3_vl_lm_head_side_rotation,
+    build_qwen3_vl_r1,
+    build_qwen3_vl_r2,
+    extract_and_reset_qwen3_vl_final_norm_scale,
+    fuse_qwen3_vl_text_layer_norms,
+    get_qwen3_vl_head_dim,
+    get_qwen3_vl_text_hidden_size,
+    rotate_qwen3_vl_deepstack_outputs,
+    rotate_qwen3_vl_ov_r2,
+    rotate_qwen3_vl_text_layer_r1,
+)
+from tico.quantization.algorithm.spinquant.rotation_utils import (
+    infer_device,
+    infer_dtype,
+)
+from tico.quantization.algorithm.spinquant.spin_qwen3_vl import (
+    SpinQwen3VLForConditionalGeneration,
+)
+from tico.quantization.config.qwen3_vl_spinquant import Qwen3VLSpinQuantConfig
+from tico.quantization.quantizer import BaseQuantizer
+from tico.quantization.quantizer_registry import register_quantizer
+
+
+@register_quantizer(Qwen3VLSpinQuantConfig)
+class Qwen3VLSpinQuantQuantizer(BaseQuantizer):
+    """
+    Quantizer that applies tied-embedding-safe SpinQuant to Qwen3-VL.
+
+    This implementation assumes Qwen3-VL word embeddings are tied. It preserves
+    the tied storage by using runtime boundary Linear modules:
+        - model.language_model.rotate_embedding
+        - rotate_lm_head
+
+    Decoder-layer R1/R2 rotations and DeepStack output rotations are fused into
+    weights during conversion.
+    """
+
+    def __init__(self, config: Qwen3VLSpinQuantConfig):
+        """
+        Initialize the Qwen3-VL SpinQuant quantizer.
+
+        Parameters:
+            config: Qwen3-VL SpinQuant configuration.
+        """
+        super().__init__(config)
+        self.config = config
+
+    @torch.no_grad()
+    def prepare(
+        self,
+        model: nn.Module,
+        args: Optional[Any] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> nn.Module:
+        """
+        Convert a Qwen3-VL model into a SpinQwen3VL model.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+            args: Unused. Kept for API compatibility.
+            kwargs: Unused. Kept for API compatibility.
+
+        Returns:
+            A SpinQwen3VL model initialized from the source model.
+
+        Raises:
+            TypeError: If the input is not an nn.Module.
+            ValueError: If the model is not a tied Qwen3-VL model.
+        """
+        assert isinstance(self.config, Qwen3VLSpinQuantConfig)
+        validate_qwen3_vl_for_spinquant(
+            model,
+            self.config,
+            require_spin_runtime=False,
+        )
+        return self._convert_to_spin_qwen3_vl(model)
+
+    @torch.no_grad()
+    def convert(
+        self,
+        model: nn.Module,
+        args: Optional[Any] = None,
+        kwargs: Optional[dict[str, Any]] = None,
+    ) -> nn.Module:
+        """
+        Apply Qwen3-VL SpinQuant rotation fusion.
+
+        Parameters:
+            model: Prepared SpinQwen3VL model.
+            args: Unused. Kept for API compatibility.
+            kwargs: Unused. Kept for API compatibility.
+
+        Returns:
+            The rotated and fused model.
+
+        Raises:
+            ValueError: If the prepared model violates the tied embedding assumption.
+        """
+        assert isinstance(self.config, Qwen3VLSpinQuantConfig)
+        validate_qwen3_vl_for_spinquant(
+            model,
+            self.config,
+            require_spin_runtime=True,
+        )
+
+        fuse_qwen3_vl_text_layer_norms(model, self.config)
+
+        hidden_size = get_qwen3_vl_text_hidden_size(model)
+        device = infer_device(model)
+
+        if self.config.apply_r1:
+            r1 = build_qwen3_vl_r1(model, self.config)
+        else:
+            r1 = torch.eye(hidden_size, device=device, dtype=torch.float64)
+
+        final_norm_scale = extract_and_reset_qwen3_vl_final_norm_scale(
+            model,
+            self.config,
+        )
+
+        apply_qwen3_vl_embedding_side_rotation(model, self.config, r1)
+        apply_qwen3_vl_lm_head_side_rotation(
+            model,
+            self.config,
+            r1,
+            norm_scale=final_norm_scale,
+        )
+
+        components = resolve_qwen3_vl_spinquant_components(model, self.config)
+        layers = components.text_layers
+        head_dim = get_qwen3_vl_head_dim(model)
+
+        iterator = enumerate(layers)
+        if self.config.show_progress:
+            iterator = tqdm(
+                iterator,
+                total=len(layers),
+                desc="Applying Qwen3-VL SpinQuant rotations",
+            )
+
+        for layer_idx, layer in iterator:
+            if self.config.apply_r1:
+                rotate_qwen3_vl_text_layer_r1(layer, r1)
+
+            if self.config.apply_r2:
+                r2 = build_qwen3_vl_r2(
+                    init_method=self.config.init_method,
+                    r2_map=self.config.r2_map,
+                    layer_idx=layer_idx,
+                    head_dim=head_dim,
+                    device=device,
+                )
+                rotate_qwen3_vl_ov_r2(layer, r2, head_dim)
+
+        if self.config.apply_r1:
+            rotate_qwen3_vl_deepstack_outputs(model, self.config, r1)
+
+        assert_tied_word_embedding(model, self.config)
+        return model
+
+    @torch.no_grad()
+    def _convert_to_spin_qwen3_vl(
+        self,
+        model: nn.Module,
+    ) -> SpinQwen3VLForConditionalGeneration:
+        """
+        Create a SpinQwen3VLForConditionalGeneration instance from Qwen3-VL.
+
+        Parameters:
+            model: Source Qwen3-VL model.
+
+        Returns:
+            A SpinQwen3VL model with copied source weights and identity runtime
+            rotation layers.
+        """
+        target_device = infer_device(model)
+        target_dtype = infer_dtype(model)
+
+        spin_model = SpinQwen3VLForConditionalGeneration(model.config)
+        spin_model.to(device=target_device, dtype=target_dtype)
+
+        missing_keys, unexpected_keys = spin_model.load_state_dict(
+            model.state_dict(),
+            strict=False,
+        )
+
+        self._validate_state_dict_keys(
+            missing_keys=missing_keys,
+            unexpected_keys=unexpected_keys,
+        )
+
+        self._initialize_spin_weights(spin_model)
+        self._force_tied_word_embedding(spin_model)
+        assert isinstance(self.config, Qwen3VLSpinQuantConfig)
+        assert_tied_word_embedding(spin_model, self.config)
+        self._copy_runtime_attributes(src=model, dst=spin_model)
+        self._force_tied_word_embedding(spin_model)
+        assert_tied_word_embedding(spin_model, self.config)
+
+        if model.training:
+            spin_model.train()
+        else:
+            spin_model.eval()
+
+        return spin_model
+
+    @torch.no_grad()
+    def _initialize_spin_weights(
+        self,
+        model: SpinQwen3VLForConditionalGeneration,
+    ) -> None:
+        """
+        Initialize Qwen3-VL SpinQuant runtime layers as identity transforms.
+
+        Parameters:
+            model: Prepared SpinQwen3VL model.
+        """
+        assert isinstance(self.config, Qwen3VLSpinQuantConfig)
+        components = resolve_qwen3_vl_spinquant_components(model, self.config)
+        self._init_linear_as_identity(components.language_model.rotate_embedding)
+        self._init_linear_as_identity(model.rotate_lm_head)
+
+    @torch.no_grad()
+    def _force_tied_word_embedding(
+        self,
+        model: SpinQwen3VLForConditionalGeneration,
+    ) -> None:
+        """
+        Force the SpinQwen3VL input embedding and LM head to share storage.
+
+        `load_state_dict` copies tensor values into existing Parameter
+        objects and does not preserve aliasing between tied parameters. Some
+        transformers versions also do not materialize Qwen3-VL ties through
+        `tie_weights()` for small synthetic configs. SpinQuant relies on the
+        tied-weight invariant, so the alias is restored explicitly here.
+
+        Parameters:
+            model: Prepared SpinQwen3VL model to update in-place.
+        """
+        assert isinstance(self.config, Qwen3VLSpinQuantConfig)
+        components = resolve_qwen3_vl_spinquant_components(model, self.config)
+        embed_tokens = getattr(components.language_model, "embed_tokens")
+        if not isinstance(embed_tokens, nn.Embedding):
+            raise TypeError(
+                "Expected language_model.embed_tokens to be nn.Embedding, "
+                f"got {type(embed_tokens).__name__}."
+            )
+
+        components.lm_head.weight = embed_tokens.weight
+
+        if hasattr(model, "config"):
+            model.config.tie_word_embeddings = True
+            if hasattr(model.config, "text_config"):
+                model.config.text_config.tie_word_embeddings = True
+
+    @torch.no_grad()
+    def _init_linear_as_identity(self, layer: nn.Linear) -> None:
+        """
+        Initialize a square Linear layer as identity.
+
+        Parameters:
+            layer: Target Linear layer.
+
+        Raises:
+            ValueError: If the layer is not square.
+        """
+        if layer.in_features != layer.out_features:
+            raise ValueError(
+                "SpinQuant runtime layers must be square, but got "
+                f"in_features={layer.in_features}, out_features={layer.out_features}."
+            )
+
+        eye = torch.eye(
+            layer.in_features,
+            device=layer.weight.device,
+            dtype=layer.weight.dtype,
+        )
+        layer.weight.copy_(eye)
+
+        if layer.bias is not None:
+            layer.bias.zero_()
+
+    def _validate_state_dict_keys(
+        self,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+    ) -> None:
+        """
+        Validate state_dict loading results for SpinQwen3VL conversion.
+
+        Parameters:
+            missing_keys: Keys missing when loading the source state_dict.
+            unexpected_keys: Extra keys from the source state_dict.
+
+        Raises:
+            ValueError: If unexpected missing or unexpected keys are found.
+        """
+        expected_missing = {
+            "model.language_model.rotate_embedding.weight",
+            "rotate_lm_head.weight",
+        }
+
+        missing_set = set(missing_keys)
+        unexpected_missing = missing_set - expected_missing
+
+        if unexpected_missing:
+            raise ValueError(
+                "Unexpected missing keys were found while converting to "
+                f"SpinQwen3VL: {sorted(unexpected_missing)}"
+            )
+
+        if unexpected_keys:
+            raise ValueError(
+                "Unexpected keys were found while converting to "
+                f"SpinQwen3VL: {sorted(unexpected_keys)}"
+            )
+
+    def _copy_runtime_attributes(
+        self,
+        src: nn.Module,
+        dst: SpinQwen3VLForConditionalGeneration,
+    ) -> None:
+        """
+        Copy runtime attributes from the source model to the SpinQwen3VL model.
+
+        Parameters:
+            src: Source Qwen3-VL model.
+            dst: Destination SpinQwen3VL model.
+        """
+        if hasattr(src, "generation_config"):
+            dst.generation_config = src.generation_config
+
+        if hasattr(src, "name_or_path"):
+            dst.name_or_path = src.name_or_path
+
+        if hasattr(src, "_keep_in_fp32_modules"):
+            dst._keep_in_fp32_modules = src._keep_in_fp32_modules
+
+        if hasattr(src, "hf_device_map"):
+            dst.hf_device_map = src.hf_device_map
+
+        if hasattr(src, "config"):
+            dst.config = src.config

--- a/tico/quantization/algorithm/spinquant/qwen3_vl_rotation_utils.py
+++ b/tico/quantization/algorithm/spinquant/qwen3_vl_rotation_utils.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.algorithm.spinquant.fuse_norm_utils import (
+    fuse_norm_into_linears,
+    reset_norm_affine_to_identity,
+)
+from tico.quantization.algorithm.spinquant.hadamard_utils import (
+    make_random_hadamard_rotation,
+)
+from tico.quantization.algorithm.spinquant.qwen3_vl_model_utils import (
+    require_linear_attr,
+    resolve_qwen3_vl_spinquant_components,
+)
+from tico.quantization.algorithm.spinquant.rotation_utils import (
+    copy_linear_weight_,
+    infer_device,
+    left_multiply_linear_weight_,
+    make_random_orthogonal_rotation,
+    rotate_attention_inputs,
+    rotate_attention_output,
+    rotate_mlp_input,
+    rotate_mlp_output,
+    rotate_ov_proj,
+    validate_square_rotation,
+)
+from tico.quantization.config.qwen3_vl_spinquant import Qwen3VLSpinQuantConfig
+
+
+def get_qwen3_vl_text_hidden_size(model: nn.Module) -> int:
+    """
+    Return the Qwen3-VL text hidden size.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+
+    Returns:
+        Text hidden size.
+
+    Raises:
+        AttributeError: If the text configuration is missing.
+    """
+    if not hasattr(model, "config") or not hasattr(model.config, "text_config"):
+        raise AttributeError("Expected `model.config.text_config` to exist.")
+    return int(model.config.text_config.hidden_size)
+
+
+def get_qwen3_vl_head_dim(model: nn.Module) -> int:
+    """
+    Return the Qwen3-VL text attention head dimension.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+
+    Returns:
+        Attention head dimension.
+
+    Raises:
+        AttributeError: If the text configuration is missing.
+        ValueError: If the inferred dimensions are invalid.
+    """
+    if not hasattr(model, "config") or not hasattr(model.config, "text_config"):
+        raise AttributeError("Expected `model.config.text_config` to exist.")
+
+    text_config = model.config.text_config
+    if hasattr(text_config, "head_dim") and text_config.head_dim is not None:
+        return int(text_config.head_dim)
+
+    hidden_size = int(text_config.hidden_size)
+    num_heads = int(text_config.num_attention_heads)
+    if hidden_size % num_heads != 0:
+        raise ValueError(
+            f"hidden_size ({hidden_size}) must be divisible by "
+            f"num_attention_heads ({num_heads})."
+        )
+    return hidden_size // num_heads
+
+
+def build_qwen3_vl_r1(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> torch.Tensor:
+    """
+    Build the Qwen3-VL global hidden-dimension R1 rotation.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        A square rotation matrix with shape ``[hidden_size, hidden_size]``.
+
+    Raises:
+        ValueError: If the configuration is invalid.
+    """
+    hidden_size = get_qwen3_vl_text_hidden_size(model)
+    device = infer_device(model)
+
+    if config.init_method == "random":
+        return make_random_orthogonal_rotation(hidden_size, device=device)
+
+    if config.init_method == "hadamard":
+        return make_random_hadamard_rotation(hidden_size, device=device)
+
+    if config.init_method == "external":
+        if config.r1 is None:
+            raise ValueError("`r1` must be provided when init_method='external'.")
+        rotation = config.r1.to(device=device, dtype=torch.float64)
+        validate_square_rotation("r1", rotation, hidden_size)
+        return rotation
+
+    raise ValueError(f"Unsupported init_method: {config.init_method!r}")
+
+
+def build_qwen3_vl_r2(
+    *,
+    init_method: str,
+    r2_map: Optional[dict[str, torch.Tensor]],
+    layer_idx: int,
+    head_dim: int,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    """
+    Build or fetch a Qwen3-VL per-layer head-dimension R2 rotation.
+
+    Parameters:
+        init_method: Rotation initialization strategy.
+        r2_map: Optional mapping from keys to external R2 matrices.
+        layer_idx: Text decoder layer index.
+        head_dim: Attention head dimension.
+        device: Target device.
+
+    Returns:
+        A square R2 matrix or None.
+
+    Raises:
+        ValueError: If an external R2 has an invalid shape.
+    """
+    if init_method == "random":
+        return make_random_orthogonal_rotation(head_dim, device=device)
+
+    if init_method == "hadamard":
+        return make_random_hadamard_rotation(head_dim, device=device)
+
+    if init_method == "external":
+        if r2_map is None:
+            return None
+
+        candidate_keys = (
+            f"model.language_model.layers.{layer_idx}.self_attn.R2",
+            f"model.layers.{layer_idx}.self_attn.R2",
+        )
+        for key in candidate_keys:
+            rotation = r2_map.get(key)
+            if rotation is None:
+                continue
+
+            rotation = rotation.to(device=device, dtype=torch.float64)
+            validate_square_rotation(key, rotation, head_dim)
+            return rotation
+
+        return None
+
+    raise ValueError(f"Unsupported init_method: {init_method!r}")
+
+
+@torch.no_grad()
+def fuse_qwen3_vl_text_layer_norms(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> nn.Module:
+    """
+    Fold Qwen3-VL text RMSNorm affine weights into adjacent Linear layers.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        The same model instance.
+
+    Raises:
+        AttributeError: If required norm modules are missing.
+        TypeError: If adjacent modules are not Linear layers.
+    """
+    if getattr(model, "_qwen3_vl_spinquant_norms_fused", False):
+        return model
+
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+
+    for layer in components.text_layers:
+        input_norm = getattr(layer, "input_layernorm")
+        post_attn_norm = getattr(layer, "post_attention_layernorm")
+
+        q_proj = require_linear_attr(layer.self_attn, "q_proj")
+        k_proj = require_linear_attr(layer.self_attn, "k_proj")
+        v_proj = require_linear_attr(layer.self_attn, "v_proj")
+        gate_proj = require_linear_attr(layer.mlp, "gate_proj")
+        up_proj = require_linear_attr(layer.mlp, "up_proj")
+
+        fuse_norm_into_linears(input_norm, [q_proj, k_proj, v_proj])
+        fuse_norm_into_linears(post_attn_norm, [gate_proj, up_proj])
+
+        reset_norm_affine_to_identity(input_norm)
+        reset_norm_affine_to_identity(post_attn_norm)
+
+    setattr(model, "_qwen3_vl_spinquant_norms_fused", True)
+    return model
+
+
+@torch.no_grad()
+def extract_and_reset_qwen3_vl_final_norm_scale(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> torch.Tensor:
+    """
+    Extract the Qwen3-VL final text RMSNorm scale and reset it to identity.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        The original final norm scale as a float64 tensor.
+
+    Raises:
+        AttributeError: If the final norm does not expose a weight.
+    """
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+    final_norm = components.language_model.norm
+
+    if not hasattr(final_norm, "weight") or final_norm.weight is None:
+        raise AttributeError("Expected final text norm to expose `weight`.")
+
+    gamma = (
+        final_norm.weight.data.detach()
+        .to(device=final_norm.weight.device, dtype=torch.float64)
+        .clone()
+    )
+
+    reset_norm_affine_to_identity(final_norm)
+    return gamma
+
+
+@torch.no_grad()
+def apply_qwen3_vl_embedding_side_rotation(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+    r1: torch.Tensor,
+) -> None:
+    """
+    Store the input-side R1 rotation in the Qwen3-VL runtime boundary module.
+
+    Parameters:
+        model: Target SpinQwen3VL model.
+        config: Qwen3-VL SpinQuant configuration.
+        r1: Global hidden-dimension rotation matrix.
+
+    Notes:
+        The runtime transform should compute ``x @ R1``. For ``nn.Linear``,
+        ``output = x @ weight.T``, so the stored weight is ``R1.T``.
+    """
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+    rotate_embedding = require_linear_attr(
+        components.language_model, "rotate_embedding"
+    )
+    copy_linear_weight_(rotate_embedding, r1.T)
+
+
+@torch.no_grad()
+def apply_qwen3_vl_lm_head_side_rotation(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+    r1: torch.Tensor,
+    norm_scale: torch.Tensor,
+) -> None:
+    """
+    Store the output-side R1 correction and final norm scale.
+
+    Parameters:
+        model: Target SpinQwen3VL model.
+        config: Qwen3-VL SpinQuant configuration.
+        r1: Global hidden-dimension rotation matrix.
+        norm_scale: Original final RMSNorm affine scale.
+
+    Notes:
+        The runtime transform should compute ``x @ R1.T @ diag(norm_scale)``.
+        For ``nn.Linear``, this is represented by storing
+        ``diag(norm_scale) @ R1`` as the weight.
+    """
+    rotate_lm_head = require_linear_attr(model, "rotate_lm_head")
+
+    gamma = norm_scale.to(device=r1.device, dtype=torch.float64)
+    if gamma.ndim != 1 or gamma.numel() != r1.shape[0]:
+        raise ValueError(
+            f"`norm_scale` must have shape [{r1.shape[0]}], got {tuple(gamma.shape)}."
+        )
+
+    weight = gamma.view(-1, 1) * r1
+    copy_linear_weight_(rotate_lm_head, weight)
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_text_layer_r1(
+    layer: nn.Module,
+    r1: torch.Tensor,
+) -> None:
+    """
+    Fuse R1 into one Qwen3-VL text decoder layer.
+
+    Parameters:
+        layer: Qwen3-VL text decoder layer.
+        r1: Global hidden-dimension rotation matrix.
+    """
+    rotate_attention_inputs(layer, r1)
+    rotate_attention_output(layer, r1)
+    rotate_mlp_input(layer, r1)
+    rotate_mlp_output(layer, r1)
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_ov_r2(
+    layer: nn.Module,
+    r2: Optional[torch.Tensor],
+    head_dim: int,
+) -> None:
+    """
+    Fuse OV-side R2 into one Qwen3-VL text attention layer.
+
+    Parameters:
+        layer: Qwen3-VL text decoder layer.
+        r2: Optional head-dimension R2 matrix.
+        head_dim: Attention head dimension.
+    """
+    rotate_ov_proj(layer, r2, head_dim)
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_deepstack_outputs(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+    r1: torch.Tensor,
+) -> None:
+    """
+    Fuse R1 into Qwen3-VL DeepStack visual output projections.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+        r1: Global hidden-dimension rotation matrix.
+
+    Notes:
+        Main visual merger outputs are not fused here because they are inserted
+        into ``inputs_embeds`` before the language-model entry rotation.
+        DeepStack outputs are injected inside the text decoder, so they must be
+        converted to the rotated residual basis.
+    """
+    if not config.fuse_deepstack_visual_outputs:
+        return
+
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+    for merger in components.visual_deepstack_mergers:
+        linear_fc2 = require_linear_attr(merger, "linear_fc2")
+        left_multiply_linear_weight_(linear_fc2, r1.T)

--- a/tico/quantization/algorithm/spinquant/spin_qwen3_vl.py
+++ b/tico/quantization/algorithm/spinquant/spin_qwen3_vl.py
@@ -1,0 +1,287 @@
+# Copyright 2025 The Qwen Team and The HuggingFace Inc. team. All rights reserved.
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional, Union
+
+import torch
+import torch.nn as nn
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+    Qwen3VLForConditionalGeneration,
+    Qwen3VLModel,
+    Qwen3VLTextModel,
+    Qwen3VLVisionModel,
+)
+
+try:
+    from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+        Qwen3VLCausalLMOutputWithPast,
+    )
+except ImportError:
+    Qwen3VLCausalLMOutputWithPast = CausalLMOutputWithPast
+
+
+def _build_causal_lm_output(**kwargs: Any) -> Any:
+    """
+    Build a Qwen3-VL causal LM output while tolerating transformer version drift.
+
+    Parameters:
+        **kwargs: Output fields.
+
+    Returns:
+        A causal LM output object.
+    """
+    try:
+        return Qwen3VLCausalLMOutputWithPast(**kwargs)
+    except TypeError:
+        fallback_kwargs = dict(kwargs)
+        fallback_kwargs.pop("rope_deltas", None)
+        return CausalLMOutputWithPast(**fallback_kwargs)
+
+
+class SpinQwen3VLTextModel(Qwen3VLTextModel):
+    """
+    Qwen3-VL text model extended with an input-side SpinQuant rotation.
+
+    The added ``rotate_embedding`` layer rotates the complete input embedding
+    tensor after text and main visual embeddings are already resolved. This
+    preserves tied word embeddings because the shared embedding table itself is
+    not modified.
+    """
+
+    def __init__(self, config):
+        """
+        Initialize the SpinQwen3VL text model.
+
+        Parameters:
+            config: Qwen3-VL text configuration.
+        """
+        super().__init__(config)
+        self.rotate_embedding = nn.Linear(
+            config.hidden_size,
+            config.hidden_size,
+            bias=False,
+        )
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        visual_pos_masks: Optional[torch.Tensor] = None,
+        deepstack_visual_embeds: Optional[list[torch.Tensor]] = None,
+        **kwargs,
+    ):
+        """
+        Run the text forward pass with an input-side SpinQuant rotation.
+
+        Parameters:
+            input_ids: Optional token IDs.
+            attention_mask: Optional attention mask.
+            position_ids: Optional position IDs.
+            past_key_values: Optional KV cache.
+            inputs_embeds: Optional precomputed embeddings.
+            use_cache: Whether to use the KV cache.
+            visual_pos_masks: Optional masks for DeepStack visual positions.
+            deepstack_visual_embeds: Optional DeepStack visual embeddings.
+            **kwargs: Additional arguments forwarded to the base text model.
+
+        Returns:
+            The output of the base Qwen3-VL text model.
+        """
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError(
+                    "Exactly one of `input_ids` or `inputs_embeds` must be provided."
+                )
+            inputs_embeds = self.embed_tokens(input_ids)
+        elif input_ids is not None:
+            raise ValueError(
+                "Exactly one of `input_ids` or `inputs_embeds` must be provided."
+            )
+
+        inputs_embeds = self.rotate_embedding(inputs_embeds)
+
+        return super().forward(
+            input_ids=None,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+            **kwargs,
+        )
+
+
+class SpinQwen3VLModel(Qwen3VLModel):
+    """
+    Qwen3-VL multimodal model that uses SpinQwen3VLTextModel.
+
+    The vision tower is explicitly initialized from ``config.vision_config`` and
+    the text tower is explicitly initialized from ``config.text_config``. This
+    avoids accidentally constructing a vision wrapper with the top-level
+    Qwen3VLConfig, which would break PTQ wrapping.
+    """
+
+    def __init__(self, config):
+        """
+        Initialize the SpinQwen3VL multimodal model.
+
+        Parameters:
+            config: Qwen3-VL configuration.
+        """
+        super().__init__(config)
+        self.visual = Qwen3VLVisionModel._from_config(config.vision_config)
+        self.language_model = SpinQwen3VLTextModel._from_config(config.text_config)
+        self.rope_deltas = None
+        self.post_init()
+
+
+class SpinQwen3VLForConditionalGeneration(Qwen3VLForConditionalGeneration):
+    """
+    Qwen3-VL conditional generation model extended with SpinQuant boundaries.
+
+    This model preserves tied word embeddings by leaving ``embed_tokens`` and
+    ``lm_head`` weights unchanged. The input-side rotation is stored in
+    ``model.language_model.rotate_embedding`` and the output-side correction is
+    stored in ``rotate_lm_head``.
+    """
+
+    _tied_weights_keys = {"lm_head.weight": "model.language_model.embed_tokens.weight"}
+
+    def __init__(self, config):
+        """
+        Initialize the SpinQwen3VL conditional generation model.
+
+        Parameters:
+            config: Qwen3-VL configuration.
+        """
+        super().__init__(config)
+        self.model = SpinQwen3VLModel(config)
+
+        hidden_size = int(config.text_config.hidden_size)
+        vocab_size = int(config.text_config.vocab_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+        self.rotate_lm_head = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.LongTensor] = None,
+        pixel_values_videos: Optional[torch.Tensor] = None,
+        video_grid_thw: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        **kwargs,
+    ):
+        """
+        Run the conditional generation forward pass with an output-side rotation.
+
+        Parameters:
+            input_ids: Optional token IDs.
+            pixel_values: Optional image pixel values.
+            image_grid_thw: Optional image temporal-height-width grid.
+            pixel_values_videos: Optional video pixel values.
+            video_grid_thw: Optional video temporal-height-width grid.
+            attention_mask: Optional attention mask.
+            position_ids: Optional position IDs.
+            past_key_values: Optional KV cache.
+            inputs_embeds: Optional precomputed embeddings.
+            labels: Optional language modeling labels.
+            use_cache: Whether to use the KV cache.
+            cache_position: Optional cache positions.
+            output_attentions: Whether to return attentions.
+            output_hidden_states: Whether to return hidden states.
+            return_dict: Whether to return a ModelOutput.
+            logits_to_keep: Token positions to keep for logits.
+            **kwargs: Additional arguments forwarded to the Qwen3-VL model.
+
+        Returns:
+            A causal LM output containing logits and optional loss.
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        model_kwargs = dict(kwargs)
+        optional_kwargs = {
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+            "pixel_values_videos": pixel_values_videos,
+            "video_grid_thw": video_grid_thw,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": past_key_values,
+            "inputs_embeds": inputs_embeds,
+            "use_cache": use_cache,
+            "cache_position": cache_position,
+            "output_attentions": output_attentions,
+            "output_hidden_states": output_hidden_states,
+            "return_dict": return_dict,
+        }
+        for key, value in optional_kwargs.items():
+            if value is not None:
+                model_kwargs[key] = value
+
+        outputs = self.model(input_ids=input_ids, **model_kwargs)
+
+        hidden_states = outputs[0]
+        hidden_states = self.rotate_lm_head(hidden_states)
+
+        if isinstance(logits_to_keep, int):
+            slice_indices = slice(-logits_to_keep, None)
+        else:
+            slice_indices = logits_to_keep
+
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=int(self.config.text_config.vocab_size),
+                **kwargs,
+            )
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return _build_causal_lm_output(
+            loss=loss,
+            logits=logits,
+            past_key_values=getattr(outputs, "past_key_values", None),
+            hidden_states=getattr(outputs, "hidden_states", None),
+            attentions=getattr(outputs, "attentions", None),
+            rope_deltas=getattr(outputs, "rope_deltas", None),
+        )

--- a/tico/quantization/config/qwen3_vl_spinquant.py
+++ b/tico/quantization/config/qwen3_vl_spinquant.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Literal, Optional
+
+import torch
+
+from tico.quantization.config.base import BaseConfig
+
+
+class Qwen3VLSpinQuantConfig(BaseConfig):
+    """
+    Configuration for tied-embedding-safe SpinQuant on Qwen3-VL.
+
+    This configuration is scoped to Phase 1:
+        - text decoder R1 fusion
+        - optional attention OV-side R2 fusion
+        - tied-safe input and output boundary rotations
+        - DeepStack visual output rotation fusion
+
+    The word embedding and LM head are assumed to be tied. Therefore, the
+    boundary rotations are stored in dedicated runtime Linear modules instead
+    of directly modifying the shared embedding table.
+    """
+
+    def __init__(
+        self,
+        init_method: Literal["random", "hadamard", "external"] = "random",
+        r1: Optional[torch.Tensor] = None,
+        r2_map: Optional[Dict[str, torch.Tensor]] = None,
+        apply_r1: bool = True,
+        apply_r2: bool = True,
+        fuse_deepstack_visual_outputs: bool = True,
+        show_progress: bool = True,
+        language_model_attr: str = "model.language_model",
+        text_layers_attr: str = "model.language_model.layers",
+        visual_deepstack_mergers_attr: str = "model.visual.deepstack_merger_list",
+        lm_head_attr: str = "lm_head",
+    ):
+        """
+        Initialize Qwen3-VL SpinQuant configuration.
+
+        Parameters:
+            init_method:
+                Strategy for resolving rotation matrices.
+
+                - "random": use random orthogonal matrices.
+                - "hadamard": use randomized Hadamard orthogonal matrices.
+                - "external": use user-provided matrices.
+
+            r1:
+                Optional global hidden-dimension rotation matrix. This is
+                required when ``init_method == "external"`` and ``apply_r1`` is
+                enabled.
+
+            r2_map:
+                Optional mapping from module keys to per-layer head-dimension
+                rotation matrices.
+
+                Supported example keys:
+                    - "model.language_model.layers.0.self_attn.R2"
+                    - "model.layers.0.self_attn.R2"
+
+            apply_r1:
+                Whether to apply the global hidden-dimension R1 rotation.
+
+            apply_r2:
+                Whether to apply the OV-side head-dimension R2 rotation.
+
+            fuse_deepstack_visual_outputs:
+                Whether to fuse R1 into DeepStack visual output projections.
+                Main visual merger outputs are not fused because they pass
+                through the input-side runtime rotation.
+
+            show_progress:
+                If True, display a tqdm progress bar during conversion.
+
+            language_model_attr:
+                Dotted path to the Qwen3-VL text model.
+
+            text_layers_attr:
+                Dotted path to the Qwen3-VL text decoder layers.
+
+            visual_deepstack_mergers_attr:
+                Dotted path to the DeepStack merger module list.
+
+            lm_head_attr:
+                Dotted path to the final language modeling head.
+        """
+        self.init_method = init_method
+        self.r1 = r1
+        self.r2_map = r2_map
+        self.apply_r1 = apply_r1
+        self.apply_r2 = apply_r2
+        self.fuse_deepstack_visual_outputs = fuse_deepstack_visual_outputs
+        self.show_progress = show_progress
+        self.language_model_attr = language_model_attr
+        self.text_layers_attr = text_layers_attr
+        self.visual_deepstack_mergers_attr = visual_deepstack_mergers_attr
+        self.lm_head_attr = lm_head_attr
+
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validate the configuration.
+
+        Raises:
+            ValueError: If a configuration value is invalid.
+            TypeError: If a field has an unexpected type.
+        """
+        if self.init_method not in {"random", "hadamard", "external"}:
+            raise ValueError(f"Unsupported init_method: {self.init_method!r}")
+
+        if self.apply_r1 and self.init_method == "external" and self.r1 is None:
+            raise ValueError(
+                "`r1` must be provided when init_method='external' and apply_r1=True."
+            )
+
+        if self.r1 is not None and not isinstance(self.r1, torch.Tensor):
+            raise TypeError(f"`r1` must be a torch.Tensor, got {type(self.r1)}.")
+
+        if self.r2_map is not None:
+            if not isinstance(self.r2_map, dict):
+                raise TypeError(
+                    f"`r2_map` must be a dict[str, torch.Tensor], got {type(self.r2_map)}."
+                )
+
+            for key, value in self.r2_map.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"Invalid r2_map key: {key!r}")
+                if not isinstance(value, torch.Tensor):
+                    raise TypeError(
+                        f"r2_map[{key!r}] must be a torch.Tensor, got {type(value)}."
+                    )
+
+        for field_name in (
+            "language_model_attr",
+            "text_layers_attr",
+            "visual_deepstack_mergers_attr",
+            "lm_head_attr",
+        ):
+            field_value = getattr(self, field_name)
+            if not isinstance(field_value, str) or not field_value:
+                raise ValueError(
+                    f"{field_name} must be a non-empty string, got {field_value!r}."
+                )
+
+    @property
+    def name(self) -> str:
+        return "spinquant"

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -26,6 +26,7 @@ from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
 from tico.quantization.algorithm.smoothquant.smooth_quant import apply_smoothing
 from tico.quantization.config.builders import build_qwen3_vl_ptq_config
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
+from tico.quantization.config.qwen3_vl_spinquant import Qwen3VLSpinQuantConfig
 from tico.quantization.evaluation.hellaswag_eval_utils import (
     evaluate_hellaswag,
     get_hellaswag_accuracy,
@@ -205,7 +206,10 @@ def parse_args():
         "--lm_head_weight_bits",
         type=int,
         default=4,
-        help="Number of bits for lm_head quantization.",
+        help=(
+            "Number of bits for lm_head quantization. Qwen3-VL SpinQuant assumes "
+            "tied word embeddings, so this must match --embedding_weight_bits."
+        ),
     )
     parser.add_argument(
         "--gptq_mse",
@@ -287,6 +291,51 @@ def parse_args():
         default=2,
         help="Spatial merge size for vision tokens.",
     )
+
+    # SpinQuant arguments
+    parser.add_argument(
+        "--spinquant",
+        action="store_true",
+        default=False,
+        help="Apply tied-embedding-safe Qwen3-VL SpinQuant before SmoothQuant/GPTQ/PTQ.",
+    )
+    parser.add_argument(
+        "--spinquant_init_method",
+        choices=["random", "hadamard", "external"],
+        default="random",
+        help="Rotation initialization method for Qwen3-VL SpinQuant.",
+    )
+    parser.add_argument(
+        "--spinquant_disable_r1",
+        action="store_true",
+        default=False,
+        help="Disable global hidden-dimension R1 rotation.",
+    )
+    parser.add_argument(
+        "--spinquant_disable_r2",
+        action="store_true",
+        default=False,
+        help="Disable OV-side head-dimension R2 rotation.",
+    )
+    parser.add_argument(
+        "--spinquant_disable_deepstack_fusion",
+        action="store_true",
+        default=False,
+        help="Disable R1 fusion for Qwen3-VL DeepStack visual output projections.",
+    )
+    parser.add_argument(
+        "--spinquant_r1_path",
+        type=str,
+        default=None,
+        help="Optional path to an external R1 tensor.",
+    )
+    parser.add_argument(
+        "--spinquant_r2_map_path",
+        type=str,
+        default=None,
+        help="Optional path to an external R2 tensor map.",
+    )
+
     # SmoothQuant arguments (for LayerNorm-based vision components and RMSNorm-based text components)
     parser.add_argument(
         "--smoothquant",
@@ -524,6 +573,19 @@ def evaluate_model_coco(
     nsamples: int = 50,
     max_seq_len: Optional[int] = None,
 ):
+    """
+    Evaluate a model on the mini COCO captioning benchmark.
+
+    Args:
+        model: Model to evaluate.
+        processor: Hugging Face processor.
+        device: Target device string.
+        nsamples: Number of evaluation samples. -1 means full dataset.
+        max_seq_len: Optional maximum text sequence length.
+
+    Returns:
+        COCO metric dictionary.
+    """
     with (
         io.StringIO() as buffer,
         contextlib.redirect_stdout(buffer),
@@ -603,6 +665,86 @@ def print_markdown_comparison(
     print(sep)
     print(original_row)
     print(quantized_row)
+
+
+def load_torch_object(path: Optional[str]) -> Any:
+    """
+    Load a torch object from disk if a path is provided.
+
+    Args:
+        path: Optional file path.
+
+    Returns:
+        Loaded object, or None if the path is None.
+    """
+    if path is None:
+        return None
+    return torch.load(path, map_location="cpu")
+
+
+def ensure_spinquant_compatible_args(args: argparse.Namespace) -> None:
+    """
+    Validate command-line options that interact with Qwen3-VL SpinQuant.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Raises:
+        ValueError: If incompatible options are enabled together.
+    """
+    if not args.spinquant:
+        return
+
+    if args.smoothquant and args.smoothquant_components in {"text", "both"}:
+        raise ValueError(
+            "Qwen3-VL SpinQuant Phase 1 does not support text SmoothQuant "
+            "together. Use --smoothquant_components vision or disable SmoothQuant."
+        )
+
+    if args.embedding_weight_bits != args.lm_head_weight_bits:
+        raise ValueError(
+            "Qwen3-VL SpinQuant assumes tied word embeddings, so "
+            "--embedding_weight_bits and --lm_head_weight_bits must match."
+        )
+
+
+def apply_spinquant_if_enabled(
+    model: torch.nn.Module,
+    args: argparse.Namespace,
+) -> torch.nn.Module:
+    """
+    Apply Qwen3-VL SpinQuant before SmoothQuant/GPTQ/PTQ if requested.
+
+    Args:
+        model: Floating-point Qwen3-VL model.
+        args: Parsed command-line arguments.
+
+    Returns:
+        The original model if SpinQuant is disabled, otherwise a SpinQwen3VL
+        model with fused rotations.
+    """
+    if not args.spinquant:
+        return model
+
+    r1 = load_torch_object(args.spinquant_r1_path)
+    r2_map = load_torch_object(args.spinquant_r2_map_path)
+
+    spinquant_config = Qwen3VLSpinQuantConfig(
+        init_method=args.spinquant_init_method,
+        r1=r1,
+        r2_map=r2_map,
+        apply_r1=not args.spinquant_disable_r1,
+        apply_r2=not args.spinquant_disable_r2,
+        fuse_deepstack_visual_outputs=not args.spinquant_disable_deepstack_fusion,
+        show_progress=not args.hide_progress,
+    )
+
+    print("Applying Qwen3-VL SpinQuant …")
+    model = prepare(model, spinquant_config, inplace=True)
+    model = convert(model, inplace=True)
+    model.eval()
+    print("Qwen3-VL SpinQuant complete.")
+    return model
 
 
 def has_gptq_targets(args) -> bool:
@@ -844,12 +986,24 @@ def get_num_deepstack_mergers(q_m) -> int:
     return num_deepstack_mergers
 
 
-def apply_smoothquant_if_requested(model, calib_inputs, args) -> None:
+def apply_smoothquant_if_requested(
+    model: torch.nn.Module,
+    calib_inputs: list[dict[str, torch.Tensor]],
+    args: argparse.Namespace,
+) -> None:
     """
     Apply SmoothQuant smoothing when requested.
 
     Calibration maxima are collected from Linear module inputs, then passed to
     SmoothQuant appliers for the selected Qwen3-VL components.
+
+    Args:
+        model: Target model.
+        calib_inputs: Calibration inputs.
+        args: Parsed command-line arguments.
+
+    Raises:
+        ValueError: If SmoothQuant is enabled without target components.
     """
     if not args.smoothquant:
         return
@@ -1164,6 +1318,7 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
 
 def main() -> None:
     args = parse_args()
+    ensure_spinquant_compatible_args(args)
     print(args)
 
     torch.manual_seed(args.seed)
@@ -1183,6 +1338,11 @@ def main() -> None:
     print(f"DType               : {args.dtype}")
     print(f"Calib seq len       : {args.calib_seq_len}")
     print(f"Max seq len         : {args.max_seq_len}")
+    print(f"Use SpinQuant       : {args.spinquant}")
+    if args.spinquant:
+        print(f"SpinQuant init      : {args.spinquant_init_method}")
+        print(f"SpinQuant R1        : {not args.spinquant_disable_r1}")
+        print(f"SpinQuant R2        : {not args.spinquant_disable_r2}")
     print(f"Use GPTQ            : {use_gptq}")
     print(f"GPTQ vision         : {gptq_vision}")
     print(f"GPTQ text           : {gptq_text}")
@@ -1252,6 +1412,7 @@ def main() -> None:
         max_seq_len=args.calib_seq_len,
     )
 
+    model = apply_spinquant_if_enabled(model, args)
     apply_smoothquant_if_requested(model, calib_inputs, args)
 
     q_m = model

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -28,6 +28,7 @@ from transformers.generation.utils import GenerationMixin
 
 @try_register(
     "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLForConditionalGeneration",
+    "tico.quantization.algorithm.spinquant.spin_qwen3_vl.SpinQwen3VLForConditionalGeneration",
 )
 class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
     """
@@ -69,6 +70,20 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
             qcfg=qcfg.child("lm_head") if qcfg else None,
             fp_name=join_name(fp_name, "lm_head"),
         )
+
+        rotate_lm_head_cfg = qcfg.child("rotate_lm_head") if qcfg else None
+        # `rotate_lm_head` exists only for SpinQuant-style custom models.
+        # For a standard model, skip creating the wrapper and
+        # bypass it during forward.
+        self.rotate_lm_head = None
+        if hasattr(fp_model, "rotate_lm_head") and isinstance(
+            fp_model.rotate_lm_head, torch.nn.Module
+        ):
+            self.rotate_lm_head = PTQWrapper(
+                fp_model.rotate_lm_head,
+                rotate_lm_head_cfg,
+                fp_name=join_name(fp_name, "rotate_lm_head"),
+            )
 
     def forward(
         self,
@@ -128,6 +143,9 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
         )
 
         hidden_states = outputs[0]
+
+        if self.rotate_lm_head is not None:
+            hidden_states = self.rotate_lm_head(hidden_states)
 
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         slice_indices = (

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
@@ -27,6 +27,7 @@ from tico.quantization.wrapq.wrappers.registry import try_register
 
 @try_register(
     "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLModel",
+    "tico.quantization.algorithm.spinquant.spin_qwen3_vl.SpinQwen3VLModel",
 )
 class QuantQwen3VLModel(QuantModuleBase):
     """

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -28,6 +28,7 @@ from transformers.cache_utils import Cache
 
 @try_register(
     "transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLTextModel",
+    "tico.quantization.algorithm.spinquant.spin_qwen3_vl.SpinQwen3VLTextModel",
 )
 class QuantQwen3VLTextModel(QuantModuleBase):
     """
@@ -63,6 +64,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
 
         # --- Wrap submodules via PTQWrapper ----------------------------------
         embed_tokens_cfg = qcfg.child("embed_tokens") if qcfg else None
+        rotate_embed_cfg = qcfg.child("rotate_embedding") if qcfg else None
         layers_cfg = qcfg.child("layers") if qcfg else None
         norm_cfg = qcfg.child("norm") if qcfg else None
 
@@ -71,6 +73,19 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             qcfg=embed_tokens_cfg,
             fp_name=join_name(fp_name, "embed_tokens"),
         )
+
+        # `rotate_embedding` exists only for SpinQuant-style custom models.
+        # For a standard model, skip creating the wrapper and bypass it
+        # during forward.
+        self.rotate_embedding = None
+        if hasattr(fp_model, "rotate_embedding") and isinstance(
+            fp_model.rotate_embedding, torch.nn.Module
+        ):
+            self.rotate_embedding = PTQWrapper(
+                fp_model.rotate_embedding,
+                rotate_embed_cfg,
+                fp_name=join_name(fp_name, "rotate_embedding"),
+            )
 
         # Wrap each decoder layer
         self.layers = nn.ModuleList()
@@ -523,6 +538,9 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             inputs_embeds = self.embed_tokens(input_ids)
         else:
             inputs_embeds = self._fq(inputs_embeds, self.obs_inputs_embeds)
+
+        if hasattr(self.module, "rotate_embedding"):
+            inputs_embeds = self.module.rotate_embedding(inputs_embeds)
 
         batch_size, seq_len, _ = inputs_embeds.shape
         past_seen_tokens = (


### PR DESCRIPTION
This commit applies SpinQuant to Qwen3-VL.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>

```bash
python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
--model /group-volume/Qwen3-VL-4B-Instruct/ --trust-remote-code \
--spinquant --nsamples_for_qcalibration 128 --spinquant_init_method random \
--ppl_dataset=wikitext2 --ppl_stride=2048 --gptq_mse mse \
--embedding_weight_bits 4 --lm_head_weight_bits 4
/usr/local/lib/python3.10/site-packages/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.2) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
  warnings.warn(
Namespace(model='/group-volume/Qwen3-VL-4B-Instruct/', device='cuda', dtype='float32', seed=42, trust_remote_code=True, hf_token=None, no_GPTQ=False, no_PTQ=False, cache_dir=None, nsamples_for_qcalibration=128, nsamples_for_evaluation=50, calib_seq_len=2048, max_seq_len=2048, linear_weight_bits=4, vision_patch_embed_weight_bits=8, embedding_weight_bits=4, lm_head_weight_bits=4, gptq_mse='mse', eval_tasks=None, sensitivity_path=None, quantize_vision=True, quantize_text=True, quantize_lm_head=True, move_cache_to_cpu=False, groupsize=-1, percdamp=0.01, actorder=True, static_groups=False, verbose=False, hide_progress=False, grid_thw=[8, 24, 24], visual_start_idx=0, spatial_merge_size=2, spinquant=True, spinquant_init_method='random', spinquant_disable_r1=False, spinquant_disable_r2=False, spinquant_disable_deepstack_fusion=False, spinquant_r1_path=None, spinquant_r2_map_path=None, smoothquant=False, smoothquant_alpha=0.5, smoothquant_components=None, print_quantized_model=False, mmlu_subjects=None, mmlu_n_shots=5, mmlu_n_samples=-1, mmlu_batch_size=1, mmmu_subjects=None, mmmu_n_shots=5, mmmu_n_samples=-1, ppl_dataset='wikitext2', ppl_stride=2048, ppl_split='test')
=== Config ===
Model              : /group-volume/Qwen3-VL-4B-Instruct/
Device             : cuda
DType              : float32
Calib seq len      : 2048
Max seq len        : 2048
Quantize vision    : True
Quantize text      : True
Quantize lm_head   : True
Use SpinQuant      : True
SpinQuant init     : random
SpinQuant R1       : True
SpinQuant R2       : True
Use GPTQ           : True
Use PTQ            : True
Use SmoothQuant    : False
grid_thw           : (8, 24, 24)
spatial_merge_size : 2
visual_start_idx   : 0

# ..

# token embedding, lm_head: 4 bits
Quantized PPL: 12.13
# 8-bits
Quantized PPL: 11.42
```