### PR TITLE
[quantization] Use right rotate_embedding

### DIFF
--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -539,8 +539,8 @@ class QuantQwen3VLTextModel(QuantModuleBase):
         else:
             inputs_embeds = self._fq(inputs_embeds, self.obs_inputs_embeds)
 
-        if hasattr(self.module, "rotate_embedding"):
-            inputs_embeds = self.module.rotate_embedding(inputs_embeds)
+        if self.rotate_embedding is not None:
+            input_embeds = self.rotate_embedding(input_embeds)  # type: ignore[has-type]
 
         batch_size, seq_len, _ = inputs_embeds.shape
         past_seen_tokens = (


### PR DESCRIPTION
This commit uses wrapped rotate_embedding instead of fp module.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>