### PR TITLE
[quantization] Support Qwen3VL inputs_embeds without attention mask

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_model.py
@@ -545,6 +545,28 @@ class TestQuantQwen3VLModel(unittest.TestCase):
             output.last_hidden_state.shape, (batch_size, seq_len, self.hidden_size)
         )
 
+    def test_forward_with_inputs_embeds_without_attention_mask(self):
+        """Test text-only inputs_embeds path when attention_mask is omitted."""
+        ptq_config = self._make_ptq_config(grid_thw=(1, 8, 8))
+        q_model = QuantQwen3VLModel(self.fp_model, qcfg=ptq_config)
+
+        batch_size = 2
+        seq_len = 20
+        inputs_embeds = torch.randn(batch_size, seq_len, self.hidden_size)
+
+        with torch.no_grad():
+            output = q_model(input_ids=None, inputs_embeds=inputs_embeds)
+
+        self.assertTrue(hasattr(output, "last_hidden_state"))
+        self.assertTrue(hasattr(output, "rope_deltas"))
+        self.assertEqual(
+            output.last_hidden_state.shape,
+            (batch_size, seq_len, self.hidden_size),
+        )
+        self.assertEqual(output.rope_deltas.shape, (batch_size, 1))
+        self.assertEqual(output.rope_deltas.device, inputs_embeds.device)
+        self.assertEqual(output.rope_deltas.dtype, torch.long)
+
     def test_forward_with_inputs_embeds_and_images(self):
         """Test forward pass with inputs_embeds and images (triggers QuantQwen3VLModel._get_placeholder_mask)."""
         thw = (1, 8, 8)

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_model.py
@@ -463,6 +463,7 @@ class QuantQwen3VLModel(QuantModuleBase):
                 image_grid_thw=image_grid_thw,
                 video_grid_thw=video_grid_thw,
                 attention_mask=attention_mask,
+                inputs_embeds=inputs_embeds,
             )
             self.rope_deltas = rope_deltas
         # then use the prev pre-calculated rope-deltas to get the correct position ids
@@ -483,10 +484,11 @@ class QuantQwen3VLModel(QuantModuleBase):
 
     def _get_rope_index(
         self,
-        input_ids: torch.Tensor,
-        image_grid_thw: torch.Tensor,
-        video_grid_thw: torch.Tensor,
-        attention_mask: torch.Tensor,
+        input_ids: torch.Tensor | None,
+        image_grid_thw: torch.Tensor | None,
+        video_grid_thw: torch.Tensor | None,
+        attention_mask: torch.Tensor | None,
+        inputs_embeds: torch.Tensor | None = None,
     ):
         """Calculate 3D rope index based on image and video sizes."""
         # Since we use timestamps to separate videos, video_grid_thw should be split
@@ -552,6 +554,7 @@ class QuantQwen3VLModel(QuantModuleBase):
 
                     if ed_image < ed_video:
                         # This is an image
+                        assert image_grid_thw is not None
                         t, h, w = (
                             image_grid_thw[image_index][0],
                             image_grid_thw[image_index][1],
@@ -562,6 +565,7 @@ class QuantQwen3VLModel(QuantModuleBase):
                         ed = ed_image
                     else:
                         # This is a video
+                        assert video_grid_thw is not None
                         t, h, w = (
                             video_grid_thw[video_index][0],
                             video_grid_thw[video_index][1],
@@ -661,15 +665,25 @@ class QuantQwen3VLModel(QuantModuleBase):
                 )[0]
                 mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
             else:
+                if input_ids is not None:
+                    batch_size, seq_len = input_ids.shape
+                    device = input_ids.device
+                    dtype = input_ids.dtype
+                else:
+                    assert inputs_embeds is not None
+                    batch_size, seq_len = inputs_embeds.shape[:2]
+                    device = inputs_embeds.device
+                    dtype = torch.long
+
                 position_ids = (
-                    torch.arange(input_ids.shape[1], device=input_ids.device)
+                    torch.arange(seq_len, device=device, dtype=dtype)
                     .view(1, 1, -1)
-                    .expand(3, input_ids.shape[0], -1)
+                    .expand(3, batch_size, -1)
                 )
                 mrope_position_deltas = torch.zeros(
-                    [input_ids.shape[0], 1],
-                    device=input_ids.device,
-                    dtype=input_ids.dtype,
+                    [batch_size, 1],
+                    device=device,
+                    dtype=dtype,
                 )
 
             return position_ids, mrope_position_deltas


### PR DESCRIPTION
Use inputs_embeds as the shape/device source when Qwen3VL receives text-only inputs_embeds without input_ids or attention_mask.

Previously, the text-only RoPE fallback unconditionally referenced `input_ids` in the no-attention-mask path, causing inputs_embeds-only forward calls to fail with NoneType attribute errors.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>