### PR TITLE
[DRAFT] [NO_MERGE] GPTQv2(GPTQAQ)

### DIFF
--- a/tico/quantization/algorithm/fpi_gptq/util.py
+++ b/tico/quantization/algorithm/fpi_gptq/util.py
@@ -28,11 +28,12 @@ def quantize(x, scale, zero, maxq):
     return scale * (q - zero)
 
 
-def iterate_GPTQ(scale, zero, maxq, W, Hinv, max_num_of_iters=50):
+def iterate_GPTQ(scale, zero, maxq, W, Hinv, max_num_of_iters=50, P=None):
 
     cur_weights = W.clone()
     mults = torch.pow(torch.diag(Hinv), -1)
     Hinv_U = torch.triu(Hinv, diagonal=1)
+    P_U = torch.triu(P, diagonal=1) if P is not None else None
 
     init_weights = W.clone()
     for _ in range(max_num_of_iters):
@@ -40,6 +41,9 @@ def iterate_GPTQ(scale, zero, maxq, W, Hinv, max_num_of_iters=50):
 
         d_W = torch.mul((cur_weights - cur_Q), mults)
         cur_weights = init_weights - torch.matmul(d_W, Hinv_U)
+        # GPTQv2: Apply P correction
+        if P_U is not None:
+            cur_weights += torch.matmul(cur_Q, P_U)
         del d_W, cur_Q
         d_W = cur_Q = None
         if torch.cuda.is_available():

--- a/tico/quantization/algorithm/gptq/gptq.py
+++ b/tico/quantization/algorithm/gptq/gptq.py
@@ -18,8 +18,9 @@
 
 # https://github.com/IST-DASLab/gptq/blob/2d65066/gptq.py
 
+import math
 import time
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 import torch.nn as nn
@@ -163,7 +164,10 @@ def get_matmul_input_for_convtranspose2d(layer, inp):
 
 
 class GPTQ:
-    def __init__(self, layer):
+    """
+    GPTQ quantization class supporting both standard GPTQ and GPTQv2.
+    """
+    def __init__(self, layer, **kwargs):
         self.layer = layer
         self.dev = self.layer.weight.device
         W = layer.weight.data.clone()
@@ -180,8 +184,30 @@ class GPTQ:
         )
         self.nsamples = 0
         self.quantizer: Quantizer = Quantizer()
+        # GPTQv2: for tracking FP vs quantized input difference
+        self.dXXT: Optional[torch.Tensor] = None
+        self.native_inp: Optional[List[torch.Tensor]] = None
+        self.kwargs = kwargs
 
-    def add_batch(self, inp, out):
+    def add_batch(self, inp, out=None):
+        """
+        Add a batch of inputs to the Hessian approximation.
+        
+        For GPTQv2, also processes native_inp (FP inputs) and computes dXXT.
+        """
+        # Process native input for GPTQv2 (before reshaping inp)
+        native_inp_processed = None
+        if hasattr(self, "native_inp") and self.native_inp is not None and len(self.native_inp) > 0:
+            native = self.native_inp.pop(0)
+            if native is not None:
+                native_inp_processed = native
+            if len(native_inp_processed.shape) == 2:
+                native_inp_processed = native_inp_processed.unsqueeze(0)
+            if isinstance(self.layer, nn.Linear):
+                if len(native_inp_processed.shape) > 2:
+                    native_inp_processed = native_inp_processed.reshape((-1, native_inp_processed.shape[-1]))
+                native_inp_processed = native_inp_processed.t()
+        
         if len(inp.shape) == 2:
             inp = inp.unsqueeze(0)
         tmp = inp.shape[0]
@@ -296,6 +322,16 @@ class GPTQ:
         self.nsamples += tmp
         inp = inp.double()
         self.H += inp.matmul(inp.t()).to(device=self.H.device, dtype=self.H.dtype)  # type: ignore[union-attr]
+        # GPTQv2: Compute dXXT using native (FP) vs processed input difference
+        if native_inp_processed is not None:
+            if self.dXXT is None:
+                self.dXXT = torch.zeros_like(self.H)
+            
+            native_inp_processed = native_inp_processed.double()
+            dX = native_inp_processed.to(inp.device) - inp
+            self.dXXT += dX.matmul(inp.t()).float()
+            del native, native_inp_processed
+            native = native_inp_processed = None
 
     def fasterquant(
         self,
@@ -305,7 +341,20 @@ class GPTQ:
         actorder=False,
         static_groups=False,
         verbose=False,
+        just_quantize=False,
     ):
+        """
+        Perform GPTQ quantization.
+        
+        Args:
+            blocksize: Block size for GPTQ
+            percdamp: Damping factor for Hessian
+            groupsize: Group size for groupwise quantization (-1 for no grouping)
+            actorder: Whether to use activation ordering
+            static_groups: Whether to use static groups
+            verbose: Whether to print verbose output
+            just_quantize: If True, only quantize weights without GPTQ optimization
+        """
         W = self.layer.weight.data.clone()
         if isinstance(self.layer, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
             W = W.flatten(1)  # reshaped to matrix (OUT_channels x the_rest)
@@ -332,6 +381,10 @@ class GPTQ:
         dead = torch.diag(H) == 0
         H[dead, dead] = 1
         W[:, dead] = 0
+        
+        # GPTQv2: Zero out dead elements in dXXT
+        if self.dXXT is not None:
+            self.dXXT[:, dead] = 0
 
         if groupsize != -1 and self.quantizer.mse in {"mse_for_gptq", "smse_for_gptq"}:
             raise ValueError(
@@ -354,6 +407,8 @@ class GPTQ:
             W = W[:, perm]
             H = H[perm][:, perm]
             invperm = torch.argsort(perm)
+            if self.dXXT is not None:
+                self.dXXT = self.dXXT[perm][:, perm]
 
         Losses = torch.zeros_like(W)
         Q = torch.zeros_like(W)
@@ -367,8 +422,14 @@ class GPTQ:
         H = torch.cholesky_inverse(H)
         H = torch.linalg.cholesky(H, upper=True).float()
         Hinv = H
+        
+        # GPTQv2: Compute P correction matrix from dXXT
+        P = None
+        if self.dXXT is not None:
+            alpha = 0.25
+            P = alpha * ((self.dXXT @ Hinv.T).triu_(diagonal=1)) @ Hinv
 
-        self.quantizer.update(W, Hinv, perm)
+        self.quantizer.update(W, Hinv, perm, P=P)
 
         assert isinstance(Hinv, torch.Tensor)
         for i1 in range(0, self.columns, blocksize):
@@ -380,6 +441,7 @@ class GPTQ:
             Err1 = torch.zeros_like(W1)
             Losses1 = torch.zeros_like(W1)
             Hinv1 = Hinv[i1:i2, i1:i2]
+            P1 = P[i1:i2, i1:i2] if P is not None else None
 
             for i in range(count):
                 w = W1[:, i]
@@ -408,12 +470,18 @@ class GPTQ:
 
                 err1 = (w - q) / d
                 W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+                # GPTQv2: Apply P correction
+                if P1 is not None:
+                    W1[:, i:] += w.unsqueeze(1).matmul(P1[i, i:].unsqueeze(0))
                 Err1[:, i] = err1
 
             Q[:, i1:i2] = Q1
             Losses[:, i1:i2] = Losses1 / 2
 
             W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+            # GPTQv2: Apply P correction to remaining weights
+            if P is not None:
+                W[:, i2:] += W1.matmul(P[i1:i2, i2:])
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
@@ -469,5 +537,6 @@ class GPTQ:
         self.H = None
         self.Losses = None
         self.Trace = None
+        self.dXXT = None
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/tico/quantization/algorithm/gptq/llama_quantizer.py
+++ b/tico/quantization/algorithm/gptq/llama_quantizer.py
@@ -919,9 +919,9 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         
-#        if ptq_wrapped:
-#            self._calibrate_norm_lm_head_ptq(model)
-#            model.freeze_qparams()
+        if ptq_wrapped:
+            self._calibrate_norm_lm_head_ptq(model)
+            model.freeze_qparams()
         
         # Restore the original cache configuration.
         config = self._get_config(model)

--- a/tico/quantization/algorithm/gptq/llama_quantizer.py
+++ b/tico/quantization/algorithm/gptq/llama_quantizer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import functools
 import types
 from typing import Any, Callable, Dict, List, Optional
 
@@ -35,6 +36,58 @@ from tico.quantization.wrapq.wrappers.nn.quant_embedding import QuantEmbedding
 from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.utils.utils import move_to_device
+from transformers import Conv1D
+
+
+class FPInputsCache:
+    """
+    Class for saving full-precision output in each layer (GPTQv2).
+    """
+
+    def __init__(self, sequential):
+        self.fp_cache = {}
+        self.names = tuple(name for names in sequential for name in names)
+        for name in self.names:
+            self.fp_cache[name] = []
+        self.handles = []
+
+    def cache_fp_input(self, m, inp, out, name):
+        inp = inp[0].detach()
+
+       # if isinstance(m, (torch.nn.Linear, Conv1D)):
+       #     if len(inp.shape) == 3:
+       #         inp = inp.reshape((-1, inp.shape[-1]))
+       #     inp = inp.t()
+       # elif isinstance(m, torch.nn.Conv2d):
+       #     unfold = torch.nn.Unfold(
+       #         m.kernel_size,
+       #         dilation=m.dilation,
+       #         padding=m.padding,
+       #         stride=m.stride,
+       #     )
+       #     inp = unfold(inp)
+       #     inp = inp.permute([1, 0, 2])
+       #     inp = inp.flatten(1)
+
+        self.fp_cache[name] += [inp.cpu()]
+
+    def add_hook(self, full):
+        for name in self.names:
+            self.handles.append(
+                full[name].register_forward_hook(
+                    functools.partial(self.cache_fp_input, name=name)
+                )
+            )
+
+    def clear_hook(self):
+        for h in self.handles:
+            h.remove()
+        self.handles = []
+        torch.cuda.empty_cache()
+
+    def clear_cache(self):
+        for name in self.names:
+            self.fp_cache[name] = []
 
 
 def move_to_cpu(obj):
@@ -401,13 +454,14 @@ class LlamaGPTQQuantizer(BaseQuantizer):
 
         gptq_conf = self.config
         assert isinstance(gptq_conf, LlamaGPTQConfig)
-        if gptq_conf.use_orig_model_inference is True:
+        if gptq_conf.use_orig_model_inference is True or gptq_conf.gptq_v2:
             device = next(model.parameters()).device
             model = model.cpu()
             self.orig_model = copy.deepcopy(model)
             model = model.to(device)
         else:
             self.orig_model = None
+        
         # Replace the first layer with defined function to capture calibration data.
         layers = self._get_decoder_layers(model)
         self._first_layer_ref = layers[0]
@@ -505,40 +559,11 @@ class LlamaGPTQQuantizer(BaseQuantizer):
 
         embed_tokens.freeze_qparams()
 
-    def _calibrate_model_norm_ptq(self, model: torch.nn.Module) -> None:
-        """
-        Calibrate PTQ observers for model.norm (PTQ-only, no GPTQ).
-        
-        Calibrates weight, input activation, and output activation observers.
-        """
-        model_norm = self._get_model_norm_ptq_wrapper(model)
-        if model_norm is None:
-            return
-
-        # Calibrate weight observer immediately (fixed)
-        obs_weight = model_norm.get_observer("weight")
-        if obs_weight is not None:
-            obs_weight.collect(model_norm.module.weight)
-            obs_weight.enabled = False
-            obs_weight.compute_qparams()
-
-        # Calibrate input and output activation observers
-        device = next(model.parameters()).device
-        batch_num = self.num_batches
-        
-        for batch_idx in range(batch_num):
-            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
-            hidden_states = move_to_device(hidden_states, device)
-            model_norm(hidden_states)
-
-        # Freeze activation observers
-        #model_norm.freeze_qparams()
-
     def _calibrate_norm_lm_head_ptq(self, model: torch.nn.Module) -> None:
         """
-        Calibrate PTQ observers for lm_head (PTQ-only, no GPTQ).
+        Calibrate PTQ observers for  norm and lm_head (PTQ-only, no GPTQ).
         
-        Calibrates weight, input activation, and output activation observers.
+        Calibrates weights, input activations, and output activations observers.
         """
         lm_head = self._get_lm_head_ptq_wrapper(model)
         if lm_head is None:
@@ -619,6 +644,12 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         
         quantizers: Dict[str, Any] = {}
         batch_num = self.num_batches
+        
+        # GPTQv2: Collect FP inputs from original model before quantization
+        need_float_inference = gptq_conf.gptq_v2 
+        fp_inps = None
+        if need_float_inference and orig_layers is not None:
+            fp_inps = copy.deepcopy(self.cache_args)
         for l_idx, layer in enumerate(
             tqdm(
                 target_layers,
@@ -636,7 +667,7 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                 ],
             )
 
-            sequential = True #False
+            sequential = False#True #False
             # Define groups for quantizing by internal structure (standard Llama modules)
             if sequential is True:
                 #sequential processing
@@ -675,6 +706,31 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                 if cur_seq:
                     sequential.append(cur_seq)
 
+            # GPTQv2: Set up FPInputsCache for collecting FP inputs per submodule
+            fp_inputs_cache = None
+            if need_float_inference and orig_layers is not None:
+                fp_inputs_cache = FPInputsCache(sequential)
+                orig_full = _find(
+                    orig_layers[l_idx],
+                    layers=[
+                        torch.nn.Linear,
+                        QuantLinear
+                    ],
+                )
+                fp_inputs_cache.add_hook(orig_full)
+                device = next(model.parameters()).device
+                for batch_idx in range(batch_num):
+                    cache_args_batch = gather_single_batch_from_list(fp_inps, batch_idx)
+                    cache_args_batch = move_to_device(cache_args_batch, device)
+                    cache_kwargs_batch = gather_single_batch_from_dict(self.cache_kwargs, batch_idx)
+                    cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+                    
+                    orig_layer = orig_layers[l_idx].to(device)
+                    orig_layer(*cache_args_batch, **cache_kwargs_batch)
+                    orig_layer.cpu()
+                    
+                fp_inputs_cache.clear_hook()
+
             # 2) Set up GPTQ objects and gather stats
             for names in sequential:
                 subset = {n: full[n] for n in names}
@@ -706,6 +762,10 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                         mse=gptq_conf.mse,
                         sensitivity=cur_sensitivity,
                     )
+
+                    # GPTQv2: Assign native_inp from FPInputsCache
+                    if fp_inputs_cache is not None and name in fp_inputs_cache.fp_cache:
+                        gptq[name].native_inp = fp_inputs_cache.fp_cache[name]
 
                 # Hook to collect (inp, out) for GPTQ
                 def add_batch(name):
@@ -772,7 +832,7 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                 device = next(model.parameters()).device
                 for batch_idx in tqdm(
                     range(batch_num),
-                    desc=f"[L{l_idx}] activaions calibration",
+                    desc=f"[L{l_idx}] activations calibration",
                     leave=False,
                     unit="batch",
                     disable=not gptq_conf.show_progress,
@@ -786,7 +846,7 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                         self.cache_kwargs, batch_idx
                     )
                     cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
-                    outs = layer(*cache_args_batch, **cache_kwargs_batch)
+                    layer(*cache_args_batch, **cache_kwargs_batch)
                     
                 if ptq_wrapped:
                     layer.freeze_qparams()   
@@ -810,8 +870,26 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                     self.cache_kwargs, batch_idx
                 )
                 cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
