### PR TITLE
[examples] Add Qwen3-VL evaluation preset config

### DIFF
--- a/tico/quantization/examples/README.md
+++ b/tico/quantization/examples/README.md
@@ -33,6 +33,12 @@ python -m tico.quantization.examples.quantize \
   --model Qwen/Qwen3-VL-2B-Instruct
 ```
 
+```bash
+python -m tico.quantization.examples.quantize \
+  --config tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml \
+  --model Qwen/Qwen3-VL-2B-Instruct
+```
+
 ### Evaluate
 
 ```bash

--- a/tico/quantization/examples/configs/README.md
+++ b/tico/quantization/examples/configs/README.md
@@ -18,11 +18,12 @@ Use:
 Examples:
 
 ```text
+llama_eval_suite.yaml
 llama_gptq_ptq.yaml
 llama_ptq_only.yaml
+qwen3_vl_eval_suite.yaml
 qwen3_vl_gptq_ptq.yaml
 qwen3_vl_ptq_only.yaml
-qwen3_vl_synthetic_smoke.yaml
 ```
 
 Use lower snake case. Keep names descriptive but short.
@@ -222,6 +223,7 @@ evaluation:
     - vqav2
     - textvqa
   coco: false
+  llava_bench: false
   mmlu:
     enabled: false
     subjects: null

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
@@ -1,0 +1,121 @@
+model:
+  family: qwen3_vl
+  name_or_path: Qwen/Qwen3-VL-2B-Instruct
+  trust_remote_code: true
+  hf_token: null
+  cache_dir: null
+
+runtime:
+  device: cuda
+  dtype: float32
+  seed: 42
+  show_progress: true
+
+calibration:
+  datasets:
+    - dataset: vqav2
+      split: testdev
+      n_samples: 128
+    - dataset: wikitext2
+      split: train
+      n_samples: 128
+  seq_len: 2048
+
+model_args:
+  vision:
+    grid_thw: [8, 24, 24]
+    visual_start_idx: 0
+    spatial_merge_size: 2
+
+pipeline:
+  - name: spinquant
+    enabled: true
+    init_method: random
+    disable_r1: false
+    disable_r2: false
+    disable_deepstack_fusion: false
+    r1_path: null
+    r2_map_path: null
+
+  - name: smoothquant
+    enabled: false
+    alpha: 0.5
+    components: both
+    custom_alpha_map: null
+
+  - name: gptq
+    enabled: true
+    weight_bits: 4
+    weight_bits_overrides: {}
+    perchannel: true
+    symmetric: false
+    mse: null
+    sensitivity_path: null
+    percdamp: 0.01
+    groupsize: -1
+    actorder: true
+    static_groups: false
+    verbose: false
+    show_progress: true
+    quantize_vision: true
+    quantize_text: true
+    quantize_lm_head: false
+    quantize_vision_patch_embed: true
+    quantize_vision_blocks: true
+    quantize_vision_merger: true
+    quantize_vision_deepstack_mergers: true
+    quantize_text_layers: true
+    move_cache_to_cpu: false
+
+  - name: ptq
+    enabled: true
+    activation_dtype: int16
+    default_qscheme: per_tensor_symm
+    linear_weight_bits: 4
+    vision_patch_embed_weight_bits: 8
+    embedding_weight_bits: 8
+    lm_head_weight_bits: 8
+    norm_dtype: int16
+    norm_weight_dtype: int16
+    strict_wrap: true
+
+evaluation:
+  enabled: true
+  vlm_tasks:
+    - vqav2
+    - textvqa
+  coco: true
+  llava_bench: true
+  mmlu:
+    enabled: true
+    subjects: null
+    n_shots: 5
+    n_samples: -1
+    batch_size: 1
+  hellaswag:
+    enabled: true
+    n_shots: 10
+    n_samples: -1
+    batch_size: 1
+  mmmu:
+    enabled: true
+    dataset: MMMU/MMMU
+    subjects: null
+    n_shots: 5
+    n_samples: -1
+    max_new_tokens: 16
+    temperature: 0.0
+    verbose: false
+  ppl:
+    enabled: true
+    dataset: wikitext2
+    split: test
+    stride: 512
+  n_samples: -1
+  max_seq_len: 2048
+
+export:
+  enabled: false
+  output_dir: ./out/qwen3_vl_eval_suite
+  artifacts:
+    - ptq_checkpoint

--- a/tico/quantization/recipes/adapters/qwen3_vl.py
+++ b/tico/quantization/recipes/adapters/qwen3_vl.py
@@ -373,6 +373,7 @@ class Qwen3VLAdapter(ModelAdapter):
                 model=ctx.model,
                 processor=ctx.processor,
                 device=str(ctx.device),
+                dataset_name="coco",
                 n_samples=n_samples,
                 max_seq_len=max_seq_len,
             )
@@ -387,6 +388,19 @@ class Qwen3VLAdapter(ModelAdapter):
                 max_seq_len=max_seq_len,
             )
             print_coco_score_results("\n=== Llava Bench Evaluation ===", llava_results)
+
+        if eval_cfg.get("llava_bench", False):
+            llava_bench_results = evaluate_coco(
+                model=ctx.model,
+                processor=ctx.processor,
+                device=str(ctx.device),
+                dataset_name="llava_bench",
+                n_samples=n_samples,
+                max_seq_len=max_seq_len,
+            )
+            print("\n=== LLaVA Bench Evaluation ===")
+            for metric, value in llava_bench_results.items():
+                print(f"{metric:<10} {value:.3f}")
 
         mmlu = eval_cfg.get("mmlu", {})
         if mmlu.get("enabled", False):

--- a/tico/quantization/recipes/evaluation/vlm.py
+++ b/tico/quantization/recipes/evaluation/vlm.py
@@ -100,6 +100,7 @@ def evaluate_coco(
     device: str,
     n_samples: int,
     max_seq_len: int | None,
+    dataset_name: str = "coco",
 ) -> dict[str, float]:
     """
     Evaluate the COCO captioning dataset with COCO-style metrics.


### PR DESCRIPTION
- add a config for evaluation-only workflows
- support VQA, COCO, MMLU, HellaSwag, MMMU, and PPL configs
- update example documentation for evaluation usage

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>