### PR TITLE
[test] Add missing license header

### DIFF
--- a/test/unit_test/quantization/test_circle_executor.py
+++ b/test/unit_test/quantization/test_circle_executor.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
This commit adds missing license header.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>