### PR TITLE
[quantization] Refactor observer traversal to separate local and recursive loop

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_patch_embed.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_vision_patch_embed.py
@@ -141,14 +141,21 @@ class TestQuantQwen3VLVisionPatchEmbed(unittest.TestCase):
 
     def test_observer_count(self):
         """
-        Test that the wrapper has the correct number of observers.
-        - 2 local observers (obs_hidden, obs_output)
-        - 3 observers from wrapped Conv3d (obs_weight, obs_act_in, obs_act_out)
+        Test observer ownership and recursive enumeration.
+        - PatchEmbed owns no local observers directly.
+        - Recursive named_observers() exposes 3 observers from wrapped Conv3d.
         """
         q_patch = QuantQwen3VLVisionPatchEmbed(self.fp_patch_embed)
 
-        observers = list(q_patch._all_observers())
-        self.assertEqual(len(observers), 3)  # 3 from Conv3d
+        local_observers = list(q_patch._all_observers())
+        self.assertEqual(len(local_observers), 0)
+
+        observers = list(q_patch.named_observers())
+        self.assertEqual(len(observers), 3)
+        self.assertSetEqual(
+            {name for name, _ in observers},
+            {"proj.weight", "proj.act_in", "proj.act_out"},
+        )
 
     def test_registration_in_registry(self):
         """

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_decoder.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_decoder.py
@@ -423,7 +423,5 @@ class QuantFairseqDecoder(QuantModuleBase):
         return x, new_k_list, new_v_list  # [1,B,C], lists of [B*H, Tnew, Dh]
 
     def _all_observers(self) -> Iterable:
-        """Yield all observers from wrapped decoder layers (if any)."""
-        for m in self.layers:
-            if isinstance(m, QuantModuleBase):
-                yield from m._all_observers()
+        """This wrapper owns no observers directly."""
+        return ()

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_decoder_layer.py
@@ -468,25 +468,9 @@ class QuantFairseqDecoderLayer(QuantModuleBase):
         )  # [1,B,C], attn, [B*H, Tnew, Dh], [B*H, Tnew, Dh]
 
     def _all_observers(self) -> Iterable:
-        """
-        Expose all observers from child PTQ-wrapped modules.
-        This layer itself does not add extra per-tensor observers.
-        """
-        # local observers
+        """Return observers owned directly by this decoder layer."""
         yield from (
             self.obs_activation_fn,
             self.obs_prev_self_k_in,
             self.obs_prev_self_v_in,
         )
-
-        for m in (
-            self.self_attn,
-            self.encoder_attn,
-            self.fc1,
-            self.fc2,
-            self.encoder_attn_layer_norm,
-            self.self_attn_layer_norm,
-            self.final_layer_norm,
-        ):
-            if isinstance(m, QuantModuleBase) and m is not None:
-                yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_encoder.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_encoder.py
@@ -326,6 +326,5 @@ class QuantFairseqEncoder(QuantModuleBase):
         return state_dict
 
     def _all_observers(self):
-        for m in self.layers:
-            if isinstance(m, QuantModuleBase):
-                yield from m._all_observers()
+        # This wrapper owns no observers directly.
+        return ()

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_encoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_encoder_layer.py
@@ -152,12 +152,3 @@ class QuantFairseqEncoderLayer(QuantModuleBase):
 
     def _all_observers(self):
         yield from (self.obs_activation_fn,)
-        for m in (
-            self.self_attn,
-            self.fc1,
-            self.fc2,
-            self.self_attn_layer_norm,
-            self.final_layer_norm,
-        ):
-            if isinstance(m, QuantModuleBase):
-                yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/fairseq/quant_mha.py
+++ b/tico/quantization/wrapq/wrappers/fairseq/quant_mha.py
@@ -381,6 +381,3 @@ class QuantFairseqMultiheadAttention(QuantModuleBase):
             self.obs_softmax,
             self.obs_attn_out,
         )
-        for m in (self.q_proj, self.k_proj, self.v_proj, self.out_proj):
-            if isinstance(m, QuantModuleBase):
-                yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -1071,7 +1071,6 @@ class QuantLlamaAttention(QuantModuleBase):
         raise RuntimeError(f"Invalid attention layout: {self.attn_options.layout!r}")
 
     def _all_observers(self):
-        # local first
         yield from (
             self.obs_hidden,
             self.obs_cos,
@@ -1104,9 +1103,6 @@ class QuantLlamaAttention(QuantModuleBase):
             self.obs_present_key,
             self.obs_present_value,
         )
-        # recurse into children that are QuantModuleBase
-        for m in (self.q_proj, self.k_proj, self.v_proj, self.o_proj):
-            yield from m._all_observers()
 
     def as_export_module(
         self,

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -376,10 +376,12 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         raise RuntimeError("Invalid return_type configuration.")
 
     def _all_observers(self):
-        yield from (self.obs_attn_mask, self.obs_cos, self.obs_sin)
-        yield from self.self_attn._all_observers()
-        yield from self.mlp._all_observers()
-        yield self.obs_mlp_residual_out
+        yield from (
+            self.obs_attn_mask,
+            self.obs_cos,
+            self.obs_sin,
+            self.obs_mlp_residual_out,
+        )
 
     def as_export_module(self, mode: ExportMode = "prefill", *, return_kv: bool = True):
         """