-
-                if orig_layers is None:
+                if fp_inps is not None:
+                    fp_cache_args_batch = gather_single_batch_from_list(fp_inps, batch_idx)
+                    fp_cache_args_batch = move_to_device(fp_cache_args_batch, device)
+                    orig_layer = orig_layers[l_idx].to(device)
+                    fp_outs = orig_layer(*fp_cache_args_batch, **cache_kwargs_batch)
+                    #fp_outs = layer(*fp_cache_args_batch, **cache_kwargs_batch)
+                    orig_layer.cpu()
+                    fp_outs = fp_outs[0] if isinstance(fp_outs, tuple) else fp_outs
+                    # Update inputs for next iteration.
+                    if len(fp_inps) > 0:
+                        if hasattr(fp_outs, "to") and hasattr(
+                            fp_inps[0][batch_idx], "device"
+                        ):
+                            fp_inps[0][batch_idx] = fp_outs.to(
+                                fp_inps[0][batch_idx].device
+                            )
+                        else:
+                            fp_inps[0][batch_idx] = fp_outs
+                    
+                if orig_layers is None or self.config.gptq_v2 is True:
                     outs = layer(*cache_args_batch, **cache_kwargs_batch)
                 else:
                     orig_layer = orig_layers[l_idx].to(device)
@@ -840,11 +918,10 @@ class LlamaGPTQQuantizer(BaseQuantizer):
 
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
-
-        self._calibrate_norm_lm_head_ptq(model)
         
-        if ptq_wrapped:
-            model.freeze_qparams()
+#        if ptq_wrapped:
+#            self._calibrate_norm_lm_head_ptq(model)
+#            model.freeze_qparams()
         
         # Restore the original cache configuration.
         config = self._get_config(model)

--- a/tico/quantization/algorithm/gptq/llama_quantizer.py
+++ b/tico/quantization/algorithm/gptq/llama_quantizer.py
@@ -22,18 +22,83 @@ from tqdm.auto import tqdm
 from tico.quantization.algorithm.gptq.gptq import GPTQ
 from tico.quantization.algorithm.gptq.utils import (
     find_layers,
+    find_layers_deep,
     gather_single_batch_from_dict,
     gather_single_batch_from_list,
 )
 from tico.quantization.config.llama_gptq import LlamaGPTQConfig
 from tico.quantization.quantizer import BaseQuantizer
 from tico.quantization.quantizer_registry import register_quantizer
+from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.nn.quant_embedding import QuantEmbedding
+from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.utils.utils import move_to_device
 
 
 def move_to_cpu(obj):
     return move_to_device(obj, "cpu")
 
+def print_minmax_values(model: torch.nn.Module) -> None:
+    """
+    Print min/max values from all PTQ observers in the quantized model.
+
+    This function traverses the model hierarchy and prints the min/max statistics
+    collected by each AffineObserverBase instance. Useful for debugging and
+    inspecting quantization ranges after calibration.
+
+    For per-tensor observers, prints scalar min/max values.
+    For per-channel observers, prints the global min/max range and channel shape.
+
+    Args:
+        model: A PTQ-quantized model with observers containing min/max statistics.
+
+    Example usage:
+        # After calibration and before/after conversion:
+        print_minmax_values(q_m)
+    """
+    from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
+    from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+
+    print("\n" + "=" * 80)
+    print("PTQ Model Min/Max Values")
+    print("=" * 80)
+    print(f"{'Module Name':<50} | {'Observer':<25} | Min/Max Values")
+    print("-" * 80)
+
+    count = 0
+    for module_name, module in model.named_modules():
+        if not isinstance(module, QuantModuleBase):
+            continue
+
+        for obs_name, obs in module.named_observers(recurse=True):
+            if not isinstance(obs, AffineObserverBase):
+                continue
+
+            if not hasattr(obs, "min_val") or not hasattr(obs, "max_val"):
+                continue
+
+            min_val = obs.min_val
+            max_val = obs.max_val
+
+            # Format output based on per-tensor vs per-channel
+            if min_val.numel() == 1:
+                # Per-tensor: scalar values
+                values_str = f"min={min_val.item():.6f}, max={max_val.item():.6f}"
+            else:
+                # Per-channel: show shape and range
+                values_str = (
+                    f"min={min_val.min().item():.6f}..{max_val.max().item():.6f} "
+                    f"(shape={tuple(min_val.shape)})"
+                )
+
+            print(f"{module_name:<50} | {obs_name:<25} | {values_str}")
+            count += 1
+
+    print("-" * 80)
+    print(f"Total observers: {count}")
+    print("=" * 80 + "\n")
 
 class StopForward(Exception):
     """Custom exception used to stop the forward pass after the first layer."""
@@ -107,16 +172,190 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         """Check if the model is a SpinLlamaForCausalLM (has rotate_lm_head)."""
         return hasattr(model, "rotate_lm_head") and model.rotate_lm_head is not None
 
+    @staticmethod
+    def _is_ptq_wrapped(model: torch.nn.Module) -> bool:
+        """Check if the model has been wrapped with PTQ prepare().
+
+        After PTQ prepare(), the top-level model becomes a
+        ``QuantLlamaForCausalLM`` whose ``.model`` attribute is a
+        ``PTQWrapper`` (instead of a plain ``LlamaModel``).
+        """
+        return isinstance(model, PTQWrapper)
+
     def _get_decoder_layers(self, model: torch.nn.Module):
-        """Get the decoder layers from a Llama model."""
-        return model.model.layers
+        """Get the decoder layers from a Llama model.
+
+        Handles both raw models and PTQ-wrapped models.
+
+        After PTQ prepare() the top-level model is ``QuantLlamaForCausalLM``
+        which stores the Llama body in ``self.model`` (a ``PTQWrapper``).
+        The actual ``LlamaModel`` is at ``model.model.wrapped``.
+
+        If the model is already a ``QuantLlamaModel`` (e.g. the body
+        without the CausalLM wrapper), its layers are directly at
+        ``model.layers``.
+        """
+        # Case 1: model has a .model child (LlamaForCausalLM / QuantLlamaForCausalLM)
+        if hasattr(model, "model"):
+            model_attr = model.model
+            if isinstance(model_attr, QuantModuleBase):
+                # PTQ-wrapped: .model is PTQWrapper → .wrapped is QuantLlamaModel
+                return model_attr.wrapped.layers
+            return model_attr.layers
+
+        # Case 2: model IS the LlamaModel / QuantLlamaModel directly
+        if isinstance(model, QuantModuleBase):
+            return model.wrapped.model.wrapped.layers
+
+        # Case 3: plain LlamaModel
+        return model.layers
 
     def _get_orig_decoder_layers(self, model: torch.nn.Module):
-        """Get the decoder layers from the original model copy."""
         if self.orig_model is not None:
-            return self.orig_model.model.layers
+            if hasattr(self.orig_model, "model"):
+                return self.orig_model.model.layers
+            elif hasattr(self.orig_model, "wrapped"):
+                return self.orig_model.wrapped.model.wrapped.layers
+            return self.orig_model.layers
         return None
 
