### PR TITLE
[evaluation]  Continue video-mme dataset support for qwen3-vl adapter

### DIFF
--- a/test/quantization/recipes/test_video_mme_evaluation.py
+++ b/test/quantization/recipes/test_video_mme_evaluation.py
@@ -95,6 +95,359 @@ class TestVideoMmeEvaluation(unittest.TestCase):
         self.assertEqual(captured["use_cache"], "/tmp/cache")
 
 
+class TestCoerceIntAttr(unittest.TestCase):
+    """Tests for ``_coerce_int_attr``."""
+
+    def test_none_returns_default(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr(None, 42), 42)
+
+    def test_int_returns_int(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr(7, 42), 7)
+
+    def test_float_returns_int(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr(3.14, 42), 3)
+
+    def test_list_with_one_element_returns_first(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr([16], 42), 16)
+
+    def test_list_with_multiple_elements_returns_first(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr([16, 32], 42), 16)
+
+    def test_tuple_with_one_element_returns_first(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr((2,), 42), 2)
+
+    def test_empty_list_returns_default(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr([], 42), 42)
+
+    def test_empty_tuple_returns_default(self):
+        from tico.quantization.evaluation.lmms_eval_utils import _coerce_int_attr
+
+        self.assertEqual(_coerce_int_attr((), 42), 42)
+
+
+class TestProcessorVisionFactor(unittest.TestCase):
+    """Tests for ``_processor_vision_factor``."""
+
+    def _make_processor(self, patch_size=None, merge_size=None):
+        from types import SimpleNamespace
+
+        image_processor = SimpleNamespace()
+        if patch_size is not None:
+            image_processor.patch_size = patch_size
+        if merge_size is not None:
+            image_processor.merge_size = merge_size
+        return SimpleNamespace(image_processor=image_processor)
+
+    def test_qwen3_vl_defaults(self):
+        """Qwen3-VL default: patch_size=16, merge_size=2 → factor=32."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _processor_vision_factor,
+        )
+
+        proc = self._make_processor(patch_size=16, merge_size=2)
+        self.assertEqual(_processor_vision_factor(proc), 32)
+
+    def test_qwen3_vl_list_attrs(self):
+        """Qwen3-VL sometimes stores patch_size/merge_size as lists."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _processor_vision_factor,
+        )
+
+        proc = self._make_processor(patch_size=[16], merge_size=[2])
+        self.assertEqual(_processor_vision_factor(proc), 32)
+
+    def test_missing_attrs_uses_defaults(self):
+        """Missing patch_size/merge_size → defaults 16 and 2 → factor=32."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _processor_vision_factor,
+        )
+
+        proc = self._make_processor()
+        self.assertEqual(_processor_vision_factor(proc), 32)
+
+    def test_no_image_processor_uses_defaults(self):
+        """No image_processor at all → defaults 16 and 2 → factor=32."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _processor_vision_factor,
+        )
+
+        proc = SimpleNamespace()
+        self.assertEqual(_processor_vision_factor(proc), 32)
+
+    def test_custom_patch_and_merge(self):
+        """Custom values: patch_size=14, merge_size=1 → factor=14."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _processor_vision_factor,
+        )
+
+        proc = self._make_processor(patch_size=14, merge_size=1)
+        self.assertEqual(_processor_vision_factor(proc), 14)
+
+    def test_minimum_factor_is_1(self):
+        """patch_size=0, merge_size=0 → max(1, 0) = 1."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _processor_vision_factor,
+        )
+
+        proc = self._make_processor(patch_size=0, merge_size=0)
+        self.assertEqual(_processor_vision_factor(proc), 1)
+
+
+class TestComputeVideoMaxPixelsForBudget(unittest.TestCase):
+    """Tests for ``_compute_video_max_pixels_for_budget``."""
+
+    def _make_processor(self, patch_size=16, merge_size=2):
+        from types import SimpleNamespace
+
+        image_processor = SimpleNamespace(patch_size=patch_size, merge_size=merge_size)
+        return SimpleNamespace(image_processor=image_processor)
+
+    def test_budget_2048_10_frames(self):
+        """Budget 2048, 10 frames → max_pixels=180224."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_px, min_px, adj_frames = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=2048,
+            max_num_frames=10,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+        )
+        self.assertEqual(max_px, 180224)
+        self.assertEqual(min_px, 180224)
+        self.assertEqual(adj_frames, 10)
+
+    def test_budget_2048_32_frames(self):
+        """Budget 2048, 32 frames → max_pixels=56320."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_px, min_px, adj_frames = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=2048,
+            max_num_frames=32,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+        )
+        self.assertEqual(max_px, 56320)
+        self.assertEqual(min_px, 56320)
+        self.assertEqual(adj_frames, 32)
+
+    def test_budget_2048_5_frames(self):
+        """Budget 2048, 5 frames → max_pixels=360448, min_pixels=200704."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_px, min_px, adj_frames = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=2048,
+            max_num_frames=5,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+        )
+        self.assertEqual(max_px, 360448)
+        self.assertEqual(min_px, 200704)
+        self.assertEqual(adj_frames, 5)
+
+    def test_large_budget_no_reduction(self):
+        """Large budget (32768) should not reduce pixels significantly."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_px, min_px, adj_frames = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=32768,
+            max_num_frames=32,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+        )
+        self.assertEqual(max_px, 1039360)
+        self.assertEqual(min_px, 200704)
+        self.assertEqual(adj_frames, 32)
+
+    def test_tight_budget_reduces_frames(self):
+        """Very tight budget: max_num_frames should be reduced."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_px, min_px, adj_frames = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=300,
+            max_num_frames=32,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+        )
+        self.assertEqual(adj_frames, 14)
+        self.assertEqual(max_px, 1024)
+        self.assertEqual(min_px, 1024)
+
+    def test_zero_visual_budget_raises(self):
+        """Zero or negative visual budget should raise ValueError."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        with self.assertRaises(ValueError):
+            _compute_video_max_pixels_for_budget(
+                max_position_embeddings=100,
+                max_num_frames=10,
+                max_new_tokens=50,
+                processor=self._make_processor(),
+                text_token_margin=256,
+            )
+
+    def test_custom_text_token_margin(self):
+        """Custom text_token_margin affects the visual budget."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_px_default, _, _ = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=2048,
+            max_num_frames=10,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+            text_token_margin=256,
+        )
+        max_px_large_margin, _, _ = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=2048,
+            max_num_frames=10,
+            max_new_tokens=30,
+            processor=self._make_processor(),
+            text_token_margin=1024,
+        )
+        self.assertLess(max_px_large_margin, max_px_default)
+
+    def test_total_tokens_within_budget(self):
+        """Verify total tokens do not exceed max_position_embeddings."""
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _compute_video_max_pixels_for_budget,
+        )
+
+        max_pos = 2048
+        max_new = 30
+        margin = 256
+        n_frames = 10
+        max_px, _, adj_frames = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=max_pos,
+            max_num_frames=n_frames,
+            max_new_tokens=max_new,
+            processor=self._make_processor(),
+            text_token_margin=margin,
+        )
+        tokens_per_frame = max_px // (32 * 32)
+        total_tokens = adj_frames * tokens_per_frame + margin + max_new
+        self.assertLessEqual(total_tokens, max_pos)
+
+
+class TestGetMaxPositionEmbeddings(unittest.TestCase):
+    """Tests for ``_get_max_position_embeddings``."""
+
+    def test_qwen3_vl_config(self):
+        """Qwen3-VL stores max_position_embeddings under text_config."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_max_position_embeddings,
+        )
+
+        class TextConfig:
+            max_position_embeddings = 32768
+
+        class Config:
+            text_config = TextConfig()
+
+        model = SimpleNamespace(config=Config())
+        self.assertEqual(_get_max_position_embeddings(model), 32768)
+
+    def test_direct_config_attr(self):
+        """Models without text_config use direct max_position_embeddings."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_max_position_embeddings,
+        )
+
+        class Config:
+            max_position_embeddings = 4096
+
+        model = SimpleNamespace(config=Config())
+        self.assertEqual(_get_max_position_embeddings(model), 4096)
+
+    def test_no_config_returns_none(self):
+        """Model without config returns None."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_max_position_embeddings,
+        )
+
+        model = SimpleNamespace()
+        self.assertIsNone(_get_max_position_embeddings(model))
+
+    def test_config_without_max_pos_returns_none(self):
+        """Config without max_position_embeddings returns None."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_max_position_embeddings,
+        )
+
+        model = SimpleNamespace(config=SimpleNamespace())
+        self.assertIsNone(_get_max_position_embeddings(model))
+
+    def test_text_config_takes_precedence(self):
+        """text_config.max_position_embeddings takes precedence over direct."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_max_position_embeddings,
+        )
+
+        class TextConfig:
+            max_position_embeddings = 32768
+
+        class Config:
+            text_config = TextConfig()
+            max_position_embeddings = 4096
+
+        model = SimpleNamespace(config=Config())
+        self.assertEqual(_get_max_position_embeddings(model), 32768)
+
+    def test_returns_int(self):
+        """Return value is always int, even if config stores something else."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import (
+            _get_max_position_embeddings,
+        )
+
+        class Config:
+            max_position_embeddings = 8192.0
+
+        model = SimpleNamespace(config=Config())
+        result = _get_max_position_embeddings(model)
+        self.assertIsInstance(result, int)
+        self.assertEqual(result, 8192)
+
+
 class TestLmmsEvalUtils(unittest.TestCase):
     """Tests for the low-level lmms-eval wrapper utilities."""
 
@@ -126,6 +479,68 @@ class TestLmmsEvalUtils(unittest.TestCase):
         )
 
         self.assertEqual(model_args["max_num_frames"], 5)
+
+    def test_build_model_args_with_budget_sets_max_pixels(self):
+        """When max_position_embeddings is provided, max_pixels is computed."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import _build_model_args
+
+        model = MagicMock()
+        type(model).__name__ = "Qwen3VLForConditionalGeneration"
+        model.config._name_or_path = "Qwen/Qwen3-VL-2B-Instruct"
+
+        image_processor = SimpleNamespace(patch_size=16, merge_size=2)
+        proc = SimpleNamespace(image_processor=image_processor)
+
+        _, args = _build_model_args(
+            model,
+            max_num_frames=10,
+            max_position_embeddings=2048,
+            max_new_tokens=30,
+            processor=proc,
+        )
+        self.assertIn("max_pixels", args)
+        self.assertIn("min_pixels", args)
+        self.assertIn("max_num_frames", args)
+        self.assertEqual(args["max_pixels"], 180224)
+        self.assertEqual(args["max_num_frames"], 10)
+
+    def test_build_model_args_without_budget_no_processor(self):
+        """Without processor, no budget computation even if max_pos given."""
+        from tico.quantization.evaluation.lmms_eval_utils import _build_model_args
+
+        model = MagicMock()
+        type(model).__name__ = "Qwen3VLForConditionalGeneration"
+        model.config._name_or_path = "Qwen/Qwen3-VL-2B-Instruct"
+
+        _, args = _build_model_args(
+            model, max_num_frames=10, max_position_embeddings=2048
+        )
+        self.assertNotIn("max_pixels", args)
+        self.assertIn("max_num_frames", args)
+
+    def test_build_model_args_budget_adjusts_max_num_frames(self):
+        """Tight budget adjusts max_num_frames downward."""
+        from types import SimpleNamespace
+
+        from tico.quantization.evaluation.lmms_eval_utils import _build_model_args
+
+        model = MagicMock()
+        type(model).__name__ = "Qwen3VLForConditionalGeneration"
+        model.config._name_or_path = "Qwen/Qwen3-VL-2B-Instruct"
+
+        image_processor = SimpleNamespace(patch_size=16, merge_size=2)
+        proc = SimpleNamespace(image_processor=image_processor)
+
+        _, args = _build_model_args(
+            model,
+            max_num_frames=32,
+            max_position_embeddings=300,
+            max_new_tokens=30,
+            processor=proc,
+        )
+        self.assertLessEqual(args["max_num_frames"], 32)
 
     def test_check_lmms_eval_available_raises_when_missing(self):
         """_check_lmms_eval_available should raise RuntimeError if lmms-eval is not installed."""

