### PR TITLE
[quantization] Fix quant_text_model wrapper for Qwen3-vl

### DIFF
--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_model.py
@@ -540,7 +540,7 @@ class QuantQwen3VLTextModel(QuantModuleBase):
             inputs_embeds = self._fq(inputs_embeds, self.obs_inputs_embeds)
 
         if self.rotate_embedding is not None:
-            input_embeds = self.rotate_embedding(input_embeds)  # type: ignore[has-type]
+            inputs_embeds = self.rotate_embedding(inputs_embeds)
 
         batch_size, seq_len, _ = inputs_embeds.shape
         past_seen_tokens = (


### PR DESCRIPTION
This commit fixes typo in `quant_text_model` wrapper for Qwen3-vl

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>