+    @staticmethod
+    def _find_ptq_layers(layer: torch.nn.Module, layers=None, name=""):
+        """Find quantizable submodules inside a PTQ-wrapped decoder layer.
+
+        Navigates the ``PTQWrapper(.wrapped)`` hierarchy transparently so
+        that the returned names match the **original** model structure
+        (e.g. ``"self_attn.q_proj"`` instead of
+        ``"wrapped.self_attn.wrapped.q_proj.wrapped.module"``).
+
+        Returns a dict mapping *local* name → raw ``nn.Module``
+        (e.g. the ``nn.Linear`` inside ``QuantLinear.module``).
+        """
+        if layers is None:
+            layers = [torch.nn.Linear]
+
+        # Direct match
+        if type(layer) in layers:
+            return {name: layer}
+
+        # Unwrap QuantModuleBase that stores the original layer in .module
+        if hasattr(layer, "module") and isinstance(getattr(layer, "module"), torch.nn.Module):
+            inner = layer.module
+            if type(inner) in layers:
+                return {name: inner}
+
+        res: Dict[str, torch.nn.Module] = {}
+        for child_name, child in layer.named_children():
+            # Skip the "wrapped" level of PTQWrapper to keep names clean
+            from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+            if child_name == "wrapped" and isinstance(layer, PTQWrapper):
+                new_name = name  # don't append "wrapped"
+            else:
+                new_name = name + "." + child_name if name != "" else child_name
+
+            res.update(
+                LlamaGPTQQuantizer._find_ptq_layers(
+                    child, layers=layers, name=new_name
+                )
+            )
+        return res
+    
+    @staticmethod
+    def reset_layer_observers(layer: torch.nn.Module, save_obs) -> None:
+        """
+        Reset all observers (weight and activation) in a layer.
+
+        This clears the min/max statistics collected by observers, allowing
+        them to collect fresh calibration data.
+
+        Args:
+            layer: A QuantModuleBase (e.g., PTQWrapper) containing observers
+        """
+        for m in layer.modules():
+            if isinstance(m, QuantModuleBase):
+                for name, obs in m.named_observers(recurse=False):
+                    if obs in save_obs:
+                        continue
+                    obs.reset()
+
+    @staticmethod
+    def remove_wrapped_substrings(s: str) -> str:
+        
+        s = s.replace(".wrapped", "")
+        s = s.replace("wrapped.", "")
+        s = s.replace("wrapped", "")
+        return s
+
+    @staticmethod
+    def _inject_gptq_qparams_into_layer(
+        layer: torch.nn.Module,
+        gptq_quantizers: Dict[str, Any],
+        *,
+        verbose: bool = False,
+    ):
+        """Inject GPTQ (scale, zero-point) into the PTQ weight observers
+        of *all* ``QuantModuleBase`` descendants inside *layer*, then call
+        ``freeze_qparams()`` to lock every observer (weight + activation).
+
+        This is used when GPTQ runs on a PTQ-prepared model: GPTQ quantizes
+        the weights, and we push the resulting qparams into the PTQ weight
+        observers so the PTQ graph uses the same quantization parameters.
+        """
+        seen = set()
+        missed_modules = []
+        saved_obs = set()
+        for m in layer.modules():
+            if not isinstance(m, QuantModuleBase):
+                continue
+            if m.fp_name is None:
+                continue
+
+            quantizer = gptq_quantizers.get(m.fp_name)
+            obs = m.get_observer("weight")
+
+            # Only care about modules that should have weight observers
+            if obs is None:
+                continue
+
+            if quantizer is None:
+                missed_modules.append(m.fp_name)
+                #saved_obs.add(obs) #not-gptq weight
+                #obs.enabled = False
+                continue
+
+            assert isinstance(obs, AffineObserverBase)
+            obs.load_qparams(quantizer.scale, quantizer.zero, lock=True)
+            seen.add(m.fp_name)
+            saved_obs.add(obs)
+            
+            #m.freeze_qparams()
+
+        unused = set(gptq_quantizers.keys()) - seen
+        LlamaGPTQQuantizer.reset_layer_observers(layer, saved_obs)
+        
+        if verbose:
+            print(f"\n  [GPTQ → PTQ injection] matched={len(seen)}, "
+                  f"missed={len(missed_modules)}, unused={len(unused)}")
+            if missed_modules:
+                print(f"    missed: {missed_modules[:5]}")
+          # if unused:
+          #     print(f"    unused: {list(unused)[:5]}")
+
+        # Freeze all observers (weight + activation) for this layer.
+        # The layer is a PTQWrapper (QuantModuleBase), and freeze_qparams()
+        # propagates to all child QuantModuleBase descendants.
+        # This transitions the layer from CALIB → QUANT mode.
+       # if isinstance(layer, QuantModuleBase):
+       #     layer.freeze_qparams()
+
+    def _get_config(self, m):
+        """Get config from model, handling PTQ wrappers."""
+        if hasattr(m, 'config'):
+            return m.config
+        if hasattr(m, 'wrapped'):
+            return self._get_config(m.wrapped)
+        return None
+    
     @torch.no_grad()
     def prepare(
         self,
@@ -170,7 +409,8 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         else:
             self.orig_model = None
         # Replace the first layer with defined function to capture calibration data.
-        self._first_layer_ref = model.model.layers[0]
+        layers = self._get_decoder_layers(model)
+        self._first_layer_ref = layers[0]
 
         assert hasattr(self._first_layer_ref, "forward")
         # Backup the original forward of the first layer
@@ -194,13 +434,137 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         model.forward = types.MethodType(model_forward_wrapper, model)
 
         # Disable use_cache during calibration
-        if hasattr(model, "config") and hasattr(model.config, "use_cache"):
-            self.orig_use_cache = model.config.use_cache
-            model.config.use_cache = False
+        # Handle PTQ-wrapped models by unwrapping to get to the config
+        config = self._get_config(model)
+        if config is not None and hasattr(config, "use_cache"):
+            self.orig_use_cache = config.use_cache
+            config.use_cache = False
         else:
             self.orig_use_cache = None
 
         return model
+    def _get_embed_tokens_ptq_wrapper(self, model: torch.nn.Module) -> Optional[QuantModuleBase]:
+        """
+        Get the PTQ wrapper for embed_tokens.
+        
+        This only handles PTQ-wrapped embed_tokens (QuantEmbedding).
+        Returns None if not found or not PTQ-wrapped.
+        """
+        for m in model.modules():
+            if isinstance(m, QuantEmbedding):
+                fp_name = getattr(m, 'fp_name', None)
+                if fp_name is not None and 'embed_tokens' in fp_name:
+                    return m
+        return None
+
+    def _get_model_norm_ptq_wrapper(self, model: torch.nn.Module) -> Optional[QuantModuleBase]:
+        """
+        Get the PTQ wrapper for model.norm.
+        
+        This only handles PTQ-wrapped model.norm (QuantRMSNorm).
+        Returns None if not found or not PTQ-wrapped.
+        """
+        from tico.quantization.wrapq.wrappers.ops.quant_rmsnorm import QuantRMSNorm
+        from tico.quantization.wrapq.wrappers.nn.quant_layernorm import QuantLayerNorm
+        
+        for m in model.modules():
+            if isinstance(m, (QuantRMSNorm, QuantLayerNorm)):
+                fp_name = getattr(m, 'fp_name', None)
+                if fp_name is not None and fp_name.endswith('.norm'):
+                    return m
+        return None
+
+    def _get_lm_head_ptq_wrapper(self, model: torch.nn.Module) -> Optional[QuantModuleBase]:
+        """
+        Get the PTQ wrapper for lm_head.
+        
+        This only handles PTQ-wrapped lm_head (QuantLinear).
+        Returns None if not found or not PTQ-wrapped.
+        """
+        for m in model.modules():
+            if isinstance(m, QuantLinear):
+                fp_name = getattr(m, 'fp_name', None)
+                if fp_name is not None and 'lm_head' in fp_name:
+                    return m
+        return None
+    
+    def _calibrate_embed_tokens_ptq(self, model: torch.nn.Module) -> None:
+        """
+        Calibrate PTQ observers for embed_tokens (PTQ-only, no GPTQ).
+        
+        Calibrates weight, input activation, and output activation observers.
+        """
+        embed_tokens = self._get_embed_tokens_ptq_wrapper(model)
+        if embed_tokens is None:
+            return
+
+        # Calibrate weight observer immediately (fixed)
+        obs_weight = embed_tokens.get_observer("weight")
+        if obs_weight is not None:
+            obs_weight.collect(embed_tokens.module.weight)
+
+        embed_tokens.freeze_qparams()
+
+    def _calibrate_model_norm_ptq(self, model: torch.nn.Module) -> None:
+        """
+        Calibrate PTQ observers for model.norm (PTQ-only, no GPTQ).
+        
+        Calibrates weight, input activation, and output activation observers.
+        """
+        model_norm = self._get_model_norm_ptq_wrapper(model)
+        if model_norm is None:
+            return
+
+        # Calibrate weight observer immediately (fixed)
+        obs_weight = model_norm.get_observer("weight")
+        if obs_weight is not None:
+            obs_weight.collect(model_norm.module.weight)
+            obs_weight.enabled = False
+            obs_weight.compute_qparams()
+
+        # Calibrate input and output activation observers
+        device = next(model.parameters()).device
+        batch_num = self.num_batches
+        
+        for batch_idx in range(batch_num):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+            model_norm(hidden_states)
+
+        # Freeze activation observers
+        #model_norm.freeze_qparams()
+
+    def _calibrate_norm_lm_head_ptq(self, model: torch.nn.Module) -> None:
+        """
+        Calibrate PTQ observers for lm_head (PTQ-only, no GPTQ).
+        
+        Calibrates weight, input activation, and output activation observers.
+        """
+        lm_head = self._get_lm_head_ptq_wrapper(model)
+        if lm_head is None:
+            return
+
+        # Calibrate weight observer immediately (fixed)
+        obs_weight = lm_head.get_observer("weight")
+        if obs_weight is not None:
+            obs_weight.collect(lm_head.module.weight)
+            obs_weight.enabled = False
+            obs_weight.compute_qparams()
+
+        # Calibrate input and output activation observers
+        device = next(model.parameters()).device
+        batch_num = self.num_batches
+        model_norm = self._get_model_norm_ptq_wrapper(model)
+        
+        for batch_idx in range(batch_num):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+            hidden_states = model_norm(hidden_states)
+            lm_head(hidden_states)
+
+        # Freeze activation observers
+        model_norm.freeze_qparams()
+        lm_head.freeze_qparams()
 
     @torch.no_grad()
     def convert(self, model):
@@ -235,15 +599,26 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         assert isinstance(gptq_conf, LlamaGPTQConfig)
         gptq_conf.validate()
 
+        ptq_wrapped = self._is_ptq_wrapped(model)
+
         # Identify layers
         target_layers = self._get_decoder_layers(model)
         orig_layers = self._get_orig_decoder_layers(model)
-
-        module_name = {}
+        
+        module_name: Dict[torch.nn.Module, str] = {}
         for name, module in model.named_modules():
             module_name[module] = name
 
+        self._calibrate_embed_tokens_ptq(model)
+        
+        # Choose the right layer-finder depending on whether the model is
+        # PTQ-wrapped.  When it is, nn.Linear modules are hidden inside
+        # QuantLinear.module and PTQWrapper.wrapped layers, so we need
+        # _find_ptq_layers which transparently skips the "wrapped" level.
+        _find = self._find_ptq_layers if ptq_wrapped else find_layers
+        
         quantizers: Dict[str, Any] = {}
+        batch_num = self.num_batches
         for l_idx, layer in enumerate(
             tqdm(
                 target_layers,
@@ -253,24 +628,44 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             )
         ):
             # 1) Identify quantizable submodules within the layer
-            full = find_layers(
+            full = _find(
                 layer,
                 layers=[
                     torch.nn.Linear,
-                    torch.nn.Conv2d,
-                    torch.nn.Conv1d,
-                    torch.nn.Conv3d,
-                    torch.nn.ConvTranspose2d,
+                    QuantLinear
                 ],
             )
 
+            sequential = True #False
             # Define groups for quantizing by internal structure (standard Llama modules)
-            all_names = [
-                ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
-                ["self_attn.o_proj"],
-                ["mlp.gate_proj", "mlp.up_proj"],
-                ["mlp.down_proj"],
-            ]
+            if sequential is True:
+                #sequential processing
+                all_names = [
+                    # Wrapped paths (for PTQ-wrapped models) - must come first
+                    ["wrapped.self_attn.wrapped.q_proj.wrapped", "wrapped.self_attn.wrapped.k_proj.wrapped", "wrapped.self_attn.wrapped.v_proj.wrapped"],
+                    ["wrapped.self_attn.wrapped.o_proj.wrapped"],
+                    ["wrapped.mlp.wrapped.gate_proj.wrapped", "wrapped.mlp.wrapped.up_proj.wrapped"],
+                    ["wrapped.mlp.wrapped.down_proj.wrapped"],
+                    # Standard unwrapped paths
+                    ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+                    ["self_attn.o_proj"],
+                    ["mlp.gate_proj", "mlp.up_proj"],
+                    ["mlp.down_proj"],
+                ]
+            else:
+                #process all internal linears at once
+                all_names = [
+                    # Wrapped paths (for PTQ-wrapped models) - must come first
+                    ["wrapped.self_attn.wrapped.q_proj.wrapped", "wrapped.self_attn.wrapped.k_proj.wrapped", "wrapped.self_attn.wrapped.v_proj.wrapped",
+                    "wrapped.self_attn.wrapped.o_proj.wrapped",
+                    "wrapped.mlp.wrapped.gate_proj.wrapped", "wrapped.mlp.wrapped.up_proj.wrapped",
+                    "wrapped.mlp.wrapped.down_proj.wrapped"],
+                    # Standard unwrapped paths
+                    ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj",
+                    "self_attn.o_proj",
+                    "mlp.gate_proj", "mlp.up_proj",
+                    "mlp.down_proj"],
+                ]
 
             # Filter to only existing modules and group them
             existing_names = set(full.keys())
@@ -286,19 +681,22 @@ class LlamaGPTQQuantizer(BaseQuantizer):
 
                 gptq: Dict[str, GPTQ] = {}
                 for name in subset:
-                    gptq[name] = GPTQ(subset[name])
+                    sub_layer = subset[name]
+                    nn_layer = sub_layer.module if hasattr(sub_layer, "module") else sub_layer
+                    gptq[name] = GPTQ(nn_layer)
                     full_module_name = module_name[subset[name]]
-                    weight_bits = self._resolve_weight_bits(
+                    weight_bits = 4
+                    self._resolve_weight_bits(
                         gptq_conf,
-                        full_module_name=full_module_name,
-                        local_module_name=name,
+                        full_module_name=self.remove_wrapped_substrings(full_module_name),
+                        local_module_name=self.remove_wrapped_substrings(name),
                     )
                     if (
                         gptq_conf.sensitivity is not None
                         and isinstance(gptq_conf.sensitivity, dict)
-                        and full_module_name in gptq_conf.sensitivity
+                        and self.remove_wrapped_substrings(full_module_name) in gptq_conf.sensitivity
                     ):
-                        cur_sensitivity = gptq_conf.sensitivity[full_module_name]
+                        cur_sensitivity = gptq_conf.sensitivity[self.remove_wrapped_substrings(full_module_name)]
                     else:
                         cur_sensitivity = None
                     gptq[name].quantizer.configure(
@@ -321,7 +719,6 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                     handles.append(subset[name].register_forward_hook(add_batch(name)))
 
                 # Run layer forward over all cached batches to build Hessian/statistics
-                batch_num = self.num_batches
                 device = next(model.parameters()).device
                 for batch_idx in tqdm(
                     range(batch_num),
@@ -360,9 +757,41 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                         static_groups=gptq_conf.static_groups,
                         verbose=gptq_conf.verbose,
                     )
-                    quantizers[full_module_name] = gptq[name].quantizer
+                    quantizers[self.remove_wrapped_substrings(full_module_name)] = gptq[name].quantizer
                     gptq[name].free()
+                    
+            # --- PTQ-wrapped: inject GPTQ qparams and freeze the layer ---
+            if ptq_wrapped:
+                self._inject_gptq_qparams_into_layer(
+                    layer,
+                    quantizers,
+                    verbose=gptq_conf.verbose,
+                )
+                layer.enable_calibration()
+                calibrated = False
+                device = next(model.parameters()).device
+                for batch_idx in tqdm(
+                    range(batch_num),
+                    desc=f"[L{l_idx}] activaions calibration",
+                    leave=False,
+                    unit="batch",
+                    disable=not gptq_conf.show_progress,
+                ):
+                    cache_args_batch = gather_single_batch_from_list(
+                        self.cache_args, batch_idx
+                    )
+                    cache_args_batch = move_to_device(cache_args_batch, device)
 
+                    cache_kwargs_batch = gather_single_batch_from_dict(
+                        self.cache_kwargs, batch_idx
+                    )
+                    cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+                    outs = layer(*cache_args_batch, **cache_kwargs_batch)
+                    
+                if ptq_wrapped:
+                    layer.freeze_qparams()   
+                    calibrated = True
+                    
             # 4) After quantization, re-run the layer to produce outputs for the next layer
             device = next(model.parameters()).device
             for batch_idx in tqdm(
@@ -388,6 +817,9 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                     orig_layer = orig_layers[l_idx].to(device)
                     outs = orig_layer(*cache_args_batch, **cache_kwargs_batch)
                     orig_layer.cpu()
+                    if ptq_wrapped and not calibrated:
+                        # nevertheless we should calibrate
+                        layer(*cache_args_batch, **cache_kwargs_batch)
                 # LLaMA's decoder layer return type differs across Transformers versions:
                 # some return a tuple (hidden_states, ...), others return just a tensor.
                 # This line ensures we always take the first element when it's a tuple.
@@ -402,28 +834,29 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                         )
                     else:
                         self.cache_args[0][batch_idx] = outs
+            
+            if ptq_wrapped and not calibrated:
+                layer.freeze_qparams()   
 
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
-        # Optionally quantize lm_head
-        if gptq_conf.quantize_lm_head and hasattr(model, "lm_head"):
-            self._quantize_lm_head(model, quantizers, module_name)
-
-        # Optionally quantize rotate_lm_head (SpinLlamaForCausalLM only)
-        if gptq_conf.quantize_rotate_lm_head and self._is_spinllama_model(model):
-            self._quantize_rotate_lm_head(model, quantizers, module_name)
-
+        self._calibrate_norm_lm_head_ptq(model)
+        
+        if ptq_wrapped:
+            model.freeze_qparams()
+        
         # Restore the original cache configuration.
+        config = self._get_config(model)
         if self.orig_use_cache is not None:
-            model.config.use_cache = self.orig_use_cache
+            config.use_cache = self.orig_use_cache
 
         # Clear caches to free memory
         self.cache_args.clear()
         self.cache_kwargs.clear()
         self.num_batches = 0
 
-        model.quantizers = quantizers
+       # model.quantizers = quantizers
 
         return model
 
@@ -439,9 +872,17 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         This method consumes cached decoder outputs, applies the final model
         normalization, collects GPTQ statistics for `lm_head`, and then
         quantizes the output head weights.
+
+        When the model is PTQ-wrapped, the inner ``nn.Linear`` is used for
+        GPTQ hooks and the outer PTQ wrapper is used for the forward pass
+        (so activation observers collect data).  After GPTQ quantization,
+        qparams are injected into PTQ weight observers and ``freeze_qparams()``
+        is called.
         """
         gptq_conf = self.config
         assert isinstance(gptq_conf, LlamaGPTQConfig)
+
+        ptq_wrapped = self._is_ptq_wrapped(model)
 
         # prepare data for lm_head
         batch_num = self.num_batches
@@ -456,7 +897,11 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
             hidden_states = move_to_device(hidden_states, device)
             if self.orig_model is None:
-                hidden_states = model.model.norm(hidden_states)
+                # PTQ-wrapped model has .model.wrapped.norm; raw has .model.norm
+                model_norm = model.model
+                if ptq_wrapped:
+                    model_norm = model_norm.wrapped
+                hidden_states = model_norm.norm(hidden_states)
             else:
                 norm = self.orig_model.model.norm.to(device)
                 hidden_states = norm(hidden_states)
@@ -464,8 +909,15 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             if len(self.cache_args) > 0:
                 self.cache_args[0][batch_idx] = move_to_cpu(hidden_states)
 
-        layer = model.lm_head
-        gptq = GPTQ(layer)
+        # For PTQ-wrapped models, lm_head is a PTQWrapper → need inner nn.Linear
+        lm_head_module = model.lm_head
+        if ptq_wrapped:
+            # model.lm_head is PTQWrapper → .wrapped is QuantLinear → .module is nn.Linear
+            lm_head_inner = lm_head_module.wrapped.module
+        else:
+            lm_head_inner = lm_head_module
+
+        gptq = GPTQ(lm_head_inner)
         full_module_name = "lm_head"
         weight_bits = self._resolve_weight_bits(
             gptq_conf,
@@ -495,10 +947,10 @@ class LlamaGPTQQuantizer(BaseQuantizer):
 
             return _hook
 
-        handles = [layer.register_forward_hook(add_batch())]
+        handles = [lm_head_inner.register_forward_hook(add_batch())]
 
         # Run layer forward over all cached batches to build Hessian/statistics
-        device = next(layer.parameters()).device  # in case lm_head is located on cpu
+        device = next(lm_head_inner.parameters()).device  # in case lm_head is located on cpu
         for batch_idx in tqdm(
             range(batch_num),
             desc=f"[lm_head] collecting",
@@ -509,7 +961,9 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
             hidden_states = move_to_device(hidden_states, device)
 
-            layer(hidden_states)
+            # Forward through the PTQ-wrapped lm_head (activates observers)
+            # or the raw lm_head.
+            lm_head_module(hidden_states)
 
         # Remove handles
         for h in handles:
@@ -527,6 +981,14 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         )
         quantizers[f"lm_head"] = gptq.quantizer
         gptq.free()
+
+        # PTQ-wrapped: inject GPTQ qparams and freeze lm_head observers
+        if ptq_wrapped:
+            self._inject_gptq_qparams_into_layer(
+                lm_head_module,
+                quantizers,
+                verbose=gptq_conf.verbose,
+            )
 
     def _quantize_rotate_lm_head(
         self,
@@ -562,8 +1024,16 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             if len(self.cache_args) > 0:
                 self.cache_args[0][batch_idx] = move_to_cpu(hidden_states)
 
-        layer = model.rotate_lm_head
-        gptq = GPTQ(layer)
+        ptq_wrapped = self._is_ptq_wrapped(model)
+
+        # For PTQ-wrapped models, rotate_lm_head is a PTQWrapper → need inner nn.Linear
+        rotate_lm_head_module = model.rotate_lm_head
+        if ptq_wrapped:
+            rotate_lm_head_inner = rotate_lm_head_module.wrapped.module
+        else:
+            rotate_lm_head_inner = rotate_lm_head_module
+
+        gptq = GPTQ(rotate_lm_head_inner)
         full_module_name = "rotate_lm_head"
         weight_bits = self._resolve_weight_bits(
             gptq_conf,
@@ -593,10 +1063,10 @@ class LlamaGPTQQuantizer(BaseQuantizer):
 
             return _hook
 
-        handles = [layer.register_forward_hook(add_batch())]
+        handles = [rotate_lm_head_inner.register_forward_hook(add_batch())]
 
         # Run layer forward over all cached batches to build Hessian/statistics
-        device = next(layer.parameters()).device
+        device = next(rotate_lm_head_inner.parameters()).device
         for batch_idx in tqdm(
             range(batch_num),
             desc=f"[rotate_lm_head] collecting",
@@ -607,7 +1077,9 @@ class LlamaGPTQQuantizer(BaseQuantizer):
             hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
             hidden_states = move_to_device(hidden_states, device)
 
-            layer(hidden_states)
+            # Forward through the PTQ-wrapped rotate_lm_head (activates observers)
+            # or the raw rotate_lm_head.
+            rotate_lm_head_module(hidden_states)
 
         # Remove handles
         for h in handles:
@@ -625,3 +1097,11 @@ class LlamaGPTQQuantizer(BaseQuantizer):
         )
         quantizers[f"rotate_lm_head"] = gptq.quantizer
         gptq.free()
+
+        # PTQ-wrapped: inject GPTQ qparams and freeze rotate_lm_head observers
+        if ptq_wrapped:
+            self._inject_gptq_qparams_into_layer(
+                rotate_lm_head_module,
+                quantizers,
+                verbose=gptq_conf.verbose,
+            )

--- a/tico/quantization/algorithm/gptq/llama_quantizer.py
+++ b/tico/quantization/algorithm/gptq/llama_quantizer.py
@@ -263,7 +263,22 @@ class LlamaGPTQQuantizer(BaseQuantizer):
                     torch.nn.ConvTranspose2d,
                 ],
             )
-            sequential = [list(full.keys())]
+
+            # Define groups for quantizing by internal structure (standard Llama modules)
+            all_names = [
+                ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+                ["self_attn.o_proj"],
+                ["mlp.gate_proj", "mlp.up_proj"],
+                ["mlp.down_proj"],
+            ]
+
+            # Filter to only existing modules and group them
+            existing_names = set(full.keys())
+            sequential = []
+            for names in all_names:
+                cur_seq = [name for name in names if name in existing_names]
+                if cur_seq:
+                    sequential.append(cur_seq)
 
             # 2) Set up GPTQ objects and gather stats
             for names in sequential:

--- a/tico/quantization/algorithm/gptq/llama_quantizer.py
+++ b/tico/quantization/algorithm/gptq/llama_quantizer.py
@@ -1,0 +1,612 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import types
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+from tqdm.auto import tqdm
+
+from tico.quantization.algorithm.gptq.gptq import GPTQ
+from tico.quantization.algorithm.gptq.utils import (
+    find_layers,
+    gather_single_batch_from_dict,
+    gather_single_batch_from_list,
+)
+from tico.quantization.config.llama_gptq import LlamaGPTQConfig
+from tico.quantization.quantizer import BaseQuantizer
+from tico.quantization.quantizer_registry import register_quantizer
+from tico.utils.utils import move_to_device
+
+
+def move_to_cpu(obj):
+    return move_to_device(obj, "cpu")
+
+
+class StopForward(Exception):
+    """Custom exception used to stop the forward pass after the first layer."""
+
+    pass
+
+
+@register_quantizer(LlamaGPTQConfig)
+class LlamaGPTQQuantizer(BaseQuantizer):
+    """
+    Llama-specific quantizer for applying the GPTQ algorithm (typically for weight quantization).
+
+    This quantizer is designed specifically for Llama-family models, including:
+        - LlamaForCausalLM (standard Hugging Face Llama models)
+        - SpinLlamaForCausalLM (Llama models with SpinQuant rotation layers)
+
+    This implementation expects:
+        1) prepare(model, ...) to only attach hooks/Catchers and NOT run the model internally.
+        2) The user runs the model with arbitrary number of batches to collect calibration data.
+        3) convert(model) to consume the collected data and apply GPTQ.
+
+    Unlike the generic GPTQQuantizer, this implementation:
+        - Properly handles Llama-specific architecture (model.layers, lm_head)
+        - Supports SpinLlamaForCausalLM with rotate_lm_head layer
+        - Provides Llama-specific configuration options
+    """
+
+    def __init__(self, config: LlamaGPTQConfig):
+        super().__init__(config)
+
+        # cache_args[i] -> list of the i-th positional argument for each batch
+        self.cache_args: List[List[Any]] = []
+        # cache_kwargs[k] -> list of the value for keyword k for each batch
+        self.cache_kwargs: Dict[str, List[Any]] = {}
+        self.num_batches: int = 0
+
+        # References to original forwards for restoration
+        self._orig_model_forward: Optional[Callable[..., Any]] = None
+        self._orig_layer_forward: Optional[Callable[..., Any]] = None
+        self._first_layer_ref: Optional[torch.nn.Module] = None
+
+        # Reference to original model for use_orig_model_inference
+        self.orig_model: Optional[torch.nn.Module] = None
+
+    def _resolve_weight_bits(
+        self,
+        gptq_conf: LlamaGPTQConfig,
+        *,
+        full_module_name: str,
+        local_module_name: str,
+    ) -> int:
+        """Resolve the effective bit-width for a quantized submodule."""
+        if full_module_name in gptq_conf.weight_bits_overrides:
+            return gptq_conf.weight_bits_overrides[full_module_name]
+
+        if local_module_name in gptq_conf.weight_bits_overrides:
+            return gptq_conf.weight_bits_overrides[local_module_name]
+
+        suffix_matches = [
+            bits
+            for pattern, bits in gptq_conf.weight_bits_overrides.items()
+            if full_module_name.endswith(f".{pattern}")
+        ]
+
+        if suffix_matches:
+            return suffix_matches[-1]
+
+        return gptq_conf.weight_bits
+
+    def _is_spinllama_model(self, model: torch.nn.Module) -> bool:
+        """Check if the model is a SpinLlamaForCausalLM (has rotate_lm_head)."""
+        return hasattr(model, "rotate_lm_head") and model.rotate_lm_head is not None
+
+    def _get_decoder_layers(self, model: torch.nn.Module):
+        """Get the decoder layers from a Llama model."""
+        return model.model.layers
+
+    def _get_orig_decoder_layers(self, model: torch.nn.Module):
+        """Get the decoder layers from the original model copy."""
+        if self.orig_model is not None:
+            return self.orig_model.model.layers
+        return None
+
+    @torch.no_grad()
+    def prepare(
+        self,
+        model: torch.nn.Module,
+        args: Optional[Any] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Overrides the forward method of the first Llama layer (layer 0) to capture the
+        input required for calibration.
+
+        When the user calls `model(...)`, we intercept (and store) the inputs to that
+        layer, then raise an exception to stop the forward pass immediately. These
+        captured inputs are then utilized to calibrate the quantization parameters
+        for the GPTQ.
+
+        Parameters:
+            model (torch.nn.Module): The target PyTorch model
+            args (Any, optional): Unused (kept for API compatibility)
+            kwargs (Dict[str, Any], optional): Unused (kept for API compatibility)
+
+        Returns:
+            torch.nn.Module: The model with the catcher attached
+        """
+        # Define the catcher to store inputs/kwargs and stop the execution
+        def forward(layer, *args, **kwargs):
+            """
+            Stores this batch's inputs and kwargs, then raises StopForward to stop computation.
+            """
+            # Store positional args
+            for idx, item in enumerate(args):
+                if (idx + 1) > len(self.cache_args):
+                    self.cache_args.append([])
+                self.cache_args[idx].append(move_to_cpu(item))
+            # Store keyword args
+            for k, v in kwargs.items():
+                if self.cache_kwargs.get(k, None) is None:
+                    self.cache_kwargs[k] = []
+                self.cache_kwargs[k].append(move_to_cpu(v))
+
+            self.num_batches += 1
+            raise StopForward  # stop after the first layer
+
+        gptq_conf = self.config
+        assert isinstance(gptq_conf, LlamaGPTQConfig)
+        if gptq_conf.use_orig_model_inference is True:
+            device = next(model.parameters()).device
+            model = model.cpu()
+            self.orig_model = copy.deepcopy(model)
+            model = model.to(device)
+        else:
+            self.orig_model = None
+        # Replace the first layer with defined function to capture calibration data.
+        self._first_layer_ref = model.model.layers[0]
+
+        assert hasattr(self._first_layer_ref, "forward")
+        # Backup the original forward of the first layer
+        assert isinstance(self._first_layer_ref, torch.nn.Module)
+        self._orig_layer_forward = self._first_layer_ref.forward
+        self._first_layer_ref.forward = types.MethodType(forward, self._first_layer_ref)
+
+        def model_forward_wrapper(_model, *m_args, **m_kwargs):
+            """
+            Wrapper to ignore StopForward exceptions so the user's training loop doesn't crash.
+            """
+            try:
+                assert self._orig_model_forward is not None
+                return self._orig_model_forward(*m_args, **m_kwargs)
+            except StopForward:
+                # We stopped after the first layer; return None or dummy output if needed.
+                return None
+
+        # Backup model.forward so we can suppress StopForward
+        self._orig_model_forward = model.forward
+        model.forward = types.MethodType(model_forward_wrapper, model)
+
+        # Disable use_cache during calibration
+        if hasattr(model, "config") and hasattr(model.config, "use_cache"):
+            self.orig_use_cache = model.config.use_cache
+            model.config.use_cache = False
+        else:
+            self.orig_use_cache = None
+
+        return model
+
+    @torch.no_grad()
+    def convert(self, model):
+        """
+        Perform GPTQ quantization using cached first-layer inputs.
+
+        Steps:
+          1) Restore original forwards (no more catching).
+          2) Iterate through each Transformer layer sequentially:
+             a) For each layer, register forward hooks to collect (inp, out) stats for GPTQ.
+             b) Run the layer on cached inputs for all batches.
+             c) Apply GPTQ and update the weights.
+             d) Re-run the layer to produce outputs for the next layer; update cached inputs.
+          3) Optionally apply GPTQ to lm_head and rotate_lm_head when configured.
+          4) Restore model.config.use_cache if needed and clear internal caches.
+
+        Parameters:
+            model (torch.nn.Module): The prepared model.
+
+        Returns:
+            torch.nn.Module: Quantized model.
+        """
+        # Restore original forwards (we no longer want to stop after first layer)
+        assert self._orig_model_forward is not None
+        model.forward = self._orig_model_forward
+        assert (
+            self._first_layer_ref is not None and self._orig_layer_forward is not None
+        )
+        self._first_layer_ref.forward = self._orig_layer_forward
+
+        gptq_conf = self.config
+        assert isinstance(gptq_conf, LlamaGPTQConfig)
+        gptq_conf.validate()
+
+        # Identify layers
+        target_layers = self._get_decoder_layers(model)
+        orig_layers = self._get_orig_decoder_layers(model)
+
+        module_name = {}
+        for name, module in model.named_modules():
+            module_name[module] = name
+
+        quantizers: Dict[str, Any] = {}
+        for l_idx, layer in enumerate(
+            tqdm(
+                target_layers,
+                desc="Quantizing layers",
+                unit="layer",
+                disable=not gptq_conf.show_progress,
+            )
+        ):
+            # 1) Identify quantizable submodules within the layer
+            full = find_layers(
+                layer,
+                layers=[
+                    torch.nn.Linear,
+                    torch.nn.Conv2d,
+                    torch.nn.Conv1d,
+                    torch.nn.Conv3d,
+                    torch.nn.ConvTranspose2d,
+                ],
+            )
+            sequential = [list(full.keys())]
+
+            # 2) Set up GPTQ objects and gather stats
+            for names in sequential:
+                subset = {n: full[n] for n in names}
+
+                gptq: Dict[str, GPTQ] = {}
+                for name in subset:
+                    gptq[name] = GPTQ(subset[name])
+                    full_module_name = module_name[subset[name]]
+                    weight_bits = self._resolve_weight_bits(
+                        gptq_conf,
+                        full_module_name=full_module_name,
+                        local_module_name=name,
+                    )
+                    if (
+                        gptq_conf.sensitivity is not None
+                        and isinstance(gptq_conf.sensitivity, dict)
+                        and full_module_name in gptq_conf.sensitivity
+                    ):
+                        cur_sensitivity = gptq_conf.sensitivity[full_module_name]
+                    else:
+                        cur_sensitivity = None
+                    gptq[name].quantizer.configure(
+                        bits=weight_bits,
+                        perchannel=gptq_conf.perchannel,
+                        sym=gptq_conf.symmetric,
+                        mse=gptq_conf.mse,
+                        sensitivity=cur_sensitivity,
+                    )
+
+                # Hook to collect (inp, out) for GPTQ
+                def add_batch(name):
+                    def _hook(_, inp, out):
+                        gptq[name].add_batch(inp[0].data, out.data)
+
+                    return _hook
+
+                handles = []
+                for name in subset:
+                    handles.append(subset[name].register_forward_hook(add_batch(name)))
+
+                # Run layer forward over all cached batches to build Hessian/statistics
+                batch_num = self.num_batches
+                device = next(model.parameters()).device
+                for batch_idx in tqdm(
+                    range(batch_num),
+                    desc=f"[L{l_idx}] collecting",
+                    leave=False,
+                    unit="batch",
+                    disable=not gptq_conf.show_progress,
+                ):
+                    cache_args_batch = gather_single_batch_from_list(
+                        self.cache_args, batch_idx
+                    )
+                    cache_args_batch = move_to_device(cache_args_batch, device)
+
+                    cache_kwargs_batch = gather_single_batch_from_dict(
+                        self.cache_kwargs, batch_idx
+                    )
+                    cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+
+                    layer(*cache_args_batch, **cache_kwargs_batch)
+
+                # Remove handles
+                for h in handles:
+                    h.remove()
+
+                # 3) Quantize each submodule
+                for name in subset:
+                    full_module_name = module_name[subset[name]]
+
+                    if gptq_conf.verbose:
+                        print(f"[Layer {l_idx}] {name} -> Quantizing ...")
+
+                    gptq[name].fasterquant(
+                        percdamp=gptq_conf.percdamp,
+                        groupsize=gptq_conf.groupsize,
+                        actorder=gptq_conf.actorder,
+                        static_groups=gptq_conf.static_groups,
+                        verbose=gptq_conf.verbose,
+                    )
+                    quantizers[full_module_name] = gptq[name].quantizer
+                    gptq[name].free()
+
+            # 4) After quantization, re-run the layer to produce outputs for the next layer
+            device = next(model.parameters()).device
+            for batch_idx in tqdm(
+                range(batch_num),
+                desc=f"[L{l_idx}] re-forward",
+                leave=False,
+                unit="batch",
+                disable=not gptq_conf.show_progress,
+            ):
+                cache_args_batch = gather_single_batch_from_list(
+                    self.cache_args, batch_idx
+                )
+                cache_args_batch = move_to_device(cache_args_batch, device)
+
+                cache_kwargs_batch = gather_single_batch_from_dict(
+                    self.cache_kwargs, batch_idx
+                )
+                cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+
+                if orig_layers is None:
+                    outs = layer(*cache_args_batch, **cache_kwargs_batch)
+                else:
+                    orig_layer = orig_layers[l_idx].to(device)
+                    outs = orig_layer(*cache_args_batch, **cache_kwargs_batch)
+                    orig_layer.cpu()
+                # LLaMA's decoder layer return type differs across Transformers versions:
+                # some return a tuple (hidden_states, ...), others return just a tensor.
+                # This line ensures we always take the first element when it's a tuple.
+                outs = outs[0] if isinstance(outs, tuple) else outs
+                # Update inputs for next iteration.
+                if len(self.cache_args) > 0:
+                    if hasattr(outs, "to") and hasattr(
+                        self.cache_args[0][batch_idx], "device"
+                    ):
+                        self.cache_args[0][batch_idx] = outs.to(
+                            self.cache_args[0][batch_idx].device
+                        )
+                    else:
+                        self.cache_args[0][batch_idx] = outs
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        # Optionally quantize lm_head
+        if gptq_conf.quantize_lm_head and hasattr(model, "lm_head"):
+            self._quantize_lm_head(model, quantizers, module_name)
+
+        # Optionally quantize rotate_lm_head (SpinLlamaForCausalLM only)
+        if gptq_conf.quantize_rotate_lm_head and self._is_spinllama_model(model):
+            self._quantize_rotate_lm_head(model, quantizers, module_name)
+
+        # Restore the original cache configuration.
+        if self.orig_use_cache is not None:
+            model.config.use_cache = self.orig_use_cache
+
+        # Clear caches to free memory
+        self.cache_args.clear()
+        self.cache_kwargs.clear()
+        self.num_batches = 0
+
+        model.quantizers = quantizers
+
+        return model
+
+    def _quantize_lm_head(
+        self,
+        model: torch.nn.Module,
+        quantizers: Dict[str, Any],
+        module_name: Dict[torch.nn.Module, str],
+    ):
+        """
+        Apply GPTQ to the language-model output head.
+
+        This method consumes cached decoder outputs, applies the final model
+        normalization, collects GPTQ statistics for `lm_head`, and then
+        quantizes the output head weights.
+        """
+        gptq_conf = self.config
+        assert isinstance(gptq_conf, LlamaGPTQConfig)
+
+        # prepare data for lm_head
+        batch_num = self.num_batches
+        device = next(model.parameters()).device
+        for batch_idx in tqdm(
+            range(batch_num),
+            desc=f"[model.norm] re-forward",
+            leave=False,
+            unit="batch",
+            disable=not gptq_conf.show_progress,
+        ):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+            if self.orig_model is None:
+                hidden_states = model.model.norm(hidden_states)
+            else:
+                norm = self.orig_model.model.norm.to(device)
+                hidden_states = norm(hidden_states)
+                norm = norm.cpu()
+            if len(self.cache_args) > 0:
+                self.cache_args[0][batch_idx] = move_to_cpu(hidden_states)
+
+        layer = model.lm_head
+        gptq = GPTQ(layer)
+        full_module_name = "lm_head"
+        weight_bits = self._resolve_weight_bits(
+            gptq_conf,
+            full_module_name=full_module_name,
+            local_module_name="lm_head",
+        )
+        if (
+            gptq_conf.sensitivity is not None
+            and isinstance(gptq_conf.sensitivity, dict)
+            and full_module_name in gptq_conf.sensitivity
+        ):
+            cur_sensitivity = gptq_conf.sensitivity[full_module_name]
+        else:
+            cur_sensitivity = None
+        gptq.quantizer.configure(
+            bits=weight_bits,
+            perchannel=gptq_conf.perchannel,
+            sym=gptq_conf.symmetric,
+            mse=gptq_conf.mse,
+            sensitivity=cur_sensitivity,
+        )
+
+        # Hook to collect (inp, out) for GPTQ
+        def add_batch():
+            def _hook(_, inp, out):
+                gptq.add_batch(inp[0].data, out.data)
+
+            return _hook
+
+        handles = [layer.register_forward_hook(add_batch())]
+
+        # Run layer forward over all cached batches to build Hessian/statistics
+        device = next(layer.parameters()).device  # in case lm_head is located on cpu
+        for batch_idx in tqdm(
+            range(batch_num),
+            desc=f"[lm_head] collecting",
+            leave=False,
+            unit="batch",
+            disable=not gptq_conf.show_progress,
+        ):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+
+            layer(hidden_states)
+
+        # Remove handles
+        for h in handles:
+            h.remove()
+
+        # Quantize
+        if gptq_conf.verbose:
+            print(f"[lm_head] -> Quantizing ...")
+        gptq.fasterquant(
+            percdamp=gptq_conf.percdamp,
+            groupsize=gptq_conf.groupsize,
+            actorder=gptq_conf.actorder,
+            static_groups=gptq_conf.static_groups,
+            verbose=gptq_conf.verbose,
+        )
+        quantizers[f"lm_head"] = gptq.quantizer
+        gptq.free()
+
+    def _quantize_rotate_lm_head(
+        self,
+        model: torch.nn.Module,
+        quantizers: Dict[str, Any],
+        module_name: Dict[torch.nn.Module, str],
+    ):
+        """
+        Apply GPTQ to the rotate_lm_head rotation layer (SpinLlamaForCausalLM only).
+
+        This method quantizes the rotate_lm_head layer weights using GPTQ.
+        It should only be called when `LlamaGPTQConfig.quantize_rotate_lm_head` is enabled
+        and the model has a rotate_lm_head attribute (i.e., is a SpinLlamaForCausalLM).
+        """
+        gptq_conf = self.config
+        assert isinstance(gptq_conf, LlamaGPTQConfig)
+
+        if not self._is_spinllama_model(model):
+            return
+
+        # prepare data for rotate_lm_head
+        batch_num = self.num_batches
+        device = next(model.parameters()).device
+        for batch_idx in tqdm(
+            range(batch_num),
+            desc=f"[rotate_lm_head] re-forward",
+            leave=False,
+            unit="batch",
+            disable=not gptq_conf.show_progress,
+        ):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+            if len(self.cache_args) > 0:
+                self.cache_args[0][batch_idx] = move_to_cpu(hidden_states)
+
+        layer = model.rotate_lm_head
+        gptq = GPTQ(layer)
+        full_module_name = "rotate_lm_head"
+        weight_bits = self._resolve_weight_bits(
+            gptq_conf,
+            full_module_name=full_module_name,
+            local_module_name="rotate_lm_head",
+        )
+        if (
+            gptq_conf.sensitivity is not None
+            and isinstance(gptq_conf.sensitivity, dict)
+            and full_module_name in gptq_conf.sensitivity
+        ):
+            cur_sensitivity = gptq_conf.sensitivity[full_module_name]
+        else:
+            cur_sensitivity = None
+        gptq.quantizer.configure(
+            bits=weight_bits,
+            perchannel=gptq_conf.perchannel,
+            sym=gptq_conf.symmetric,
+            mse=gptq_conf.mse,
+            sensitivity=cur_sensitivity,
+        )
+
+        # Hook to collect (inp, out) for GPTQ
+        def add_batch():
+            def _hook(_, inp, out):
+                gptq.add_batch(inp[0].data, out.data)
+
+            return _hook
+
+        handles = [layer.register_forward_hook(add_batch())]
+
+        # Run layer forward over all cached batches to build Hessian/statistics
+        device = next(layer.parameters()).device
+        for batch_idx in tqdm(
+            range(batch_num),
+            desc=f"[rotate_lm_head] collecting",
+            leave=False,
+            unit="batch",
+            disable=not gptq_conf.show_progress,
+        ):
+            hidden_states = gather_single_batch_from_list(self.cache_args, batch_idx)[0]
+            hidden_states = move_to_device(hidden_states, device)
+
+            layer(hidden_states)
+
+        # Remove handles
+        for h in handles:
+            h.remove()
+
+        # Quantize
+        if gptq_conf.verbose:
+            print(f"[rotate_lm_head] -> Quantizing ...")
+        gptq.fasterquant(
+            percdamp=gptq_conf.percdamp,
+            groupsize=gptq_conf.groupsize,
+            actorder=gptq_conf.actorder,
+            static_groups=gptq_conf.static_groups,
+            verbose=gptq_conf.verbose,
+        )
+        quantizers[f"rotate_lm_head"] = gptq.quantizer
+        gptq.free()

