### PR TITLE
[evaluation] Video-mme dataset support

### DIFF
--- a/test/quantization/recipes/test_video_mme_evaluation.py
+++ b/test/quantization/recipes/test_video_mme_evaluation.py
@@ -1,0 +1,406 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from quantization.recipes.optional_dependency_stubs import (
+        install_optional_dependency_stubs,
+    )
+except ModuleNotFoundError:
+    from optional_dependency_stubs import install_optional_dependency_stubs
+
+install_optional_dependency_stubs()
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import tico.quantization.recipes.evaluation.video_mme as video_mme
+
+
+class TestVideoMmeEvaluation(unittest.TestCase):
+    """Smoke tests for the Video-MME evaluation recipe helper."""
+
+    def test_evaluate_and_print_video_mme_delegates_to_lmms_eval(self):
+        """evaluate_and_print_video_mme should call evaluate_vlm_on_tasks with video_mme task."""
+        captured = {}
+
+        def fake_evaluate_vlm_on_tasks(**kwargs):
+            captured.update(kwargs)
+            return {"results": {"video_mme": {"acc": 0.5}}}
+
+        def fake_print_lmms_eval_results(results):
+            pass  # no-op for test
+
+        with (
+            patch.object(
+                video_mme, "evaluate_vlm_on_tasks", fake_evaluate_vlm_on_tasks
+            ),
+            patch.object(
+                video_mme, "print_lmms_eval_results", fake_print_lmms_eval_results
+            ),
+        ):
+            result = video_mme.evaluate_and_print_video_mme(
+                model=MagicMock(),
+                processor=MagicMock(),
+                device="cuda",
+                batch_size=1,
+                max_new_tokens=16,
+            )
+
+        # Verify the task is "videomme" (lmms-eval task name)
+        self.assertEqual(captured["tasks"], ["videomme"])
+        # Verify other args are passed through
+        self.assertEqual(captured["device"], "cuda")
+        self.assertEqual(captured["batch_size"], 1)
+        self.assertEqual(captured["max_new_tokens"], 16)
+        # Verify results are returned
+        self.assertIn("results", result)
+
+    def test_evaluate_and_print_video_mme_passes_cache_args(self):
+        """Cache-related arguments should be forwarded to evaluate_vlm_on_tasks."""
+        captured = {}
+
+        def fake_evaluate_vlm_on_tasks(**kwargs):
+            captured.update(kwargs)
+            return {"results": {}}
+
+        def fake_print_lmms_eval_results(results):
+            pass
+
+        with (
+            patch.object(
+                video_mme, "evaluate_vlm_on_tasks", fake_evaluate_vlm_on_tasks
+            ),
+            patch.object(
+                video_mme, "print_lmms_eval_results", fake_print_lmms_eval_results
+            ),
+        ):
+            video_mme.evaluate_and_print_video_mme(
+                model=MagicMock(),
+                processor=MagicMock(),
+                device="cpu",
+                use_cache="/tmp/cache",
+                cache_dir="/tmp/hf_cache",
+            )
+
+        self.assertEqual(captured["use_cache"], "/tmp/cache")
+        self.assertEqual(captured["cache_dir"], "/tmp/hf_cache")
+
+
+class TestLmmsEvalUtils(unittest.TestCase):
+    """Tests for the low-level lmms-eval wrapper utilities."""
+
+    def test_build_model_args_infers_qwen3_vl(self):
+        """_build_model_args should infer 'qwen3_vl' from a Qwen3-VL model object."""
+        from tico.quantization.evaluation.lmms_eval_utils import _build_model_args
+
+        model = MagicMock()
+        type(model).__name__ = "Qwen3VLForConditionalGeneration"
+        model_name_str = "Qwen/Qwen3-VL-2B-Instruct"
+        model.config._name_or_path = model_name_str
+
+        processor = MagicMock()
+        processor.tokenizer.name_or_path = model_name_str
+
+        model_name, model_args = _build_model_args(
+            model, processor, device="cuda", batch_size=2, max_new_tokens=16
+        )
+
+        self.assertEqual(model_name, "qwen3_vl")
+        self.assertEqual(model_args["pretrained"], model_name_str)
+        # Only 'pretrained' is in model_args; batch_size, device,
+        # max_new_tokens, and tokenizer are NOT (they'd cause errors
+        # with lmms-eval model constructors like Qwen3_VL).
+        self.assertNotIn("batch_size", model_args)
+        self.assertNotIn("device", model_args)
+        self.assertNotIn("max_new_tokens", model_args)
+        self.assertNotIn("tokenizer", model_args)
+
+    def test_build_model_args_passes_max_num_frames(self):
+        """_build_model_args should include max_num_frames in model_args."""
+        from tico.quantization.evaluation.lmms_eval_utils import _build_model_args
+
+        model = MagicMock()
+        type(model).__name__ = "Qwen3VLForConditionalGeneration"
+        model.config._name_or_path = "Qwen/Qwen3-VL-2B-Instruct"
+
+        processor = MagicMock()
+
+        model_name, model_args = _build_model_args(
+            model,
+            processor,
+            device="cuda",
+            batch_size=1,
+            max_new_tokens=16,
+            max_num_frames=5,
+        )
+
+        self.assertEqual(model_args["max_num_frames"], 5)
+
+    def test_check_lmms_eval_available_raises_when_missing(self):
+        """_check_lmms_eval_available should raise RuntimeError if lmms-eval is not installed."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _check_lmms_eval_available,
+        )
+
+        with patch.dict("sys.modules", {"lmms_eval": None}):
+            with self.assertRaises(RuntimeError) as ctx:
+                _check_lmms_eval_available()
+            self.assertIn("lmms-eval", str(ctx.exception))
+
+    def test_get_custom_tasks_dir_finds_lmms_tasks(self):
+        """_get_custom_tasks_dir should find the lmms_tasks directory shipped with TICO."""
+        from tico.quantization.evaluation.lmms_eval_utils import _get_custom_tasks_dir
+
+        tasks_dir = _get_custom_tasks_dir()
+        self.assertIsNotNone(tasks_dir)
+        self.assertTrue(tasks_dir.endswith("lmms_tasks"))
+
+    def test_print_results_fallback(self):
+        """Fallback printer should handle float and non-float values."""
+        import contextlib
+
+        import io
+
+        from tico.quantization.evaluation.lmms_eval_utils import _print_results_fallback
+
+        results = {
+            "results": {
+                "video_mme": {
+                    "acc,none": 0.6543,
+                    "num_samples": 900,
+                }
+            }
+        }
+
+        with contextlib.redirect_stdout(io.StringIO()) as buffer:
+            _print_results_fallback(results)
+
+        output = buffer.getvalue()
+        self.assertIn("video_mme", output)
+        self.assertIn("0.6543", output)
+        self.assertIn("900", output)
+
+
+class TestComputeVideoChunkPatterns(unittest.TestCase):
+    """Tests for _compute_video_chunk_patterns."""
+
+    def test_limit_1_downloads_1_chunk(self):
+        """A limit of 1 should download only 1 video chunk."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_chunk_patterns,
+        )
+
+        patterns = _compute_video_chunk_patterns(limit=1)
+        self.assertIn("videos_chunked_01.zip", patterns)
+        self.assertNotIn("videos_chunked_02.zip", patterns)
+
+    def test_limit_41_downloads_2_chunks(self):
+        """A limit of 41 (> _SAMPLES_PER_CHUNK) should download 2 chunks."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_chunk_patterns,
+        )
+
+        patterns = _compute_video_chunk_patterns(limit=41)
+        self.assertIn("videos_chunked_01.zip", patterns)
+        self.assertIn("videos_chunked_02.zip", patterns)
+        self.assertNotIn("videos_chunked_03.zip", patterns)
+
+    def test_limit_none_downloads_all_chunks(self):
+        """No limit (None) should download all 20 chunks."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_chunk_patterns,
+        )
+
+        patterns = _compute_video_chunk_patterns(limit=None)
+        self.assertIn("videos_chunked_01.zip", patterns)
+        self.assertIn("videos_chunked_20.zip", patterns)
+        self.assertNotIn("videos_chunked_21.zip", patterns)
+
+    def test_always_includes_base_patterns(self):
+        """Base patterns (parquet, gitattributes, README, subtitle) should always be present."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_chunk_patterns,
+        )
+
+        patterns = _compute_video_chunk_patterns(limit=1)
+        self.assertIn("*.parquet", patterns)
+        self.assertIn(".gitattributes", patterns)
+        self.assertIn("README.md", patterns)
+        self.assertIn("subtitle.zip", patterns)
+
+
+class TestPatchSnapshotDownloadForLimit(unittest.TestCase):
+    """Tests for _patch_snapshot_download_for_limit."""
+
+    def test_returns_context_manager(self):
+        """_patch_snapshot_download_for_limit should return a context manager."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _patch_snapshot_download_for_limit,
+        )
+
+        ctx = _patch_snapshot_download_for_limit(limit=10)
+        # Should be usable as a context manager
+        self.assertTrue(hasattr(ctx, "__enter__"))
+        self.assertTrue(hasattr(ctx, "__exit__"))
+
+    def test_non_videomme_repo_passes_through(self):
+        """Patched snapshot_download should pass through non-Video-MME repos unchanged."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _patch_snapshot_download_for_limit,
+        )
+
+        ctx = _patch_snapshot_download_for_limit(limit=10)
+        with ctx:
+            # After patching, calling snapshot_download with a non-Video-MME
+            # repo should go through to the original function.
+            # We just verify the context manager works without error.
+            pass
+
+
+class TestVerboseFlagPropagation(unittest.TestCase):
+    """Tests for verbose flag propagation via LMMS_VERBOSE env var."""
+
+    def test_evaluate_vlm_on_tasks_sets_lmms_verbose_env(self):
+        """evaluate_vlm_on_tasks should set LMMS_VERBOSE env var based on verbose flag."""
+        import os
+
+        from tico.quantization.evaluation.lmms_eval_utils import evaluate_vlm_on_tasks
+
+        # We can't actually run evaluate_vlm_on_tasks (needs lmms-eval + GPU),
+        # but we can test that the env var is set correctly by checking
+        # the function source or by mocking. Here we just verify the env var
+        # mechanism works.
+        os.environ["LMMS_VERBOSE"] = "1"
+        self.assertEqual(os.environ.get("LMMS_VERBOSE"), "1")
+
+        os.environ["LMMS_VERBOSE"] = "0"
+        self.assertEqual(os.environ.get("LMMS_VERBOSE"), "0")
+
+        # Clean up
+        os.environ.pop("LMMS_VERBOSE", None)
+
+
+class TestVideommeMiniUtils(unittest.TestCase):
+    """Tests for the videomme_mini task utility functions."""
+
+    def test_available_video_ids_empty_dir(self):
+        """_available_video_ids should return empty set for non-existent directory."""
+        # Import with stubs
+        try:
+            from quantization.recipes.optional_dependency_stubs import (
+                install_optional_dependency_stubs,
+            )
+        except ModuleNotFoundError:
+            from optional_dependency_stubs import install_optional_dependency_stubs
+
+        install_optional_dependency_stubs()
+
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini.utils import (
+            _available_video_ids,
+        )
+
+        # With default _data_dir (likely doesn't exist in test env)
+        result = _available_video_ids()
+        # Should return a set (possibly empty)
+        self.assertIsInstance(result, set)
+
+    def test_doc_to_visual_returns_empty_for_missing_video(self):
+        """videomme_doc_to_visual should return [] for missing videos."""
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini.utils import (
+            videomme_doc_to_visual,
+        )
+
+        doc = {"videoID": "nonexistent_video_12345"}
+        result = videomme_doc_to_visual(doc)
+        self.assertEqual(result, [])
+
+    def test_doc_to_visual_returns_path_for_existing_video(self):
+        """videomme_doc_to_visual should return [path] for an existing video file."""
+        import os
+        import tempfile
+
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini import (
+            utils as vm_utils,
+        )
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini.utils import (
+            videomme_doc_to_visual,
+        )
+
+        # Create a temporary directory with a fake video
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_data_dir = vm_utils._data_dir
+            vm_utils._data_dir = tmpdir
+            try:
+                # Create a fake video file
+                video_id = "test_video_abc"
+                video_path = os.path.join(tmpdir, video_id + ".mp4")
+                with open(video_path, "w") as f:
+                    f.write("fake")
+
+                doc = {"videoID": video_id}
+                result = videomme_doc_to_visual(doc)
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0], video_path)
+            finally:
+                vm_utils._data_dir = original_data_dir
+
+    def test_process_docs_filters_by_available_videos(self):
+        """videomme_process_docs should filter dataset to only available videos."""
+        import os
+        import tempfile
+        from unittest.mock import MagicMock
+
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini import (
+            utils as vm_utils,
+        )
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini.utils import (
+            videomme_process_docs,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_data_dir = vm_utils._data_dir
+            vm_utils._data_dir = tmpdir
+            try:
+                # Create one video file
+                with open(os.path.join(tmpdir, "available_video.mp4"), "w") as f:
+                    f.write("fake")
+
+                # Mock dataset
+                mock_dataset = MagicMock()
+                mock_dataset.filter.return_value = ["filtered_result"]
+
+                videomme_process_docs(mock_dataset)
+                # filter should have been called since we have available videos
+                mock_dataset.filter.assert_called_once()
+            finally:
+                vm_utils._data_dir = original_data_dir
+
+    def test_verbose_flag_controls_print(self):
+        """Print statements should be suppressed when LMMS_VERBOSE is not set."""
+        import os
+
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini import (
+            utils as vm_utils,
+        )
+
+        # Ensure verbose is off
+        os.environ.pop("LMMS_VERBOSE", None)
+        # Re-evaluate _VERBOSE by reimporting the module is tricky,
+        # so we just test the _VERBOSE flag directly.
+        # Since _VERBOSE is evaluated at import time, we test the env var logic.
+        self.assertFalse(os.getenv("LMMS_VERBOSE", "").lower() in ("1", "true", "yes"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/recipes/test_video_mme_evaluation.py
+++ b/test/quantization/recipes/test_video_mme_evaluation.py
@@ -90,11 +90,9 @@ class TestVideoMmeEvaluation(unittest.TestCase):
                 processor=MagicMock(),
                 device="cpu",
                 use_cache="/tmp/cache",
-                cache_dir="/tmp/hf_cache",
             )
 
         self.assertEqual(captured["use_cache"], "/tmp/cache")
-        self.assertEqual(captured["cache_dir"], "/tmp/hf_cache")
 
 
 class TestLmmsEvalUtils(unittest.TestCase):
@@ -109,22 +107,10 @@ class TestLmmsEvalUtils(unittest.TestCase):
         model_name_str = "Qwen/Qwen3-VL-2B-Instruct"
         model.config._name_or_path = model_name_str
 
-        processor = MagicMock()
-        processor.tokenizer.name_or_path = model_name_str
-
-        model_name, model_args = _build_model_args(
-            model, processor, device="cuda", batch_size=2, max_new_tokens=16
-        )
+        model_name, model_args = _build_model_args(model)
 
         self.assertEqual(model_name, "qwen3_vl")
         self.assertEqual(model_args["pretrained"], model_name_str)
-        # Only 'pretrained' is in model_args; batch_size, device,
-        # max_new_tokens, and tokenizer are NOT (they'd cause errors
-        # with lmms-eval model constructors like Qwen3_VL).
-        self.assertNotIn("batch_size", model_args)
-        self.assertNotIn("device", model_args)
-        self.assertNotIn("max_new_tokens", model_args)
-        self.assertNotIn("tokenizer", model_args)
 
     def test_build_model_args_passes_max_num_frames(self):
         """_build_model_args should include max_num_frames in model_args."""
@@ -134,14 +120,8 @@ class TestLmmsEvalUtils(unittest.TestCase):
         type(model).__name__ = "Qwen3VLForConditionalGeneration"
         model.config._name_or_path = "Qwen/Qwen3-VL-2B-Instruct"
 
-        processor = MagicMock()
-
         model_name, model_args = _build_model_args(
             model,
-            processor,
-            device="cuda",
-            batch_size=1,
-            max_new_tokens=16,
             max_num_frames=5,
         )
 
@@ -164,7 +144,7 @@ class TestLmmsEvalUtils(unittest.TestCase):
 
         tasks_dir = _get_custom_tasks_dir()
         self.assertIsNotNone(tasks_dir)
-        self.assertTrue(tasks_dir.endswith("lmms_tasks"))
+        self.assertTrue(tasks_dir.endswith("lmms_tasks"))  # type: ignore[union-attr]
 
     def test_print_results_fallback(self):
         """Fallback printer should handle float and non-float values."""
@@ -205,16 +185,18 @@ class TestComputeVideoChunkPatterns(unittest.TestCase):
         self.assertIn("videos_chunked_01.zip", patterns)
         self.assertNotIn("videos_chunked_02.zip", patterns)
 
-    def test_limit_41_downloads_2_chunks(self):
-        """A limit of 41 (> _SAMPLES_PER_CHUNK) should download 2 chunks."""
+    def test_limit_61_downloads_3_chunks(self):
+        """A limit of 61 (> 2*_SAMPLES_PER_CHUNK) should download 3 chunks."""
         from tico.quantization.evaluation.lmms_eval_utils import (
             _compute_video_chunk_patterns,
         )
 
-        patterns = _compute_video_chunk_patterns(limit=41)
+        # _SAMPLES_PER_CHUNK = 30, so ceil(61/30) = 3 chunks
+        patterns = _compute_video_chunk_patterns(limit=61)
         self.assertIn("videos_chunked_01.zip", patterns)
         self.assertIn("videos_chunked_02.zip", patterns)
-        self.assertNotIn("videos_chunked_03.zip", patterns)
+        self.assertIn("videos_chunked_03.zip", patterns)
+        self.assertNotIn("videos_chunked_04.zip", patterns)
 
     def test_limit_none_downloads_all_chunks(self):
         """No limit (None) should download all 20 chunks."""
@@ -266,6 +248,144 @@ class TestPatchSnapshotDownloadForLimit(unittest.TestCase):
             # repo should go through to the original function.
             # We just verify the context manager works without error.
             pass
+
+
+class TestGetDownloadedVideommeChunks(unittest.TestCase):
+    """Tests for _get_downloaded_videomme_chunks."""
+
+    def test_returns_empty_set_when_no_cache(self):
+        """Should return empty set when HF cache dir doesn't exist."""
+        # With a non-existent HF_HOME, should return empty set
+        import os
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_downloaded_videomme_chunks,
+        )
+
+        original_hf = os.environ.get("HF_HOME")
+        try:
+            os.environ["HF_HOME"] = "/tmp/nonexistent_hf_cache_12345"
+            result = _get_downloaded_videomme_chunks()
+            self.assertIsInstance(result, set)
+            self.assertEqual(len(result), 0)
+        finally:
+            if original_hf is not None:
+                os.environ["HF_HOME"] = original_hf
+            else:
+                os.environ.pop("HF_HOME", None)
+
+    def test_finds_chunks_in_fake_cache(self):
+        """Should find chunk zips in a fake cache directory."""
+        import os
+        import tempfile
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_downloaded_videomme_chunks,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the expected directory structure
+            repo_dir = os.path.join(tmpdir, "hub", "datasets--lmms-lab--Video-MME")
+            snap_dir = os.path.join(repo_dir, "snapshots", "abc123")
+            os.makedirs(snap_dir)
+
+            # Create fake chunk files
+            for name in ["videos_chunked_01.zip", "videos_chunked_02.zip"]:
+                with open(os.path.join(snap_dir, name), "w") as f:
+                    f.write("fake zip content")
+
+            # Create a non-chunk file that should be ignored
+            with open(os.path.join(snap_dir, "subtitle.zip"), "w") as f:
+                f.write("fake subtitle")
+
+            original_hf = os.environ.get("HF_HOME")
+            try:
+                os.environ["HF_HOME"] = tmpdir
+                result = _get_downloaded_videomme_chunks()
+                self.assertIn("videos_chunked_01.zip", result)
+                self.assertIn("videos_chunked_02.zip", result)
+                self.assertNotIn("subtitle.zip", result)
+                self.assertEqual(len(result), 2)
+            finally:
+                if original_hf is not None:
+                    os.environ["HF_HOME"] = original_hf
+                else:
+                    os.environ.pop("HF_HOME", None)
+
+
+class TestEnsureVideommeChunksDownloaded(unittest.TestCase):
+    """Tests for _ensure_videomme_chunks_downloaded."""
+
+    def test_skips_download_when_all_chunks_cached(self):
+        """Should not call snapshot_download when all needed chunks are cached."""
+        import os
+        import tempfile
+        from unittest.mock import MagicMock, patch
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _ensure_videomme_chunks_downloaded,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the cache with chunk 01 already present
+            repo_dir = os.path.join(tmpdir, "hub", "datasets--lmms-lab--Video-MME")
+            snap_dir = os.path.join(repo_dir, "snapshots", "abc123")
+            os.makedirs(snap_dir)
+            with open(os.path.join(snap_dir, "videos_chunked_01.zip"), "w") as f:
+                f.write("fake")
+
+            original_hf = os.environ.get("HF_HOME")
+            try:
+                os.environ["HF_HOME"] = tmpdir
+
+                with patch("huggingface_hub.snapshot_download") as mock_dl:
+                    _ensure_videomme_chunks_downloaded(limit=1)
+                    # Should NOT call snapshot_download since chunk 01 is cached
+                    mock_dl.assert_not_called()
+            finally:
+                if original_hf is not None:
+                    os.environ["HF_HOME"] = original_hf
+                else:
+                    os.environ.pop("HF_HOME", None)
+
+    def test_downloads_missing_chunks(self):
+        """Should download only missing chunks when some are cached."""
+        import os
+        import tempfile
+        from unittest.mock import patch
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _ensure_videomme_chunks_downloaded,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create the cache with chunk 01 already present
+            repo_dir = os.path.join(tmpdir, "hub", "datasets--lmms-lab--Video-MME")
+            snap_dir = os.path.join(repo_dir, "snapshots", "abc123")
+            os.makedirs(snap_dir)
+            with open(os.path.join(snap_dir, "videos_chunked_01.zip"), "w") as f:
+                f.write("fake")
+
+            original_hf = os.environ.get("HF_HOME")
+            try:
+                os.environ["HF_HOME"] = tmpdir
+
+                with patch("huggingface_hub.snapshot_download") as mock_dl:
+                    # limit=31 needs 2 chunks (01 and 02), but 01 is cached
+                    _ensure_videomme_chunks_downloaded(limit=31)
+                    mock_dl.assert_called_once()
+                    call_kwargs = mock_dl.call_args
+                    allow_patterns = call_kwargs.kwargs.get(
+                        "allow_patterns"
+                    ) or call_kwargs[1].get("allow_patterns")
+                    # Should only download chunk 02 (01 is cached)
+                    self.assertIn("videos_chunked_02.zip", allow_patterns)
+                    self.assertNotIn("videos_chunked_01.zip", allow_patterns)
+            finally:
+                if original_hf is not None:
+                    os.environ["HF_HOME"] = original_hf
+                else:
+                    os.environ.pop("HF_HOME", None)
 
 
 class TestVerboseFlagPropagation(unittest.TestCase):
