### PR TITLE
[interpreter] Fix Circle inference input binding

### DIFF
--- a/test/unit_test/utils/test_infer.py
+++ b/test/unit_test/utils/test_infer.py
@@ -13,17 +13,24 @@
 # limitations under the License.
 
 import unittest
+from typing import ClassVar
+from unittest.mock import patch
 
 import numpy as np
 
 import tico
 import torch
+from tico.interpreter.interpreter import Interpreter
+from tico.interpreter import infer as infer_module
 
 from test.modules.op.add import SimpleAdd
 from test.modules.op.avg_pool2d import AvgPoolWithPaddingKwargs
 from test.modules.op.cat import SimpleCatDefault, SimpleCatWithDim
 
 
+@unittest.skipUnless(
+    Interpreter.is_available(), "one-compiler is required for circle inference"
+)
 class InferSimpleAddTest(unittest.TestCase):
     def setUp(self):
         # Input: torch.ones(1), torch.ones(1)
@@ -58,6 +65,9 @@ class InferSimpleAddTest(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(
+    Interpreter.is_available(), "one-compiler is required for circle inference"
+)
 class InferCatTest(unittest.TestCase):
     def test_concat(self):
         # convert
@@ -90,6 +100,9 @@ class InferCatTest(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(
+    Interpreter.is_available(), "one-compiler is required for circle inference"
+)
 class InferAvgPoolReverseKwargsTest(unittest.TestCase):
     def test_avgpool_reverse_kwargs(self):
         # convert
@@ -111,3 +124,58 @@ class InferAvgPoolReverseKwargsTest(unittest.TestCase):
         np.testing.assert_allclose(
             actual=circle_model(**kwargs), desired=out_np, rtol=1e-4, atol=1e-4
         )
+
+
+class FakeInterpreter:
+    instances: ClassVar[list["FakeInterpreter"]] = []
+
+    def __init__(self, circle_binary):
+        self.circle_binary = circle_binary
+        self.writes = []
+        self.interpreted = False
+        FakeInterpreter.instances.append(self)
+
+    def writeInputTensor(self, input_idx, input_data):
+        self.writes.append((input_idx, input_data.clone()))
+
+    def interpret(self):
+        self.interpreted = True
+
+    def readOutputTensor(self, output_idx, output):
+        output.fill(0)
+
+
+class InferInputBindingTest(unittest.TestCase):
+    def test_infer_binds_kwargs_in_model_input_order(self):
+        m = AvgPoolWithPaddingKwargs()
+        args, kwargs = m.get_example_inputs()
+        circle_model = tico.convert(m.eval(), args, kwargs)
+
+        tensor0 = torch.randn(2, 4, 8, 16)
+        tensor1 = torch.randn(2, 4, 4, 8)
+        FakeInterpreter.instances = []
+
+        with patch.object(infer_module, "Interpreter", FakeInterpreter):
+            infer_module.infer(
+                circle_model.circle_binary, tensor0=tensor0, tensor1=tensor1
+            )
+
+        fake = FakeInterpreter.instances[0]
+        self.assertTrue(fake.interpreted)
+        self.assertEqual(fake.writes[0][0], 0)
+        self.assertEqual(fake.writes[0][1].shape, tensor1.shape)
+        self.assertTrue(torch.equal(fake.writes[0][1], tensor1))
+        self.assertEqual(fake.writes[1][0], 1)
+        self.assertEqual(fake.writes[1][1].shape, tensor0.shape)
+        self.assertTrue(torch.equal(fake.writes[1][1], tensor0))
+
+
+class InterpreterAvailabilityTest(unittest.TestCase):
+    def test_missing_interpreter_library_does_not_raise_during_cleanup(self):
+        with patch.object(
+            Interpreter, "LIB_PATH", Interpreter.LIB_PATH.parent / "missing.so"
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "Please install one-compiler for circle inference"
+            ):
+                Interpreter(b"")

--- a/test/unit_test/utils/test_infer.py
+++ b/test/unit_test/utils/test_infer.py
@@ -20,8 +20,8 @@ import numpy as np
 
 import tico
 import torch
-from tico.interpreter.interpreter import Interpreter
 from tico.interpreter import infer as infer_module
+from tico.interpreter.interpreter import Interpreter
 
 from test.modules.op.add import SimpleAdd
 from test.modules.op.avg_pool2d import AvgPoolWithPaddingKwargs

--- a/tico/interpreter/infer.py
+++ b/tico/interpreter/infer.py
@@ -12,82 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Sequence
+from typing import Any
 
 import numpy as np
-import torch
 from circle_schema import circle
 
 from tico.interpreter.interpreter import Interpreter
-from tico.serialize.circle_mapping import np_dtype_from_circle_dtype, to_circle_dtype
-from tico.utils.installed_packages import is_dynamic_cache_available
-
-
-def flatten_and_convert(inputs: Sequence) -> tuple:
-    result = []  # type: ignore[var-annotated]
-    for item in inputs:
-        if item is None:
-            continue
-
-        # 1. recursion on list and tuple
-        if isinstance(item, (list, tuple)):
-            result.extend(flatten_and_convert(item))
-            continue
-
-        # 2. handle DynamicCache
-        if is_dynamic_cache_available():
-            from transformers.cache_utils import DynamicCache
-
-            if isinstance(item, DynamicCache):
-                # NOTE The tensor order is: key_in → key_out → value_in → value_out
-                #
-                # Refer to https://github.com/huggingface/transformers/blob/3457e8e73e4f5532cc69059682b1ba4484d7e7e8/src/transformers/cache_utils.py#L557
-                # ```py
-                # self.key_cache[layer_idx] = torch.cat([self.key_cache[layer_idx], key_states], dim=-2)
-                # self.value_cache[layer_idx] = torch.cat([self.value_cache[layer_idx], value_states], dim=-2)
-                # ```
-                result.extend(item.key_cache)
-                result.extend(item.value_cache)
-                continue
-
-        # 3. Convert to tensors
-        result.append(item if isinstance(item, torch.Tensor) else torch.tensor(item))
-
-    return tuple(result)
+from tico.serialize.circle_mapping import np_dtype_from_circle_dtype
+from tico.utils.signature import ModelInputSpec
 
 
 def infer(circle_binary: bytes, *args: Any, **kwargs: Any) -> Any:
-    # When converting a model, it is assumed that the order of keyword arguments is maintained.
-    raw_inputs = args + tuple(kwargs.values())
-    user_inputs = flatten_and_convert(raw_inputs)
+    input_spec = ModelInputSpec(circle_binary)
+    user_inputs = input_spec.bind(args, kwargs, check=True)
 
-    # Get input spec from circle binary.
+    # Get input/output spec from circle binary.
     model = circle.Model.Model.GetRootAsModel(circle_binary, 0)
     assert model.SubgraphsLength() == 1
     graph = model.Subgraphs(0)
-    model_input_tensors = [
-        graph.Tensors(graph.Inputs(o)) for o in range(graph.InputsLength())
-    ]
-    model_input_shapes_np = [t.ShapeAsNumpy() for t in model_input_tensors]
-    model_input_types_cm = [t.Type() for t in model_input_tensors]
-
-    # Check if given inputs' dtype and shape from users match the inputs' from model binary.
-    if len(model_input_shapes_np) != len(user_inputs):
-        raise RuntimeError(
-            f"Mismatch input length: input({len(user_inputs)}) != circle model({len(model_input_shapes_np)})"
-        )
-    for input_idx, user_input in enumerate(user_inputs):
-        # Shape
-        if list(user_input.shape) != list(model_input_shapes_np[input_idx]):
-            raise RuntimeError(
-                f"Mismatch input {input_idx} shape : input({user_input.shape}) != circle model({model_input_shapes_np[input_idx]})"
-            )
-        # Data type
-        user_input_type_cm = to_circle_dtype(user_input.dtype)
-        if user_input_type_cm != model_input_types_cm[input_idx]:
-            raise RuntimeError(
-                f"Mismatch input {input_idx} data type : input({user_input_type_cm}) != circle model({model_input_types_cm[input_idx]})"
-            )
 
     # Initialize interpreter
     intp = Interpreter(circle_binary)

--- a/tico/interpreter/interpreter.py
+++ b/tico/interpreter/interpreter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 import torch
@@ -33,10 +34,15 @@ class Interpreter:
     library do not cause undefined behavior in Python.
     """
 
+    LIB_PATH: ClassVar[Path] = Path("/usr/share/one/lib/libcircle_interpreter_cffi.so")
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return cls.LIB_PATH.is_file()
+
     def __init__(self, circle_binary: bytes):
         self.ffi = FFI()
-        self.ffi.cdef(
-            """
+        self.ffi.cdef("""
           typedef struct InterpreterWrapper InterpreterWrapper;
 
           const char *get_last_error(void);
@@ -46,21 +52,22 @@ class Interpreter:
           void Interpreter_interpret(InterpreterWrapper *intp);
           void Interpreter_writeInputTensor(InterpreterWrapper *intp, const int input_idx, const void *data, size_t input_size);
           void Interpreter_readOutputTensor(InterpreterWrapper *intp, const int output_idx, void *output, size_t output_size);
-        """
-        )
+        """)
         # TODO Check if one-compiler version is compatible. Whether it has .so file or not for CFFI.
-        intp_lib_path = Path("/usr/share/one/lib/libcircle_interpreter_cffi.so")
-        if not intp_lib_path.is_file():
+        if not self.is_available():
             raise RuntimeError("Please install one-compiler for circle inference.")
-        self.C = self.ffi.dlopen(str(intp_lib_path))
+        self.C = self.ffi.dlopen(str(self.LIB_PATH))
 
         # Initialize interpreter
         self.intp = self.C.Interpreter_new(circle_binary, len(circle_binary))
         self.check_for_errors()
 
     def delete(self):
+        if not hasattr(self, "C") or not hasattr(self, "intp"):
+            return
         self.C.Interpreter_delete(self.intp)
         self.check_for_errors()
+        del self.intp
 
     def interpret(self):
         self.C.Interpreter_interpret(self.intp)

--- a/tico/interpreter/interpreter.py
+++ b/tico/interpreter/interpreter.py
@@ -17,6 +17,7 @@ from typing import ClassVar
 
 import numpy as np
 import torch
+
 from cffi import FFI
 
 
@@ -42,7 +43,8 @@ class Interpreter:
 
     def __init__(self, circle_binary: bytes):
         self.ffi = FFI()
-        self.ffi.cdef("""
+        self.ffi.cdef(
+            """
           typedef struct InterpreterWrapper InterpreterWrapper;
 
           const char *get_last_error(void);
@@ -52,7 +54,8 @@ class Interpreter:
           void Interpreter_interpret(InterpreterWrapper *intp);
           void Interpreter_writeInputTensor(InterpreterWrapper *intp, const int input_idx, const void *data, size_t input_size);
           void Interpreter_readOutputTensor(InterpreterWrapper *intp, const int output_idx, void *output, size_t output_size);
-        """)
+        """
+        )
         # TODO Check if one-compiler version is compatible. Whether it has .so file or not for CFFI.
         if not self.is_available():
             raise RuntimeError("Please install one-compiler for circle inference.")


### PR DESCRIPTION
Use `ModelInputSpec.bind` in `tico/interpreter/infer.py` to
 produce `user_inputs` so `*args`/`**kwargs` are bound and
ordered according to the Circle model input signature.

TICO-DCO-1.0-Signed-off-by: seongwoo mhs4670go@naver.com