--- a/tico/quantization/algorithm/gptq/quant.py
+++ b/tico/quantization/algorithm/gptq/quant.py
@@ -259,7 +259,7 @@ class Quantizer(nn.Module):
 
         self._grid_search(x, xmin, xmax, compute_error)
 
-    def update(self, x, Hinv, perm):
+    def update(self, x, Hinv, perm, P=None):
         if self.mse is None or (
             self.mse != "smse_for_gptq" and self.mse != "mse_for_gptq"
         ):
@@ -276,14 +276,14 @@ class Quantizer(nn.Module):
             if perm is not None:
                 sensitivity = sensitivity[:, perm.to(x.device)]
 
-        self._optimize_gptq_adjusted(x, Hinv, sensitivity, xmin, xmax)
+        self._optimize_gptq_adjusted(x, Hinv, sensitivity, xmin, xmax, P=P)
 
         self._reshape_scale_zero(shape, weight=True)
 
         del sensitivity
         sensitivity = None
 
-    def _optimize_gptq_adjusted(self, x, Hinv, sensitivity, xmin, xmax):
+    def _optimize_gptq_adjusted(self, x, Hinv, sensitivity, xmin, xmax, P=None):
         """Optimize scale and zero using GPTQ-aware MSE/SMSE grid search.
 
         Args:
@@ -292,6 +292,7 @@ class Quantizer(nn.Module):
             sensitivity: Sensitivity tensor for weighted MSE
             xmin: Minimum values per channel
             xmax: Maximum values per channel
+            P: GPTQv2 P correction matrix (optional)
         """
         num_of_iters = 15
 