--- a/tico/quantization/evaluation/lmms_eval_utils.py
+++ b/tico/quantization/evaluation/lmms_eval_utils.py
@@ -700,9 +700,9 @@ def evaluate_vlm_on_tasks(
         eval_kwargs["limit"] = limit
     if use_cache is not None:
         eval_kwargs["use_cache"] = use_cache
-    if max_new_tokens is not None:
-        gen_kwargs = f"max_new_tokens={max_new_tokens}"
-        eval_kwargs["gen_kwargs"] = gen_kwargs
+
+    gen_kwargs = f"max_new_tokens={_effective_max_new_tokens}"
+    eval_kwargs["gen_kwargs"] = gen_kwargs
 
     # Auto-register custom task directories (e.g. videomme_mini) by
     # creating a ``TaskManager`` with ``include_path`` pointing to the

--- a/tico/quantization/evaluation/lmms_eval_utils.py
+++ b/tico/quantization/evaluation/lmms_eval_utils.py
@@ -438,6 +438,82 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
     return _restore()
 
 
+def _patch_video_frame_budget(
+    *,
+    max_pixels: int,
+    min_pixels: int,
+    max_num_frames: int,
+):
+    """Patch the lmms-eval ``Qwen3_VL`` wrapper to enforce the video frame budget.
+
+    This is a safety net that overrides ``max_pixels``, ``min_pixels``, and
+    ``max_num_frames`` on the ``Qwen3_VL`` wrapper after instantiation.
+    While the primary mechanism is passing these values via ``model_args``,
+    this patch ensures the budget is enforced even if the model_args parsing
+    has edge cases.
+
+    The patch works by monkey-patching ``__init__`` to set the instance
+    attributes after the original initialization.
+
+    The patch is automatically undone when the returned context manager exits.
+
+    Args:
+        max_pixels: Maximum pixels per video frame.
+        min_pixels: Minimum pixels per video frame.
+        max_num_frames: Maximum number of video frames.
+
+    Returns:
+        A context manager that restores the original ``__init__`` on exit.
+    """
+    import contextlib
+
+    _patched_classes = []
+
+    # Patch both the simple and chat Qwen3_VL wrappers
+    for _module_path, _class_name in [
+        ("lmms_eval.models.simple.qwen3_vl", "Qwen3_VL"),
+        ("lmms_eval.models.chat.qwen3_vl", "Qwen3_VL"),
+    ]:
+        try:
+            import importlib
+
+            _module = importlib.import_module(_module_path)
+            _cls = getattr(_module, _class_name)
+            _patched_classes.append(_cls)
+        except (ImportError, AttributeError):
+            continue
+
+    if not _patched_classes:
+        return contextlib.nullcontext()
+
+    _original_inits = {cls: cls.__init__ for cls in _patched_classes}
+
+    def _make_patched_init(orig_init, max_pixels, min_pixes, max_num_frames):
+        def _patched_init(self, *args, **kwargs):
+            orig_init(self, *args, **kwargs)
+            # Override the instance attributes set by the original __init__
+            self.max_pixels = max_pixels
+            self.min_pixels = min_pixes
+            self.max_num_frames = max_num_frames
+
+        return _patched_init
+
+    for _cls in _patched_classes:
+        _cls.__init__ = _make_patched_init(
+            _original_inits[_cls], max_pixels, min_pixels, max_num_frames
+        )
+
+    @contextlib.contextmanager
+    def _restore():
+        try:
+            yield
+        finally:
+            for _cls in _patched_classes:
+                _cls.__init__ = _original_inits[_cls]
+
+    return _restore()
+
+
 def _patch_subsample_video_inputs_for_debug():
     """
     This monkey-patches the ``_subsample_video_inputs`` method on the
@@ -524,6 +600,7 @@ def evaluate_vlm_on_tasks(
             task names.  Any task registered in ``lmms-eval`` is accepted.
         device: Device string for inference (e.g. ``"cuda"``, ``"cpu"``).
         batch_size: Batch size for generation.  Defaults to 1.
+        max_num_frames: The maximum number of frames that will be extracted from the video uniformly.
         max_new_tokens: Maximum number of tokens to generate per sample.
         use_cache: Optional path to an ``lmms-eval`` results cache directory.
             When set, results are cached and can be reused across runs.
@@ -556,8 +633,28 @@ def evaluate_vlm_on_tasks(
     else:
         # Unwrap fake-quant wrapper if present
         inner_model = getattr(model, "wrapped", model)
-        # Determine the lmms-eval model name and build model_args
-        model_name, model_args_dict = _build_model_args(inner_model, max_num_frames)
+
+        # Detect if the model is a PTQ wrapper with a static context budget.
+        # Quantized models have a static causal mask of size
+        # max_position_embeddings that cannot be exceeded at runtime.
+        # When evaluating video benchmarks, the total token count
+        # (text + visual tokens from all frames) must fit within this
+        # budget, so we compute max_pixels/min_pixels per frame.
+        _max_pos_emb = _get_max_position_embeddings(inner_model)
+        _effective_max_new_tokens = max_new_tokens if max_new_tokens is not None else 30
+
+        # Determine the lmms-eval model name and build model_args.
+        # When max_position_embeddings is available, the budget-aware
+        # computation adjusts max_pixels, min_pixels, and max_num_frames
+        # so that the total token count stays within the static budget.
+        model_name, model_args_dict = _build_model_args(
+            inner_model,
+            max_num_frames=max_num_frames,
+            max_position_embeddings=_max_pos_emb,
+            max_new_tokens=_effective_max_new_tokens,
+            processor=processor,
+        )
+
         # Patch ``from_pretrained`` so that ``lmms-eval`` reuses the
         # already-loaded model and processor instead of downloading and
         # loading them a second time.
@@ -629,6 +726,22 @@ def evaluate_vlm_on_tasks(
     # Patch _subsample_video_inputs to add debug logging
     _subsample_ctx = _patch_subsample_video_inputs_for_debug()
 
+    # Apply the video frame budget safety net patch when budget parameters
+    # were computed.  This monkey-patches the Qwen3_VL wrapper's __init__
+    # to override max_pixels, min_pixels, and max_num_frames after
+    # instantiation, ensuring the budget is enforced even if model_args
+    # parsing has edge cases.
+    _budget_ctx = contextlib.nullcontext()
+    _budget_max_pixels = model_args_dict.get("max_pixels")
+    _budget_min_pixels = model_args_dict.get("min_pixels")
+    _budget_max_num_frames = model_args_dict.get("max_num_frames")
+    if _budget_max_pixels is not None and _budget_min_pixels is not None:
+        _budget_ctx = _patch_video_frame_budget(
+            max_pixels=_budget_max_pixels,
+            min_pixels=_budget_min_pixels,
+            max_num_frames=_budget_max_num_frames or max_num_frames,
+        )
+
     # Proactively download any missing Video-MME video chunk zips before
     # lmms-eval runs.  This is incremental: if some chunks are already in
     # the HF cache from a previous run (possibly with a smaller limit), only
@@ -656,7 +769,7 @@ def evaluate_vlm_on_tasks(
     if _is_videomme and limit is not None and isinstance(limit, int) and limit > 0:
         _download_ctx = _patch_snapshot_download_for_limit(limit)
 
-    with _model_ctx, _subsample_ctx:
+    with _model_ctx, _subsample_ctx, _budget_ctx:
         if _download_ctx is not None:
             with _download_ctx:
                 results = simple_evaluate(**eval_kwargs)
@@ -686,9 +799,130 @@ def _get_custom_tasks_dir() -> str | None:
     return None
 
 
+def _coerce_int_attr(value: Any, default: int) -> int:
+    """Convert scalar or one-element processor attributes to an integer."""
+    if value is None:
+        return default
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return default
+        return int(value[0])
+    return int(value)
+
+
+def _processor_vision_factor(processor: Any) -> int:
+    """Return the pixel stride of one merged visual token step.
+
+    For Qwen3-VL the vision factor is ``patch_size × merge_size`` (default
+    ``16 × 2 = 32``).  Each visual token covers a ``vision_factor ×
+    vision_factor`` pixel region, so ``tokens = pixels / vision_factor²``.
+    """
+    image_processor = getattr(processor, "image_processor", None)
+    patch_size = _coerce_int_attr(getattr(image_processor, "patch_size", None), 16)
+    merge_size = _coerce_int_attr(getattr(image_processor, "merge_size", None), 2)
+    return max(1, patch_size * merge_size)
+
+
+def _compute_video_max_pixels_for_budget(
+    *,
+    max_position_embeddings: int,
+    max_num_frames: int,
+    max_new_tokens: int,
+    processor: Any,
+    text_token_margin: int = 256,
+) -> tuple[int, int, int]:
+    """Compute ``max_pixels`` per video frame to fit within the static context budget.
+
+    Quantized (PTQ) models use a static causal mask of size
+    ``max_position_embeddings``.  When evaluating video benchmarks the total
+    token count (text + visual tokens from all frames) must not exceed this
+    budget.  This function computes the maximum number of pixels per frame
+    that keeps the total within budget, and optionally reduces
+    ``max_num_frames`` when the budget is too tight.
+
+    Args:
+        max_position_embeddings: Static context length.
+        max_num_frames: Requested maximum number of video frames.
+        max_new_tokens: Tokens reserved for generation output.
+        processor: The Hugging Face processor (used to determine the vision
+            factor).
+        text_token_margin: Extra margin for text tokens (system prompt,
+            special tokens, etc.).
+
+    Returns:
+        A ``(max_pixels, min_pixels, adjusted_max_num_frames)`` tuple where
+        ``max_pixels`` and ``min_pixels`` are the per-frame pixel caps to
+        pass to the lmms-eval model wrapper, and
+        ``adjusted_max_num_frames`` is the possibly-reduced frame count.
+    """
+    vision_factor = _processor_vision_factor(processor)
+
+    # input_budget = tokens available for input (excluding generation)
+    input_budget = max_position_embeddings - max_new_tokens
+
+    # visual_budget = tokens available for visual tokens (excluding text margin)
+    visual_budget = input_budget - text_token_margin
+    if visual_budget <= 0:
+        raise ValueError(
+            f"Not enough context budget for video frames: "
+            f"max_position_embeddings={max_position_embeddings}, "
+            f"max_new_tokens={max_new_tokens}, "
+            f"text_token_margin={text_token_margin}. "
+            f"Visual budget would be {visual_budget}."
+        )
+
+    # max tokens per frame
+    max_tokens_per_frame = visual_budget // max_num_frames
+
+    # If budget is too tight, reduce max_num_frames
+    adjusted_max_num_frames = max_num_frames
+    if max_tokens_per_frame < 1:
+        adjusted_max_num_frames = max(1, visual_budget)  # 1 token per frame minimum
+        max_tokens_per_frame = 1
+
+    # Convert tokens to pixels
+    # tokens_per_frame = (H / vision_factor) × (W / vision_factor)
+    # pixels_per_frame = H × W = tokens_per_frame × vision_factor²
+    max_pixels = max_tokens_per_frame * vision_factor * vision_factor
+
+    # Ensure min_pixels is at most max_pixels (default min_pixels=200,704
+    # can exceed the computed max_pixels for tight budgets)
+    min_pixels = min(256 * 28 * 28, max_pixels)
+
+    # Ensure max_pixels is at least min_pixels
+    max_pixels = max(max_pixels, min_pixels)
+
+    return max_pixels, min_pixels, adjusted_max_num_frames
+
+
+def _get_max_position_embeddings(model: Any) -> int | None:
+    """Extract ``max_position_embeddings`` from a model config.
+
+    Handles both plain transformers models and PTQ-wrapped models.
+    Returns ``None`` if the attribute cannot be found.
+    """
+    config = getattr(model, "config", None)
+    if config is None:
+        return None
+
+    # Qwen3-VL stores it under text_config
+    text_config = getattr(config, "text_config", None)
+    if text_config is not None and hasattr(text_config, "max_position_embeddings"):
+        return int(text_config.max_position_embeddings)
+
+    # Direct attribute
+    if hasattr(config, "max_position_embeddings"):
+        return int(config.max_position_embeddings)
+
+    return None
+
+
 def _build_model_args(
     model: Any,
     max_num_frames: int = 32,
+    max_position_embeddings: int | None = None,
+    max_new_tokens: int = 30,
+    processor: Any = None,
 ) -> tuple[str, dict[str, Any]]:
     """Build the ``model`` name and ``model_args`` dict for ``simple_evaluate``.
 
@@ -696,6 +930,23 @@ def _build_model_args(
     (from the registry) and a ``model_args`` dict that is forwarded to the
     model constructor.  This helper infers the correct model name from the
     Python model object and builds the args dict.
+
+    When *max_position_embeddings* is provided (i.e. the model has a static
+    context budget such as a PTQ-quantized model), the function computes
+    ``max_pixels`` and ``min_pixels`` per video frame so that the total
+    token count stays within budget.  It also adjusts ``max_num_frames``
+    downward if the budget is too tight for the requested frame count.
+
+    Args:
+        model: The Hugging Face model object.
+        max_num_frames: Requested maximum number of video frames.
+        max_position_embeddings: Static context length of the model.  When
+            provided, ``max_pixels`` and ``min_pixels`` are computed from
+            the budget.
+        max_new_tokens: Tokens reserved for generation output.  Only used
+            when *max_position_embeddings* is set.
+        processor: The Hugging Face processor.  Required when
+            *max_position_embeddings* is set to determine the vision factor.
 
     Returns:
         A ``(model_name, model_args_dict)`` tuple.
@@ -733,12 +984,38 @@ def _build_model_args(
     if pretrained is not None:
         model_args_dict["pretrained"] = pretrained
 
-    # Pass max_num_frames to the lmms-eval model wrapper.
-    # The Qwen3_VL wrapper accepts this in __init__ and uses it in
-    # _subsample_video_inputs to control how many frames are sampled
-    # from each video.
-    if max_num_frames is not None:
-        model_args_dict["max_num_frames"] = max_num_frames
+    # When a static context budget is provided, compute max_pixels and
+    # min_pixels per video frame so that the total token count stays within
+    # the budget.
+    if max_position_embeddings is not None and processor is not None:
+        (
+            budget_max_pixels,
+            budget_min_pixels,
+            adjusted_max_num_frames,
+        ) = _compute_video_max_pixels_for_budget(
+            max_position_embeddings=max_position_embeddings,
+            max_num_frames=max_num_frames,
+            max_new_tokens=max_new_tokens,
+            processor=processor,
+        )
+        model_args_dict["max_pixels"] = budget_max_pixels
+        model_args_dict["min_pixels"] = budget_min_pixels
+        model_args_dict["max_num_frames"] = adjusted_max_num_frames
+
+        print(
+            f"[INFO] Video frame budget computed for static context: "
+            f"max_position_embeddings={max_position_embeddings}, "
+            f"max_num_frames={max_num_frames} -> {adjusted_max_num_frames}, "
+            f"max_pixels={budget_max_pixels}, "
+            f"min_pixels={budget_min_pixels}"
+        )
+    else:
+        # Pass max_num_frames to the lmms-eval model wrapper.
+        # The Qwen3_VL wrapper accepts this in __init__ and uses it in
+        # _subsample_video_inputs to control how many frames are sampled
+        # from each video.
+        if max_num_frames is not None:
+            model_args_dict["max_num_frames"] = max_num_frames
 
     return lmms_model_name, model_args_dict
 

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
@@ -116,6 +116,14 @@ evaluation:
       max_new_tokens: 256
       temperature: 0.0
       swap_order: true
+  videomme:
+    enabled: true
+    batch_size: 1
+    max_new_tokens: 30
+    n_samples: -1
+    max_num_frames: 32
+    use_cache: null
+    verbose: false
   mmlu:
     enabled: true
     subjects: null

--- a/tico/quantization/recipes/adapters/qwen3_vl.py
+++ b/tico/quantization/recipes/adapters/qwen3_vl.py
@@ -424,14 +424,21 @@ class Qwen3VLAdapter(ModelAdapter):
 
         videomme = eval_cfg.get("videomme", {})
         if videomme.get("enabled", False):
+            n_samples = int(videomme.get("n_samples", -1))
+            max_num_frames = int(videomme.get("max_num_frames", 32))
+            if max_num_frames <= 0:
+                raise ValueError(
+                    "evaluation.videomme.max_num_frames must be a positive integer."
+                )
+
             evaluate_and_print_video_mme(
                 model=ctx.model,
                 processor=ctx.processor,
                 device=str(ctx.device),
                 batch_size=int(videomme.get("batch_size", 1)),
                 max_new_tokens=int(videomme.get("max_new_tokens", 30)),
-                n_samples=int(videomme.get("n_samples", -1)),
-                max_num_frames=int(videomme.get("max_num_frames", -1)),
+                n_samples=n_samples if n_samples > 0 else None,
+                max_num_frames=max_num_frames,
                 use_cache=videomme.get("use_cache", None),
                 verbose=bool(videomme.get("verbose", eval_cfg.get("verbose", False))),
             )

--- a/tico/quantization/recipes/adapters/qwen3_vl.py
+++ b/tico/quantization/recipes/adapters/qwen3_vl.py
@@ -32,6 +32,7 @@ from tico.quantization.recipes.evaluation.llava_bench_judge import (
 )
 from tico.quantization.recipes.evaluation.mmlu import evaluate_and_print_mmlu
 from tico.quantization.recipes.evaluation.mmmu import evaluate_and_print_mmmu
+from tico.quantization.recipes.evaluation.video_mme import evaluate_and_print_video_mme
 from tico.quantization.recipes.evaluation.vlm import (
     evaluate_coco,
     evaluate_llava_bench,
@@ -420,6 +421,20 @@ class Qwen3VLAdapter(ModelAdapter):
                 max_seq_len=max_seq_len,
             )
             print_coco_score_results("\n=== Llava Bench Evaluation ===", llava_results)
+
+        videomme = eval_cfg.get("videomme", {})
+        if videomme.get("enabled", False):
+            evaluate_and_print_video_mme(
+                model=ctx.model,
+                processor=ctx.processor,
+                device=str(ctx.device),
+                batch_size=int(videomme.get("batch_size", 1)),
+                max_new_tokens=int(videomme.get("max_new_tokens", 30)),
+                n_samples=int(videomme.get("n_samples", -1)),
+                max_num_frames=int(videomme.get("max_num_frames", -1)),
+                use_cache=videomme.get("use_cache", None),
+                verbose=bool(videomme.get("verbose", eval_cfg.get("verbose", False))),
+            )
 
         mmlu = eval_cfg.get("mmlu", {})
         if mmlu.get("enabled", False):

--- a/tico/quantization/recipes/evaluation/video_mme.py
+++ b/tico/quantization/recipes/evaluation/video_mme.py
@@ -37,8 +37,9 @@ def evaluate_and_print_video_mme(
     processor: Any,
     device: str,
     batch_size: int = 1,
+    max_num_frames: int = 32,
     max_new_tokens: int = 30,
-    limit: int | None = None,
+    n_samples: int | None = None,
     use_cache: str | None = None,
     verbose: bool = True,
 ) -> dict[str, Any]:
@@ -48,9 +49,9 @@ def evaluate_and_print_video_mme(
     ``tasks=["videomme"]`` (or ``tasks=["videomme_mini"]`` when *mini*
     is ``True``) and prints the results in a formatted table.
 
-    The *limit* parameter restricts the number of samples evaluated,
+    The *n_samples* parameter restricts the number of samples evaluated,
     which also limits how many videos are downloaded.  For example,
-    ``limit=10`` will only download only first zip file and evaluate
+    ``n_samples=10`` will only download only first zip file and evaluate
     the first 10 samples. This uses a custom ``videomme_mini`` task
     YAML (shipped with TICO) that specifies ``test_split: test``.
 
@@ -59,8 +60,9 @@ def evaluate_and_print_video_mme(
         processor: The matching ``AutoProcessor`` for the model.
         device: Device string for inference (e.g. ``"cuda"``, ``"cpu"``).
         batch_size: Batch size for generation.  Defaults to 1.
+        max_num_frames: The maximum number of frames that will be extracted from the video uniformly.
         max_new_tokens: Maximum number of tokens to generate per sample.
-        limit: If set, only evaluate the first *limit* samples.  This
+        n_samples: If set, only evaluate the first *n_samples* samples.  This
             also limits how many videos are downloaded.  Defaults to
             ``None`` (download and evaluate all samples).
         use_cache: Optional path to an ``lmms-eval`` results cache directory.
@@ -80,13 +82,14 @@ def evaluate_and_print_video_mme(
         tasks=["videomme"],
         device=device,
         batch_size=batch_size,
+        max_num_frames=max_num_frames,
         max_new_tokens=max_new_tokens,
-        limit=limit,
+        limit=n_samples,
         use_cache=use_cache,
         verbose=verbose,
     )
 
-    print(f"\n=== Video-MME Evaluation (limit={limit}) ===")
+    print(f"\n=== Video-MME Evaluation (limit={n_samples}) ===")
     print_lmms_eval_results(results)
 
     return results

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -512,7 +512,8 @@ def parse_args():
         type=int,
         default=32,
         help="Maximum number of frames to sample from each video for Video-MME evaluation. "
-        "Default is 5 for fitting within max_position_embeddings (2048).",
+        "Keep in mind that increasing max number of frames leads to a decrease of pixels number per frame, "
+        "since the total token count should stay within the static context budget of the quantized model (max_position_embeddings=2048).",
     )
 
     return parser.parse_args()

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -489,28 +489,28 @@ def parse_args():
 
     # Video-MME evaluation arguments
     parser.add_argument(
-        "--video_mme",
+        "--videomme",
         action="store_true",
         default=False,
         help="Evaluate on Video-MME benchmark via lmms-eval.",
     )
     parser.add_argument(
-        "--video_mme_max_new_tokens",
+        "--videomme_max_new_tokens",
         type=int,
         default=None,
         help="Maximum number of tokens to generate per Video-MME sample.",
     )
     parser.add_argument(
-        "--video_mme_limit",
+        "--videomme_n_samples",
         type=int,
         default=None,
         help="Limit the number of Video-MME samples to evaluate (and download). "
-        "E.g. --video_mme_limit 10 evaluates only the first 10 samples.",
+        "E.g. --videomme_n_samples 10 evaluates only the first 10 samples.",
     )
     parser.add_argument(
-        "--video_mme_max_num_frames",
+        "--videomme_max_num_frames",
         type=int,
-        default=5,
+        default=32,
         help="Maximum number of frames to sample from each video for Video-MME evaluation. "
         "Default is 5 for fitting within max_position_embeddings (2048).",
     )
@@ -1270,21 +1270,21 @@ def evaluate_original_model(model, processor, args):
         )
         print_mmmu_results(original_mmmu_results)
 
-    if args.video_mme:
+    if args.videomme:
         print(
-            f"\n=== Video-MME Evaluation (Original Model) (limit={args.video_mme_limit}) ==="
+            f"\n=== Video-MME Evaluation (Original Model) (limit={args.videomme_n_samples}) ==="
         )
-        original_video_mme_results = evaluate_vlm_on_tasks(
+        original_videomme_results = evaluate_vlm_on_tasks(
             model=model,
             processor=processor,
             tasks=["videomme"],
             device=args.device,
-            max_new_tokens=args.video_mme_max_new_tokens,
-            limit=args.video_mme_limit,
+            max_new_tokens=args.videomme_max_new_tokens,
+            limit=args.videomme_n_samples,
             verbose=args.verbose,
-            max_num_frames=args.video_mme_max_num_frames,
+            max_num_frames=args.videomme_max_num_frames,
         )
-        print_lmms_eval_results(original_video_mme_results)
+        print_lmms_eval_results(original_videomme_results)
 
     if args.ppl_dataset:
         print("\n=== PPL Evaluation (Original Model) ===")
@@ -1394,21 +1394,21 @@ def evaluate_quantized_model(model, processor, args, original_results=None) -> N
         )
         print_mmmu_results(quantized_mmmu_results)
 
-    if args.video_mme:
+    if args.videomme:
         print(
-            f"\n=== Video-MME Evaluation (Quantized Model) (limit={args.video_mme_limit}) ==="
+            f"\n=== Video-MME Evaluation (Quantized Model) (limit={args.videomme_n_samples}) ==="
         )
-        quantized_video_mme_results = evaluate_vlm_on_tasks(
+        quantized_videomme_results = evaluate_vlm_on_tasks(
             model=model,
             processor=processor,
             tasks=["videomme"],
             device=args.device,
-            max_new_tokens=args.video_mme_max_new_tokens,
-            limit=args.video_mme_limit,
+            max_new_tokens=args.videomme_max_new_tokens,
+            limit=args.videomme_n_samples,
             verbose=args.verbose,
-            max_num_frames=args.video_mme_max_num_frames,
+            max_num_frames=args.videomme_max_num_frames,
         )
-        print_lmms_eval_results(quantized_video_mme_results)
+        print_lmms_eval_results(quantized_videomme_results)
 
     if args.ppl_dataset:
         print("\n=== PPL Evaluation (Quantized Model) ===")


### PR DESCRIPTION
This commit introduces:
- continue video-mme dataset support for qwen3-vl adapter
- automatic video frame resizing to fit within the static context budget of PTQ-quantized models
- refactoring videomme arguments
- tests



TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>