--- a/tico/quantization/wrapq/wrappers/llama/quant_mlp.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_mlp.py
@@ -89,9 +89,6 @@ class QuantLlamaMLP(QuantModuleBase):
         return self.down_proj(h)
 
     def _all_observers(self):
-        # local first
         yield self.obs_act_in
         yield self.obs_mul
-        # recurse into children that are QuantModuleBase
-        for m in (self.gate_proj, self.up_proj, self.down_proj, self.act_fn):
-            yield from m._all_observers()
+        # Child observers are handled by QuantModuleBase recursion.

--- a/tico/quantization/wrapq/wrappers/llama/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model.py
@@ -630,14 +630,4 @@ class QuantLlamaModel(QuantModuleBase):
         return output if return_dict else output.to_tuple()
 
     def _all_observers(self):
-        # Recurse into children that are QuantModuleBase
         yield from (self.obs_causal_mask, self.obs_cos, self.obs_sin)
-
-        for m in (self.embed_tokens, self.norm):
-            yield from m._all_observers()
-
-        if self.rotate_embedding is not None:
-            yield from self.rotate_embedding._all_observers()
-
-        for m in self.layers:
-            yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_model_for_causal_lm.py
@@ -284,11 +284,8 @@ class QuantLlamaForCausalLM(QuantModuleBase, GenerationMixin):
         )
 
     def _all_observers(self):
