### PR TITLE
[quantization] Support Evaluation of Qwen3-VL With llava-bench-in-the-wild Dataset

### DIFF
--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -187,13 +187,13 @@ def get_item_coco(ex: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def get_item_llama_bench_in_the_wild(ex: dict[str, Any]) -> dict[str, Any]:
+def get_item_llava_bench_in_the_wild(ex: dict[str, Any]) -> dict[str, Any]:
     return {
         "image": ex["image"],
         "question": ex["question"],
         "id": ex["question_id"],
-        "image_id": ex["image_id"],
-        "file_name": ex["image_id"],
+        "image_id": ex["question_id"],  # unique evaluation key
+        "file_name": ex["image_id"],  # original image filename
         "golds": [ex["gpt_answer"]],
     }
 
@@ -262,9 +262,9 @@ DATASETS: dict[str, dict[str, Any]] = {
         ],
         "is_text_only": False,
     },
-    "llama_bench": {
+    "llava_bench": {
         "default_split": "train",
-        "adapter": get_item_llama_bench_in_the_wild,
+        "adapter": get_item_llava_bench_in_the_wild,
         "candidates": [
             "lmms-lab/llava-bench-in-the-wild",
         ],
@@ -423,7 +423,9 @@ def generate_answer(
         image=image,
         question=question,
         return_tensors="pt",
-        max_seq_len=max_seq_len,
+        # length of (inputs + max_new_tokens) should not exceed model's max_seq_len
+        # because quantized model has precomputed static causal mask and RoPE for max_seq_len
+        max_seq_len=max_seq_len - max_new_tokens,  # type: ignore[operator]
     )
     inputs = move_inputs_to_device(inputs, device)
 
@@ -644,8 +646,8 @@ def get_coco_scores_on_dataset(
 
     if "coco" in dataset_name.lower():
         get_item = get_item_coco
-    elif "llama_bench" in dataset_name.lower():
-        get_item = get_item_llama_bench_in_the_wild
+    elif "llava_bench" in dataset_name.lower():
+        get_item = get_item_llava_bench_in_the_wild
     else:
         raise ValueError(f"Invalid dataset_name={dataset_name}")
 
@@ -671,8 +673,21 @@ def get_coco_scores_on_dataset(
                 max_seq_len=max_seq_len,
             )
         except (ValueError, RuntimeError) as error:
-            print(f"[WARNING] The prompt was too long. Skipping.")
-            print(f"Error: {error}")
+            message = str(error).lower()
+            if not any(
+                marker in message
+                for marker in (
+                    "too long",
+                    "max_position_embeddings",
+                    "maximum context length",
+                    "sequence length",
+                    "truncation",
+                )
+            ):
+                raise
+
+            print("[WARNING] The prompt was too long. Skipping.")
+            print(f"{type(error).__name__}: {error}")
             continue
 
         # Store result
@@ -703,7 +718,11 @@ def get_coco_scores_on_dataset(
             print("golds[:10]:", [repr(x) for x in gold_answers[:10]])
             print("-" * 60)
 
-    assert results
+    if not results:
+        raise RuntimeError(
+            "No evaluation results were collected. "
+            "All samples may have been skipped due to prompt length errors."
+        )
     assert images
     assert annotations
 

--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -179,8 +179,22 @@ def get_item_coco(ex: dict[str, Any]) -> dict[str, Any]:
     """
     return {
         "image": ex["image"],
-        "question": ex.get("question", ""),
-        "golds": _extract_golds(ex.get("answer")),
+        "question": ex["question"],
+        "id": ex["id"],
+        "image_id": ex["question_id"],
+        "file_name": ex["file_name"],
+        "golds": ex["answer"],
+    }
+
+
+def get_item_llama_bench_in_the_wild(ex: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "image": ex["image"],
+        "question": ex["question"],
+        "id": ex["question_id"],
+        "image_id": ex["image_id"],
+        "file_name": ex["image_id"],
+        "golds": [ex["gpt_answer"]],
     }
 
 
@@ -247,6 +261,13 @@ DATASETS: dict[str, dict[str, Any]] = {
             "lmms-lab/COCO-Caption2017",
         ],
         "is_text_only": False,
+    },
+    "llama_bench": {
+        "default_split": "train",
+        "adapter": get_item_llama_bench_in_the_wild,
+        "candidates": [
+            "lmms-lab/llava-bench-in-the-wild",
+        ],
     },
     "wikitext2": {
         "default_split": "test",
@@ -560,6 +581,7 @@ def compute_bleu_scores(
 def get_coco_scores_on_dataset(
     model,
     processor,
+    dataset_name: str,
     ds: Iterable[dict[str, Any]],
     device: str | torch.device,
     max_new_tokens: int = 30,
@@ -620,25 +642,38 @@ def get_coco_scores_on_dataset(
     images: list[CocoImage] = []
     annotations: list[CocoAnnotation] = []
 
-    for i, ex in enumerate(ds, 1):
-        image: Any = ex["image"]
-        question: str = ex["question"]
-        id: int = ex["id"]
-        image_id: str = ex["question_id"]
-        file_name: str = ex["file_name"]
-        gold_answers: list[str] = ex["answer"]
+    if "coco" in dataset_name.lower():
+        get_item = get_item_coco
+    elif "llama_bench" in dataset_name.lower():
+        get_item = get_item_llama_bench_in_the_wild
+    else:
+        raise ValueError(f"Invalid dataset_name={dataset_name}")
 
-        # Generate caption
-        pred = generate_answer(
-            model=model,
-            processor=processor,
-            image=image,
-            question=question,
-            device=device,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
-            max_seq_len=max_seq_len,
-        )
+    for i, ex in enumerate(ds, 1):
+        sample: dict[str, Any] = get_item(ex)
+
+        image: Any = sample["image"]
+        question: str = sample["question"]
+        id: int = sample["id"]
+        image_id: str = sample["image_id"]
+        file_name: str = sample["file_name"]
+        gold_answers: list[str] = sample["golds"]
+
+        try:
+            pred = generate_answer(
+                model=model,
+                processor=processor,
+                image=image,
+                question=question,
+                device=device,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                max_seq_len=max_seq_len,
+            )
+        except (ValueError, RuntimeError) as error:
+            print(f"[WARNING] The prompt was too long. Skipping.")
+            print(f"Error: {error}")
+            continue
 
         # Store result
         result: CocoResult = {"image_id": image_id, "caption": pred}

--- a/tico/quantization/recipes/evaluation/vlm.py
+++ b/tico/quantization/recipes/evaluation/vlm.py
@@ -74,6 +74,7 @@ def evaluate_coco(
         return get_coco_scores_on_dataset(
             model=model,
             processor=processor,
+            dataset_name="coco",
             ds=dataset,
             device=device,
             max_seq_len=max_seq_len,

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -582,7 +582,7 @@ def evaluate_model(
     return results
 
 
-def evaluate_model_coco(
+def evaluate_model_with_coco_score(
     model,
     processor,
     device: str,
@@ -591,12 +591,13 @@ def evaluate_model_coco(
     max_seq_len: Optional[int] = None,
 ):
     """
-    Evaluate a model on the mini COCO captioning benchmark.
+    Evaluate a model on the provided dataset with COCO score
 
     Args:
         model: Model to evaluate.
         processor: Hugging Face processor.
         device: Target device string.
+        dataset_name: Dataset name for evaluation
         nsamples: Number of evaluation samples. -1 means full dataset.
         max_seq_len: Optional maximum text sequence length.
 
@@ -614,43 +615,6 @@ def evaluate_model_coco(
         max_seq_len=max_seq_len,
     )
     return result
-
-
-def evaluate_model_llama_bench(
-    model,
-    processor,
-    device: str,
-    nsamples: int = 50,
-    max_seq_len: Optional[int] = None,
-):
-    """
-    Evaluate a model on the mini COCO captioning benchmark.
-
-    Args:
-        model: Model to evaluate.
-        processor: Hugging Face processor.
-        device: Target device string.
-        nsamples: Number of evaluation samples. -1 means full dataset.
-        max_seq_len: Optional maximum text sequence length.
-
-    Returns:
-        COCO metric dictionary.
-    """
-    with (
-        io.StringIO() as buffer,
-        contextlib.redirect_stdout(buffer),
-        contextlib.redirect_stderr(buffer),
-    ):
-        ds, _ = get_dataset("coco", n=nsamples)
-        result = get_coco_scores_on_dataset(
-            model=model,
-            processor=processor,
-            dataset_name="llama_bench",
-            ds=ds,
-            device=device,
-            max_seq_len=max_seq_len,
-        )
-        return result
 
 
 def move_batch_to_device(
@@ -1206,7 +1170,7 @@ def evaluate_original_model(model, processor, args):
 
         if "coco" in args.eval_tasks:
             print("\n=== COCO Evaluation (Original Model) ===")
-            results = evaluate_model_coco(
+            results = evaluate_model_with_coco_score(
                 model=model,
                 processor=processor,
                 device=args.device,
@@ -1217,13 +1181,13 @@ def evaluate_original_model(model, processor, args):
             for metric, value in results.items():
                 print(f"{metric:<10} {value:.3f}")
 
-        if "llama_bench" in args.eval_tasks:
-            print("\n=== Llama Bench Evaluation (Original Model) ===")
-            results = evaluate_model_coco(
+        if "llava_bench" in args.eval_tasks:
+            print("\n=== Llava Bench Evaluation (Original Model) ===")
+            results = evaluate_model_with_coco_score(
                 model=model,
                 processor=processor,
                 device=args.device,
-                dataset_name="llama_bench",
+                dataset_name="llava_bench",
                 nsamples=args.nsamples_for_evaluation,
                 max_seq_len=args.max_seq_len,
             )
@@ -1314,7 +1278,7 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
 
         if "coco" in args.eval_tasks:
             print("\n=== COCO Evaluation (Quantized Model) ===")
-            results = evaluate_model_coco(
+            results = evaluate_model_with_coco_score(
                 model=model,
                 processor=processor,
                 device=args.device,
@@ -1325,13 +1289,13 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
             for metric, value in results.items():
                 print(f"{metric:<10} {value:.3f}")
 
-        if "llama_bench" in args.eval_tasks:
-            print("\n=== Llama Bench Evaluation (Original Model) ===")
-            results = evaluate_model_coco(
+        if "llava_bench" in args.eval_tasks:
+            print("\n=== Llava Bench Evaluation (Quantized Model) ===")
+            results = evaluate_model_with_coco_score(
                 model=model,
                 processor=processor,
                 device=args.device,
-                dataset_name="llama_bench",
+                dataset_name="llava_bench",
                 nsamples=args.nsamples_for_evaluation,
                 max_seq_len=args.max_seq_len,
             )

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -586,6 +586,40 @@ def evaluate_model_coco(
     model,
     processor,
     device: str,
+    dataset_name: str,
+    nsamples: int = 50,
+    max_seq_len: Optional[int] = None,
+):
+    """
+    Evaluate a model on the mini COCO captioning benchmark.
+
+    Args:
+        model: Model to evaluate.
+        processor: Hugging Face processor.
+        device: Target device string.
+        nsamples: Number of evaluation samples. -1 means full dataset.
+        max_seq_len: Optional maximum text sequence length.
+
+    Returns:
+        COCO metric dictionary.
+    """
+
+    ds, _ = get_dataset(dataset_name, n=nsamples)
+    result = get_coco_scores_on_dataset(
+        model=model,
+        processor=processor,
+        dataset_name=dataset_name,
+        ds=ds,
+        device=device,
+        max_seq_len=max_seq_len,
+    )
+    return result
+
+
+def evaluate_model_llama_bench(
+    model,
+    processor,
+    device: str,
     nsamples: int = 50,
     max_seq_len: Optional[int] = None,
 ):
@@ -611,6 +645,7 @@ def evaluate_model_coco(
         result = get_coco_scores_on_dataset(
             model=model,
             processor=processor,
+            dataset_name="llama_bench",
             ds=ds,
             device=device,
             max_seq_len=max_seq_len,
@@ -1175,6 +1210,20 @@ def evaluate_original_model(model, processor, args):
                 model=model,
                 processor=processor,
                 device=args.device,
+                dataset_name="coco",
+                nsamples=args.nsamples_for_evaluation,
+                max_seq_len=args.max_seq_len,
+            )
+            for metric, value in results.items():
+                print(f"{metric:<10} {value:.3f}")
+
+        if "llama_bench" in args.eval_tasks:
+            print("\n=== Llama Bench Evaluation (Original Model) ===")
+            results = evaluate_model_coco(
+                model=model,
+                processor=processor,
+                device=args.device,
+                dataset_name="llama_bench",
                 nsamples=args.nsamples_for_evaluation,
                 max_seq_len=args.max_seq_len,
             )
@@ -1269,6 +1318,20 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
                 model=model,
                 processor=processor,
                 device=args.device,
+                dataset_name="coco",
+                nsamples=args.nsamples_for_evaluation,
+                max_seq_len=args.max_seq_len,
+            )
+            for metric, value in results.items():
+                print(f"{metric:<10} {value:.3f}")
+
+        if "llama_bench" in args.eval_tasks:
+            print("\n=== Llama Bench Evaluation (Original Model) ===")
+            results = evaluate_model_coco(
+                model=model,
+                processor=processor,
+                device=args.device,
+                dataset_name="llama_bench",
                 nsamples=args.nsamples_for_evaluation,
                 max_seq_len=args.max_seq_len,
             )


### PR DESCRIPTION
## What

This change adds support for evaluating Qwen3-VL models on the [lmms-lab/llava-bench-in-the-wild](https://huggingface.co/datasets/lmms-lab/llava-bench-in-the-wild) benchmark, reusing the existing COCO evaluation infrastructure in `vlm_eval_utils.py`.

## Why

COCO captioning is listed as a required benchmark for Qwen3-VL in [PTQ Evaluation — Qwen3-VL](https://github.sec.samsung.net/one-project/TICO/issues/192). The llava-bench-in-the-wild dataset is a complementary benchmark to COCO as described in [LLaVA Bench documentation](https://github.com/haotian-liu/LLaVA/blob/main/docs/LLaVA_Bench.md). While COCO provides multiple reference captions per image, llava-bench-in-the-wild provides a single GPT-generated ground-truth answer per question, making it a valuable additional signal for VLM evaluation quality.

## Dataset Format

- question_id (int)
- question (string) : question (prompt, request)
- image (PIL.Image) : image
- caption (string)
- gpt_answer (string) : ground truth answer
- category (string)
- image_id (string) : image file name

## Implementation Details

Two files were modified:

1. **`tico/quantization/evaluation/vlm_eval_utils.py`** — Extended the evaluation utilities to support the new dataset:
   - Added `get_item_llama_bench_in_the_wild()` adapter that maps llava-bench-in-the-wild fields (`question_id` → `id`, `image_id` → `image_id`/`file_name`, `gpt_answer` → `golds`) to the common format consumed by `get_coco_scores_on_dataset()`.
   - Updated `get_item_coco()` to return all required fields explicitly (`id`, `image_id`, `file_name`, `golds`) instead of using `.get()` with defaults.
   - Registered `"llama_bench"` dataset entry in the `DATASETS` registry with the new adapter and `lmms-lab/llava-bench-in-the-wild` as the candidate dataset.
   - Added `dataset_name` parameter to `get_coco_scores_on_dataset()` to dispatch to the correct adapter (`get_item_coco` or `get_item_llama_bench_in_the_wild`) based on dataset name.
   - Added error handling (`try/except`) around `generate_answer()` to gracefully skip prompts that are too long rather than crashing the evaluation.

2. **`tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py`** — Integrated llama_bench evaluation into the quantization script:
   - Refactored `evaluate_model_coco()` to accept a `dataset_name` parameter, making it reusable for both COCO and llama_bench evaluations.
   - Added `evaluate_model_llama_bench()` convenience wrapper for llama_bench evaluation.
   - Added `"llama_bench"` as a supported `--eval_tasks` option in both `evaluate_original_model()` and `evaluate_quantized_model()`, with proper section headers and metric reporting.

## Example

```bash
python tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py \
    --model=Qwen/Qwen3-VL-4B-Instruct \
    --cache_dir=/home/d.savchenkov/models/qwen3-vl-4b \
    --trust-remote-code \
    --no_GPTQ \
    --eval_tasks=llama_bench \
    --nsamples_for_evaluation=50 \
    --embedding_weight_bits=16 \
    --vision_patch_embed_weight_bits=16 \
    --linear_weight_bits=16 \
    --lm_head_weight_bits=16 \
    --nsamples_for_qcalibration=10 \
    --verbose
```

```
=== Llama Bench Evaluation (Original Model) ===
...
id: 7
image_id: 002.jpg
Q: Imagine the fragrance of the fruits in the image. How would you describe this to someone who has never had this fruit before?
pred: 'Sweet, floral, and slightly tangy with a hint of tropical fruitiness.'
pred_norm: 'sweet floral and slightly tangy with hint of tropical fruitiness'
golds[:10]: ["'The fragrance of the mangosteens in the image can be described as sweet and slightly floral, with a hint of citrus aroma. It is a delicate and pleasant smell that entices you to try the fruit.'"]
...

CIDEr      0.011
Bleu_1     0.063
Bleu_2     0.038
Bleu_3     0.023
Bleu_4     0.016

=== Llama Bench Evaluation (Original Model) ===
...
id: 7
image_id: 002.jpg
Q: Imagine the fragrance of the fruits in the image. How would you describe this to someone who has never had this fruit before?
pred: 'Rich, earthy, slightly sweet with hints of tropical fruit and a faint floral undertone, like a blend of dark berries and green leaves.'
pred_norm: 'rich earthy slightly sweet with hints of tropical fruit and faint floral undertone like blend of dark berries and green leaves'
golds[:10]: ["'The fragrance of the mangosteens in the image can be described as sweet and slightly floral, with a hint of citrus aroma. It is a delicate and pleasant smell that entices you to try the fruit.'"]
...

CIDEr      0.036
Bleu_1     0.092
Bleu_2     0.053
Bleu_3     0.030
Bleu_4     0.016
```
