### PR TITLE
[quantization] Fix instability

### DIFF
--- a/tico/quantization/algorithm/spinquant/hadamard_utils.py
+++ b/tico/quantization/algorithm/spinquant/hadamard_utils.py
@@ -473,7 +473,7 @@ def make_random_hadamard_rotation(
     if device is None:
         device = torch.device("cpu")
 
-    signs = torch.randint(0, 2, (size,), device=device, dtype=torch.int64)
+    signs = torch.randint(0, 2, (size,), device="cpu", dtype=torch.int64).to(device)
     signs = signs.to(torch.float64).mul_(2.0).sub_(1.0)
     eye = torch.eye(size, device=device, dtype=torch.float64)
     signed_eye = signs.unsqueeze(1) * eye

--- a/tico/quantization/algorithm/spinquant/rotation_utils.py
+++ b/tico/quantization/algorithm/spinquant/rotation_utils.py
@@ -73,7 +73,7 @@ def make_random_orthogonal_rotation(
     Returns:
         A square orthogonal matrix.
     """
-    random_matrix = torch.randn(size, size, device=device, dtype=dtype)
+    random_matrix = torch.randn(size, size, device="cpu", dtype=dtype).to(device)
     q, r = torch.linalg.qr(random_matrix)
     signs = torch.sign(torch.diag(r))
     signs = torch.where(signs == 0, torch.ones_like(signs), signs)


### PR DESCRIPTION
This commit fixes instability in spinquant.

Please see https://github.com/pytorch/pytorch/issues/158398 and https://stackoverflow.com/questions/77471104/pytorch-randdevice-vs-rand-todevice

Running:
```
python tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py --model HuggingFaceTB/SmolLM2-135M-Instruct --max_seq_len 2048 --linear_weight_bits 4  --nsamples_for_qcalibration 16 --device cuda --lm_head_weight_bits 8 --decode_calibration_steps 8 --no_GPTQ
```
produces:
|GPU| quantized_PPL|
|--|-----------|
|GPU_0|57.71|
|GPU_1|57.71|

compare with https://github.com/Samsung/TICO/issues/656#issuecomment-4542025383

Related: #656 

TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>