-        # recurse into children that are QuantModuleBase
-        for m in (self.model, self.lm_head):
-            yield from m._all_observers()
-        if self.rotate_lm_head is not None:
-            yield from self.rotate_lm_head._all_observers()
+        # This wrapper owns no observers directly.
+        return ()
 
     def as_export_module(
         self, mode: ExportMode = "prefill", return_kv: bool = True

--- a/tico/quantization/wrapq/wrappers/ptq_wrapper.py
+++ b/tico/quantization/wrapq/wrappers/ptq_wrapper.py
@@ -60,17 +60,21 @@ class PTQWrapper(QuantModuleBase):
         """
         return ()  # no local observers
 
-    def named_observers(self):
+    def named_observers(self, *, recurse: bool = True):
         """
         Proxy to the wrapped module so debugging tools can still enumerate observers.
         """
-        yield from self.wrapped.named_observers()
+        if not recurse:
+            return
+        yield from self.wrapped.named_observers(recurse=True)
 
-    def get_observer(self, name: str):
+    def get_observer(self, name: str, *, recurse: bool = True):
         """
         Proxy to the wrapped module for direct lookup by name.
         """
-        return self.wrapped.get_observer(name)
+        if not recurse:
+            return None
+        return self.wrapped.get_observer(name, recurse=True)
 
     def extra_repr(self) -> str:
         return self.wrapped.extra_repr()

--- a/tico/quantization/wrapq/wrappers/quant_module_base.py
+++ b/tico/quantization/wrapq/wrappers/quant_module_base.py
@@ -80,6 +80,31 @@ class QuantModuleBase(nn.Module, ABC):
                 # `m` is a container or a non-quant leaf: keep descending until we hit quant modules
                 stack.extend(list(m.children()))
 
+    def _named_child_quant_modules(self):
+        """
+        Yield immediate QuantModuleBase descendants with their module-tree names,
+        skipping over pure containers.
+
+        This mirrors _child_quant_modules(), but preserves stable prefixes so
+        recursive observer names remain unique, e.g. `q_proj.weight` and
+        `k_proj.weight` instead of multiple ambiguous `weight` entries.
+        """
+        seen = set()
+        stack = list(reversed(list(self.named_children())))
+
+        while stack:
+            prefix, m = stack.pop()
+            if isinstance(m, QuantModuleBase):
+                if id(m) not in seen:
+                    seen.add(id(m))
+                    yield prefix, m
+                # Do not recurse into `m` here; its own named_observers() will
+                # handle its subtree and keep names relative to that child.
+            elif isinstance(m, (nn.ModuleList, nn.ModuleDict, nn.Sequential)):
+                children = list(m.named_children())
+                for child_name, child in reversed(children):
+                    stack.append((f"{prefix}.{child_name}", child))
+
     def enable_calibration(self) -> None:
         self._mode = Mode.CALIB
         for obs in self._all_observers():
@@ -111,16 +136,31 @@ class QuantModuleBase(nn.Module, ABC):
 
     @abstractmethod
     def _all_observers(self) -> Iterable[ObserverBase]:
-        """Return every observer owned by this module."""
+        """Return observers owned directly by this module.
+
+        Child QuantModuleBase instances are traversed by the base lifecycle
+        methods, so subclasses must not yield child observers here.
+        """
         ...
 
-    def named_observers(self) -> Iterable[Tuple[str, ObserverBase]]:
+    def named_observers(
+        self, *, recurse: bool = True
+    ) -> Iterable[Tuple[str, ObserverBase]]:
         for obs in self._all_observers():
             yield obs.name, obs
 
-    def get_observer(self, name: str) -> Optional[ObserverBase]:
-        for obs in self._all_observers():
-            if obs.name == name:
+        if not recurse:
+            return
+
+        for child_name, child in self._named_child_quant_modules():
+            for name, obs in child.named_observers(recurse=True):
+                yield f"{child_name}.{name}", obs
+
+    def get_observer(
+        self, name: str, *, recurse: bool = True
+    ) -> Optional[ObserverBase]:
+        for obs_name, obs in self.named_observers(recurse=recurse):
+            if obs_name == name:
                 return obs
         return None
 

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -185,10 +185,8 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
         return output
 
     def _all_observers(self) -> Iterable:
-        """Yield all observers from this module and wrapped submodules."""
-        # No local observers - all observers are in wrapped submodules
-        # This method is required by QuantModuleBase but yields nothing
-        return iter([])
+        """This wrapper owns no observers directly."""
+        return ()
 
     @property
     def device(self):

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attention.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attention.py
@@ -261,7 +261,6 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         return out, attn_weights
 
     def _all_observers(self) -> Iterable:
-        # local first
         yield from (
             self.obs_hidden,
             self.obs_cos,
@@ -288,13 +287,3 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
             self.obs_attn_weights,
             self.obs_attn_out_h,
         )
-
-        for m in (
-            self.q_proj,
-            self.k_proj,
-            self.v_proj,
-            self.o_proj,
-            self.q_norm,
-            self.k_norm,
-        ):
-            yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_mlp.py
@@ -103,11 +103,7 @@ class QuantQwen3VLTextMLP(QuantModuleBase):
         return h
 
     def _all_observers(self) -> Iterable:
-        # Yield local observers
         yield self.obs_act_in
         yield self.obs_gated_out
         yield self.obs_act_out
-
-        # Recurse into children that are QuantModuleBase
-        for m in (self.gate_proj, self.up_proj, self.down_proj, self.act_fn):
-            yield from m._all_observers()
+        # Child observers are handled by QuantModuleBase recursion.

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attention.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attention.py
@@ -214,5 +214,3 @@ class QuantQwen3VLVisionAttention(QuantModuleBase):
             self.obs_softmax,
             self.obs_attn_out,
         )
-        for m in (self.qkv, self.proj):
-            yield from m._all_observers()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_mlp.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_mlp.py
@@ -90,6 +90,4 @@ class QuantQwen3VLVisionMLP(QuantModuleBase):
     def _all_observers(self) -> Iterable:
         yield self.obs_act_in
         yield self.obs_act_out
-        # recurse into children that are QuantModuleBase
-        for m in (self.linear_fc1, self.linear_fc2, self.act_fn):
-            yield from m._all_observers()
+        # Child observers are handled by QuantModuleBase recursion.

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_embed.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_embed.py
@@ -94,6 +94,5 @@ class QuantQwen3VLVisionPatchEmbed(QuantModuleBase):
         return hidden
 
     def _all_observers(self) -> Iterable:
-        """Yield all observers from this module and wrapped submodules."""
-        # Observers from wrapped Conv3d layer
-        yield from self.proj.wrapped._all_observers()
+        """This wrapper owns no observers directly."""
+        return ()

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_patch_merger.py
@@ -115,7 +115,5 @@ class QuantQwen3VLVisionPatchMerger(QuantModuleBase):
         return x
 
     def _all_observers(self) -> Iterable:
-        """Yield all observers from this module and wrapped submodules."""
-        # Observers from wrapped submodules
-        for module in (self.norm, self.linear_fc1, self.act_fn, self.linear_fc2):
-            yield from module.wrapped._all_observers()
+        """This wrapper owns no observers directly."""
+        return ()


### PR DESCRIPTION
Update QuantModuleBase so _all_observers() is reserved for observers owned directly by each wrapper, while public named_observers()/get_observer() can recursively enumerate child quant modules with qualified names.

This avoids double-processing child observers during calibration/freeze while preserving recursive observer lookup for debugging and tests.

Related: https://github.com/Samsung/TICO/issues/494#issuecomment-3935517335

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>