@@ -303,6 +304,7 @@ class Quantizer(nn.Module):
                 x,
                 Hinv,
                 max_num_of_iters=num_of_iters,
+                P=P,
             )
             if sensitivity is not None:
                 assert self.mse == "smse_for_gptq"

--- a/tico/quantization/algorithm/gptq/quantizer.py
+++ b/tico/quantization/algorithm/gptq/quantizer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import copy
+import functools
 import types
 from typing import Any, Callable, Dict, List, Optional
 
@@ -30,6 +31,41 @@ from tico.quantization.config.gptq import GPTQConfig
 from tico.quantization.quantizer import BaseQuantizer
 from tico.quantization.quantizer_registry import register_quantizer
 from tico.utils.utils import move_to_device
+
+
+class FPInputsCache:
+    """
+    Class for saving full-precision output in each layer (GPTQv2).
+    """
+
+    def __init__(self, sequential):
+        self.fp_cache = {}
+        self.names = tuple(name for names in sequential for name in names)
+        for name in self.names:
+            self.fp_cache[name] = []
+        self.handles = []
+
+    def cache_fp_input(self, m, inp, out, name):
+        inp = inp[0].detach()
+        self.fp_cache[name] += [inp.cpu()]
+
+    def add_hook(self, full):
+        for name in self.names:
+            self.handles.append(
+                full[name].register_forward_hook(
+                    functools.partial(self.cache_fp_input, name=name)
+                )
+            )
+
+    def clear_hook(self):
+        for h in self.handles:
+            h.remove()
+        self.handles = []
+        torch.cuda.empty_cache()
+
+    def clear_cache(self):
+        for name in self.names:
+            self.fp_cache[name] = []
 
 
 def move_to_cpu(obj):