@@ -386,20 +506,25 @@ class TestVideommeMiniUtils(unittest.TestCase):
             finally:
                 vm_utils._data_dir = original_data_dir
 
-    def test_verbose_flag_controls_print(self):
-        """Print statements should be suppressed when LMMS_VERBOSE is not set."""
+    def test_is_verbose_reflects_runtime_env_changes(self):
+        """_is_verbose() should reflect runtime changes to LMMS_VERBOSE env var."""
         import os
 
-        from tico.quantization.evaluation.lmms_tasks.videomme_mini import (
-            utils as vm_utils,
+        from tico.quantization.evaluation.lmms_tasks.videomme_mini.utils import (
+            _is_verbose,
         )
 
         # Ensure verbose is off
         os.environ.pop("LMMS_VERBOSE", None)
-        # Re-evaluate _VERBOSE by reimporting the module is tricky,
-        # so we just test the _VERBOSE flag directly.
-        # Since _VERBOSE is evaluated at import time, we test the env var logic.
-        self.assertFalse(os.getenv("LMMS_VERBOSE", "").lower() in ("1", "true", "yes"))
+        self.assertFalse(_is_verbose())
+
+        # Set verbose on at runtime – _is_verbose() should pick it up immediately
+        os.environ["LMMS_VERBOSE"] = "1"
+        self.assertTrue(_is_verbose())
+
+        # Turn it off again
+        os.environ.pop("LMMS_VERBOSE", None)
+        self.assertFalse(_is_verbose())
 
 
 if __name__ == "__main__":

--- a/tico/quantization/evaluation/lmms_eval_utils.py
+++ b/tico/quantization/evaluation/lmms_eval_utils.py
@@ -101,7 +101,7 @@ def _compute_video_chunk_patterns(limit: int | None) -> list[str]:
     Returns:
         List of ``allow_patterns`` strings for ``snapshot_download``.
     """
-    _SAMPLES_PER_CHUNK = 40  # approximate number of samples per zip
+    _SAMPLES_PER_CHUNK = 30  # approximate number of samples per zip
     _MAX_CHUNKS = 20  # maximum number of video chunk zips
 
     base_patterns = [
@@ -128,6 +128,106 @@ def _compute_video_chunk_patterns(limit: int | None) -> list[str]:
         ]
 
     return base_patterns + video_patterns
+
+
+def _get_downloaded_videomme_chunks() -> set[str]:
+    """Check which Video-MME video chunk zips are already in the HF cache.
+
+    Scans the HuggingFace cache directory for the Video-MME dataset repo
+    and returns the set of chunk zip filenames that have already been
+    downloaded (e.g. ``{"videos_chunked_01.zip", "videos_chunked_02.zip"}``).
+
+    Returns:
+        A set of zip filenames found in the cache, or an empty set if the
+        cache directory does not exist yet.
+    """
+    import re
+
+    try:
+        import huggingface_hub
+    except ImportError:
+        return set()
+
+    # The HF cache stores dataset repos under:
+    #   <HF_HOME>/hub/datasets--lmms-lab--Video-MME/
+    # Inside, the actual files are under blobs/ (content-addressed) but
+    # snapshot directories contain symlinks.  We scan snapshots for the
+    # zip filenames.
+    hf_home = os.path.expanduser(os.getenv("HF_HOME", "~/.cache/huggingface/"))
+    repo_dir = os.path.join(hf_home, "hub", "datasets--lmms-lab--Video-MME")
+
+    if not os.path.isdir(repo_dir):
+        return set()
+
+    downloaded = set()
+    _chunk_re = re.compile(r"^videos_chunked_\d+\.zip$")
+    for root, dirs, files in os.walk(repo_dir):
+        for f in files:
+            if _chunk_re.match(f):
+                # Check that the file has actual content (not just a pointer)
+                fpath = os.path.join(root, f)
+                if os.path.getsize(fpath) > 0:
+                    downloaded.add(f)
+
+    return downloaded
+
+
+def _ensure_videomme_chunks_downloaded(limit: int | None) -> None:
+    """Download any missing Video-MME zip chunks needed for the given limit.
+
+    This function proactively downloads only the chunks that are not already
+    in the HuggingFace cache.  It is incremental: if you previously ran with
+    ``limit=30`` (1 chunk) and now run with ``limit=60`` (2 chunks), only
+    the second chunk is downloaded.
+
+    When *limit* is ``None``, all 20 chunks are downloaded (if not already
+    cached).
+
+    This must be called **before** ``simple_evaluate`` so that the chunks
+    are available when lmms-eval's dataset loading runs.
+
+    Args:
+        limit: Maximum number of samples to evaluate.  ``None`` means
+            download all chunks.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        return  # huggingface_hub not available; nothing to download
+
+    needed_patterns = _compute_video_chunk_patterns(limit)
+    # Separate base patterns (parquet, etc.) from video chunk zips
+    needed_chunks = {p for p in needed_patterns if p.startswith("videos_chunked_")}
+    needed_base = [p for p in needed_patterns if not p.startswith("videos_chunked_")]
+
+    # Check which chunks are already in the cache
+    already_downloaded = _get_downloaded_videomme_chunks()
+
+    # Compute which chunks are missing
+    missing_chunks = needed_chunks - already_downloaded
+
+    if not missing_chunks and already_downloaded:
+        print(
+            f"[INFO] All {len(needed_chunks)} needed Video-MME chunks already "
+            f"downloaded ({len(already_downloaded)} in cache)."
+        )
+        return
+
+    # Download missing chunks + base patterns (parquet, subtitle, etc.)
+    download_patterns = needed_base + sorted(missing_chunks)
+
+    if missing_chunks:
+        print(
+            f"[INFO] Downloading {len(missing_chunks)} missing Video-MME chunks: "
+            f"{sorted(missing_chunks)}  "
+            f"({len(already_downloaded)} already in cache)"
+        )
+
+    snapshot_download(
+        "lmms-lab/Video-MME",
+        allow_patterns=download_patterns,
+        repo_type="dataset",
+    )
 
 
 def _patch_snapshot_download_for_limit(limit: int | None):
@@ -252,6 +352,16 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
 
     from transformers import AutoProcessor, AutoTokenizer
 
+    # --- Ensure the model has a .config attribute ---
+    # When the model is a PTQ wrapper (has .wrapped), lmms-eval's
+    # Qwen3_VL.__init__ accesses self._model.config, which would fail
+    # because the wrapper class doesn't define it.  We dynamically add
+    # it as an instance attribute that delegates to the inner model's
+    # config.  This avoids modifying ptq_wrapper.py.
+    _inner = getattr(model, "wrapped", None)
+    if _inner is not None and not hasattr(model, "config"):
+        model.config = _inner.config
+
     # --- Patch model class from_pretrained ---
     # Collect all model classes that might be used by lmms-eval
     _model_classes = []
@@ -283,9 +393,7 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
     _original_model_fps = {cls: cls.from_pretrained for cls in _model_classes}
 
     # Replace from_pretrained on each class with a function that returns
-    # the already-loaded model on the first call.  We use a simple list
-    # as a mutable flag so the closure can mutate it.
-    _model_returned = [False]
+    # the already-loaded model.
 
     for cls in _model_classes:
         # We must capture the original unbound function for the fallback.
@@ -293,10 +401,7 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
 
         def _make_patched_fp(orig_fn):
             def _patched_from_pretrained(cls_arg, *args, **kwargs):
-                if not _model_returned[0]:
-                    _model_returned[0] = True
-                    return model
-                return orig_fn(*args, **kwargs)
+                return model
 
             return _patched_from_pretrained
 
@@ -304,26 +409,18 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
 
     # --- Patch AutoProcessor.from_pretrained ---
     _original_processor_fp = AutoProcessor.from_pretrained
-    _processor_returned = [False]
 
     def _patched_processor_fp(cls_arg, *args, **kwargs):
-        if not _processor_returned[0]:
-            _processor_returned[0] = True
-            return processor
-        return _original_processor_fp(*args, **kwargs)
+        return processor
 
     AutoProcessor.from_pretrained = classmethod(_patched_processor_fp)
 
     # --- Patch AutoTokenizer.from_pretrained ---
     _original_tokenizer_fp = AutoTokenizer.from_pretrained
     _tokenizer = getattr(processor, "tokenizer", None)
-    _tokenizer_returned = [False]
 
     def _patched_tokenizer_fp(cls_arg, *args, **kwargs):
-        if not _tokenizer_returned[0] and _tokenizer is not None:
-            _tokenizer_returned[0] = True
-            return _tokenizer
-        return _original_tokenizer_fp(*args, **kwargs)
+        return _tokenizer
 
     AutoTokenizer.from_pretrained = classmethod(_patched_tokenizer_fp)
 
@@ -356,13 +453,10 @@ def _patch_subsample_video_inputs_for_debug():
     try:
         from lmms_eval.models.simple.qwen3_vl import Qwen3_VL
     except ImportError:
+        return contextlib.nullcontext()
 
-        @contextlib.contextmanager
-        def _noop():
-            yield
-
-        return _noop()
-
+    if not hasattr(Qwen3_VL, "_subsample_video_inputs"):
+        return contextlib.nullcontext()
     _original_subsample = Qwen3_VL._subsample_video_inputs
 
     def _patched_subsample(self, video_inputs, video_metadatas=None):
@@ -396,11 +490,10 @@ def evaluate_vlm_on_tasks(
     tasks: list[str] | str,
     device: str = "cuda",
     batch_size: int = 1,
-    max_new_tokens: int = 16,
     max_num_frames: int = 32,
-    limit: int | float | None = None,
+    max_new_tokens: int | None = None,
+    limit: int | None = None,
     use_cache: str | None = None,
-    cache_dir: str | None = None,
     verbose: bool = True,
     **kwargs: Any,
 ) -> dict[str, Any]:
@@ -434,7 +527,6 @@ def evaluate_vlm_on_tasks(
         max_new_tokens: Maximum number of tokens to generate per sample.
         use_cache: Optional path to an ``lmms-eval`` results cache directory.
             When set, results are cached and can be reused across runs.
-        cache_dir: Optional cache directory for Hugging Face datasets.
         verbose: Whether to print detailed evaluation logs.
         **kwargs: Additional keyword arguments forwarded to
             ``lmms_eval.evaluator.simple_evaluate``.
@@ -451,15 +543,25 @@ def evaluate_vlm_on_tasks(
     _check_lmms_eval_available()
     _patch_lmms_eval_broken_tasks()
 
+    import contextlib
+
     from lmms_eval.evaluator import simple_evaluate
 
-    # Unwrap fake-quant wrapper if present
-    inner_model = getattr(model, "wrapped", model)
-
-    # Determine the lmms-eval model name and build model_args
-    model_name, model_args_dict = _build_model_args(
-        inner_model, processor, device, batch_size, max_new_tokens, max_num_frames
-    )
+    if isinstance(model, str):
+        model_name = model
+        model_args_dict = {}
+        if max_num_frames is not None:
+            model_args_dict["max_num_frames"] = max_num_frames
+        _model_ctx = contextlib.nullcontext()
+    else:
+        # Unwrap fake-quant wrapper if present
+        inner_model = getattr(model, "wrapped", model)
+        # Determine the lmms-eval model name and build model_args
+        model_name, model_args_dict = _build_model_args(inner_model, max_num_frames)
+        # Patch ``from_pretrained`` so that ``lmms-eval`` reuses the
+        # already-loaded model and processor instead of downloading and
+        # loading them a second time.
+        _model_ctx = _patch_from_pretrained_to_reuse_model(model, processor)
 
     # Propagate verbose flag to custom task utils via environment variable.
     # The videomme_mini utils.py checks LMMS_VERBOSE to decide whether to
@@ -474,6 +576,14 @@ def evaluate_vlm_on_tasks(
         tasks_list = [t.strip() for t in tasks.split(",") if t.strip()]
     else:
         tasks_list = list(tasks)
+
+    # Partial Video-MME downloads require videomme_mini, which filters samples by
+    # local video availability.
+    if limit is not None:
+        tasks_list = [
+            "videomme_mini" if task in ("videomme", "video_mme") else task
+            for task in tasks_list
+        ]
 
     # Convert model_args dict to the key=value string format expected by
     # ``simple_evaluate`` → ``create_from_arg_string`` →
@@ -493,8 +603,9 @@ def evaluate_vlm_on_tasks(
         eval_kwargs["limit"] = limit
     if use_cache is not None:
         eval_kwargs["use_cache"] = use_cache
-    if cache_dir is not None:
-        eval_kwargs["cache_dir"] = cache_dir
+    if max_new_tokens is not None:
+        gen_kwargs = f"max_new_tokens={max_new_tokens}"
+        eval_kwargs["gen_kwargs"] = gen_kwargs
 
     # Auto-register custom task directories (e.g. videomme_mini) by
     # creating a ``TaskManager`` with ``include_path`` pointing to the
@@ -508,27 +619,41 @@ def evaluate_vlm_on_tasks(
         task_manager = TaskManager(
             verbosity=eval_kwargs.get("verbosity", "DEBUG"),
             include_path=custom_tasks_dir,
+            model_name=model_name,
         )
         eval_kwargs["task_manager"] = task_manager
 
     # Forward any additional kwargs (may override task_manager)
     eval_kwargs.update(kwargs)
 
-    # Patch ``from_pretrained`` so that ``lmms-eval`` reuses the
-    # already-loaded model and processor instead of downloading and
-    # loading them a second time (which would waste time, disk space,
-    # and GPU memory).
-    _model_ctx = _patch_from_pretrained_to_reuse_model(model, processor)
-
     # Patch _subsample_video_inputs to add debug logging
     _subsample_ctx = _patch_subsample_video_inputs_for_debug()
 
-    # When *limit* is set, patch ``huggingface_hub.snapshot_download`` to
-    # download only the first neccesary video zip files for Video-MME (~5-10 GB instead of
-    # ~100 GB).  The ``videomme_mini`` task's ``process_docs`` then
-    # filters the dataset to only include samples with available videos.
+    # Proactively download any missing Video-MME video chunk zips before
+    # lmms-eval runs.  This is incremental: if some chunks are already in
+    # the HF cache from a previous run (possibly with a smaller limit), only
+    # the newly needed chunks are downloaded.
+    _is_videomme = any(
+        t in ("videomme", "video_mme", "videomme_mini") for t in tasks_list
+    )
+    if _is_videomme:
+        _ensure_videomme_chunks_downloaded(limit)  # type: ignore[arg-type]
+
+        # Reset the videomme_mini utils module's _printed_prompts set so
+        # that prompts are printed again for this evaluation run.
+        try:
+            from tico.quantization.evaluation.lmms_tasks.videomme_mini.utils import (
+                _reset_printed_prompts,
+            )
+
+            _reset_printed_prompts()
+        except ImportError:
+            pass
+
+    # When *limit* is set, also patch ``huggingface_hub.snapshot_download``
+    # as a safety net to prevent lmms-eval from downloading all chunks.
     _download_ctx = None
-    if limit is not None and isinstance(limit, int) and limit > 0:
+    if _is_videomme and limit is not None and isinstance(limit, int) and limit > 0:
         _download_ctx = _patch_snapshot_download_for_limit(limit)
 
     with _model_ctx, _subsample_ctx:
@@ -563,10 +688,6 @@ def _get_custom_tasks_dir() -> str | None:
 
 def _build_model_args(
     model: Any,
-    processor: Any,
-    device: str,
-    batch_size: int,
-    max_new_tokens: int,
     max_num_frames: int = 32,
 ) -> tuple[str, dict[str, Any]]:
     """Build the ``model`` name and ``model_args`` dict for ``simple_evaluate``.

--- a/tico/quantization/evaluation/lmms_eval_utils.py
+++ b/tico/quantization/evaluation/lmms_eval_utils.py
@@ -1,0 +1,657 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VLM evaluation utilities using the ``lmms-eval`` library.
+
+The primary entry point is :func:`evaluate_vlm_on_tasks`, which accepts a
+Hugging Face VLM + processor pair and delegates all benchmark-specific
+logic (dataset loading, prompt formatting, answer extraction, scoring) to
+``lmms-eval``.
+
+Supported tasks include but are not limited to:
+
+- ``video_mme`` – Video-MME video understanding benchmark
+- ``mmstar`` – MMStar benchmark
+- ``mathvista`` – MathVista benchmark
+- ``mmbench`` – MMBench benchmark
+
+Any task registered in ``lmms-eval`` can be passed via the *tasks*
+parameter.
+"""
+
+import os
+from typing import Any
+
+
+def _check_lmms_eval_available() -> None:
+    """Raise a clear error if ``lmms-eval`` is not installed."""
+    try:
+        import decord  # noqa: F401
+        import lmms_eval  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "lmms-eval is required for VLM evaluation via lmms-eval. "
+            "Install it with:  pip install lmms-eval decord"
+        ) from exc
+
+
+def _patch_lmms_eval_broken_tasks() -> None:
+    """Work around packaging bugs in installed ``lmms-eval`` versions.
+
+    Some versions of ``lmms-eval`` (notably v0.7.1) ship task directories
+    that are missing YAML template files (``_default_template_yaml``,
+    ``_default_template_*_yaml``, etc.) expected by :class:`TaskManager`
+    during initialization.  This causes ``FileNotFoundError`` crashes that
+    prevent *any* task from running.
+
+    This function monkey-patches ``lmms_eval.utils.load_yaml_config`` so
+    that missing YAML files are treated as empty configs instead of
+    raising an exception.  The patch is idempotent and only applied once.
+    """
+    try:
+        import lmms_eval.utils as lmms_utils
+    except ImportError:
+        return
+
+    # Only patch once
+    if getattr(lmms_utils, "_tico_patched", False):
+        return
+
+    _original_load_yaml_config = lmms_utils.load_yaml_config
+
+    def _patched_load_yaml_config(yaml_path=None, mode="simple", **kwargs):
+        try:
+            return _original_load_yaml_config(yaml_path=yaml_path, mode=mode, **kwargs)
+        except FileNotFoundError:
+            # Return an empty config for missing YAML files so that
+            # TaskManager initialization does not crash.
+            return {}
+
+    lmms_utils.load_yaml_config = _patched_load_yaml_config
+    lmms_utils._tico_patched = True
+
+
+def _compute_video_chunk_patterns(limit: int | None) -> list[str]:
+    """Compute ``allow_patterns`` for Video-MME based on sample limit.
+
+    Video-MME stores videos as ~20 zip files (~5 GB each, ~30 videos each)
+    in the HuggingFace repository.  ``snapshot_download`` downloads **all**
+    repo files by default, totalling ~100 GB.  When *limit* is set we only
+    need a few samples, so downloading everything is wasteful.
+
+    This function returns an ``allow_patterns`` list that includes the
+    parquet metadata, subtitle zip, and enough video chunk zips to cover
+    the requested number of samples.
+
+    Args:
+        limit: Maximum number of samples to evaluate.  ``None`` means
+            download all video chunks.
+
+    Returns:
+        List of ``allow_patterns`` strings for ``snapshot_download``.
+    """
+    _SAMPLES_PER_CHUNK = 40  # approximate number of samples per zip
+    _MAX_CHUNKS = 20  # maximum number of video chunk zips
+
+    base_patterns = [
+        "*.parquet",
+        ".gitattributes",
+        "README.md",
+        "subtitle.zip",
+    ]
+
+    if limit is None:
+        # No limit → download all video chunks
+        video_patterns = [
+            f"videos_chunked_{i:02d}.zip" for i in range(1, _MAX_CHUNKS + 1)
+        ]
+    else:
+        # Calculate how many chunks we need based on the limit.
+        # Each chunk contains ~30 videos, so we need ceil(limit / 30) chunks.
+        import math
+
+        num_chunks = min(math.ceil(limit / _SAMPLES_PER_CHUNK), _MAX_CHUNKS)
+        num_chunks = max(num_chunks, 1)  # at least 1 chunk
+        video_patterns = [
+            f"videos_chunked_{i:02d}.zip" for i in range(1, num_chunks + 1)
+        ]
+
+    return base_patterns + video_patterns
+
+
+def _patch_snapshot_download_for_limit(limit: int | None):
+    """Patch ``huggingface_hub.snapshot_download`` to limit Video-MME downloads.
+
+    Video-MME stores videos as ~20 zip files (~5 GB each) in the HuggingFace
+    repository.  ``snapshot_download`` downloads **all** repo files by default,
+    totalling ~100 GB.  When *limit* is set we only need a few samples, so
+    downloading everything is wasteful.
+
+    This patch intercepts ``snapshot_download`` for the Video-MME repo and
+    adds ``allow_patterns`` to download only the parquet metadata + enough
+    video chunk zips to cover the requested number of samples.  Each chunk
+    contains ~30 videos (~5 GB), so:
+
+    - ``limit ≤ 30``  → 1 chunk  (~5 GB)
+    - ``limit ≤ 60``  → 2 chunks (~10 GB)
+    - ``limit ≤ 90``  → 3 chunks (~15 GB)
+    - etc.
+
+    The ``videomme_mini`` task's ``process_docs`` then filters the dataset to
+    only include samples whose videos have been extracted.
+
+    The patch is automatically undone when the returned context manager exits.
+
+    Args:
+        limit: Maximum number of samples to evaluate.  ``None`` means no
+            limit (download all chunks).
+
+    Returns:
+        A context manager that restores the original ``snapshot_download``
+        on exit.
+    """
+    import contextlib
+
+    try:
+        import huggingface_hub
+    except ImportError:
+
+        @contextlib.contextmanager
+        def _noop():
+            yield
+
+        return _noop()
+
+    _original_module_fn = huggingface_hub.snapshot_download
+
+    _VIDEOMME_REPO_IDS = {
+        "lmms-lab/Video-MME",
+        "lmms-lab/video-mme",
+    }
+
+    # Compute allow_patterns based on the limit.
+    _zip_patterns = _compute_video_chunk_patterns(limit)
+
+    def _patched_snapshot_download(repo_id, *args, **kwargs):
+        """Patched snapshot_download that limits Video-MME downloads."""
+        if repo_id not in _VIDEOMME_REPO_IDS:
+            return _original_module_fn(repo_id, *args, **kwargs)
+
+        # For Video-MME: download only parquet + needed zip files
+        # NOTE: The parameter is ``allow_patterns``
+        allow_patterns = kwargs.get("allow_patterns")
+        if allow_patterns is None:
+            kwargs["allow_patterns"] = _zip_patterns
+
+        return _original_module_fn(repo_id, *args, **kwargs)
+
+    # Apply the monkey-patch to the module-level function.
+    huggingface_hub.snapshot_download = _patched_snapshot_download
+
+    # Additionally, ``lmms_eval.api.task`` does
+    # ``from huggingface_hub import snapshot_download`` at import time,
+    # creating a LOCAL reference that bypasses the module-level attribute.
+    _lmms_task_refs = {}
+    try:
+        import lmms_eval.api.task as _lmms_task
+
+        if hasattr(_lmms_task, "snapshot_download"):
+            _lmms_task_refs[_lmms_task] = _lmms_task.snapshot_download
+            _lmms_task.snapshot_download = _patched_snapshot_download
+    except ImportError:
+        pass
+
+    @contextlib.contextmanager
+    def _restore():
+        try:
+            yield
+        finally:
+            huggingface_hub.snapshot_download = _original_module_fn
+            for _mod, _orig_fn in _lmms_task_refs.items():
+                _mod.snapshot_download = _orig_fn
+
+    return _restore()
+
+
+def _patch_from_pretrained_to_reuse_model(model, processor):
+    """Patch ``from_pretrained`` to return the already-loaded model and processor.
+
+    ``lmms-eval`` always instantiates the model from scratch via
+    ``from_pretrained(pretrained, ...)``, which downloads ``model.safetensors``
+    and loads it into GPU memory a second time.  This wastes time, disk space,
+    and GPU memory (likely causing OOM).
+
+    This function monkey-patches ``from_pretrained`` on the relevant
+    ``transformers`` model classes so that the first call returns the
+    already-loaded *model* object, and patches ``AutoProcessor.from_pretrained``
+    and ``AutoTokenizer.from_pretrained`` to return the already-loaded
+    *processor* and its ``.tokenizer`` attribute.
+
+    The patches are automatically undone when the returned context manager exits.
+
+    Args:
+        model: The already-loaded Hugging Face model.
+        processor: The already-loaded Hugging Face processor.
+
+    Returns:
+        A context manager that restores the original ``from_pretrained``
+        methods on exit.
+    """
+    import contextlib
+
+    from transformers import AutoProcessor, AutoTokenizer
+
+    # --- Patch model class from_pretrained ---
+    # Collect all model classes that might be used by lmms-eval
+    _model_classes = []
+    try:
+        from transformers import Qwen3VLForConditionalGeneration as _Q3
+
+        _model_classes.append(_Q3)
+    except ImportError:
+        pass
+    try:
+        from transformers import Qwen3VLMoeForConditionalGeneration as _Q3M
+
+        _model_classes.append(_Q3M)
+    except ImportError:
+        pass
+    try:
+        from transformers import Qwen2_5_VLForConditionalGeneration as _Q25
+
+        _model_classes.append(_Q25)
+    except ImportError:
+        pass
+    try:
+        from transformers import Qwen2VLForConditionalGeneration as _Q2
+
+        _model_classes.append(_Q2)
+    except ImportError:
+        pass
+
+    _original_model_fps = {cls: cls.from_pretrained for cls in _model_classes}
+
+    # Replace from_pretrained on each class with a function that returns
+    # the already-loaded model on the first call.  We use a simple list
+    # as a mutable flag so the closure can mutate it.
+    _model_returned = [False]
+
+    for cls in _model_classes:
+        # We must capture the original unbound function for the fallback.
+        _orig_fn = cls.from_pretrained
+
+        def _make_patched_fp(orig_fn):
+            def _patched_from_pretrained(cls_arg, *args, **kwargs):
+                if not _model_returned[0]:
+                    _model_returned[0] = True
+                    return model
+                return orig_fn(*args, **kwargs)
+
+            return _patched_from_pretrained
+
+        cls.from_pretrained = classmethod(_make_patched_fp(_orig_fn))
+
+    # --- Patch AutoProcessor.from_pretrained ---
+    _original_processor_fp = AutoProcessor.from_pretrained
+    _processor_returned = [False]
+
+    def _patched_processor_fp(cls_arg, *args, **kwargs):
+        if not _processor_returned[0]:
+            _processor_returned[0] = True
+            return processor
+        return _original_processor_fp(*args, **kwargs)
+
+    AutoProcessor.from_pretrained = classmethod(_patched_processor_fp)
+
+    # --- Patch AutoTokenizer.from_pretrained ---
+    _original_tokenizer_fp = AutoTokenizer.from_pretrained
+    _tokenizer = getattr(processor, "tokenizer", None)
+    _tokenizer_returned = [False]
+
+    def _patched_tokenizer_fp(cls_arg, *args, **kwargs):
+        if not _tokenizer_returned[0] and _tokenizer is not None:
+            _tokenizer_returned[0] = True
+            return _tokenizer
+        return _original_tokenizer_fp(*args, **kwargs)
+
+    AutoTokenizer.from_pretrained = classmethod(_patched_tokenizer_fp)
+
+    @contextlib.contextmanager
+    def _restore():
+        try:
+            yield
+        finally:
+            # Restore original from_pretrained methods
+            for cls, orig_fp in _original_model_fps.items():
+                cls.from_pretrained = orig_fp
+            AutoProcessor.from_pretrained = _original_processor_fp
+            AutoTokenizer.from_pretrained = _original_tokenizer_fp
+
+    return _restore()
+
+
+def _patch_subsample_video_inputs_for_debug():
+    """
+    This monkey-patches the ``_subsample_video_inputs`` method on the
+    lmms-eval ``Qwen3_VL`` model wrapper to print debug information.
+
+    The patch is automatically undone when the returned context manager exits.
+
+    Returns:
+        A context manager that restores the original method on exit.
+    """
+    import contextlib
+
+    try:
+        from lmms_eval.models.simple.qwen3_vl import Qwen3_VL
+    except ImportError:
+
+        @contextlib.contextmanager
+        def _noop():
+            yield
+
+        return _noop()
+
+    _original_subsample = Qwen3_VL._subsample_video_inputs
+
+    def _patched_subsample(self, video_inputs, video_metadatas=None):
+        if video_inputs is not None:
+            for i, vi in enumerate(video_inputs):
+                total = vi.shape[0]
+                max_nf = self.max_num_frames
+                print(
+                    f"[INFO] _subsample_video_inputs: video {i}: "
+                    f"total_frames={total}, max_num_frames={max_nf}, "
+                    f"will subsample to ~{min(total, max_nf)} frames",
+                    flush=True,
+                )
+        return _original_subsample(self, video_inputs, video_metadatas)
+
+    Qwen3_VL._subsample_video_inputs = _patched_subsample
+
+    @contextlib.contextmanager
+    def _restore():
+        try:
+            yield
+        finally:
+            Qwen3_VL._subsample_video_inputs = _original_subsample
+
+    return _restore()
+
+
+def evaluate_vlm_on_tasks(
+    model: Any,
+    processor: Any,
+    tasks: list[str] | str,
+    device: str = "cuda",
+    batch_size: int = 1,
+    max_new_tokens: int = 16,
+    max_num_frames: int = 32,
+    limit: int | float | None = None,
+    use_cache: str | None = None,
+    cache_dir: str | None = None,
+    verbose: bool = True,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Evaluate a VLM on one or more ``lmms-eval`` tasks.
+
+    This function calls :func:`lmms_eval.evaluator.simple_evaluate`, delegating
+    all benchmark-specific logic (dataset loading, prompt formatting, answer
+    extraction, scoring) to the library.
+
+    The model is passed via ``model_args`` as a dict so that ``lmms-eval``
+    instantiates the correct model wrapper from its registry.  The
+    ``model`` parameter should be a string name recognised by
+    ``lmms-eval`` (e.g. ``"qwen3_vl"``).  If a *model* object is
+    passed instead, it is auto-detected and the appropriate ``lmms-eval``
+    model name is inferred from the model class.
+
+    Args:
+        model: A Hugging Face VLM (e.g. ``Qwen3_VLForConditionalGeneration``)
+            **or** a string model name recognised by ``lmms-eval`` (e.g.
+            ``"qwen3_vl"``).  If a model object is passed, the function
+            attempts to infer the ``lmms-eval`` model name automatically.
+            If the model has a ``.wrapped`` attribute (fake-quant wrapper),
+            the inner model is used automatically.
+        processor: The matching ``AutoProcessor`` for the model.  Its
+            ``.tokenizer`` attribute is passed to the ``lmms-eval`` model
+            wrapper.
+        tasks: A single task name (e.g. ``"video_mme"``) or a list of
+            task names.  Any task registered in ``lmms-eval`` is accepted.
+        device: Device string for inference (e.g. ``"cuda"``, ``"cpu"``).
+        batch_size: Batch size for generation.  Defaults to 1.
+        max_new_tokens: Maximum number of tokens to generate per sample.
+        use_cache: Optional path to an ``lmms-eval`` results cache directory.
+            When set, results are cached and can be reused across runs.
+        cache_dir: Optional cache directory for Hugging Face datasets.
+        verbose: Whether to print detailed evaluation logs.
+        **kwargs: Additional keyword arguments forwarded to
+            ``lmms_eval.evaluator.simple_evaluate``.
+
+    Returns:
+        A dictionary of evaluation results as returned by
+        ``lmms_eval.evaluator.simple_evaluate``.  The structure includes
+        ``"results"`` (per-task metrics) and ``"configs"`` (task
+        configuration details).
+
+    Raises:
+        RuntimeError: If ``lmms-eval`` is not installed.
+    """
+    _check_lmms_eval_available()
+    _patch_lmms_eval_broken_tasks()
+
+    from lmms_eval.evaluator import simple_evaluate
+
+    # Unwrap fake-quant wrapper if present
+    inner_model = getattr(model, "wrapped", model)
+
+    # Determine the lmms-eval model name and build model_args
+    model_name, model_args_dict = _build_model_args(
+        inner_model, processor, device, batch_size, max_new_tokens, max_num_frames
+    )
+
+    # Propagate verbose flag to custom task utils via environment variable.
+    # The videomme_mini utils.py checks LMMS_VERBOSE to decide whether to
+    # print prompts, video paths, etc.
+    os.environ["LMMS_VERBOSE"] = "1" if verbose else "0"
+
+    print(f"evaluate_vlm_on_tasks: model={model_name}, max_num_frames={max_num_frames}")
+    print(f"model_args: {model_args_dict}")
+
+    # Normalise tasks to a list
+    if isinstance(tasks, str):
+        tasks_list = [t.strip() for t in tasks.split(",") if t.strip()]
+    else:
+        tasks_list = list(tasks)
+
+    # Convert model_args dict to the key=value string format expected by
+    # ``simple_evaluate`` → ``create_from_arg_string`` →
+    # ``simple_parse_args_string``.
+    model_args_str = ",".join(f"{k}={v}" for k, v in model_args_dict.items())
+
+    eval_kwargs: dict[str, Any] = {
+        "model": model_name,
+        "model_args": model_args_str,
+        "tasks": tasks_list,
+        "batch_size": batch_size,
+        "device": device,
+        "verbosity": "INFO" if verbose else "WARNING",
+    }
+
+    if limit is not None:
+        eval_kwargs["limit"] = limit
+    if use_cache is not None:
+        eval_kwargs["use_cache"] = use_cache
+    if cache_dir is not None:
+        eval_kwargs["cache_dir"] = cache_dir
+
+    # Auto-register custom task directories (e.g. videomme_mini) by
+    # creating a ``TaskManager`` with ``include_path`` pointing to the
+    # ``lmms_tasks`` directory shipped with TICO.  ``simple_evaluate``
+    # does not accept ``include_path`` directly, but it does accept a
+    # ``task_manager`` parameter.
+    custom_tasks_dir = _get_custom_tasks_dir()
+    if custom_tasks_dir is not None and "task_manager" not in kwargs:
+        from lmms_eval.tasks import TaskManager
+
+        task_manager = TaskManager(
+            verbosity=eval_kwargs.get("verbosity", "DEBUG"),
+            include_path=custom_tasks_dir,
+        )
+        eval_kwargs["task_manager"] = task_manager
+
+    # Forward any additional kwargs (may override task_manager)
+    eval_kwargs.update(kwargs)
+
+    # Patch ``from_pretrained`` so that ``lmms-eval`` reuses the
+    # already-loaded model and processor instead of downloading and
+    # loading them a second time (which would waste time, disk space,
+    # and GPU memory).
+    _model_ctx = _patch_from_pretrained_to_reuse_model(model, processor)
+
+    # Patch _subsample_video_inputs to add debug logging
+    _subsample_ctx = _patch_subsample_video_inputs_for_debug()
+
+    # When *limit* is set, patch ``huggingface_hub.snapshot_download`` to
+    # download only the first neccesary video zip files for Video-MME (~5-10 GB instead of
+    # ~100 GB).  The ``videomme_mini`` task's ``process_docs`` then
+    # filters the dataset to only include samples with available videos.
+    _download_ctx = None
+    if limit is not None and isinstance(limit, int) and limit > 0:
+        _download_ctx = _patch_snapshot_download_for_limit(limit)
+
+    with _model_ctx, _subsample_ctx:
+        if _download_ctx is not None:
+            with _download_ctx:
+                results = simple_evaluate(**eval_kwargs)
+        else:
+            results = simple_evaluate(**eval_kwargs)
+
+    return results
+
+
+def _get_custom_tasks_dir() -> str | None:
+    """Return the path to TICO's custom ``lmms_tasks`` directory.
+
+    This directory contains custom task YAML files (e.g.
+    ``videomme_mini``) that are not part of the upstream ``lmms-eval``
+    package.  The path is passed to ``simple_evaluate`` via the
+    ``include_path`` parameter so that custom tasks can be discovered.
+
+    Returns:
+        The absolute path to the ``lmms_tasks`` directory, or ``None``
+        if it does not exist.
+    """
+    import pathlib
+
+    tasks_dir = pathlib.Path(__file__).parent / "lmms_tasks"
+    if tasks_dir.is_dir():
+        return str(tasks_dir)
+    return None
+
+
+def _build_model_args(
+    model: Any,
+    processor: Any,
+    device: str,
+    batch_size: int,
+    max_new_tokens: int,
+    max_num_frames: int = 32,
+) -> tuple[str, dict[str, Any]]:
+    """Build the ``model`` name and ``model_args`` dict for ``simple_evaluate``.
+
+    In ``lmms-eval`` v0.7+, ``simple_evaluate`` takes a model name string
+    (from the registry) and a ``model_args`` dict that is forwarded to the
+    model constructor.  This helper infers the correct model name from the
+    Python model object and builds the args dict.
+
+    Returns:
+        A ``(model_name, model_args_dict)`` tuple.
+    """
+    model_cls_name = type(model).__name__.lower()
+
+    # Map model class names to lmms-eval registry names
+    if "qwen3" in model_cls_name and (
+        "vl" in model_cls_name or "visual" in model_cls_name
+    ):
+        lmms_model_name = "qwen3_vl"
+    elif "qwen2" in model_cls_name and (
+        "vl" in model_cls_name or "visual" in model_cls_name
+    ):
+        lmms_model_name = "qwen2_5_vl"
+    elif "qwen" in model_cls_name and (
+        "vl" in model_cls_name or "visual" in model_cls_name
+    ):
+        lmms_model_name = "qwen2_5_vl"
+    elif "llava" in model_cls_name:
+        lmms_model_name = "llava_hf"
+    elif "internvl" in model_cls_name:
+        lmms_model_name = "internvl_hf"
+    else:
+        # Fallback: use the generic huggingface model
+        lmms_model_name = "huggingface"
+
+    # Get the Hugging Face model id from the model config if available
+    pretrained = None
+    if hasattr(model, "config") and hasattr(model.config, "_name_or_path"):
+        pretrained = model.config._name_or_path
+
+    model_args_dict: dict[str, Any] = {}
+
+    if pretrained is not None:
+        model_args_dict["pretrained"] = pretrained
+
+    # Pass max_num_frames to the lmms-eval model wrapper.
+    # The Qwen3_VL wrapper accepts this in __init__ and uses it in
+    # _subsample_video_inputs to control how many frames are sampled
+    # from each video.
+    if max_num_frames is not None:
+        model_args_dict["max_num_frames"] = max_num_frames
+
+    return lmms_model_name, model_args_dict
+
+
+def print_lmms_eval_results(results: dict[str, Any]) -> None:
+    """Print ``lmms-eval`` results in a formatted table.
+
+    This uses ``lmms_eval``'s built-in ``make_table`` utility when
+    available, and falls back to a simple custom printer.
+
+    Args:
+        results: The results dictionary returned by
+            :func:`evaluate_vlm_on_tasks`.
+    """
+    try:
+        from lmms_eval.utils import make_table
+
+        print(make_table(results))
+    except ImportError:
+        _print_results_fallback(results)
+
+
+def _print_results_fallback(results: dict[str, Any]) -> None:
+    """Print results when ``make_table`` is not available.
+
+    Args:
+        results: The results dictionary returned by
+            :func:`evaluate_vlm_on_tasks`.
+    """
+    task_results = results.get("results", {})
+    for task_name, metrics in task_results.items():
+        print(f"\n=== {task_name} ===")
+        for metric_name, value in metrics.items():
+            if isinstance(value, float):
+                print(f"  {metric_name:<40} {value:.4f}")
+            else:
+                print(f"  {metric_name:<40} {value}")

--- a/tico/quantization/evaluation/lmms_tasks/videomme_mini/utils.py
+++ b/tico/quantization/evaluation/lmms_tasks/videomme_mini/utils.py
@@ -48,7 +48,14 @@ _data_dir = os.path.join(_cache_dir, "data")
 
 # Verbose flag: set LMMS_VERBOSE=1 (or pass --verbose to the quantization
 # script) to enable debug printing.  By default, printing is suppressed.
-_VERBOSE = os.getenv("LMMS_VERBOSE", "").lower() in ("1", "true", "yes")
+# NOTE: We use a helper function instead of a module-level variable so that
+# changes to the LMMS_VERBOSE environment variable at runtime are reflected
+# immediately (e.g. when evaluate_vlm_on_tasks sets it before calling
+# simple_evaluate).
+
+
+def _is_verbose() -> bool:
+    return os.getenv("LMMS_VERBOSE", "").lower() in ("1", "true", "yes")
 
 
 def _available_video_ids() -> set[str]:
@@ -77,9 +84,8 @@ def videomme_process_docs(dataset):
     """
     available = _available_video_ids()
     if not available:
-        # If no videos are extracted yet, return the dataset as-is.
-        # The download/extraction may happen later in the task init.
-        return dataset
+        # If no videos are extracted yet, raise RuntimeError.
+        raise RuntimeError("There are no avaiable videos from extracted zip files")
     return dataset.filter(lambda x: x["videoID"] in available)
 
 
@@ -97,7 +103,7 @@ def videomme_doc_to_visual(doc):
     """
     video_path = os.path.join(_data_dir, doc["videoID"] + ".mp4")
     if os.path.exists(video_path):
-        if _VERBOSE:
+        if _is_verbose():
             print(
                 f"[INFO] doc_to_visual: returning video path: {video_path}",
                 file=sys.stderr,
@@ -107,14 +113,14 @@ def videomme_doc_to_visual(doc):
     for ext in (".MP4", ".mkv"):
         alt_path = os.path.join(_data_dir, doc["videoID"] + ext)
         if os.path.exists(alt_path):
-            if _VERBOSE:
+            if _is_verbose():
                 print(
                     f"[INFO] doc_to_visual: returning video path: {alt_path}",
                     file=sys.stderr,
                 )
             return [alt_path]
     # Video not available – skip gracefully
-    if _VERBOSE:
+    if _is_verbose():
         print(
             f"[INFO] Video not found: {video_path}, skipping sample",
             file=sys.stderr,
@@ -126,6 +132,11 @@ def videomme_doc_to_visual(doc):
 # lmms-eval calls doc_to_text multiple times per sample (task construction,
 # batching, generation), so we deduplicate by (videoID, question).
 _printed_prompts: set[tuple[str, str]] = set()
+
+
+def _reset_printed_prompts() -> None:
+    """Clear the set of already-printed prompt keys."""
+    _printed_prompts.clear()
 
 
 def videomme_doc_to_text(doc, lmms_eval_specific_kwargs=None):
@@ -143,7 +154,7 @@ def videomme_doc_to_text(doc, lmms_eval_specific_kwargs=None):
     full_prompt = _upstream_doc_to_text(doc, lmms_eval_specific_kwargs)
 
     # Print the final prompt for debugging (once per unique sample, only when verbose)
-    if _VERBOSE:
+    if _is_verbose():
         video_id = doc.get("videoID", "<unknown>")
         question = doc.get("question", "")
         key = (video_id, question)

--- a/tico/quantization/evaluation/lmms_tasks/videomme_mini/utils.py
+++ b/tico/quantization/evaluation/lmms_tasks/videomme_mini/utils.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Video-MME mini task utilities.
+#
+# This module re-exports most functions from the upstream ``lmms-eval``
+# Video-MME task but overrides two key functions:
+#
+# * ``videomme_doc_to_visual`` – handles missing video files gracefully
+#   (returns an empty list instead of calling ``sys.exit``).
+#
+# * ``videomme_process_docs`` – filters the dataset to only include
+#   samples whose video files have been downloaded and extracted.
+#   This is essential when using ``allow_patterns`` to download only a
+#   subset of the video zip files (e.g. only ``videos_chunked_01.zip``).
+
+import os
+import sys
+
+from lmms_eval.tasks.videomme.utils import (  # noqa: F401
+    CATEGORIES,
+    SUB_CATEGORIES,
+    TASK_CATEGORIES,
+    VIDEO_TYPE,
+    videomme_aggregate_results,
+    videomme_process_results,
+)
+
+# We override videomme_doc_to_text below to add debug printing,
+# so we do NOT re-export it from upstream.
+
+# Resolve the cache directory the same way the upstream utils.py does.
+_hf_home = os.getenv("HF_HOME", "~/.cache/huggingface/")
+_hf_home = os.path.expanduser(_hf_home)
+_cache_dir = os.path.join(_hf_home, "videomme")
+_data_dir = os.path.join(_cache_dir, "data")
+
+# Verbose flag: set LMMS_VERBOSE=1 (or pass --verbose to the quantization
+# script) to enable debug printing.  By default, printing is suppressed.
+_VERBOSE = os.getenv("LMMS_VERBOSE", "").lower() in ("1", "true", "yes")
+
+
+def _available_video_ids() -> set[str]:
+    """Return the set of video IDs that have been downloaded and extracted.
+
+    A video ID is the stem of the video filename (e.g. ``"HwnB8aCn8yE"``
+    from ``"HwnB8aCn8yE.mp4"``).
+    """
+    if not os.path.isdir(_data_dir):
+        return set()
+    return {
+        os.path.splitext(f)[0]
+        for f in os.listdir(_data_dir)
+        if f.endswith((".mp4", ".MP4", ".mkv"))
+    }
+
+
+def videomme_process_docs(dataset):
+    """Filter the dataset to only include samples with available videos.
+
+    When using ``allow_patterns`` to download only a subset of the video
+    zip files (e.g. only ``videos_chunked_01.zip``), many samples in the
+    parquet metadata will reference videos that have not been downloaded.
+    This filter removes those samples so that evaluation only runs on
+    available data.
+    """
+    available = _available_video_ids()
+    if not available:
+        # If no videos are extracted yet, return the dataset as-is.
+        # The download/extraction may happen later in the task init.
+        return dataset
+    return dataset.filter(lambda x: x["videoID"] in available)
+
+
+def videomme_doc_to_visual(doc):
+    """Return the video path for a sample, or an empty list if missing.
+
+    The upstream ``videomme_doc_to_visual`` calls ``sys.exit()`` when a
+    video file is not found.  This override returns an empty list instead,
+    allowing evaluation to continue with the samples that *are* available.
+
+    NOTE: Frame extraction is NOT done here.  The video path is returned
+    as-is, and frame sampling is handled by the lmms-eval model wrapper
+    (e.g. ``Qwen3_VL._subsample_video_inputs``) which uses the
+    ``max_num_frames`` parameter.
+    """
+    video_path = os.path.join(_data_dir, doc["videoID"] + ".mp4")
+    if os.path.exists(video_path):
+        if _VERBOSE:
+            print(
+                f"[INFO] doc_to_visual: returning video path: {video_path}",
+                file=sys.stderr,
+            )
+        return [video_path]
+    # Try alternate extensions
+    for ext in (".MP4", ".mkv"):
+        alt_path = os.path.join(_data_dir, doc["videoID"] + ext)
+        if os.path.exists(alt_path):
+            if _VERBOSE:
+                print(
+                    f"[INFO] doc_to_visual: returning video path: {alt_path}",
+                    file=sys.stderr,
+                )
+            return [alt_path]
+    # Video not available – skip gracefully
+    if _VERBOSE:
+        print(
+            f"[INFO] Video not found: {video_path}, skipping sample",
+            file=sys.stderr,
+        )
+    return []
+
+
+# Track which samples have already been printed to avoid duplicate output.
+# lmms-eval calls doc_to_text multiple times per sample (task construction,
+# batching, generation), so we deduplicate by (videoID, question).
+_printed_prompts: set[tuple[str, str]] = set()
+
+
+def videomme_doc_to_text(doc, lmms_eval_specific_kwargs=None):
+    """Build the text prompt for a sample and print it for debugging.
+
+    This is an override of the upstream ``videomme_doc_to_text`` that adds
+    a ``print()`` call so you can see the final prompt sent to the model.
+    Deduplicates by (videoID, question) to avoid printing the same sample
+    multiple times (lmms-eval calls this function several times per sample).
+    """
+    from lmms_eval.tasks.videomme.utils import (
+        videomme_doc_to_text as _upstream_doc_to_text,
+    )
+
+    full_prompt = _upstream_doc_to_text(doc, lmms_eval_specific_kwargs)
+
+    # Print the final prompt for debugging (once per unique sample, only when verbose)
+    if _VERBOSE:
+        video_id = doc.get("videoID", "<unknown>")
+        question = doc.get("question", "")
+        key = (video_id, question)
+        if key not in _printed_prompts:
+            _printed_prompts.add(key)
+            print(
+                f"\n{'='*60}\n"
+                f"[PROMPT] videoID={video_id}\n"
+                f"{'-'*60}\n"
+                f"{full_prompt}\n"
+                f"{'='*60}",
+                file=sys.stderr,
+            )
+
+    return full_prompt

--- a/tico/quantization/evaluation/lmms_tasks/videomme_mini/videomme_mini.yaml
+++ b/tico/quantization/evaluation/lmms_tasks/videomme_mini/videomme_mini.yaml
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Video-MME mini task – evaluates only on samples with available videos.
+#
+# When ``allow_patterns`` is used to download only a subset of video zips
+# (e.g. only ``videos_chunked_01.zip``), many samples in the parquet
+# metadata reference videos that haven't been downloaded.  This task
+# uses ``process_docs`` to filter the dataset to only include samples
+# whose video files exist on disk.
+#
+# The ``videomme_doc_to_visual`` override also handles missing videos
+# gracefully (returns empty list instead of ``sys.exit``).
+#
+# Usage with lmms-eval CLI:
+#   lmms-eval --model qwen3_vl --tasks videomme_mini --include_path <this_dir>
+#
+# Usage via TICO evaluate_vlm_on_tasks:
+#   evaluate_vlm_on_tasks(model, processor, tasks="videomme_mini")
+
+dataset_path: lmms-lab/Video-MME
+dataset_kwargs:
+  token: False
+  cache_dir: videomme
+  video: True
+task: videomme_mini
+test_split: test
+process_docs: !function utils.videomme_process_docs
+output_type: generate_until
+cluster_key: videoID
+doc_to_visual: !function utils.videomme_doc_to_visual
+doc_to_text: !function utils.videomme_doc_to_text
+doc_to_target: "answer"
+generation_kwargs:
+  max_new_tokens: 16
+  temperature: 0
+  top_p: 1.0
+  num_beams: 1
+  do_sample: false
+process_results: !function utils.videomme_process_results
+metric_list:
+  - metric: videomme_perception_score
+    aggregation: !function utils.videomme_aggregate_results
+    higher_is_better: true
+lmms_eval_specific_kwargs:
+  default:
+    pre_prompt: ""
+    post_prompt: "\nAnswer with the option's letter from the given choices directly."
+  gpt4v:
+    pre_prompt: ""
+    post_prompt: "Answer the question with A, B, C, or D."
+  llava_vid:
+    pre_prompt: ""
+    post_prompt: "The best answer is:"
+  qwen3_vl:
+    format: "qwen3_vl"
+    frame_num: 1
+    pre_prompt: "Question: "
+    post_prompt: "Answer with the option letter only."
+  xcomposer2_4khd:
+    pre_prompt: "[UNUSED_TOKEN_146]user\n"
+    post_prompt: " Answer this question with A, B, C, or D.[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n"
+metadata:
+  - version: 0.0

--- a/tico/quantization/evaluation/lmms_tasks/videomme_mini/videomme_mini.yaml
+++ b/tico/quantization/evaluation/lmms_tasks/videomme_mini/videomme_mini.yaml
@@ -31,7 +31,6 @@
 
 dataset_path: lmms-lab/Video-MME
 dataset_kwargs:
-  token: False
   cache_dir: videomme
   video: True
 task: videomme_mini

--- a/tico/quantization/recipes/evaluation/video_mme.py
+++ b/tico/quantization/recipes/evaluation/video_mme.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recipe helper for Video-MME evaluation via ``lmms-eval``.
+
+This module provides :func:`evaluate_and_print_video_mme`, a thin wrapper
+that delegates all benchmark-specific logic (video frame extraction, prompt
+formatting, answer extraction, scoring) to the ``lmms-eval`` library.
+
+The ``lmms-eval`` and ``decord`` packages must be installed separately::
+
+    pip install lmms-eval decord
+"""
+
+from typing import Any
+
+from tico.quantization.evaluation.lmms_eval_utils import (
+    evaluate_vlm_on_tasks,
+    print_lmms_eval_results,
+)
+
+
+def evaluate_and_print_video_mme(
+    *,
+    model: Any,
+    processor: Any,
+    device: str,
+    batch_size: int = 1,
+    max_new_tokens: int = 30,
+    limit: int | None = None,
+    use_cache: str | None = None,
+    cache_dir: str | None = None,
+    verbose: bool = True,
+) -> dict[str, Any]:
+    """Evaluate a VLM on the Video-MME benchmark and print results.
+
+    This function calls :func:`evaluate_vlm_on_tasks` with
+    ``tasks=["videomme"]`` (or ``tasks=["videomme_mini"]`` when *mini*
+    is ``True``) and prints the results in a formatted table.
+
+    The *limit* parameter restricts the number of samples evaluated,
+    which also limits how many videos are downloaded.  For example,
+    ``limit=10`` will only download only first zip file and evaluate 
+    the first 10 samples. This uses a custom ``videomme_mini`` task
+    YAML (shipped with TICO) that specifies ``test_split: test[:100]``.
+
+    Args:
+        model: A Hugging Face VLM (e.g. ``Qwen3_VLForConditionalGeneration``).
+        processor: The matching ``AutoProcessor`` for the model.
+        device: Device string for inference (e.g. ``"cuda"``, ``"cpu"``).
+        batch_size: Batch size for generation.  Defaults to 1.
+        max_new_tokens: Maximum number of tokens to generate per sample.
+        limit: If set, only evaluate the first *limit* samples.  This
+            also limits how many videos are downloaded.  Defaults to
+            ``None`` (download and evaluate all samples).
+        use_cache: Optional path to an ``lmms-eval`` results cache directory.
+        cache_dir: Optional cache directory for Hugging Face datasets.
+        verbose: Whether to print detailed evaluation logs.
+
+    Returns:
+        A dictionary of evaluation results as returned by
+        ``lmms_eval.evaluator.simple_evaluate``.
+
+    Raises:
+        RuntimeError: If ``lmms-eval`` is not installed.
+    """
+    # When *limit* is set, always use ``videomme_mini`` because it has
+    # ``process_docs`` (filters to available videos) and a graceful
+    # ``doc_to_visual`` (returns [] instead of sys.exit on missing videos).
+    # The upstream ``videomme`` task calls ``sys.exit()`` when a video
+    # file is not found, which crashes the process when only a subset
+    # of video zips has been downloaded.
+    task_name = "videomme_mini" if (limit is not None) else "videomme"
+
+    results = evaluate_vlm_on_tasks(
+        model=model,
+        processor=processor,
+        tasks=[task_name],
+        device=device,
+        batch_size=batch_size,
+        max_new_tokens=max_new_tokens,
+        limit=limit,
+        use_cache=use_cache,
+        cache_dir=cache_dir,
+        verbose=verbose,
+    )
+
+    print(f"\n=== Video-MME Evaluation (limit={limit}) ===")
+    print_lmms_eval_results(results)
+
+    return results

--- a/tico/quantization/recipes/evaluation/video_mme.py
+++ b/tico/quantization/recipes/evaluation/video_mme.py
@@ -40,7 +40,6 @@ def evaluate_and_print_video_mme(
     max_new_tokens: int = 30,
     limit: int | None = None,
     use_cache: str | None = None,
-    cache_dir: str | None = None,
     verbose: bool = True,
 ) -> dict[str, Any]:
     """Evaluate a VLM on the Video-MME benchmark and print results.
@@ -51,9 +50,9 @@ def evaluate_and_print_video_mme(
 
     The *limit* parameter restricts the number of samples evaluated,
     which also limits how many videos are downloaded.  For example,
-    ``limit=10`` will only download only first zip file and evaluate 
+    ``limit=10`` will only download only first zip file and evaluate
     the first 10 samples. This uses a custom ``videomme_mini`` task
-    YAML (shipped with TICO) that specifies ``test_split: test[:100]``.
+    YAML (shipped with TICO) that specifies ``test_split: test``.
 
     Args:
         model: A Hugging Face VLM (e.g. ``Qwen3_VLForConditionalGeneration``).
@@ -65,7 +64,6 @@ def evaluate_and_print_video_mme(
             also limits how many videos are downloaded.  Defaults to
             ``None`` (download and evaluate all samples).
         use_cache: Optional path to an ``lmms-eval`` results cache directory.
-        cache_dir: Optional cache directory for Hugging Face datasets.
         verbose: Whether to print detailed evaluation logs.
 
     Returns:
@@ -75,24 +73,16 @@ def evaluate_and_print_video_mme(
     Raises:
         RuntimeError: If ``lmms-eval`` is not installed.
     """
-    # When *limit* is set, always use ``videomme_mini`` because it has
-    # ``process_docs`` (filters to available videos) and a graceful
-    # ``doc_to_visual`` (returns [] instead of sys.exit on missing videos).
-    # The upstream ``videomme`` task calls ``sys.exit()`` when a video
-    # file is not found, which crashes the process when only a subset
-    # of video zips has been downloaded.
-    task_name = "videomme_mini" if (limit is not None) else "videomme"
 
     results = evaluate_vlm_on_tasks(
         model=model,
         processor=processor,
-        tasks=[task_name],
+        tasks=["videomme"],
         device=device,
         batch_size=batch_size,
         max_new_tokens=max_new_tokens,
         limit=limit,
         use_cache=use_cache,
-        cache_dir=cache_dir,
         verbose=verbose,
     )
 

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -33,6 +33,10 @@ from tico.quantization.evaluation.hellaswag_eval_utils import (
     get_hellaswag_accuracy,
     print_hellaswag_results,
 )
+from tico.quantization.evaluation.lmms_eval_utils import (
+    evaluate_vlm_on_tasks,
+    print_lmms_eval_results,
+)
 from tico.quantization.evaluation.mmlu_eval_utils import (
     evaluate_mmlu,
     print_mmlu_results,
@@ -52,7 +56,6 @@ from tico.quantization.evaluation.vlm_eval_utils import (
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
-
 
 DTYPE_MAP = {
     "float32": torch.float32,
@@ -482,6 +485,34 @@ def parse_args():
         type=str,
         default="test",
         help="Split for PPL evaluation",
+    )
+
+    # Video-MME evaluation arguments
+    parser.add_argument(
+        "--video_mme",
+        action="store_true",
+        default=False,
+        help="Evaluate on Video-MME benchmark via lmms-eval.",
+    )
+    parser.add_argument(
+        "--video_mme_max_new_tokens",
+        type=int,
+        default=16,
+        help="Maximum number of tokens to generate per Video-MME sample.",
+    )
+    parser.add_argument(
+        "--video_mme_limit",
+        type=int,
+        default=None,
+        help="Limit the number of Video-MME samples to evaluate (and download). "
+        "E.g. --video_mme_limit 10 evaluates only the first 10 samples.",
+    )
+    parser.add_argument(
+        "--video_mme_max_num_frames",
+        type=int,
+        default=5,
+        help="Maximum number of frames to sample from each video for Video-MME evaluation. "
+        "Default is 5 for fitting within max_position_embeddings (2048).",
     )
 
     return parser.parse_args()
@@ -1239,6 +1270,23 @@ def evaluate_original_model(model, processor, args):
         )
         print_mmmu_results(original_mmmu_results)
 
+    if args.video_mme:
+        video_mme_task = "videomme_mini" if (args.video_mme_limit) else "videomme"
+        print(
+            f"\n=== Video-MME Evaluation (Original Model) (limit={args.video_mme_limit}) ==="
+        )
+        original_video_mme_results = evaluate_vlm_on_tasks(
+            model=model,
+            processor=processor,
+            tasks=[video_mme_task],
+            device=args.device,
+            max_new_tokens=args.video_mme_max_new_tokens,
+            limit=args.video_mme_limit,
+            verbose=args.verbose,
+            max_num_frames=args.video_mme_max_num_frames,
+        )
+        print_lmms_eval_results(original_video_mme_results)
+
     if args.ppl_dataset:
         print("\n=== PPL Evaluation (Original Model) ===")
         ds_ppl, _ = get_dataset(args.ppl_dataset, split=args.ppl_split, n=-1)
@@ -1346,6 +1394,23 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
             verbose=args.verbose,
         )
         print_mmmu_results(quantized_mmmu_results)
+
+    if args.video_mme:
+        video_mme_task = "videomme_mini" if (args.video_mme_limit) else "videomme"
+        print(
+            f"\n=== Video-MME Evaluation (Quantized Model) (limit={args.video_mme_limit}) ==="
+        )
+        quantized_video_mme_results = evaluate_vlm_on_tasks(
+            model=model,
+            processor=processor,
+            tasks=[video_mme_task],
+            device=args.device,
+            max_new_tokens=args.video_mme_max_new_tokens,
+            limit=args.video_mme_limit,
+            verbose=args.verbose,
+            max_num_frames=args.video_mme_max_num_frames,
+        )
+        print_lmms_eval_results(quantized_video_mme_results)
 
     if args.ppl_dataset:
         print("\n=== PPL Evaluation (Quantized Model) ===")

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -497,7 +497,7 @@ def parse_args():
     parser.add_argument(
         "--video_mme_max_new_tokens",
         type=int,
-        default=16,
+        default=None,
         help="Maximum number of tokens to generate per Video-MME sample.",
     )
     parser.add_argument(
@@ -1271,14 +1271,13 @@ def evaluate_original_model(model, processor, args):
         print_mmmu_results(original_mmmu_results)
 
     if args.video_mme:
-        video_mme_task = "videomme_mini" if (args.video_mme_limit) else "videomme"
         print(
             f"\n=== Video-MME Evaluation (Original Model) (limit={args.video_mme_limit}) ==="
         )
         original_video_mme_results = evaluate_vlm_on_tasks(
             model=model,
             processor=processor,
-            tasks=[video_mme_task],
+            tasks=["videomme"],
             device=args.device,
             max_new_tokens=args.video_mme_max_new_tokens,
             limit=args.video_mme_limit,
@@ -1396,14 +1395,13 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
         print_mmmu_results(quantized_mmmu_results)
 
     if args.video_mme:
-        video_mme_task = "videomme_mini" if (args.video_mme_limit) else "videomme"
         print(
             f"\n=== Video-MME Evaluation (Quantized Model) (limit={args.video_mme_limit}) ==="
         )
         quantized_video_mme_results = evaluate_vlm_on_tasks(
             model=model,
             processor=processor,
-            tasks=[video_mme_task],
+            tasks=["videomme"],
             device=args.device,
             max_new_tokens=args.video_mme_max_new_tokens,
             limit=args.video_mme_limit,

--- a/tico/quantization/wrapq/wrappers/ptq_wrapper.py
+++ b/tico/quantization/wrapq/wrappers/ptq_wrapper.py
@@ -88,3 +88,6 @@ class PTQWrapper(QuantModuleBase):
         evaluation and inference workflows.
         """
         return self.wrapped.generate(*args, **kwargs)
+
+    def config(self):
+        return self.wrapped.config

--- a/tico/quantization/wrapq/wrappers/ptq_wrapper.py
+++ b/tico/quantization/wrapq/wrappers/ptq_wrapper.py
@@ -88,6 +88,3 @@ class PTQWrapper(QuantModuleBase):
         evaluation and inference workflows.
         """
         return self.wrapped.generate(*args, **kwargs)
-
-    def config(self):
-        return self.wrapped.config

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attention.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attention.py
@@ -154,37 +154,49 @@ class QuantQwen3VLVisionAttention(QuantModuleBase):
         key_states = key_states.transpose(0, 1).unsqueeze(0)
         value_states = value_states.transpose(0, 1).unsqueeze(0)
 
-        # Other implementations: Process each chunk separately
+        # Split into chunks (one per image/video-frame in the batch).
+        # For a single image there is 1 chunk; for video there may be
+        # multiple chunks (one per frame group).
         lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-        splits = [
+        q_splits, k_splits, v_splits = [
             torch.split(tensor, lengths.tolist(), dim=2)
             for tensor in (query_states, key_states, value_states)
         ]
-        assert (
-            len(splits)
-            == 3  # just a single image, so (q, k, v) = (splits[0], splits[1], splits[2])
-            and len(splits[0]) == 1
-            and len(splits[1]) == 1
-            and len(splits[2]) == 1
-        )  # so we may proceed without splitted attention
+        num_chunks = len(q_splits)
         rep = query_states.size(-3) // key_states.size(-3)
         assert rep == 1  # currently no GQA is supported
 
-        attn_outputs = []
-        for n_head in range(self.num_heads):
-            k_i = key_states[:, n_head : n_head + 1, :, :]
-            v_i = value_states[:, n_head : n_head + 1, :, :]
-            q_i = query_states[:, n_head : n_head + 1, :, :]
-            logits_i = self._fq(q_i @ k_i.transpose(-2, -1), self.obs_logits)
-            # softmax
-            attn_i = torch.softmax(logits_i, -1, dtype=torch.float32).to(q_i.dtype)
-            attn_i = self._fq(attn_i, self.obs_softmax)
-            out_i = self._fq(attn_i @ v_i, self.obs_attn_out)
-            attn_outputs.append(out_i)
+        # Process each chunk independently, then concatenate.
+        # This handles both single-image (1 chunk) and video (multiple
+        # chunks) inputs.
+        chunk_outputs = []
+        for chunk_idx in range(num_chunks):
+            q_c = q_splits[chunk_idx]
+            k_c = k_splits[chunk_idx]
+            v_c = v_splits[chunk_idx]
 
-        attn_output = torch.cat(attn_outputs, dim=1)
-        attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(seq_length, -1).contiguous()
+            head_outputs = []
+            for n_head in range(self.num_heads):
+                q_i = q_c[:, n_head : n_head + 1, :, :]
+                k_i = k_c[:, n_head : n_head + 1, :, :]
+                v_i = v_c[:, n_head : n_head + 1, :, :]
+                logits_i = self._fq(q_i @ k_i.transpose(-2, -1), self.obs_logits)
+                # softmax
+                attn_i = torch.softmax(logits_i, -1, dtype=torch.float32).to(q_i.dtype)
+                attn_i = self._fq(attn_i, self.obs_softmax)
+                out_i = self._fq(attn_i @ v_i, self.obs_attn_out)
+                head_outputs.append(out_i)
+
+            # Concatenate heads: [1, num_heads, chunk_len, head_dim]
+            chunk_out = torch.cat(head_outputs, dim=1)
+            # [1, chunk_len, num_heads, head_dim] -> [chunk_len, num_heads*head_dim]
+            chunk_out = chunk_out.transpose(1, 2).contiguous()
+            chunk_len = chunk_out.shape[1]
+            chunk_out = chunk_out.reshape(chunk_len, -1).contiguous()
+            chunk_outputs.append(chunk_out)
+
+        # Concatenate all chunks back into the full sequence
+        attn_output = torch.cat(chunk_outputs, dim=0)
 
         attn_output = self.proj(attn_output)
         return attn_output


### PR DESCRIPTION
This PR adds support for evaluating quantized VLMs on the __Video-MME__ video understanding benchmark, integrated through the `lmms-eval` library.


### New files

- __`test/quantization/recipes/test_video_mme_evaluation.py`__ - Tests.
- __`tico/quantization/evaluation/lmms_eval_utils.py`__ — Core integration layer between TICO and `lmms-eval`. 

- __`tico/quantization/evaluation/lmms_tasks/videomme_mini/utils.py`__ — Custom `videomme_mini` task utilities 
- __`tico/quantization/evaluation/lmms_tasks/videomme_mini/videomme_mini.yaml`__ — Custom `videomme_mini` task YAML that references the above utils.  

### Modified files

- __`tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py`__ — Added Video-MME CLI arguments and evaluation integration:

  - `--video_mme` — Enable Video-MME evaluation
  - `--video_mme_max_new_tokens` — Max generation tokens  
  - `--video_mme_limit` — Limit number of samples
  - `--video_mme_max_num_frames` — Max frames per video (default: 5)

- __`tico/quantization/wrapq/wrappers/ptq_wrapper.py`__ 

- __`tico/quantization/wrapq/wrappers/qwen_vl/quant_vision_attention.py`__ 

### Usage example

```bash
python quantize_qwen3_vl_with_gptq.py \
    --model=Qwen/Qwen3-VL-4B-Instruct \
    --cache_dir=/path/to/hf_cache \
    --trust-remote-code \
    --video_mme \
    --video_mme_limit=40 \
    --video_mme_max_num_frames=5 \
    --gptq_mse=mse \
    --verbose
```

### Key design decisions

1. __Model reuse via monkey-patching__ — `lmms-eval` always calls `from_pretrained` internally, which would download and load the model a second time. We patch `from_pretrained` to return the already-loaded (and possibly quantized) model.

2. __Bandwidth-efficient downloads__ — Video-MME is ~100 GB total. The `--video_mme_limit` flag controls both the evaluation sample count and the number of video chunk zips downloaded (1 chunk ≈ 40 samples ≈ 5 GB).

3. __Graceful missing-video handling__ — The custom `videomme_mini` task filters out samples whose videos haven't been downloaded and returns `[]` for missing videos instead of crashing with `sys.exit()`.

4. __Verbose-controlled output__ — Debug printing (prompts, video paths, frame counts).


TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>