@@ -65,6 +101,9 @@ class GPTQQuantizer(BaseQuantizer):
         self._orig_model_forward: Optional[Callable[..., Any]] = None
         self._orig_layer_forward: Optional[Callable[..., Any]] = None
         self._first_layer_ref: Optional[torch.nn.Module] = None
+
+        # Reference to original model for use_orig_model_inference and GPTQv2
+        self.orig_model: Optional[torch.nn.Module] = None
 
     def _resolve_weight_bits(
         self,
@@ -136,7 +175,7 @@ class GPTQQuantizer(BaseQuantizer):
 
         gptq_conf = self.config
         assert isinstance(gptq_conf, GPTQConfig)
-        if gptq_conf.use_orig_model_inference is True:
+        if gptq_conf.use_orig_model_inference is True or gptq_conf.gptq_v2:
             device = next(model.parameters()).device
             model = model.cpu()
             self.orig_model = copy.deepcopy(model)
@@ -237,6 +276,13 @@ class GPTQQuantizer(BaseQuantizer):
             module_name[module] = name
 
         quantizers: Dict[str, Any] = {}
+        
+        # GPTQv2: Collect FP inputs from original model before quantization
+        need_float_inference = gptq_conf.gptq_v2
+        fp_inps = None
+        if need_float_inference and orig_layers is not None:
+            fp_inps = copy.deepcopy(self.cache_args)
+        
         for l_idx, layer in enumerate(
             tqdm(
                 target_layers,
@@ -257,6 +303,37 @@ class GPTQQuantizer(BaseQuantizer):
                 ],
             )
             sequential = [list(full.keys())]
+
+            # GPTQv2: Set up FPInputsCache for collecting FP inputs per submodule
+            fp_inputs_cache = None
+            if need_float_inference and orig_layers is not None:
+                fp_inputs_cache = FPInputsCache(sequential)
+                orig_full = find_layers(
+                    orig_layers[l_idx],
+                    layers=[
+                        torch.nn.Linear,
+                        torch.nn.Conv2d,
+                        torch.nn.Conv1d,
+                        torch.nn.Conv3d,
+                        torch.nn.ConvTranspose2d,
+                    ],
+                )
+                fp_inputs_cache.add_hook(orig_full)
+                device = next(model.parameters()).device
+                batch_num = self.num_batches
+                for batch_idx in range(batch_num):
+                    cache_args_batch = gather_single_batch_from_list(fp_inps, batch_idx)
+                    cache_args_batch = move_to_device(cache_args_batch, device)
+                    cache_kwargs_batch = gather_single_batch_from_dict(
+                        self.cache_kwargs, batch_idx
+                    )
+                    cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
+                    
+                    orig_layer = orig_layers[l_idx].to(device)
+                    orig_layer(*cache_args_batch, **cache_kwargs_batch)
+                    orig_layer.cpu()
+                    
+                fp_inputs_cache.clear_hook()
 
             # 2) Set up GPTQ objects and gather stats
             for names in sequential:
@@ -286,6 +363,10 @@ class GPTQQuantizer(BaseQuantizer):
                         mse=gptq_conf.mse,
                         sensitivity=cur_sensitivity,
                     )
+
+                    # GPTQv2: Assign native_inp from FPInputsCache
+                    if fp_inputs_cache is not None and name in fp_inputs_cache.fp_cache:
+                        gptq[name].native_inp = fp_inputs_cache.fp_cache[name]
 
                 # Hook to collect (inp, out) for GPTQ
                 def add_batch(name):
@@ -343,6 +424,7 @@ class GPTQQuantizer(BaseQuantizer):
 
             # 4) After quantization, re-run the layer to produce outputs for the next layer
             device = next(model.parameters()).device
+            batch_num = self.num_batches
             for batch_idx in tqdm(
                 range(batch_num),
                 desc=f"[L{l_idx}] re-forward",
@@ -360,7 +442,25 @@ class GPTQQuantizer(BaseQuantizer):
                 )
                 cache_kwargs_batch = move_to_device(cache_kwargs_batch, device)
 
-                if orig_layers is None:
+                if fp_inps is not None:
+                    fp_cache_args_batch = gather_single_batch_from_list(fp_inps, batch_idx)
+                    fp_cache_args_batch = move_to_device(fp_cache_args_batch, device)
+                    orig_layer = orig_layers[l_idx].to(device)
+                    fp_outs = orig_layer(*fp_cache_args_batch, **cache_kwargs_batch)
+                    orig_layer.cpu()
+                    fp_outs = fp_outs[0] if isinstance(fp_outs, tuple) else fp_outs
+                    # Update inputs for next iteration.
+                    if len(fp_inps) > 0:
+                        if hasattr(fp_outs, "to") and hasattr(
+                            fp_inps[0][batch_idx], "device"
+                        ):
+                            fp_inps[0][batch_idx] = fp_outs.to(
+                                fp_inps[0][batch_idx].device
+                            )
+                        else:
+                            fp_inps[0][batch_idx] = fp_outs
+                
+                if orig_layers is None or gptq_conf.gptq_v2 is True:
                     outs = layer(*cache_args_batch, **cache_kwargs_batch)
                 else:
                     orig_layer = orig_layers[l_idx].to(device)

--- a/tico/quantization/algorithm/gptq/utils.py
+++ b/tico/quantization/algorithm/gptq/utils.py
@@ -30,6 +30,44 @@ def find_layers(module, layers=[torch.nn.Linear], name=""):
     return res
 
 
+def find_layers_deep(module, layers=None, name=""):
+    """Like :func:`find_layers` but also recurses into ``QuantModuleBase``
+    wrappers (e.g. ``QuantLinear``) to discover the *inner* ``nn.Linear``
+    that holds the actual weight tensor.
+
+    This is needed when GPTQ runs on a PTQ-prepared model where every
+    ``nn.Linear`` has been wrapped inside a ``QuantLinear(module=nn.Linear)``.
+
+    Returns a dict mapping *local* name → ``nn.Module`` (the raw layer,
+    e.g. the ``nn.Linear`` inside ``QuantLinear.module``).
+    """
+    if layers is None:
+        layers = [torch.nn.Linear]
+
+    # Direct match on the module itself
+    if type(module) in layers:
+        return {name: module}
+
+    # Unwrap QuantModuleBase wrappers that store the original layer
+    # in a ``.module`` attribute (e.g. QuantLinear.module is nn.Linear).
+    if hasattr(module, "module") and isinstance(getattr(module, "module"), torch.nn.Module):
+        inner = module.module
+        if type(inner) in layers:
+            # Use the same name so GPTQ hooks the inner module directly.
+            return {name: inner}
+
+    res = {}
+    for name1, child in module.named_children():
+        res.update(
+            find_layers_deep(
+                child,
+                layers=layers,
+                name=name + "." + name1 if name != "" else name1,
+            )
+        )
+    return res
+
+
 def gather_single_batch_from_dict(data_dict, idx):
     """
     Gather single batch from a dict.

--- a/tico/quantization/config/gptq.py
+++ b/tico/quantization/config/gptq.py
@@ -69,6 +69,9 @@ class GPTQConfig(BaseConfig):
     # use this option to stabilize GPTQ for deep models
     use_orig_model_inference: bool = False
 
+    # GPTQv2 flag - uses FP inference for collecting inputs during quantization
+    gptq_v2: bool = False
+
     @property
     def name(self) -> str:
         return "gptq"
@@ -77,6 +80,10 @@ class GPTQConfig(BaseConfig):
         if not isinstance(self.quantize_lm_head, bool):
             raise TypeError(
                 f"quantize_lm_head must be bool. got {type(self.quantize_lm_head)}"
+            )
+        if not isinstance(self.gptq_v2, bool):
+            raise TypeError(
+                f"gptq_v2 must be bool. got {type(self.gptq_v2)}"
             )
         if self.weight_bits <= 0:
             raise ValueError(f"weight_bits must be positive. got {self.weight_bits}")

--- a/tico/quantization/config/llama_gptq.py
+++ b/tico/quantization/config/llama_gptq.py
@@ -78,6 +78,9 @@ class LlamaGPTQConfig(BaseConfig):
     # use this option to stabilize GPTQ for deep models
     use_orig_model_inference: bool = False
 
+    # GPTQv2 flag - uses FP inference for collecting inputs during quantization
+    gptq_v2: bool = False
+
     @property
     def name(self) -> str:
         return "llama_gptq"

--- a/tico/quantization/config/llama_gptq.py
+++ b/tico/quantization/config/llama_gptq.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+import torch
+
+from tico.quantization.config.base import BaseConfig
+
+
+@dataclass
+class LlamaGPTQConfig(BaseConfig):
+    """
+    Llama-specific configuration for GPTQ weight quantization.
+
+    This configuration is designed for Llama-family models (including
+    LlamaForCausalLM and SpinLlamaForCausalLM) and provides options
+    tailored to their architecture.
+
+    Attributes
+    ----------
+    weight_bits : int
+        Default bit-width applied to quantized weights.
+    weight_bits_overrides : dict[str, int]
+        Optional per-module bit-width overrides.
+
+        Supported keys are matched in the following order:
+          1) Full module name, for example `model.layers.0.self_attn.o_proj`
+          2) Layer-local module name, for example `self_attn.o_proj`
+          3) Full-name suffix, for example `self_attn.o_proj` or `down_proj`
+
+        This makes it possible to keep a default bit-width for most modules
+        while selectively increasing precision for specific projections.
+    quantize_lm_head : bool
+        Whether to apply GPTQ to the language-model output head. This option
+        is disabled by default because many language models tie
+        `lm_head.weight` with the input embedding table, and quantizing the
+        head can modify the shared embedding weights.
+    quantize_rotate_lm_head : bool
+        Whether to apply GPTQ to the `rotate_lm_head` rotation layer.
+        This option is only relevant for SpinLlamaForCausalLM models.
+        Disabled by default.
+    """
+
+    # general
+    verbose: bool = False
+    show_progress: bool = True
+
+    # model-specific quantization switches
+    quantize_lm_head: bool = False
+    quantize_rotate_lm_head: bool = False
+
+    # quantizer.configure params (weight quantization spec)
+    weight_bits: int = 8
+    weight_bits_overrides: dict[str, int] = field(default_factory=dict)
+    perchannel: bool = True
+    symmetric: bool = False
+    mse: str | None = None
+    sensitivity: dict[str, torch.Tensor] | None = None
+
+    # GPTQ.fasterquant params (algorithm hyperparams)
+    percdamp: float = 0.01
+    groupsize: int = -1
+    actorder: bool = True
+    static_groups: bool = False
+
+    # use this option to stabilize GPTQ for deep models
+    use_orig_model_inference: bool = False
+
+    @property
+    def name(self) -> str:
+        return "llama_gptq"
+
+    def validate(self) -> None:
+        if not isinstance(self.quantize_lm_head, bool):
+            raise TypeError(
+                f"quantize_lm_head must be bool. got {type(self.quantize_lm_head)}"
+            )
+        if not isinstance(self.quantize_rotate_lm_head, bool):
+            raise TypeError(
+                f"quantize_rotate_lm_head must be bool. got {type(self.quantize_rotate_lm_head)}"
+            )
+        if self.weight_bits <= 0:
+            raise ValueError(f"weight_bits must be positive. got {self.weight_bits}")
+        for module_name, bits in self.weight_bits_overrides.items():
+            if bits <= 0:
+                raise ValueError(
+                    f"weight_bits_overrides[{module_name!r}] must be positive. got {bits}"
+                )
+        if self.groupsize != -1 and self.groupsize <= 0:
+            raise ValueError(f"groupsize must be -1 or positive. got {self.groupsize}")
+        if not (0.0 < self.percdamp <= 1.0):
+            raise ValueError(f"percdamp must be in (0, 1]. got {self.percdamp}")

--- a/tico/quantization/quantizer_registry.py
+++ b/tico/quantization/quantizer_registry.py
@@ -55,6 +55,9 @@ def get_quantizer(cfg: BaseConfig) -> BaseQuantizer:
     if name:
         if name == "ptq":
             importlib.import_module(f"tico.quantization.wrapq.quantizer")
+        elif name == "llama_gptq":
+            # LlamaGPTQConfig uses a separate quantizer file within the gptq module
+            importlib.import_module(f"tico.quantization.algorithm.gptq.llama_quantizer")
         else:
             try:
                 importlib.import_module(f"tico.quantization.algorithm.{name}.quantizer")

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -58,6 +58,7 @@ from tico.quantization.algorithm.gptq.utils import SensitivityCalibrator
 from tico.quantization.config.builders import build_llm_ptq_config
 from tico.quantization.config.cle import CLEConfig
 from tico.quantization.config.gptq import GPTQConfig
+from tico.quantization.config.llama_gptq import LlamaGPTQConfig
 from tico.quantization.config.llama_attention import (
     DEFAULT_EXECUTION_PROFILE,
     SUPPORTED_EXECUTION_PROFILES,
@@ -305,6 +306,12 @@ def parse_args():
         help="Dampening parameter to be used in GPTQ. It helps to avoid degenerate,"
         "ill-conditioned matrices and serve as a tradeoff between GPTQ and ordinary min-max quantizer.",
     )
+    parser.add_argument(
+        "--use_llama_gptq",
+        action="store_true",
+        default=False,
+        help="Use LlamaGPTQConfig instead of GPTQConfig for Llama-specific GPTQ quantization.",
+    )
     return parser.parse_args()
 
 
@@ -525,29 +532,45 @@ def validate_tied_embedding_weight_bits(
 def build_gptq_config(
     args,
     sensitivity: dict[str, torch.Tensor] | None = None,
-) -> GPTQConfig:
+):
     """
     Build a GPTQ configuration from command-line arguments.
 
     GPTQ for lm_head is disabled by default because many causal language models
     tie `lm_head.weight` with the input embedding table. Users can enable it
     explicitly with `--gptq_lm_head`.
+
+    If `--use_llama_gptq` is specified, returns a LlamaGPTQConfig instead of
+    GPTQConfig for Llama-specific GPTQ quantization.
     """
     weight_bits_overrides: dict[str, int] = {}
 
     if args.gptq_lm_head:
         weight_bits_overrides["lm_head"] = args.lm_head_weight_bits
 
-    return GPTQConfig(
-        show_progress=not args.no_tqdm,
-        weight_bits=args.linear_weight_bits,
-        weight_bits_overrides=weight_bits_overrides,
-        mse=args.gptq_mse,
-        sensitivity=sensitivity,
-        quantize_lm_head=args.gptq_lm_head,
-        use_orig_model_inference=args.gptq_use_orig_model_inference,
-        percdamp=args.gptq_percdamp,
-    )
+    if args.use_llama_gptq:
+        return LlamaGPTQConfig(
+            show_progress=not args.no_tqdm,
+            weight_bits=args.linear_weight_bits,
+            weight_bits_overrides=weight_bits_overrides,
+            mse=args.gptq_mse,
+            sensitivity=sensitivity,
+            quantize_lm_head=args.gptq_lm_head,
+            quantize_rotate_lm_head=not args.no_spinquant,
+            use_orig_model_inference=args.gptq_use_orig_model_inference,
+            percdamp=args.gptq_percdamp,
+        )
+    else:
+        return GPTQConfig(
+            show_progress=not args.no_tqdm,
+            weight_bits=args.linear_weight_bits,
+            weight_bits_overrides=weight_bits_overrides,
+            mse=args.gptq_mse,
+            sensitivity=sensitivity,
+            quantize_lm_head=args.gptq_lm_head,
+            use_orig_model_inference=args.gptq_use_orig_model_inference,
+            percdamp=args.gptq_percdamp,
+        )
 
 
 def save_model_to(

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -413,6 +413,67 @@ def clear_gptq_quantizers(model: torch.nn.Module) -> None:
         delattr(model.wrapped, "quantizers")
 
 
+def print_minmax_values(model: torch.nn.Module) -> None:
+    """
+    Print min/max values from all PTQ observers in the quantized model.
+
+    This function traverses the model hierarchy and prints the min/max statistics
+    collected by each AffineObserverBase instance. Useful for debugging and
+    inspecting quantization ranges after calibration.
+
+    For per-tensor observers, prints scalar min/max values.
+    For per-channel observers, prints the global min/max range and channel shape.
+
+    Args:
+        model: A PTQ-quantized model with observers containing min/max statistics.
+
+    Example usage:
+        # After calibration and before/after conversion:
+        print_minmax_values(q_m)
+    """
+    from tico.quantization.wrapq.observers.affine_base import AffineObserverBase
+    from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+
+    print("\n" + "=" * 80)
+    print("PTQ Model Min/Max Values")
+    print("=" * 80)
+    print(f"{'Module Name':<50} | {'Observer':<25} | Min/Max Values")
+    print("-" * 80)
+
+    count = 0
+    for module_name, module in model.named_modules():
+        if not isinstance(module, QuantModuleBase):
+            continue
+
+        for obs_name, obs in module.named_observers(recurse=True):
+            if not isinstance(obs, AffineObserverBase):
+                continue
+
+            if not hasattr(obs, "min_val") or not hasattr(obs, "max_val"):
+                continue
+
+            min_val = obs.min_val
+            max_val = obs.max_val
+
+            # Format output based on per-tensor vs per-channel
+            if min_val.numel() == 1:
+                # Per-tensor: scalar values
+                values_str = f"min={min_val.item():.6f}, max={max_val.item():.6f}"
+            else:
+                # Per-channel: show shape and range
+                values_str = (
+                    f"min={min_val.min().item():.6f}..{max_val.max().item():.6f} "
+                    f"(shape={tuple(min_val.shape)})"
+                )
+
+            print(f"{module_name:<50} | {obs_name:<25} | {values_str}")
+            count += 1
+
+    print("-" * 80)
+    print(f"Total observers: {count}")
+    print("=" * 80 + "\n")
+
+
 def parse_cle_pairs(raw_pairs: list[str] | None) -> list[tuple[str, str]]:
     """
     Parse command-line CLE pairs.
@@ -559,6 +620,7 @@ def build_gptq_config(
             quantize_rotate_lm_head=not args.no_spinquant,
             use_orig_model_inference=args.gptq_use_orig_model_inference,
             percdamp=args.gptq_percdamp,
+            verbose=args.verbose,
         )
     else:
         return GPTQConfig(
@@ -570,6 +632,7 @@ def build_gptq_config(
             quantize_lm_head=args.gptq_lm_head,
             use_orig_model_inference=args.gptq_use_orig_model_inference,
             percdamp=args.gptq_percdamp,
+            verbose=args.verbose,
         )
 
 
@@ -1015,6 +1078,87 @@ def quantize_using_PTQ(q_m, calib_inputs, args):
     return q_m
 
 
+def quantize_using_PTQ_and_LlamaGPTQ(model, calib_inputs, args):
+    """
+    Combined PTQ + LlamaGPTQ pipeline.
+
+    When ``--use_llama_gptq`` and PTQ are both enabled the execution order
+    changes so that LlamaGPTQ can operate on the PTQ-wrapped model:
+
+      1. PTQ ``prepare()``  — wraps every layer with PTQWrapper / observers.
+      2. LlamaGPTQ ``prepare()`` + calibration forward passes — collects
+         first-layer inputs for GPTQ while also populating activation
+         observers in CALIB mode.
+      3. LlamaGPTQ ``convert()`` — runs GPTQ weight quantization layer by
+         layer.  After each layer it injects the resulting weight qparams
+         into the PTQ weight observers and calls ``freeze_qparams()`` so
+         subsequent forward passes use fake-quantized (QUANT mode) outputs.
+      4. PTQ ``convert()`` — finalises the PTQ graph (all observers already
+         frozen).
+
+    Because LlamaGPTQ's forward passes during collection and re-forward
+    already drive the PTQ activation observers, **no separate activation
+    calibration pass is needed** for this path.
+    """
+    # Step 1: PTQ prepare
+    print("Wrapping layers with PTQWrapper …")
+    print(f"Using PTQ execution profile: {args.profile}")
+
+    qcfg = build_llm_ptq_config(
+        model_type="llama",
+        num_hidden_layers=len(model.model.layers),
+        activation_dtype=DType.int(16),
+        default_qscheme=QScheme.PER_TENSOR_SYMM,
+        linear_weight_bits=args.linear_weight_bits,
+        embedding_weight_bits=args.embedding_weight_bits,
+        lm_head_weight_bits=args.lm_head_weight_bits,
+        spin_rotation_weight_bits=(
+            None if args.no_spinquant else args.spin_rotation_weight_bits
+        ),
+        norm_weight_dtype=DType.int(16),
+        strict_wrap=True,
+        profile=args.profile,
+    )
+    q_m = prepare(model, qcfg)
+
+    # Step 2: LlamaGPTQ prepare + calibration
+    # Temporarily remove the PTQ quantizer attribute so that the second
+    # ``prepare()`` call does not raise "prepare() already has been called."
+    # We will restore it after LlamaGPTQ convert().
+    ptq_quantizer = getattr(q_m, "tico_quantizer", None)
+    if ptq_quantizer is not None:
+        delattr(q_m, "tico_quantizer")
+
+    print("Applying LlamaGPTQ on PTQ-wrapped model …")
+    sens = compute_or_load_sensitivity(model, calib_inputs, args)
+    gptq_config = build_gptq_config(args, sensitivity=sens)
+
+    q_m = prepare(q_m, gptq_config, inplace=True)
+
+    iterator = calib_inputs
+    if not args.no_tqdm:
+        iterator = tqdm.tqdm(calib_inputs, desc="LlamaGPTQ calibration")
+
+    with torch.no_grad():
+        for inp in iterator:
+            q_m(inp.to(args.device))
+
+    # Step 3: LlamaGPTQ convert (includes freeze_qparams per layer)
+    q_m = convert(q_m, inplace=True)
+    #print_minmax_values(q_m)
+    
+    # Clean up GPTQ quantizers that are no longer needed
+    clear_gptq_quantizers(q_m)
+
+    # Step 4: PTQ convert (all observers are already frozen)
+    # Restore the PTQ quantizer that was saved before LlamaGPTQ prepare()
+    # so that PTQ convert() can find it.
+    #if ptq_quantizer is not None:
+    #    setattr(q_m, "tico_quantizer", ptq_quantizer)
+    #q_m = convert(q_m)
+
+    return q_m
+
 def evaluate(q_m, tokenizer, dataset_test, args):
     """
     Evaluate the quantized model with perplexity and optional lm-eval tasks.
@@ -1440,9 +1584,17 @@ def main():
 
     model = apply_spinquant(model, args)
     model = apply_cle(model, args)
-    model = apply_gptq(model, calib_inputs, args)
 
-    q_m = quantize_using_PTQ(model, calib_inputs, args)
+    # When both LlamaGPTQ and PTQ are enabled, run PTQ prepare first so that
+    # LlamaGPTQ operates on the PTQ-wrapped model.  LlamaGPTQ will inject its
+    # weight qparams into PTQ observers and freeze them layer-by-layer, so no
+    # separate activation calibration pass is needed.
+    if args.use_llama_gptq and not args.no_PTQ and not args.no_GPTQ:
+        q_m = quantize_using_PTQ_and_LlamaGPTQ(model, calib_inputs, args)
+    else:
+        model = apply_gptq(model, calib_inputs, args)
+        q_m = quantize_using_PTQ(model, calib_inputs, args)
+      #  print_minmax_values(q_m)
 
     evaluate(q_m, tokenizer, dataset_test, args)
     save_requested_artifacts(q_m, tokenizer, calib_inputs, args)

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -609,6 +609,7 @@ def build_gptq_config(
     if args.gptq_lm_head:
         weight_bits_overrides["lm_head"] = args.lm_head_weight_bits
 
+    gptqv2 = True
     if args.use_llama_gptq:
         return LlamaGPTQConfig(
             show_progress=not args.no_tqdm,
@@ -621,6 +622,7 @@ def build_gptq_config(
             use_orig_model_inference=args.gptq_use_orig_model_inference,
             percdamp=args.gptq_percdamp,
             verbose=args.verbose,
+            gptq_v2 = gptqv2,
         )
     else:
         return GPTQConfig(
@@ -633,6 +635,7 @@ def build_gptq_config(
             use_orig_model_inference=args.gptq_use_orig_model_inference,
             percdamp=args.gptq_percdamp,
             verbose=args.verbose,
+            gptq_v2 = gptqv2,
         )
 
 
@@ -1132,7 +1135,6 @@ def quantize_using_PTQ_and_LlamaGPTQ(model, calib_inputs, args):
     print("Applying LlamaGPTQ on PTQ-wrapped model …")
     sens = compute_or_load_sensitivity(model, calib_inputs, args)
     gptq_config = build_gptq_config(args, sensitivity=sens)
-
     q_m = prepare(q_m, gptq_config, inplace=True)
 
     iterator = calib_inputs
@@ -1442,7 +1444,7 @@ def build_calibration_inputs(
 
     random.seed(args.seed)
     calib_inputs = []
-    for _ in range(nsamples):
+    for k in range(nsamples):
         i = random.randint(0, train_ids.shape[1] - seqlen - 1)
         j = i + seqlen
         calib_inputs.append(train_ids[:, i:j].cpu())

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -307,6 +307,12 @@ def parse_args():
         "ill-conditioned matrices and serve as a tradeoff between GPTQ and ordinary min-max quantizer.",
     )
     parser.add_argument(
+        "--gptq_v2",
+        action="store_true",
+        default=False,
+        help="Enable GPTQv2 (uses FP inference for collecting inputs during quantization).",
+    )
+    parser.add_argument(
         "--use_llama_gptq",
         action="store_true",
         default=False,
@@ -609,7 +615,6 @@ def build_gptq_config(
     if args.gptq_lm_head:
         weight_bits_overrides["lm_head"] = args.lm_head_weight_bits
 
-    gptqv2 = True
     if args.use_llama_gptq:
         return LlamaGPTQConfig(
             show_progress=not args.no_tqdm,
@@ -622,7 +627,7 @@ def build_gptq_config(
             use_orig_model_inference=args.gptq_use_orig_model_inference,
             percdamp=args.gptq_percdamp,
             verbose=args.verbose,
-            gptq_v2 = gptqv2,
+            gptq_v2=args.gptq_v2,
         )
     else:
         return GPTQConfig(
@@ -635,7 +640,7 @@ def build_gptq_config(
             use_orig_model_inference=args.gptq_use_orig_model_inference,
             percdamp=args.gptq_percdamp,
             verbose=args.verbose,
-            gptq_v2 = gptqv2,
+            gptq_v2=args.gptq_v2,
         )
 
 

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -1441,7 +1441,8 @@ def build_calibration_inputs(
     train_ids = tokenizer(calib_txt, return_tensors="pt").input_ids.to(device)
 
     nsamples = args.nsamples_for_qcalibration
-    seqlen = model.config.max_position_embeddings - args.decode_calibration_steps
+    seqlen_for_decode = 0 if args.use_llama_gptq else args.decode_calibration_steps
+    seqlen = model.config.max_position_embeddings - seqlen_for_decode
     if seqlen <= 0:
         raise ValueError(
             "decode_calibration_steps must be smaller than max_position_embeddings"

--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -203,16 +203,8 @@ class QuantLlamaAttention(QuantModuleBase):
         self.obs_logits_raw = mk("logits_raw")
 
         # kv cache
-        self.obs_past_key = mk("past_key")
-        self.obs_past_value = mk("past_value")
-
-        # New kv delta
-        self.obs_new_k = mk("new_k")  # (B, n_kv, S, H)
-        self.obs_new_v = mk("new_v")  # (B, n_kv, S, H)
-
-        # Total KV after concat (used for matmul/attn)
-        self.obs_present_key = mk("present_key")  # (B, max_seq, H)
-        self.obs_present_value = mk("present_value")  # (B, max_seq, H)
+        self.obs_key = mk("key")
+        self.obs_value = mk("value")
 
         # Static causal mask template
         mask = torch.full(
@@ -487,14 +479,14 @@ class QuantLlamaAttention(QuantModuleBase):
             past_k, past_v = past_key_value
             if past_k is None or past_v is None:
                 return None
-            past_k = self._fq(past_k, self.obs_past_key)
-            past_v = self._fq(past_v, self.obs_past_value)
+            past_k = self._fq(past_k, self.obs_key)
+            past_v = self._fq(past_v, self.obs_value)
             return (past_k, past_v)
 
         past_key_value = self._get_layer_kv_from_cache(
             past_key_value,
-            k_obs=self.obs_past_key,
-            v_obs=self.obs_past_value,
+            k_obs=self.obs_key,
+            v_obs=self.obs_value,
         )
 
         return past_key_value
@@ -626,17 +618,17 @@ class QuantLlamaAttention(QuantModuleBase):
             A tuple `(present_k_i, present_v_i)` with shape `(B, K, H)`.
         """
         if past_k_i is None:
-            present_k_i = self._fq(new_k_i, self.obs_present_key)
-            present_v_i = self._fq(new_v_i, self.obs_present_value)
+            present_k_i = self._fq(new_k_i, self.obs_key)
+            present_v_i = self._fq(new_v_i, self.obs_value)
             return present_k_i, present_v_i
 
         present_k_i = self._fq(
             torch.cat([past_k_i, new_k_i], dim=1),
-            self.obs_present_key,
+            self.obs_key,
         )
         present_v_i = self._fq(
             torch.cat([past_v_i, new_v_i], dim=1),
-            self.obs_present_value,
+            self.obs_value,
         )
         return present_k_i, present_v_i
 
@@ -656,8 +648,8 @@ class QuantLlamaAttention(QuantModuleBase):
         if cache_output_mode not in ("present", "delta"):
             raise ValueError(f"Unsupported cache_output_mode: {cache_output_mode!r}")
 
-        new_k = self._fq(torch.stack(new_k_parts, dim=1), self.obs_new_k)
-        new_v = self._fq(torch.stack(new_v_parts, dim=1), self.obs_new_v)
+        new_k = self._fq(torch.stack(new_k_parts, dim=1), self.obs_key)
+        new_v = self._fq(torch.stack(new_v_parts, dim=1), self.obs_value)
 
         if cache_output_mode == "delta":
             if torch.compiler.is_compiling() and isinstance(past_key_value_in, Cache):
@@ -673,8 +665,8 @@ class QuantLlamaAttention(QuantModuleBase):
                 )  # set new cache
                 self._get_layer_kv_from_cache(
                     past_key_value_in,
-                    k_obs=self.obs_new_k,
-                    v_obs=self.obs_new_v,
+                    k_obs=self.obs_key,
+                    v_obs=self.obs_value,
                     write_back=True,
                 )
             return new_k, new_v
@@ -688,15 +680,15 @@ class QuantLlamaAttention(QuantModuleBase):
             if torch.compiler.is_compiling():
                 self._get_layer_kv_from_cache(
                     past_key_value_in,
-                    k_obs=self.obs_past_key,
-                    v_obs=self.obs_past_value,
+                    k_obs=self.obs_key,
+                    v_obs=self.obs_value,
                     write_back=True,
                 )
             return past_key_value_in
 
-        present_k = self._fq(torch.stack(present_k_parts, dim=1), self.obs_present_key)
+        present_k = self._fq(torch.stack(present_k_parts, dim=1), self.obs_key)
         present_v = self._fq(
-            torch.stack(present_v_parts, dim=1), self.obs_present_value
+            torch.stack(present_v_parts, dim=1), self.obs_value
         )
         return present_k, present_v
 
@@ -730,8 +722,8 @@ class QuantLlamaAttention(QuantModuleBase):
                 )
                 self._get_layer_kv_from_cache(
                     past_key_value_in,
-                    k_obs=self.obs_new_k,
-                    v_obs=self.obs_new_v,
+                    k_obs=self.obs_key,
+                    v_obs=self.obs_value,
                     write_back=True,
                 )
             return new_k, new_v
@@ -745,8 +737,8 @@ class QuantLlamaAttention(QuantModuleBase):
             if torch.compiler.is_compiling():
                 self._get_layer_kv_from_cache(
                     past_key_value_in,
-                    k_obs=self.obs_past_key,
-                    v_obs=self.obs_past_value,
+                    k_obs=self.obs_key,
+                    v_obs=self.obs_value,
                     write_back=True,
                 )
             return past_key_value_in
@@ -930,21 +922,21 @@ class QuantLlamaAttention(QuantModuleBase):
             self.obs_k_rot,
         )
 
-        new_k = self._fq(k, self.obs_new_k)
-        new_v = self._fq(v, self.obs_new_v)
+        new_k = self._fq(k, self.obs_key)
+        new_v = self._fq(v, self.obs_value)
 
         if past_key_value is None:
-            present_k = self._fq(new_k, self.obs_present_key)
-            present_v = self._fq(new_v, self.obs_present_value)
+            present_k = self._fq(new_k, self.obs_key)
+            present_v = self._fq(new_v, self.obs_value)
         else:
             past_k, past_v = past_key_value
             present_k = self._fq(
                 torch.cat([past_k, new_k], dim=2),
-                self.obs_present_key,
+                self.obs_key,
             )
             present_v = self._fq(
                 torch.cat([past_v, new_v], dim=2),
-                self.obs_present_value,
+                self.obs_value,
             )
 
         if self.kv_rep != 1:
@@ -1096,12 +1088,8 @@ class QuantLlamaAttention(QuantModuleBase):
             self.obs_attn_out,
             self.obs_attn_weights,
             self.obs_attn_out_h,
-            self.obs_past_key,
-            self.obs_past_value,
-            self.obs_new_k,
-            self.obs_new_v,
-            self.obs_present_key,
-            self.obs_present_value,
+            self.obs_key,
+            self.obs_value,
         )
 
     def as_export_module(


### PR DESCRIPTION
This draft introduces GPTQv2 (GPTQAQ) .

results for [HuggingFaceTB/SmolLM2-135M-Instruct](https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct)
| Config ID | PPL  | PPL_of_just_GPTQ|
|-----------|------|-|
| FP32 | 17.38 |17.38|
|SPQ_GPTQv2+PTQ_mse_256_samples| 19.25|19.70|
|SPQ_GPTQv2,PTQ_mse_256_samples| 19.30|19.70|
|SPQ_GPTQv2+PTQ_mse_for_gptq_256_samples| 19.00|19.39|
|SPQ_GPTQv2,PTQ_mse_for_gptq_256_samples| 19.11|19.39|
|GPTQv2+PTQ_mse_256_samples| 21.73|22.39|
|GPTQv2,PTQ_mse_256_samples| 21.82|22.39|

results for [unsloth/Llama-3.2-3B-Instruct](https://huggingface.co/unsloth/Llama-3.2-3B-Instruct)
| Config ID | PPL  |
|-----------|------|
| FP32 | 11.05 |
|SPQ_GPTQv2+PTQ_smse_for_gptq_512_samples| 11.55|
|SPQ_GPTQv2,PTQ_smse_for_gptq_512_samples| 11.60|
|SPQ_GPTQv2+PTQ_smse_512_samples| 11.59|



where `GPTQv2+PTQ` stands for simultaneous calibration of activations and weights, while `GPTQv2,PTQ` - sequential quantization of weights and then quantization of activations. 