### PR TITLE
[quantization] Add Qwen3-VL vision SpinQuant support

### DIFF
--- a/test/quantization/algorithm/test_qwen3_vl_spinquant.py
+++ b/test/quantization/algorithm/test_qwen3_vl_spinquant.py
@@ -45,18 +45,31 @@ except (AttributeError, ImportError, ModuleNotFoundError) as exc:
 
 
 class Qwen3VLSpinQuantConfigTest(unittest.TestCase):
-    def test_config_default_is_random(self):
+    def test_config_default_is_random_and_text_enabled(self):
         cfg = Qwen3VLSpinQuantConfig()
         self.assertEqual(cfg.init_method, "random")
         self.assertEqual(cfg.name, "spinquant")
+        self.assertTrue(cfg.enable_r1)
+        self.assertTrue(cfg.enable_r2)
+        self.assertFalse(cfg.fuse_vision_layer_norms)
+        self.assertFalse(cfg.enable_vision_r1)
+        self.assertFalse(cfg.enable_vision_r2)
 
     def test_config_accepts_hadamard(self):
         cfg = Qwen3VLSpinQuantConfig(init_method="hadamard")
         self.assertEqual(cfg.init_method, "hadamard")
 
-    def test_config_requires_r1_for_external(self):
+    def test_config_requires_r1_for_external_text_r1(self):
         with self.assertRaises(ValueError):
             Qwen3VLSpinQuantConfig(init_method="external")
+
+    def test_config_allows_external_mode_when_text_r1_is_disabled(self):
+        cfg = Qwen3VLSpinQuantConfig(
+            init_method="external",
+            enable_r1=False,
+            show_progress=False,
+        )
+        self.assertFalse(cfg.enable_r1)
 
     def test_config_rejects_non_tensor_r1(self):
         with self.assertRaises(TypeError):
@@ -78,6 +91,45 @@ class Qwen3VLSpinQuantConfigTest(unittest.TestCase):
                 init_method="random",
                 r2_map={"model.language_model.layers.0.self_attn.R2": "invalid"},  # type: ignore[dict-item]
             )
+
+    def test_config_requires_vision_norm_fusion_for_vision_r1(self):
+        with self.assertRaises(ValueError):
+            Qwen3VLSpinQuantConfig(enable_vision_r1=True)
+
+    def test_config_requires_vision_r1_for_external_vision_r1(self):
+        with self.assertRaises(ValueError):
+            Qwen3VLSpinQuantConfig(
+                enable_vision_r1=True,
+                fuse_vision_layer_norms=True,
+                vision_init_method="external",
+            )
+
+    def test_config_accepts_vision_r2_without_vision_r1(self):
+        cfg = Qwen3VLSpinQuantConfig(
+            enable_vision_r2=True,
+            vision_init_method="external",
+            vision_r2_map={
+                "model.visual.blocks.0.attn.R2": torch.eye(4, dtype=torch.float64)
+            },
+        )
+        self.assertTrue(cfg.enable_vision_r2)
+        self.assertFalse(cfg.enable_vision_r1)
+
+    def test_config_rejects_non_tensor_vision_r1(self):
+        with self.assertRaises(TypeError):
+            Qwen3VLSpinQuantConfig(
+                vision_r1="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_config_rejects_non_tensor_vision_r2_value(self):
+        with self.assertRaises(TypeError):
+            Qwen3VLSpinQuantConfig(
+                vision_r2_map={"model.visual.blocks.0.attn.R2": "invalid"},  # type: ignore[dict-item]
+            )
+
+    def test_config_rejects_non_positive_vision_rotation_tolerance(self):
+        with self.assertRaises(ValueError):
+            Qwen3VLSpinQuantConfig(vision_rotation_tolerance=0.0)
 
 
 @unittest.skipUnless(QWEN3_VL_AVAILABLE, QWEN3_VL_SKIP_REASON)
@@ -182,12 +234,6 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         """
         Force the synthetic Qwen3-VL model to match the requested tie setting.
 
-        Some transformers versions do not automatically tie ``lm_head`` to
-        ``model.language_model.embed_tokens`` when a model is constructed from a
-        tiny synthetic config. Real checkpoints can still be tied after loading,
-        but unit tests need the in-memory test model to expose the same storage
-        alias before SpinQuant validation runs.
-
         Parameters:
             model: Qwen3-VL model to update in-place.
             tie_word_embeddings: Whether to tie or explicitly untie the weights.
@@ -219,11 +265,6 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         """
         Patch tiny Qwen3-VL RoPE config fields for transformers version drift.
 
-        Some Qwen3-VL releases read ``text_config.rope_parameters`` while other
-        releases read ``text_config.rope_scaling`` directly. Unit tests construct
-        a tiny synthetic config, so both fields are populated to avoid depending
-        on one specific transformers minor version.
-
         Parameters:
             config: Qwen3-VL top-level configuration to patch in-place.
         """
@@ -253,12 +294,6 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
     def _force_tied_qwen3_vl_word_embeddings(self, model: torch.nn.Module) -> None:
         """
         Force Qwen3-VL input embeddings and LM head to share storage.
-
-        Some transformers releases do not tie synthetic Qwen3-VL models even
-        when ``tie_word_embeddings=True`` is passed to the tiny test config.
-        The production SpinQuant path assumes tied embeddings, so the test
-        helper explicitly creates the same storage alias used by real tied
-        checkpoints.
 
         Parameters:
             model: Target Qwen3-VL model.
@@ -358,12 +393,37 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
             for idx in range(int(text_config.num_hidden_layers))
         }
 
+    def _make_identity_vision_r2_map(
+        self, model: torch.nn.Module
+    ) -> dict[str, torch.Tensor]:
+        """
+        Build an identity R2 map for all Qwen3-VL vision blocks.
+
+        Parameters:
+            model: Target Qwen3-VL model.
+
+        Returns:
+            Mapping from supported vision R2 keys to identity matrices.
+        """
+        vision_config = model.config.vision_config
+        hidden_size = int(vision_config.hidden_size)
+        num_heads = int(vision_config.num_heads)
+        head_dim = hidden_size // num_heads
+        depth = int(getattr(vision_config, "depth"))
+        return {
+            f"model.visual.blocks.{idx}.attn.R2": torch.eye(
+                head_dim,
+                dtype=torch.float64,
+            )
+            for idx in range(depth)
+        }
+
     def _make_external_config(
         self,
         model: torch.nn.Module,
         r1: torch.Tensor,
         *,
-        apply_r2: bool = True,
+        enable_r2: bool = True,
     ) -> Qwen3VLSpinQuantConfig:
         """
         Build an external-rotation Qwen3-VL SpinQuant configuration.
@@ -371,7 +431,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         Parameters:
             model: Target Qwen3-VL model.
             r1: Global hidden-dimension rotation.
-            apply_r2: Whether to apply identity R2 rotations.
+            enable_r2: Whether to apply identity R2 rotations.
 
         Returns:
             A Qwen3VLSpinQuantConfig instance.
@@ -379,9 +439,87 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         return Qwen3VLSpinQuantConfig(
             init_method="external",
             r1=r1,
-            r2_map=self._make_identity_r2_map(model) if apply_r2 else None,
-            apply_r2=apply_r2,
+            r2_map=self._make_identity_r2_map(model) if enable_r2 else None,
+            enable_r2=enable_r2,
             show_progress=False,
+        )
+
+    def _right_multiply_blockwise(
+        self,
+        weight: torch.Tensor,
+        rotation: torch.Tensor,
+        block_size: int,
+    ) -> torch.Tensor:
+        """
+        Apply the same input-axis rotation to each contiguous input block.
+
+        Parameters:
+            weight: Linear weight with shape [out_features, in_features].
+            rotation: Block rotation matrix.
+            block_size: Block size on the input axis.
+
+        Returns:
+            The rotated weight tensor.
+        """
+        out_features = weight.shape[0]
+        num_blocks = weight.shape[1] // block_size
+        working = weight.to(torch.float64).reshape(out_features, num_blocks, block_size)
+        updated = working @ rotation.to(device=weight.device, dtype=torch.float64)
+        return updated.reshape_as(weight).to(device=weight.device, dtype=weight.dtype)
+
+    def _left_multiply_conv3d_output(
+        self,
+        weight: torch.Tensor,
+        rotation_t: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Apply an output-channel rotation to a Conv3d weight.
+
+        Parameters:
+            weight: Conv3d weight tensor.
+            rotation_t: Transposed output rotation matrix.
+
+        Returns:
+            The rotated Conv3d weight tensor.
+        """
+        out_channels = weight.shape[0]
+        flat = weight.to(torch.float64).reshape(out_channels, -1)
+        updated = rotation_t.to(device=weight.device, dtype=torch.float64) @ flat
+        return updated.reshape_as(weight).to(device=weight.device, dtype=weight.dtype)
+
+    def _expected_qkv_v_weight_after_r2(
+        self,
+        v_weight: torch.Tensor,
+        rotation: torch.Tensor,
+        *,
+        vision_hidden_size: int,
+        head_dim: int,
+    ) -> torch.Tensor:
+        """
+        Compute the expected V-slice weight after vision R2 fusion.
+
+        Parameters:
+            v_weight: V slice of the fused QKV projection.
+            rotation: Per-head R2 matrix.
+            vision_hidden_size: Vision hidden dimension.
+            head_dim: Per-head hidden dimension.
+
+        Returns:
+            The expected rotated V-slice weight.
+        """
+        in_features = v_weight.shape[1]
+        num_heads = vision_hidden_size // head_dim
+        working_t = v_weight.to(torch.float64).T.reshape(
+            in_features,
+            num_heads,
+            head_dim,
+        )
+        updated_t = working_t @ rotation.to(
+            device=v_weight.device,
+            dtype=torch.float64,
+        )
+        return updated_t.reshape(in_features, vision_hidden_size).T.to(
+            device=v_weight.device, dtype=v_weight.dtype
         )
 
     @torch.inference_mode()
@@ -425,10 +563,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
             )
         )
         self.assertTrue(
-            torch.allclose(
-                q_m.lm_head.weight,
-                original_state["lm_head.weight"],
-            )
+            torch.allclose(q_m.lm_head.weight, original_state["lm_head.weight"])
         )
         self.assertTrue(
             torch.allclose(
@@ -525,7 +660,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         model = self._build_qwen3_vl_model()
         hidden_size = int(model.config.text_config.hidden_size)
         r1 = self._make_permutation_rotation(hidden_size)
-        cfg = self._make_external_config(model, r1, apply_r2=True)
+        cfg = self._make_external_config(model, r1, enable_r2=True)
 
         input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
         attention_mask = torch.ones_like(input_ids)
@@ -558,7 +693,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         model = self._build_qwen3_vl_model()
         hidden_size = int(model.config.text_config.hidden_size)
         r1 = self._make_permutation_rotation(hidden_size)
-        cfg = self._make_external_config(model, r1, apply_r2=False)
+        cfg = self._make_external_config(model, r1, enable_r2=False)
 
         q_m = prepare(model, cfg)
         final_norm_scale = q_m.model.language_model.norm.weight.detach().clone()
@@ -591,7 +726,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         model = self._build_qwen3_vl_model()
         hidden_size = int(model.config.text_config.hidden_size)
         r1 = self._make_permutation_rotation(hidden_size)
-        cfg = self._make_external_config(model, r1, apply_r2=False)
+        cfg = self._make_external_config(model, r1, enable_r2=False)
 
         q_m = prepare(model, cfg)
         q_m = convert(q_m)
@@ -622,7 +757,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         model = self._build_qwen3_vl_model()
         hidden_size = int(model.config.text_config.hidden_size)
         r1 = self._make_permutation_rotation(hidden_size)
-        cfg = self._make_external_config(model, r1, apply_r2=False)
+        cfg = self._make_external_config(model, r1, enable_r2=False)
 
         q_m = prepare(model, cfg)
         before_q = (
@@ -667,7 +802,7 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         model = self._build_qwen3_vl_model(deepstack_visual_indexes=[0])
         hidden_size = int(model.config.text_config.hidden_size)
         r1 = self._make_permutation_rotation(hidden_size)
-        cfg = self._make_external_config(model, r1, apply_r2=False)
+        cfg = self._make_external_config(model, r1, enable_r2=False)
 
         q_m = prepare(model, cfg)
         main_before = q_m.model.visual.merger.linear_fc2.weight.detach().clone()
@@ -687,13 +822,218 @@ class Qwen3VLSpinQuantTest(unittest.TestCase):
         self.assertTrue(torch.allclose(deep_after, expected_deep))
 
     @torch.inference_mode()
+    def test_convert_fuses_vision_norms_when_requested(self):
+        model = self._build_qwen3_vl_model(deepstack_visual_indexes=[0])
+        cfg = Qwen3VLSpinQuantConfig(
+            enable_r1=False,
+            enable_r2=False,
+            fuse_deepstack_visual_outputs=False,
+            fuse_vision_layer_norms=True,
+            show_progress=False,
+        )
+
+        q_m = prepare(model, cfg)
+        block = q_m.model.visual.blocks[0]
+        with torch.no_grad():
+            block.norm1.weight.copy_(
+                torch.linspace(1.0, 2.0, block.norm1.weight.numel())
+            )
+            block.norm2.weight.copy_(
+                torch.linspace(2.0, 3.0, block.norm2.weight.numel())
+            )
+
+        qkv_before = block.attn.qkv.weight.detach().clone()
+        norm1_gamma = block.norm1.weight.detach().clone()
+
+        q_m = convert(q_m)
+
+        expected_qkv = qkv_before * norm1_gamma.to(qkv_before.dtype).unsqueeze(0)
+        self.assertTrue(torch.allclose(block.attn.qkv.weight, expected_qkv))
+        self.assertTrue(
+            torch.allclose(block.norm1.weight, torch.ones_like(block.norm1.weight))
+        )
+        self.assertTrue(
+            torch.allclose(block.norm2.weight, torch.ones_like(block.norm2.weight))
+        )
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.visual.merger.norm.weight,
+                torch.ones_like(q_m.model.visual.merger.norm.weight),
+            )
+        )
+        self.assertTrue(
+            torch.allclose(
+                q_m.model.visual.deepstack_merger_list[0].norm.weight,
+                torch.ones_like(q_m.model.visual.deepstack_merger_list[0].norm.weight),
+            )
+        )
+
+    @torch.inference_mode()
+    def test_convert_vision_r1_rotates_vision_weights_and_merger_inputs(self):
+        model = self._build_qwen3_vl_model(deepstack_visual_indexes=[0])
+        vision_hidden_size = int(model.config.vision_config.hidden_size)
+        vision_r1 = self._make_permutation_rotation(vision_hidden_size)
+        cfg = Qwen3VLSpinQuantConfig(
+            init_method="random",
+            enable_r1=False,
+            enable_r2=False,
+            fuse_deepstack_visual_outputs=False,
+            fuse_vision_layer_norms=True,
+            enable_vision_r1=True,
+            vision_init_method="external",
+            vision_r1=vision_r1,
+            show_progress=False,
+        )
+
+        q_m = prepare(model, cfg)
+        visual = q_m.model.visual
+        block = visual.blocks[0]
+        patch_before = visual.patch_embed.proj.weight.detach().clone()
+        pos_before = visual.pos_embed.weight.detach().clone()
+        qkv_before = block.attn.qkv.weight.detach().clone()
+        proj_before = block.attn.proj.weight.detach().clone()
+        fc1_before = block.mlp.linear_fc1.weight.detach().clone()
+        fc2_before = block.mlp.linear_fc2.weight.detach().clone()
+        merger_fc1_before = visual.merger.linear_fc1.weight.detach().clone()
+        deep_fc1_before = (
+            visual.deepstack_merger_list[0].linear_fc1.weight.detach().clone()
+        )
+
+        q_m = convert(q_m)
+
+        expected_patch = self._left_multiply_conv3d_output(patch_before, vision_r1.T)
+        expected_pos = (
+            pos_before.to(torch.float64)
+            @ vision_r1.to(device=pos_before.device, dtype=torch.float64)
+        ).to(device=pos_before.device, dtype=pos_before.dtype)
+        expected_qkv = (
+            qkv_before.to(torch.float64)
+            @ vision_r1.to(device=qkv_before.device, dtype=torch.float64)
+        ).to(
+            device=qkv_before.device,
+            dtype=qkv_before.dtype,
+        )
+        expected_proj = (
+            vision_r1.T.to(device=proj_before.device, dtype=torch.float64)
+            @ proj_before.to(torch.float64)
+        ).to(
+            device=proj_before.device,
+            dtype=proj_before.dtype,
+        )
+        expected_fc1 = (
+            fc1_before.to(torch.float64)
+            @ vision_r1.to(device=fc1_before.device, dtype=torch.float64)
+        ).to(
+            device=fc1_before.device,
+            dtype=fc1_before.dtype,
+        )
+        expected_fc2 = (
+            vision_r1.T.to(device=fc2_before.device, dtype=torch.float64)
+            @ fc2_before.to(torch.float64)
+        ).to(
+            device=fc2_before.device,
+            dtype=fc2_before.dtype,
+        )
+        expected_merger_fc1 = self._right_multiply_blockwise(
+            merger_fc1_before,
+            vision_r1,
+            vision_hidden_size,
+        )
+        expected_deep_fc1 = self._right_multiply_blockwise(
+            deep_fc1_before,
+            vision_r1,
+            vision_hidden_size,
+        )
+
+        self.assertTrue(torch.allclose(visual.patch_embed.proj.weight, expected_patch))
+        self.assertTrue(torch.allclose(visual.pos_embed.weight, expected_pos))
+        self.assertTrue(torch.allclose(block.attn.qkv.weight, expected_qkv))
+        self.assertTrue(torch.allclose(block.attn.proj.weight, expected_proj))
+        self.assertTrue(torch.allclose(block.mlp.linear_fc1.weight, expected_fc1))
+        self.assertTrue(torch.allclose(block.mlp.linear_fc2.weight, expected_fc2))
+        self.assertTrue(
+            torch.allclose(visual.merger.linear_fc1.weight, expected_merger_fc1)
+        )
+        self.assertTrue(
+            torch.allclose(
+                visual.deepstack_merger_list[0].linear_fc1.weight,
+                expected_deep_fc1,
+            )
+        )
+
+    @torch.inference_mode()
+    def test_convert_vision_r2_rotates_fused_qkv_v_slice_and_proj_input(self):
+        model = self._build_qwen3_vl_model(deepstack_visual_indexes=[0])
+        vision_hidden_size = int(model.config.vision_config.hidden_size)
+        head_dim = vision_hidden_size // int(model.config.vision_config.num_heads)
+        vision_r2 = self._make_permutation_rotation(head_dim)
+        cfg = Qwen3VLSpinQuantConfig(
+            init_method="random",
+            enable_r1=False,
+            enable_r2=False,
+            fuse_deepstack_visual_outputs=False,
+            enable_vision_r2=True,
+            vision_init_method="external",
+            vision_r2_map={"model.visual.blocks.0.attn.R2": vision_r2},
+            show_progress=False,
+        )
+
+        q_m = prepare(model, cfg)
+        block = q_m.model.visual.blocks[0]
+        qkv_before = block.attn.qkv.weight.detach().clone()
+        proj_before = block.attn.proj.weight.detach().clone()
+
+        q_m = convert(q_m)
+
+        q_before = qkv_before[:vision_hidden_size]
+        k_before = qkv_before[vision_hidden_size : 2 * vision_hidden_size]
+        v_before = qkv_before[2 * vision_hidden_size : 3 * vision_hidden_size]
+        q_after = block.attn.qkv.weight[:vision_hidden_size]
+        k_after = block.attn.qkv.weight[vision_hidden_size : 2 * vision_hidden_size]
+        v_after = block.attn.qkv.weight[2 * vision_hidden_size : 3 * vision_hidden_size]
+
+        expected_v = self._expected_qkv_v_weight_after_r2(
+            v_before,
+            vision_r2,
+            vision_hidden_size=vision_hidden_size,
+            head_dim=head_dim,
+        )
+        expected_proj = self._right_multiply_blockwise(proj_before, vision_r2, head_dim)
+
+        self.assertTrue(torch.allclose(q_after, q_before))
+        self.assertTrue(torch.allclose(k_after, k_before))
+        self.assertTrue(torch.allclose(v_after, expected_v))
+        self.assertTrue(torch.allclose(block.attn.proj.weight, expected_proj))
+
+    @torch.inference_mode()
+    def test_external_vision_r1_rejects_non_layernorm_compatible_rotation(self):
+        model = self._build_qwen3_vl_model()
+        vision_hidden_size = int(model.config.vision_config.hidden_size)
+        bad_rotation = torch.eye(vision_hidden_size, dtype=torch.float64)
+        bad_rotation[0, 0] = -1.0
+        cfg = Qwen3VLSpinQuantConfig(
+            init_method="random",
+            enable_r1=False,
+            enable_r2=False,
+            fuse_vision_layer_norms=True,
+            enable_vision_r1=True,
+            vision_init_method="external",
+            vision_r1=bad_rotation,
+            show_progress=False,
+        )
+
+        q_m = prepare(model, cfg)
+        with self.assertRaises(ValueError):
+            convert(q_m)
+
+    @torch.inference_mode()
     def test_quantizer_direct_prepare_and_convert_with_identity_external_rotation(self):
         assert Qwen3VLSpinQuantQuantizer is not None
 
         model = self._build_qwen3_vl_model()
         hidden_size = int(model.config.text_config.hidden_size)
         r1 = torch.eye(hidden_size, dtype=torch.float64)
-        cfg = self._make_external_config(model, r1, apply_r2=True)
+        cfg = self._make_external_config(model, r1, enable_r2=True)
         quantizer = Qwen3VLSpinQuantQuantizer(cfg)
 
         q_m = quantizer.prepare(model)

--- a/test/quantization/config/test_builders.py
+++ b/test/quantization/config/test_builders.py
@@ -173,6 +173,7 @@ class TestBuildQwen3VlPtqConfig(unittest.TestCase):
             vision_patch_embed_weight=affine(DType.uint(8)),
             embedding_weight=affine(DType.uint(8)),
             lm_head_weight=affine(DType.uint(8)),
+            spin_rotation_weight=affine(DType.int(16)),
             norm=affine(DType.int(16)),
             norm_weight=affine(DType.int(16)),
             strict_wrap=False,
@@ -195,8 +196,33 @@ class TestBuildQwen3VlPtqConfig(unittest.TestCase):
             DType.uint(4),
         )
         self.assertEqual(
+            cfg.overrides["model"]["language_model"]["rotate_embedding"]["weight"][  # type: ignore[index]
+                "dtype"
+            ],
+            DType.int(16),
+        )
+        self.assertEqual(
+            cfg.overrides["rotate_lm_head"]["weight"]["dtype"],  # type: ignore[index]
+            DType.int(16),
+        )
+        self.assertEqual(
             cfg.overrides["lm_head"]["weight"]["qscheme"], QScheme.PER_CHANNEL_ASYMM  # type: ignore[index]
         )
+
+    def test_build_qwen3_vl_ptq_config_omits_spin_rotation_when_not_requested(self):
+        cfg = build_qwen3_vl_ptq_config(
+            num_vision_blocks=1,
+            num_text_layers=1,
+            num_deepstack_mergers=0,
+            model_args={"vision": {"grid_thw": (1, 1, 1)}},
+            linear_weight=affine(DType.uint(4)),
+        )
+
+        self.assertNotIn(
+            "rotate_embedding",
+            cfg.overrides["model"]["language_model"],  # type: ignore[index]
+        )
+        self.assertNotIn("rotate_lm_head", cfg.overrides)  # type: ignore[operator]
 
 
 if __name__ == "__main__":

--- a/test/quantization/recipes/test_qwen_adapter.py
+++ b/test/quantization/recipes/test_qwen_adapter.py
@@ -92,6 +92,7 @@ class TestQwen3VLAdapter(unittest.TestCase):
                     "vision_patch_embed_weight": 8,
                     "embedding_weight": 8,
                     "lm_head_weight": 4,
+                    "spin_rotation_weight": "int16",
                     "norm": "int16",
                     "norm_weight": "int16",
                     "quantize_vision": True,
@@ -109,7 +110,107 @@ class TestQwen3VLAdapter(unittest.TestCase):
         self.assertEqual(captured["linear_weight"].dtype, DType.uint(4))
         self.assertEqual(captured["vision_patch_embed_weight"].dtype, DType.uint(8))
         self.assertEqual(captured["lm_head_weight"].dtype, DType.uint(4))
+        self.assertEqual(captured["spin_rotation_weight"].dtype, DType.int(16))
         self.assertFalse(captured["strict_wrap"])
+
+    def test_apply_spinquant_passes_enable_vision_options_to_config(self):
+        """Qwen3VLAdapter should pass enable-based SpinQuant options to the config."""
+        captured = {}
+        adapter = Qwen3VLAdapter()
+        model = TinyModule()
+        ctx = RecipeContext(
+            cfg={"runtime": {"show_progress": False}},
+            adapter=adapter,
+            model=model,
+        )
+
+        class FakeSpinQuantConfig:
+            """Fake SpinQuant config that records constructor keyword arguments."""
+
+            def __init__(self, **kwargs):
+                captured["config_kwargs"] = kwargs
+
+        def fake_prepare(model_arg, config, inplace=False):
+            captured["prepare"] = (model_arg, config, inplace)
+            return model_arg
+
+        def fake_convert(model_arg, inplace=False):
+            captured["convert"] = (model_arg, inplace)
+            return model_arg
+
+        stage_cfg = {
+            "init_method": "hadamard",
+            "enable_r1": False,
+            "enable_r2": False,
+            "fuse_deepstack_visual_outputs": False,
+            "enable_vision_r1": True,
+            "enable_vision_r2": True,
+            "vision_init_method": "random",
+            "require_vision_r1_layernorm_compatible": False,
+            "vision_rotation_tolerance": 1e-3,
+            "show_progress": False,
+        }
+
+        with patch.object(
+            qwen_mod, "Qwen3VLSpinQuantConfig", FakeSpinQuantConfig
+        ), patch.object(qwen_mod, "prepare", fake_prepare), patch.object(
+            qwen_mod, "convert", fake_convert
+        ):
+            with contextlib.redirect_stdout(io.StringIO()):
+                result = adapter.apply_spinquant(ctx, stage_cfg)
+
+        self.assertIs(result, model)
+        kwargs = captured["config_kwargs"]
+        self.assertEqual(kwargs["init_method"], "hadamard")
+        self.assertFalse(kwargs["enable_r1"])
+        self.assertFalse(kwargs["enable_r2"])
+        self.assertFalse(kwargs["fuse_deepstack_visual_outputs"])
+        self.assertTrue(kwargs["enable_vision_r1"])
+        self.assertTrue(kwargs["enable_vision_r2"])
+        self.assertTrue(kwargs["fuse_vision_layer_norms"])
+        self.assertEqual(kwargs["vision_init_method"], "random")
+        self.assertFalse(kwargs["require_vision_r1_layernorm_compatible"])
+        self.assertEqual(kwargs["vision_rotation_tolerance"], 1e-3)
+        self.assertEqual(captured["prepare"][2], True)
+        self.assertEqual(captured["convert"][1], True)
+
+    def test_apply_spinquant_does_not_treat_apply_keys_as_legacy_aliases(self):
+        """Qwen3VLAdapter should use enable_* keys rather than apply_* aliases."""
+        captured = {}
+        adapter = Qwen3VLAdapter()
+        model = TinyModule()
+        ctx = RecipeContext(cfg={}, adapter=adapter, model=model)
+
+        class FakeSpinQuantConfig:
+            """Fake SpinQuant config that records constructor keyword arguments."""
+
+            def __init__(self, **kwargs):
+                captured["config_kwargs"] = kwargs
+
+        with patch.object(
+            qwen_mod, "Qwen3VLSpinQuantConfig", FakeSpinQuantConfig
+        ), patch.object(
+            qwen_mod, "prepare", lambda model_arg, config, inplace=False: model_arg
+        ), patch.object(
+            qwen_mod, "convert", lambda model_arg, inplace=False: model_arg
+        ):
+            with contextlib.redirect_stdout(io.StringIO()):
+                adapter.apply_spinquant(
+                    ctx,
+                    {
+                        "apply_r1": False,
+                        "apply_r2": False,
+                        "apply_vision_r1": True,
+                        "apply_vision_r2": True,
+                        "show_progress": False,
+                    },
+                )
+
+        kwargs = captured["config_kwargs"]
+        self.assertTrue(kwargs["enable_r1"])
+        self.assertTrue(kwargs["enable_r2"])
+        self.assertFalse(kwargs["enable_vision_r1"])
+        self.assertFalse(kwargs["enable_vision_r2"])
 
     def test_build_calibration_inputs_routes_mixed_dataset_config(self):
         """Qwen3VLAdapter should route mixed calibration datasets to the data helper."""

--- a/test/quantization/recipes/test_qwen_adapter.py
+++ b/test/quantization/recipes/test_qwen_adapter.py
@@ -25,6 +25,7 @@ import contextlib
 import io
 import unittest
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import tico.quantization.recipes.adapters.qwen3_vl as qwen_mod
@@ -61,7 +62,7 @@ def _fake_qwen_model():
 class TestQwen3VLAdapter(unittest.TestCase):
     def test_build_ptq_config_uses_architecture_counts_and_model_args(self):
         """Qwen3VLAdapter should infer architecture counts before building PTQ config."""
-        captured = {}
+        captured: dict[str, Any] = {}
 
         def fake_build_qwen3_vl_ptq_config(**kwargs):
             captured.update(kwargs)
@@ -115,7 +116,7 @@ class TestQwen3VLAdapter(unittest.TestCase):
 
     def test_apply_spinquant_passes_enable_vision_options_to_config(self):
         """Qwen3VLAdapter should pass enable-based SpinQuant options to the config."""
-        captured = {}
+        captured: dict[str, Any] = {}
         adapter = Qwen3VLAdapter()
         model = TinyModule()
         ctx = RecipeContext(
@@ -173,44 +174,6 @@ class TestQwen3VLAdapter(unittest.TestCase):
         self.assertEqual(kwargs["vision_rotation_tolerance"], 1e-3)
         self.assertEqual(captured["prepare"][2], True)
         self.assertEqual(captured["convert"][1], True)
-
-    def test_apply_spinquant_does_not_treat_apply_keys_as_legacy_aliases(self):
-        """Qwen3VLAdapter should use enable_* keys rather than apply_* aliases."""
-        captured = {}
-        adapter = Qwen3VLAdapter()
-        model = TinyModule()
-        ctx = RecipeContext(cfg={}, adapter=adapter, model=model)
-
-        class FakeSpinQuantConfig:
-            """Fake SpinQuant config that records constructor keyword arguments."""
-
-            def __init__(self, **kwargs):
-                captured["config_kwargs"] = kwargs
-
-        with patch.object(
-            qwen_mod, "Qwen3VLSpinQuantConfig", FakeSpinQuantConfig
-        ), patch.object(
-            qwen_mod, "prepare", lambda model_arg, config, inplace=False: model_arg
-        ), patch.object(
-            qwen_mod, "convert", lambda model_arg, inplace=False: model_arg
-        ):
-            with contextlib.redirect_stdout(io.StringIO()):
-                adapter.apply_spinquant(
-                    ctx,
-                    {
-                        "apply_r1": False,
-                        "apply_r2": False,
-                        "apply_vision_r1": True,
-                        "apply_vision_r2": True,
-                        "show_progress": False,
-                    },
-                )
-
-        kwargs = captured["config_kwargs"]
-        self.assertTrue(kwargs["enable_r1"])
-        self.assertTrue(kwargs["enable_r2"])
-        self.assertFalse(kwargs["enable_vision_r1"])
-        self.assertFalse(kwargs["enable_vision_r2"])
 
     def test_build_calibration_inputs_routes_mixed_dataset_config(self):
         """Qwen3VLAdapter should route mixed calibration datasets to the data helper."""

--- a/tico/quantization/algorithm/spinquant/qwen3_vl_model_utils.py
+++ b/tico/quantization/algorithm/spinquant/qwen3_vl_model_utils.py
@@ -29,12 +29,16 @@ class Qwen3VLSpinQuantComponents:
         language_model: Qwen3-VL text model.
         text_layers: Text decoder layers.
         lm_head: Final language modeling head.
+        visual_model: Qwen3-VL vision model.
+        vision_blocks: Vision transformer blocks.
         visual_deepstack_mergers: DeepStack visual merger modules.
     """
 
     language_model: nn.Module
     text_layers: nn.ModuleList
     lm_head: nn.Linear
+    visual_model: nn.Module
+    vision_blocks: nn.ModuleList
     visual_deepstack_mergers: nn.ModuleList
 
 
@@ -107,6 +111,25 @@ def require_linear_attr(module: nn.Module, attr_name: str) -> nn.Linear:
     return value
 
 
+def _should_resolve_deepstack_mergers(config: Qwen3VLSpinQuantConfig) -> bool:
+    """
+    Return whether DeepStack merger modules are needed by the active options.
+
+    Parameters:
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        True if the conversion path needs DeepStack merger references.
+    """
+    return any(
+        (
+            bool(getattr(config, "fuse_deepstack_visual_outputs", False)),
+            bool(getattr(config, "enable_vision_r1", False)),
+            bool(getattr(config, "fuse_vision_layer_norms", False)),
+        )
+    )
+
+
 def resolve_qwen3_vl_spinquant_components(
     model: nn.Module,
     config: Qwen3VLSpinQuantConfig,
@@ -127,8 +150,10 @@ def resolve_qwen3_vl_spinquant_components(
     language_model = get_module_by_path(model, config.language_model_attr)
     text_layers = get_module_by_path(model, config.text_layers_attr)
     lm_head = get_module_by_path(model, config.lm_head_attr)
+    visual_model = get_module_by_path(model, config.visual_model_attr)
+    vision_blocks = get_module_by_path(model, config.vision_blocks_attr)
 
-    if config.fuse_deepstack_visual_outputs:
+    if _should_resolve_deepstack_mergers(config):
         visual_deepstack_mergers = get_module_by_path(
             model,
             config.visual_deepstack_mergers_attr,
@@ -154,6 +179,18 @@ def resolve_qwen3_vl_spinquant_components(
             f"got {type(lm_head).__name__}."
         )
 
+    if not isinstance(visual_model, nn.Module):
+        raise TypeError(
+            f"{config.visual_model_attr!r} must resolve to nn.Module, "
+            f"got {type(visual_model).__name__}."
+        )
+
+    if not isinstance(vision_blocks, nn.ModuleList):
+        raise TypeError(
+            f"{config.vision_blocks_attr!r} must resolve to nn.ModuleList, "
+            f"got {type(vision_blocks).__name__}."
+        )
+
     if not isinstance(visual_deepstack_mergers, nn.ModuleList):
         raise TypeError(
             f"{config.visual_deepstack_mergers_attr!r} must resolve to nn.ModuleList, "
@@ -164,6 +201,8 @@ def resolve_qwen3_vl_spinquant_components(
         language_model=language_model,
         text_layers=text_layers,
         lm_head=lm_head,
+        visual_model=visual_model,
+        vision_blocks=vision_blocks,
         visual_deepstack_mergers=visual_deepstack_mergers,
     )
 
@@ -248,6 +287,8 @@ def validate_qwen3_vl_for_spinquant(
 
     if not hasattr(model_config, "text_config"):
         raise ValueError("Qwen3-VL SpinQuant requires `model.config.text_config`.")
+    if not hasattr(model_config, "vision_config"):
+        raise ValueError("Qwen3-VL SpinQuant requires `model.config.vision_config`.")
 
     components = resolve_qwen3_vl_spinquant_components(model, config)
 
@@ -282,10 +323,22 @@ def validate_qwen3_vl_for_spinquant(
         for attr_name in ("gate_proj", "up_proj", "down_proj"):
             require_linear_attr(layer.mlp, attr_name)
 
-    if config.fuse_deepstack_visual_outputs:
+    if any(
+        (
+            bool(getattr(config, "fuse_vision_layer_norms", False)),
+            bool(getattr(config, "enable_vision_r1", False)),
+            bool(getattr(config, "enable_vision_r2", False)),
+        )
+    ):
+        _validate_qwen3_vl_vision_modules(components)
+
+    if _should_resolve_deepstack_mergers(config):
         for merger_idx, merger in enumerate(components.visual_deepstack_mergers):
             try:
+                require_linear_attr(merger, "linear_fc1")
                 require_linear_attr(merger, "linear_fc2")
+                if not hasattr(merger, "norm"):
+                    raise AttributeError("Expected merger to expose `norm`.")
             except Exception as exc:
                 raise type(exc)(
                     f"Invalid DeepStack merger {merger_idx}: {exc}"
@@ -296,3 +349,59 @@ def validate_qwen3_vl_for_spinquant(
     if require_spin_runtime:
         require_linear_attr(components.language_model, "rotate_embedding")
         require_linear_attr(model, "rotate_lm_head")
+
+
+def _validate_qwen3_vl_vision_modules(
+    components: Qwen3VLSpinQuantComponents,
+) -> None:
+    """
+    Validate vision modules used by optional vision-side SpinQuant.
+
+    Parameters:
+        components: Resolved Qwen3-VL components.
+
+    Raises:
+        AttributeError: If an expected submodule is missing.
+        TypeError: If an expected submodule has an invalid type.
+    """
+    visual = components.visual_model
+
+    if not hasattr(visual, "patch_embed"):
+        raise AttributeError("Expected vision model to expose `patch_embed`.")
+    if not hasattr(visual.patch_embed, "proj"):
+        raise AttributeError("Expected vision patch_embed to expose `proj`.")
+    if not isinstance(visual.patch_embed.proj, nn.Conv3d):
+        raise TypeError(
+            "Expected vision patch_embed.proj to be nn.Conv3d, "
+            f"got {type(visual.patch_embed.proj).__name__}."
+        )
+
+    if not hasattr(visual, "pos_embed"):
+        raise AttributeError("Expected vision model to expose `pos_embed`.")
+    if not isinstance(visual.pos_embed, nn.Embedding):
+        raise TypeError(
+            "Expected vision pos_embed to be nn.Embedding, "
+            f"got {type(visual.pos_embed).__name__}."
+        )
+
+    if not hasattr(visual, "merger"):
+        raise AttributeError("Expected vision model to expose `merger`.")
+    require_linear_attr(visual.merger, "linear_fc1")
+    require_linear_attr(visual.merger, "linear_fc2")
+    if not hasattr(visual.merger, "norm"):
+        raise AttributeError("Expected vision merger to expose `norm`.")
+
+    for block_idx, block in enumerate(components.vision_blocks):
+        if not hasattr(block, "norm1"):
+            raise AttributeError(f"Vision block {block_idx} is missing `norm1`.")
+        if not hasattr(block, "norm2"):
+            raise AttributeError(f"Vision block {block_idx} is missing `norm2`.")
+        if not hasattr(block, "attn"):
+            raise AttributeError(f"Vision block {block_idx} is missing `attn`.")
+        if not hasattr(block, "mlp"):
+            raise AttributeError(f"Vision block {block_idx} is missing `mlp`.")
+
+        require_linear_attr(block.attn, "qkv")
+        require_linear_attr(block.attn, "proj")
+        require_linear_attr(block.mlp, "linear_fc1")
+        require_linear_attr(block.mlp, "linear_fc2")

--- a/tico/quantization/algorithm/spinquant/qwen3_vl_quantizer.py
+++ b/tico/quantization/algorithm/spinquant/qwen3_vl_quantizer.py
@@ -28,13 +28,22 @@ from tico.quantization.algorithm.spinquant.qwen3_vl_rotation_utils import (
     apply_qwen3_vl_lm_head_side_rotation,
     build_qwen3_vl_r1,
     build_qwen3_vl_r2,
+    build_qwen3_vl_vision_r1,
+    build_qwen3_vl_vision_r2,
     extract_and_reset_qwen3_vl_final_norm_scale,
     fuse_qwen3_vl_text_layer_norms,
+    fuse_qwen3_vl_vision_layer_norms,
     get_qwen3_vl_head_dim,
     get_qwen3_vl_text_hidden_size,
+    get_qwen3_vl_vision_head_dim,
+    get_qwen3_vl_vision_hidden_size,
     rotate_qwen3_vl_deepstack_outputs,
     rotate_qwen3_vl_ov_r2,
     rotate_qwen3_vl_text_layer_r1,
+    rotate_qwen3_vl_vision_layer_r1,
+    rotate_qwen3_vl_vision_merger_inputs,
+    rotate_qwen3_vl_vision_ov_r2,
+    rotate_qwen3_vl_vision_patch_and_position_embeddings,
 )
 from tico.quantization.algorithm.spinquant.rotation_utils import (
     infer_device,
@@ -58,8 +67,8 @@ class Qwen3VLSpinQuantQuantizer(BaseQuantizer):
         - model.language_model.rotate_embedding
         - rotate_lm_head
 
-    Decoder-layer R1/R2 rotations and DeepStack output rotations are fused into
-    weights during conversion.
+    Decoder-layer text R1/R2 rotations, optional vision-tower rotations, and
+    DeepStack output rotations are fused into weights during conversion.
     """
 
     def __init__(self, config: Qwen3VLSpinQuantConfig):
@@ -131,11 +140,13 @@ class Qwen3VLSpinQuantQuantizer(BaseQuantizer):
         )
 
         fuse_qwen3_vl_text_layer_norms(model, self.config)
+        if self.config.fuse_vision_layer_norms:
+            fuse_qwen3_vl_vision_layer_norms(model, self.config)
 
         hidden_size = get_qwen3_vl_text_hidden_size(model)
         device = infer_device(model)
 
-        if self.config.apply_r1:
+        if self.config.enable_r1:
             r1 = build_qwen3_vl_r1(model, self.config)
         else:
             r1 = torch.eye(hidden_size, device=device, dtype=torch.float64)
@@ -162,14 +173,14 @@ class Qwen3VLSpinQuantQuantizer(BaseQuantizer):
             iterator = tqdm(
                 iterator,
                 total=len(layers),
-                desc="Applying Qwen3-VL SpinQuant rotations",
+                desc="Applying Qwen3-VL text SpinQuant rotations",
             )
 
         for layer_idx, layer in iterator:
-            if self.config.apply_r1:
+            if self.config.enable_r1:
                 rotate_qwen3_vl_text_layer_r1(layer, r1)
 
-            if self.config.apply_r2:
+            if self.config.enable_r2:
                 r2 = build_qwen3_vl_r2(
                     init_method=self.config.init_method,
                     r2_map=self.config.r2_map,
@@ -179,11 +190,73 @@ class Qwen3VLSpinQuantQuantizer(BaseQuantizer):
                 )
                 rotate_qwen3_vl_ov_r2(layer, r2, head_dim)
 
-        if self.config.apply_r1:
+        if self.config.enable_vision_r1 or self.config.enable_vision_r2:
+            self._convert_vision_tower(model)
+
+        if self.config.enable_r1:
             rotate_qwen3_vl_deepstack_outputs(model, self.config, r1)
 
         assert_tied_word_embedding(model, self.config)
         return model
+
+    @torch.no_grad()
+    def _convert_vision_tower(self, model: nn.Module) -> None:
+        """
+        Apply optional vision-side SpinQuant rotations to the Qwen3-VL vision tower.
+
+        Parameters:
+            model: Prepared SpinQwen3VL model.
+        """
+        assert isinstance(self.config, Qwen3VLSpinQuantConfig)
+        components = resolve_qwen3_vl_spinquant_components(model, self.config)
+        vision_layers = components.vision_blocks
+        vision_head_dim = get_qwen3_vl_vision_head_dim(model)
+        device = infer_device(model)
+
+        vision_method = self.config.vision_init_method or self.config.init_method
+
+        if self.config.enable_vision_r1:
+            vision_hidden_size = get_qwen3_vl_vision_hidden_size(model)
+            vision_r1 = build_qwen3_vl_vision_r1(model, self.config)
+        else:
+            vision_hidden_size = get_qwen3_vl_vision_hidden_size(model)
+            vision_r1 = torch.eye(
+                vision_hidden_size,
+                device=device,
+                dtype=torch.float64,
+            )
+
+        if self.config.enable_vision_r1:
+            rotate_qwen3_vl_vision_patch_and_position_embeddings(
+                model,
+                self.config,
+                vision_r1,
+            )
+
+        iterator = enumerate(vision_layers)
+        if self.config.show_progress:
+            iterator = tqdm(
+                iterator,
+                total=len(vision_layers),
+                desc="Applying Qwen3-VL vision SpinQuant rotations",
+            )
+
+        for layer_idx, layer in iterator:
+            if self.config.enable_vision_r1:
+                rotate_qwen3_vl_vision_layer_r1(layer, vision_r1)
+
+            if self.config.enable_vision_r2:
+                vision_r2 = build_qwen3_vl_vision_r2(
+                    init_method=vision_method,
+                    r2_map=self.config.vision_r2_map,
+                    layer_idx=layer_idx,
+                    head_dim=vision_head_dim,
+                    device=device,
+                )
+                rotate_qwen3_vl_vision_ov_r2(layer, vision_r2, vision_head_dim)
+
+        if self.config.enable_vision_r1:
+            rotate_qwen3_vl_vision_merger_inputs(model, self.config, vision_r1)
 
     @torch.no_grad()
     def _convert_to_spin_qwen3_vl(
@@ -255,11 +328,11 @@ class Qwen3VLSpinQuantQuantizer(BaseQuantizer):
         """
         Force the SpinQwen3VL input embedding and LM head to share storage.
 
-        `load_state_dict` copies tensor values into existing Parameter
-        objects and does not preserve aliasing between tied parameters. Some
-        transformers versions also do not materialize Qwen3-VL ties through
-        `tie_weights()` for small synthetic configs. SpinQuant relies on the
-        tied-weight invariant, so the alias is restored explicitly here.
+        `load_state_dict` copies tensor values into existing Parameter objects
+        and does not preserve aliasing between tied parameters. Some transformers
+        versions also do not materialize Qwen3-VL ties through `tie_weights()`
+        for small synthetic configs. SpinQuant relies on the tied-weight
+        invariant, so the alias is restored explicitly here.
 
         Parameters:
             model: Prepared SpinQwen3VL model to update in-place.

--- a/tico/quantization/algorithm/spinquant/qwen3_vl_rotation_utils.py
+++ b/tico/quantization/algorithm/spinquant/qwen3_vl_rotation_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from typing import Optional
 
 import torch
@@ -33,6 +34,7 @@ from tico.quantization.algorithm.spinquant.rotation_utils import (
     infer_device,
     left_multiply_linear_weight_,
     make_random_orthogonal_rotation,
+    right_multiply_linear_weight_,
     rotate_attention_inputs,
     rotate_attention_output,
     rotate_mlp_input,
@@ -92,19 +94,65 @@ def get_qwen3_vl_head_dim(model: nn.Module) -> int:
     return hidden_size // num_heads
 
 
+def get_qwen3_vl_vision_hidden_size(model: nn.Module) -> int:
+    """
+    Return the Qwen3-VL vision hidden size.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+
+    Returns:
+        Vision tower hidden size.
+
+    Raises:
+        AttributeError: If the vision configuration is missing.
+    """
+    if not hasattr(model, "config") or not hasattr(model.config, "vision_config"):
+        raise AttributeError("Expected `model.config.vision_config` to exist.")
+    return int(model.config.vision_config.hidden_size)
+
+
+def get_qwen3_vl_vision_head_dim(model: nn.Module) -> int:
+    """
+    Return the Qwen3-VL vision attention head dimension.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+
+    Returns:
+        Vision attention head dimension.
+
+    Raises:
+        AttributeError: If the vision configuration is missing.
+        ValueError: If the inferred dimensions are invalid.
+    """
+    if not hasattr(model, "config") or not hasattr(model.config, "vision_config"):
+        raise AttributeError("Expected `model.config.vision_config` to exist.")
+
+    vision_config = model.config.vision_config
+    hidden_size = int(vision_config.hidden_size)
+    num_heads = int(vision_config.num_heads)
+    if hidden_size % num_heads != 0:
+        raise ValueError(
+            f"vision hidden_size ({hidden_size}) must be divisible by "
+            f"vision num_heads ({num_heads})."
+        )
+    return hidden_size // num_heads
+
+
 def build_qwen3_vl_r1(
     model: nn.Module,
     config: Qwen3VLSpinQuantConfig,
 ) -> torch.Tensor:
     """
-    Build the Qwen3-VL global hidden-dimension R1 rotation.
+    Build the Qwen3-VL global text hidden-dimension R1 rotation.
 
     Parameters:
         model: Target Qwen3-VL model.
         config: Qwen3-VL SpinQuant configuration.
 
     Returns:
-        A square rotation matrix with shape ``[hidden_size, hidden_size]``.
+        A square rotation matrix with shape ``[text_hidden_size, text_hidden_size]``.
 
     Raises:
         ValueError: If the configuration is invalid.
@@ -137,7 +185,7 @@ def build_qwen3_vl_r2(
     device: torch.device,
 ) -> Optional[torch.Tensor]:
     """
-    Build or fetch a Qwen3-VL per-layer head-dimension R2 rotation.
+    Build or fetch a Qwen3-VL text per-layer head-dimension R2 rotation.
 
     Parameters:
         init_method: Rotation initialization strategy.
@@ -178,6 +226,234 @@ def build_qwen3_vl_r2(
         return None
 
     raise ValueError(f"Unsupported init_method: {init_method!r}")
+
+
+def _make_zero_mean_subspace_basis(
+    size: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """
+    Build an orthonormal basis whose first vector is the normalized all-ones vector.
+
+    Parameters:
+        size: Ambient dimension.
+        device: Target device.
+        dtype: Tensor dtype.
+
+    Returns:
+        A square orthonormal basis matrix.
+    """
+    if size <= 0:
+        raise ValueError(f"size must be positive, got {size}.")
+
+    mean_axis = torch.ones(size, 1, device=device, dtype=dtype) / math.sqrt(size)
+    if size == 1:
+        return mean_axis
+
+    random_tail = torch.randn(size, size - 1, device=device, dtype=dtype)
+    random_tail = random_tail - mean_axis @ (mean_axis.T @ random_tail)
+    tail_basis, _ = torch.linalg.qr(random_tail, mode="reduced")
+    return torch.cat([mean_axis, tail_basis], dim=1)
+
+
+def make_layernorm_compatible_rotation(
+    size: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype = torch.float64,
+    tail_init_method: str = "random",
+) -> torch.Tensor:
+    """
+    Create an orthogonal rotation that preserves LayerNorm equivariance.
+
+    The returned matrix R satisfies ``R @ 1 = 1``. Therefore, for row-vector
+    inputs and identity-affine LayerNorm, ``LayerNorm(x @ R) == LayerNorm(x) @ R``
+    up to numerical precision.
+
+    Parameters:
+        size: Rotation dimension.
+        device: Target device.
+        dtype: Tensor dtype.
+        tail_init_method: Initialization for the zero-mean subspace. ``"hadamard"``
+            uses a Hadamard rotation when the subspace size supports it and falls
+            back to a dense random orthogonal rotation otherwise.
+
+    Returns:
+        A square orthogonal matrix with shape ``[size, size]``.
+    """
+    if size == 1:
+        return torch.eye(1, device=device, dtype=dtype)
+
+    basis = _make_zero_mean_subspace_basis(size, device=device, dtype=torch.float64)
+
+    if tail_init_method == "hadamard":
+        try:
+            tail_rotation = make_random_hadamard_rotation(
+                size - 1,
+                device=device,
+                dtype=torch.float64,
+            )
+        except ValueError:
+            tail_rotation = make_random_orthogonal_rotation(
+                size - 1,
+                device=device,
+                dtype=torch.float64,
+            )
+    elif tail_init_method == "random":
+        tail_rotation = make_random_orthogonal_rotation(
+            size - 1,
+            device=device,
+            dtype=torch.float64,
+        )
+    else:
+        raise ValueError(f"Unsupported tail_init_method: {tail_init_method!r}")
+
+    block = torch.eye(size, device=device, dtype=torch.float64)
+    block[1:, 1:] = tail_rotation
+    rotation = basis @ block @ basis.T
+    return rotation.to(dtype=dtype)
+
+
+def validate_layernorm_compatible_rotation(
+    name: str,
+    rotation: torch.Tensor,
+    size: int,
+    *,
+    atol: float,
+) -> None:
+    """
+    Validate that a rotation is orthogonal and preserves the all-ones direction.
+
+    Parameters:
+        name: Logical name used in error messages.
+        rotation: Rotation matrix to validate.
+        size: Expected matrix size.
+        atol: Absolute tolerance.
+
+    Raises:
+        ValueError: If the rotation is invalid.
+    """
+    validate_square_rotation(name, rotation, size)
+
+    identity = torch.eye(size, device=rotation.device, dtype=torch.float64)
+    gram = rotation.T @ rotation
+    orthogonal_error = (gram - identity).abs().max().item()
+    if orthogonal_error > atol:
+        raise ValueError(
+            f"{name} must be orthogonal within atol={atol}, "
+            f"but max |R.T @ R - I| is {orthogonal_error}."
+        )
+
+    ones = torch.ones(size, 1, device=rotation.device, dtype=torch.float64)
+    ones_error = (rotation @ ones - ones).abs().max().item()
+    if ones_error > atol:
+        raise ValueError(
+            f"{name} must preserve the all-ones direction for LayerNorm-safe "
+            f"vision R1 fusion, but max |R @ 1 - 1| is {ones_error}."
+        )
+
+
+def build_qwen3_vl_vision_r1(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> torch.Tensor:
+    """
+    Build the Qwen3-VL vision hidden-dimension R1 rotation.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        A LayerNorm-compatible square rotation matrix.
+
+    Raises:
+        ValueError: If the configuration is invalid.
+    """
+    hidden_size = get_qwen3_vl_vision_hidden_size(model)
+    device = infer_device(model)
+    init_method = config.vision_init_method or config.init_method
+
+    if init_method in {"random", "hadamard"}:
+        return make_layernorm_compatible_rotation(
+            hidden_size,
+            device=device,
+            dtype=torch.float64,
+            tail_init_method=init_method,
+        )
+
+    if init_method == "external":
+        if config.vision_r1 is None:
+            raise ValueError(
+                "`vision_r1` must be provided when vision_init_method='external'."
+            )
+        rotation = config.vision_r1.to(device=device, dtype=torch.float64)
+        if config.require_vision_r1_layernorm_compatible:
+            validate_layernorm_compatible_rotation(
+                "vision_r1",
+                rotation,
+                hidden_size,
+                atol=float(config.vision_rotation_tolerance),
+            )
+        else:
+            validate_square_rotation("vision_r1", rotation, hidden_size)
+        return rotation
+
+    raise ValueError(f"Unsupported vision init_method: {init_method!r}")
+
+
+def build_qwen3_vl_vision_r2(
+    *,
+    init_method: str,
+    r2_map: Optional[dict[str, torch.Tensor]],
+    layer_idx: int,
+    head_dim: int,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    """
+    Build or fetch a Qwen3-VL vision per-layer head-dimension R2 rotation.
+
+    Parameters:
+        init_method: Rotation initialization strategy.
+        r2_map: Optional mapping from vision block keys to external R2 matrices.
+        layer_idx: Vision block index.
+        head_dim: Vision attention head dimension.
+        device: Target device.
+
+    Returns:
+        A square R2 matrix, or None when external mode does not provide one.
+    """
+    if init_method == "random":
+        return make_random_orthogonal_rotation(head_dim, device=device)
+
+    if init_method == "hadamard":
+        try:
+            return make_random_hadamard_rotation(head_dim, device=device)
+        except ValueError:
+            return make_random_orthogonal_rotation(head_dim, device=device)
+
+    if init_method == "external":
+        if r2_map is None:
+            return None
+
+        candidate_keys = (
+            f"model.visual.blocks.{layer_idx}.attn.R2",
+            f"model.visual.blocks.{layer_idx}.attn.vision_R2",
+        )
+        for key in candidate_keys:
+            rotation = r2_map.get(key)
+            if rotation is None:
+                continue
+
+            rotation = rotation.to(device=device, dtype=torch.float64)
+            validate_square_rotation(key, rotation, head_dim)
+            return rotation
+
+        return None
+
+    raise ValueError(f"Unsupported vision init_method: {init_method!r}")
 
 
 @torch.no_grad()
@@ -221,6 +497,139 @@ def fuse_qwen3_vl_text_layer_norms(
         reset_norm_affine_to_identity(post_attn_norm)
 
     setattr(model, "_qwen3_vl_spinquant_norms_fused", True)
+    return model
+
+
+@torch.no_grad()
+def _fuse_repeated_norm_into_linear(
+    norm: nn.Module,
+    linear: nn.Linear,
+    repeated_dim: int,
+) -> None:
+    """
+    Fold a per-token norm affine into a Linear that consumes concatenated tokens.
+
+    Parameters:
+        norm: Normalization module exposing ``weight`` and optionally ``bias``.
+        linear: Linear layer that consumes repeated chunks of size ``repeated_dim``.
+        repeated_dim: Chunk size matched by the norm affine.
+
+    Raises:
+        ValueError: If the linear input dimension is not a multiple of the norm size.
+    """
+    if not hasattr(norm, "weight") or norm.weight is None:
+        raise AttributeError(
+            f"Normalization module `{type(norm).__name__}` must expose `weight`."
+        )
+
+    gamma = norm.weight.data.to(torch.float64)
+    if gamma.numel() != repeated_dim:
+        raise ValueError(f"Expected norm size {repeated_dim}, got {gamma.numel()}.")
+
+    weight = linear.weight.data
+    if weight.shape[1] % repeated_dim != 0:
+        raise ValueError(
+            f"linear.in_features={weight.shape[1]} is not divisible by {repeated_dim}."
+        )
+
+    device = weight.device
+    dtype = weight.dtype
+    num_repeats = weight.shape[1] // repeated_dim
+    w64 = weight.to(torch.float64)
+    w64_chunks = w64.reshape(weight.shape[0], num_repeats, repeated_dim)
+
+    if hasattr(norm, "bias") and norm.bias is not None:
+        beta = norm.bias.data.to(torch.float64)
+        if linear.bias is None:
+            linear.bias = nn.Parameter(
+                torch.zeros(linear.out_features, device=device, dtype=dtype)
+            )
+        b64 = linear.bias.data.to(torch.float64)
+        bias_delta = torch.einsum("ord,d->or", w64_chunks, beta).sum(dim=1)
+        linear.bias.data.copy_((b64 + bias_delta).to(device=device, dtype=dtype))
+
+    fused = w64_chunks * gamma.view(1, 1, repeated_dim)
+    linear.weight.data.copy_(fused.reshape_as(w64).to(device=device, dtype=dtype))
+
+
+@torch.no_grad()
+def _fuse_vision_merger_norm_into_fc1(
+    merger: nn.Module,
+    vision_hidden_size: int,
+) -> None:
+    """
+    Fold a Qwen3-VL vision merger LayerNorm affine into ``linear_fc1``.
+
+    Parameters:
+        merger: Qwen3-VL vision patch merger.
+        vision_hidden_size: Hidden size of one vision token.
+    """
+    if not hasattr(merger, "norm"):
+        raise AttributeError("Expected vision merger to expose `norm`.")
+
+    norm = merger.norm
+    linear_fc1 = require_linear_attr(merger, "linear_fc1")
+
+    if not hasattr(norm, "weight") or norm.weight is None:
+        raise AttributeError("Expected vision merger norm to expose `weight`.")
+
+    norm_dim = int(norm.weight.numel())
+    if norm_dim == linear_fc1.in_features:
+        fuse_norm_into_linears(norm, [linear_fc1])
+    elif norm_dim == vision_hidden_size and linear_fc1.in_features % norm_dim == 0:
+        _fuse_repeated_norm_into_linear(norm, linear_fc1, norm_dim)
+    else:
+        raise ValueError(
+            "Unsupported vision merger norm/linear shape: "
+            f"norm_dim={norm_dim}, linear_fc1.in_features={linear_fc1.in_features}, "
+            f"vision_hidden_size={vision_hidden_size}."
+        )
+
+    reset_norm_affine_to_identity(norm)
+
+
+@torch.no_grad()
+def fuse_qwen3_vl_vision_layer_norms(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+) -> nn.Module:
+    """
+    Fold Qwen3-VL vision LayerNorm affine weights into adjacent Linear layers.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+
+    Returns:
+        The same model instance.
+    """
+    if getattr(model, "_qwen3_vl_spinquant_vision_norms_fused", False):
+        return model
+
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+    vision_hidden_size = get_qwen3_vl_vision_hidden_size(model)
+
+    for block in components.vision_blocks:
+        norm1 = getattr(block, "norm1")
+        norm2 = getattr(block, "norm2")
+        qkv = require_linear_attr(block.attn, "qkv")
+        linear_fc1 = require_linear_attr(block.mlp, "linear_fc1")
+
+        fuse_norm_into_linears(norm1, [qkv])
+        fuse_norm_into_linears(norm2, [linear_fc1])
+        reset_norm_affine_to_identity(norm1)
+        reset_norm_affine_to_identity(norm2)
+
+    if hasattr(components.visual_model, "merger"):
+        _fuse_vision_merger_norm_into_fc1(
+            components.visual_model.merger,
+            vision_hidden_size,
+        )
+
+    for merger in components.visual_deepstack_mergers:
+        _fuse_vision_merger_norm_into_fc1(merger, vision_hidden_size)
+
+    setattr(model, "_qwen3_vl_spinquant_vision_norms_fused", True)
     return model
 
 
@@ -351,6 +760,296 @@ def rotate_qwen3_vl_ov_r2(
     rotate_ov_proj(layer, r2, head_dim)
 
 
+def _require_conv3d_attr(module: nn.Module, attr_name: str) -> nn.Conv3d:
+    """
+    Return a required Conv3d attribute from a module.
+
+    Parameters:
+        module: Parent module.
+        attr_name: Attribute name.
+
+    Returns:
+        The resolved Conv3d module.
+    """
+    if not hasattr(module, attr_name):
+        raise AttributeError(
+            f"Expected attribute {attr_name!r} on module {type(module).__name__}."
+        )
+    value = getattr(module, attr_name)
+    if not isinstance(value, nn.Conv3d):
+        raise TypeError(
+            f"Expected {attr_name!r} to be nn.Conv3d, got {type(value).__name__}."
+        )
+    return value
+
+
+def _require_embedding_attr(module: nn.Module, attr_name: str) -> nn.Embedding:
+    """
+    Return a required Embedding attribute from a module.
+
+    Parameters:
+        module: Parent module.
+        attr_name: Attribute name.
+
+    Returns:
+        The resolved Embedding module.
+    """
+    if not hasattr(module, attr_name):
+        raise AttributeError(
+            f"Expected attribute {attr_name!r} on module {type(module).__name__}."
+        )
+    value = getattr(module, attr_name)
+    if not isinstance(value, nn.Embedding):
+        raise TypeError(
+            f"Expected {attr_name!r} to be nn.Embedding, got {type(value).__name__}."
+        )
+    return value
+
+
+@torch.no_grad()
+def _left_multiply_conv3d_output_(conv: nn.Conv3d, rotation_t: torch.Tensor) -> None:
+    """
+    Rotate the output-channel basis of a Conv3d module.
+
+    Parameters:
+        conv: Target Conv3d module.
+        rotation_t: Transposed rotation matrix with shape ``[out_channels, out_channels]``.
+    """
+    weight = conv.weight.data
+    out_channels = weight.shape[0]
+    validate_square_rotation("conv output rotation", rotation_t, out_channels)
+
+    rotation_t = rotation_t.to(device=weight.device, dtype=torch.float64)
+    flat = weight.to(torch.float64).reshape(out_channels, -1)
+    updated = rotation_t @ flat
+    conv.weight.data.copy_(
+        updated.reshape_as(weight).to(device=weight.device, dtype=weight.dtype)
+    )
+
+    if conv.bias is not None:
+        bias = conv.bias.data
+        updated_bias = rotation_t @ bias.to(torch.float64)
+        conv.bias.data.copy_(updated_bias.to(device=bias.device, dtype=bias.dtype))
+
+
+@torch.no_grad()
+def _right_multiply_embedding_weight_(
+    embedding: nn.Embedding,
+    rotation: torch.Tensor,
+) -> None:
+    """
+    Rotate an embedding table on its feature axis.
+
+    Parameters:
+        embedding: Target embedding module.
+        rotation: Rotation matrix with shape ``[embedding_dim, embedding_dim]``.
+    """
+    weight = embedding.weight.data
+    validate_square_rotation("embedding rotation", rotation, weight.shape[1])
+    updated = weight.to(torch.float64) @ rotation.to(
+        device=weight.device, dtype=torch.float64
+    )
+    embedding.weight.data.copy_(updated.to(device=weight.device, dtype=weight.dtype))
+
+
+@torch.no_grad()
+def _right_multiply_linear_weight_blockwise_(
+    module: nn.Linear,
+    rotation: torch.Tensor,
+    block_size: int,
+) -> None:
+    """
+    Right-multiply a Linear input axis by the same rotation in each block.
+
+    Parameters:
+        module: Target Linear module.
+        rotation: Block rotation matrix.
+        block_size: Size of each repeated input block.
+    """
+    weight = module.weight.data
+    if weight.shape[1] % block_size != 0:
+        raise ValueError(
+            f"linear.in_features={weight.shape[1]} is not divisible by block_size={block_size}."
+        )
+    validate_square_rotation("blockwise input rotation", rotation, block_size)
+
+    rotation = rotation.to(device=weight.device, dtype=torch.float64)
+    out_features = weight.shape[0]
+    num_blocks = weight.shape[1] // block_size
+    working = weight.to(torch.float64).reshape(out_features, num_blocks, block_size)
+    updated = working @ rotation
+    module.weight.data.copy_(
+        updated.reshape_as(weight).to(device=weight.device, dtype=weight.dtype)
+    )
+
+
+@torch.no_grad()
+def _left_multiply_qkv_v_output_blockwise_(
+    qkv: nn.Linear,
+    rotation: torch.Tensor,
+    vision_hidden_size: int,
+    head_dim: int,
+) -> None:
+    """
+    Rotate only the V slice of a fused QKV projection on its output axis.
+
+    Parameters:
+        qkv: Fused QKV Linear with output size ``3 * vision_hidden_size``.
+        rotation: Per-head rotation matrix.
+        vision_hidden_size: Vision hidden dimension.
+        head_dim: Per-head dimension.
+    """
+    if qkv.out_features != 3 * vision_hidden_size:
+        raise ValueError(
+            "Expected fused qkv out_features to equal 3 * vision_hidden_size, "
+            f"got {qkv.out_features} and {vision_hidden_size}."
+        )
+    if vision_hidden_size % head_dim != 0:
+        raise ValueError(
+            f"vision_hidden_size={vision_hidden_size} is not divisible by head_dim={head_dim}."
+        )
+    validate_square_rotation("vision R2", rotation, head_dim)
+
+    rotation = rotation.to(device=qkv.weight.device, dtype=torch.float64)
+    start = 2 * vision_hidden_size
+    end = 3 * vision_hidden_size
+    v_weight = qkv.weight.data[start:end]
+    in_features = v_weight.shape[1]
+    num_heads = vision_hidden_size // head_dim
+
+    working_t = v_weight.to(torch.float64).T.reshape(in_features, num_heads, head_dim)
+    updated_t = working_t @ rotation
+    qkv.weight.data[start:end].copy_(
+        updated_t.reshape(in_features, vision_hidden_size).T.to(
+            device=v_weight.device, dtype=v_weight.dtype
+        )
+    )
+
+    if qkv.bias is not None:
+        v_bias = qkv.bias.data[start:end]
+        bias_working = v_bias.to(torch.float64).reshape(num_heads, head_dim)
+        updated_bias = bias_working @ rotation
+        qkv.bias.data[start:end].copy_(
+            updated_bias.reshape_as(v_bias).to(device=v_bias.device, dtype=v_bias.dtype)
+        )
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_vision_patch_and_position_embeddings(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+    r1: torch.Tensor,
+) -> None:
+    """
+    Fuse vision R1 into the patch projection and absolute position embedding.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+        r1: Vision hidden-dimension R1 rotation.
+    """
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+    visual = components.visual_model
+
+    if not hasattr(visual, "patch_embed"):
+        raise AttributeError("Expected vision model to expose `patch_embed`.")
+    patch_proj = _require_conv3d_attr(visual.patch_embed, "proj")
+    pos_embed = _require_embedding_attr(visual, "pos_embed")
+
+    _left_multiply_conv3d_output_(patch_proj, r1.T)
+    _right_multiply_embedding_weight_(pos_embed, r1)
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_vision_layer_r1(
+    layer: nn.Module,
+    r1: torch.Tensor,
+) -> None:
+    """
+    Fuse LayerNorm-compatible R1 into one Qwen3-VL vision transformer block.
+
+    Parameters:
+        layer: Qwen3-VL vision block.
+        r1: Vision hidden-dimension R1 rotation.
+    """
+    qkv = require_linear_attr(layer.attn, "qkv")
+    proj = require_linear_attr(layer.attn, "proj")
+    linear_fc1 = require_linear_attr(layer.mlp, "linear_fc1")
+    linear_fc2 = require_linear_attr(layer.mlp, "linear_fc2")
+
+    right_multiply_linear_weight_(qkv, r1)
+    left_multiply_linear_weight_(proj, r1.T)
+    right_multiply_linear_weight_(linear_fc1, r1)
+    left_multiply_linear_weight_(linear_fc2, r1.T)
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_vision_merger_inputs(
+    model: nn.Module,
+    config: Qwen3VLSpinQuantConfig,
+    r1: torch.Tensor,
+) -> None:
+    """
+    Compensate vision mergers for a rotated vision residual basis.
+
+    Parameters:
+        model: Target Qwen3-VL model.
+        config: Qwen3-VL SpinQuant configuration.
+        r1: Vision hidden-dimension R1 rotation.
+    """
+    components = resolve_qwen3_vl_spinquant_components(model, config)
+    vision_hidden_size = get_qwen3_vl_vision_hidden_size(model)
+
+    mergers = [components.visual_model.merger]
+    mergers.extend(list(components.visual_deepstack_mergers))
+
+    for merger in mergers:
+        linear_fc1 = require_linear_attr(merger, "linear_fc1")
+        _right_multiply_linear_weight_blockwise_(
+            linear_fc1,
+            r1,
+            block_size=vision_hidden_size,
+        )
+
+
+@torch.no_grad()
+def rotate_qwen3_vl_vision_ov_r2(
+    layer: nn.Module,
+    r2: Optional[torch.Tensor],
+    head_dim: int,
+) -> None:
+    """
+    Fuse OV-side R2 into one Qwen3-VL vision attention block.
+
+    Parameters:
+        layer: Qwen3-VL vision block.
+        r2: Optional per-head R2 matrix. If None, this function is a no-op.
+        head_dim: Vision attention head dimension.
+    """
+    if r2 is None:
+        return
+
+    qkv = require_linear_attr(layer.attn, "qkv")
+    proj = require_linear_attr(layer.attn, "proj")
+
+    if hasattr(layer.attn, "dim"):
+        vision_hidden_size = int(layer.attn.dim)
+    else:
+        if qkv.out_features % 3 != 0:
+            raise ValueError(
+                f"Expected qkv.out_features to be divisible by 3, got {qkv.out_features}."
+            )
+        vision_hidden_size = qkv.out_features // 3
+
+    _left_multiply_qkv_v_output_blockwise_(
+        qkv,
+        r2,
+        vision_hidden_size=vision_hidden_size,
+        head_dim=head_dim,
+    )
+    _right_multiply_linear_weight_blockwise_(proj, r2, block_size=head_dim)
+
+
 @torch.no_grad()
 def rotate_qwen3_vl_deepstack_outputs(
     model: nn.Module,
@@ -358,12 +1057,12 @@ def rotate_qwen3_vl_deepstack_outputs(
     r1: torch.Tensor,
 ) -> None:
     """
-    Fuse R1 into Qwen3-VL DeepStack visual output projections.
+    Fuse text R1 into Qwen3-VL DeepStack visual output projections.
 
     Parameters:
         model: Target Qwen3-VL model.
         config: Qwen3-VL SpinQuant configuration.
-        r1: Global hidden-dimension rotation matrix.
+        r1: Text global hidden-dimension rotation matrix.
 
     Notes:
         Main visual merger outputs are not fused here because they are inserted

--- a/tico/quantization/config/builders.py
+++ b/tico/quantization/config/builders.py
@@ -360,6 +360,7 @@ def _build_qwen3_vl_overrides(
     vision_patch_embed_weight: Optional[QuantSpec],
     embedding_weight: Optional[QuantSpec],
     lm_head_weight: Optional[QuantSpec],
+    spin_rotation_weight: Optional[QuantSpec],
     norm: Optional[QuantSpec],
     norm_weight: Optional[QuantSpec],
 ) -> Dict[str, Any]:
@@ -414,6 +415,15 @@ def _build_qwen3_vl_overrides(
     if embedding_override:
         _set_nested_override(text_overrides, ("embed_tokens",), embedding_override)
 
+    spin_rotation_override = _build_weight_override(spin_rotation_weight)
+    if spin_rotation_override:
+        _set_nested_override(
+            text_overrides,
+            ("rotate_embedding",),
+            spin_rotation_override,
+        )
+        _set_nested_override(overrides, ("rotate_lm_head",), spin_rotation_override)
+
     text_overrides["layers"] = {}
     for layer_idx in range(num_text_layers):
         text_overrides["layers"][str(layer_idx)] = _build_qwen3_vl_text_layer_overrides(
@@ -450,6 +460,7 @@ def build_qwen3_vl_ptq_config(
     vision_patch_embed_weight: Optional[QuantSpec] = None,
     embedding_weight: Optional[QuantSpec] = None,
     lm_head_weight: Optional[QuantSpec] = None,
+    spin_rotation_weight: Optional[QuantSpec] = None,
     norm: Optional[QuantSpec] = None,
     norm_weight: Optional[QuantSpec] = None,
     strict_wrap: bool = True,
@@ -467,6 +478,7 @@ def build_qwen3_vl_ptq_config(
         vision_patch_embed_weight: Weight spec for vision patch embedding.
         embedding_weight: Weight spec for token embeddings.
         lm_head_weight: Weight spec for the language modeling head.
+        spin_rotation_weight: Weight spec for Qwen3-VL SpinQuant runtime rotations.
         norm: Activation spec for norm module internals.
         norm_weight: Weight spec for norm affine parameters.
         strict_wrap: If True, unsupported modules raise during wrapping.
@@ -485,6 +497,7 @@ def build_qwen3_vl_ptq_config(
         vision_patch_embed_weight=vision_patch_embed_weight,
         embedding_weight=embedding_weight,
         lm_head_weight=lm_head_weight,
+        spin_rotation_weight=spin_rotation_weight,
         norm=norm,
         norm_weight=norm_weight,
     )

--- a/tico/quantization/config/qwen3_vl_spinquant.py
+++ b/tico/quantization/config/qwen3_vl_spinquant.py
@@ -23,15 +23,26 @@ class Qwen3VLSpinQuantConfig(BaseConfig):
     """
     Configuration for tied-embedding-safe SpinQuant on Qwen3-VL.
 
-    This configuration is scoped to Phase 1:
+    This configuration covers the text-side SpinQuant path and optional
+    vision-tower rotations:
         - text decoder R1 fusion
-        - optional attention OV-side R2 fusion
-        - tied-safe input and output boundary rotations
-        - DeepStack visual output rotation fusion
+        - optional text attention OV-side R2 fusion
+        - tied-safe text input and output boundary rotations
+        - DeepStack visual output rotation fusion into the text residual basis
+        - optional vision LayerNorm affine folding
+        - optional vision residual-basis R1 rotation
+        - optional vision attention OV-side R2 rotation
 
-    The word embedding and LM head are assumed to be tied. Therefore, the
-    boundary rotations are stored in dedicated runtime Linear modules instead
-    of directly modifying the shared embedding table.
+    Qwen3-VL word embeddings are assumed to be tied. Therefore, text boundary
+    rotations are stored in dedicated runtime Linear modules instead of directly
+    modifying the shared embedding table.
+
+    The vision tower uses LayerNorm rather than RMSNorm. For exact R1 fusion,
+    vision R1 must preserve the all-ones direction so that identity-affine
+    LayerNorm remains rotation equivariant. The built-in random and hadamard
+    vision initializers therefore construct a dense orthogonal rotation that
+    fixes the all-ones vector. External vision R1 matrices are validated by
+    default.
     """
 
     def __init__(
@@ -39,52 +50,62 @@ class Qwen3VLSpinQuantConfig(BaseConfig):
         init_method: Literal["random", "hadamard", "external"] = "random",
         r1: Optional[torch.Tensor] = None,
         r2_map: Optional[Dict[str, torch.Tensor]] = None,
-        apply_r1: bool = True,
-        apply_r2: bool = True,
+        enable_r1: bool = True,
+        enable_r2: bool = True,
         fuse_deepstack_visual_outputs: bool = True,
         show_progress: bool = True,
         language_model_attr: str = "model.language_model",
         text_layers_attr: str = "model.language_model.layers",
+        visual_model_attr: str = "model.visual",
+        vision_blocks_attr: str = "model.visual.blocks",
         visual_deepstack_mergers_attr: str = "model.visual.deepstack_merger_list",
         lm_head_attr: str = "lm_head",
+        fuse_vision_layer_norms: bool = False,
+        enable_vision_r1: bool = False,
+        enable_vision_r2: bool = False,
+        vision_init_method: Optional[Literal["random", "hadamard", "external"]] = None,
+        vision_r1: Optional[torch.Tensor] = None,
+        vision_r2_map: Optional[Dict[str, torch.Tensor]] = None,
+        require_vision_r1_layernorm_compatible: bool = True,
+        vision_rotation_tolerance: float = 1e-4,
     ):
         """
         Initialize Qwen3-VL SpinQuant configuration.
 
         Parameters:
             init_method:
-                Strategy for resolving rotation matrices.
+                Strategy for resolving text rotation matrices.
 
                 - "random": use random orthogonal matrices.
                 - "hadamard": use randomized Hadamard orthogonal matrices.
                 - "external": use user-provided matrices.
 
             r1:
-                Optional global hidden-dimension rotation matrix. This is
-                required when ``init_method == "external"`` and ``apply_r1`` is
+                Optional text global hidden-dimension rotation matrix. This is
+                required when ``init_method == "external"`` and ``enable_r1`` is
                 enabled.
 
             r2_map:
-                Optional mapping from module keys to per-layer head-dimension
+                Optional mapping from text module keys to per-layer head-dimension
                 rotation matrices.
 
                 Supported example keys:
                     - "model.language_model.layers.0.self_attn.R2"
                     - "model.layers.0.self_attn.R2"
 
-            apply_r1:
-                Whether to apply the global hidden-dimension R1 rotation.
+            enable_r1:
+                Whether to apply the text global hidden-dimension R1 rotation.
 
-            apply_r2:
-                Whether to apply the OV-side head-dimension R2 rotation.
+            enable_r2:
+                Whether to apply the text OV-side head-dimension R2 rotation.
 
             fuse_deepstack_visual_outputs:
-                Whether to fuse R1 into DeepStack visual output projections.
+                Whether to fuse text R1 into DeepStack visual output projections.
                 Main visual merger outputs are not fused because they pass
-                through the input-side runtime rotation.
+                through the text input-side runtime rotation.
 
             show_progress:
-                If True, display a tqdm progress bar during conversion.
+                If True, display tqdm progress bars during conversion.
 
             language_model_attr:
                 Dotted path to the Qwen3-VL text model.
@@ -92,23 +113,78 @@ class Qwen3VLSpinQuantConfig(BaseConfig):
             text_layers_attr:
                 Dotted path to the Qwen3-VL text decoder layers.
 
+            visual_model_attr:
+                Dotted path to the Qwen3-VL vision model.
+
+            vision_blocks_attr:
+                Dotted path to the Qwen3-VL vision transformer blocks.
+
             visual_deepstack_mergers_attr:
                 Dotted path to the DeepStack merger module list.
 
             lm_head_attr:
                 Dotted path to the final language modeling head.
+
+            fuse_vision_layer_norms:
+                Whether to fold vision LayerNorm affine parameters into adjacent
+                Linear layers. This must be enabled when ``enable_vision_r1`` is
+                enabled.
+
+            enable_vision_r1:
+                Whether to rotate the vision tower residual stream with a
+                LayerNorm-compatible R1 matrix.
+
+            enable_vision_r2:
+                Whether to rotate the vision attention V/proj path with per-head
+                R2 matrices.
+
+            vision_init_method:
+                Optional rotation initialization mode for vision R1/R2. If None,
+                it falls back to ``init_method``.
+
+            vision_r1:
+                Optional vision hidden-dimension R1 matrix. This is required when
+                ``vision_init_method == "external"`` and ``enable_vision_r1`` is
+                enabled.
+
+            vision_r2_map:
+                Optional mapping from vision block keys to per-layer head-dimension
+                R2 matrices.
+
+                Supported example keys:
+                    - "model.visual.blocks.0.attn.R2"
+                    - "model.visual.blocks.0.attn.vision_R2"
+
+            require_vision_r1_layernorm_compatible:
+                If True, external vision R1 matrices must be orthogonal and must
+                preserve the all-ones direction.
+
+            vision_rotation_tolerance:
+                Absolute tolerance used when validating external vision rotations.
         """
         self.init_method = init_method
         self.r1 = r1
         self.r2_map = r2_map
-        self.apply_r1 = apply_r1
-        self.apply_r2 = apply_r2
+        self.enable_r1 = enable_r1
+        self.enable_r2 = enable_r2
         self.fuse_deepstack_visual_outputs = fuse_deepstack_visual_outputs
         self.show_progress = show_progress
         self.language_model_attr = language_model_attr
         self.text_layers_attr = text_layers_attr
+        self.visual_model_attr = visual_model_attr
+        self.vision_blocks_attr = vision_blocks_attr
         self.visual_deepstack_mergers_attr = visual_deepstack_mergers_attr
         self.lm_head_attr = lm_head_attr
+        self.fuse_vision_layer_norms = fuse_vision_layer_norms
+        self.enable_vision_r1 = enable_vision_r1
+        self.enable_vision_r2 = enable_vision_r2
+        self.vision_init_method = vision_init_method
+        self.vision_r1 = vision_r1
+        self.vision_r2_map = vision_r2_map
+        self.require_vision_r1_layernorm_compatible = (
+            require_vision_r1_layernorm_compatible
+        )
+        self.vision_rotation_tolerance = vision_rotation_tolerance
 
         self._validate()
 
@@ -120,34 +196,69 @@ class Qwen3VLSpinQuantConfig(BaseConfig):
             ValueError: If a configuration value is invalid.
             TypeError: If a field has an unexpected type.
         """
-        if self.init_method not in {"random", "hadamard", "external"}:
+        valid_methods = {"random", "hadamard", "external"}
+        if self.init_method not in valid_methods:
             raise ValueError(f"Unsupported init_method: {self.init_method!r}")
 
-        if self.apply_r1 and self.init_method == "external" and self.r1 is None:
+        if (
+            self.vision_init_method is not None
+            and self.vision_init_method not in valid_methods
+        ):
             raise ValueError(
-                "`r1` must be provided when init_method='external' and apply_r1=True."
+                f"Unsupported vision_init_method: {self.vision_init_method!r}"
+            )
+
+        if self.enable_r1 and self.init_method == "external" and self.r1 is None:
+            raise ValueError(
+                "`r1` must be provided when init_method='external' and enable_r1=True."
+            )
+
+        vision_method = self.vision_init_method or self.init_method
+        if (
+            self.enable_vision_r1
+            and vision_method == "external"
+            and self.vision_r1 is None
+        ):
+            raise ValueError(
+                "`vision_r1` must be provided when vision_init_method='external' "
+                "and enable_vision_r1=True."
+            )
+
+        if self.enable_vision_r1 and not self.fuse_vision_layer_norms:
+            raise ValueError(
+                "`fuse_vision_layer_norms` must be True when enable_vision_r1=True."
             )
 
         if self.r1 is not None and not isinstance(self.r1, torch.Tensor):
             raise TypeError(f"`r1` must be a torch.Tensor, got {type(self.r1)}.")
 
-        if self.r2_map is not None:
-            if not isinstance(self.r2_map, dict):
-                raise TypeError(
-                    f"`r2_map` must be a dict[str, torch.Tensor], got {type(self.r2_map)}."
-                )
+        if self.vision_r1 is not None and not isinstance(self.vision_r1, torch.Tensor):
+            raise TypeError(
+                f"`vision_r1` must be a torch.Tensor, got {type(self.vision_r1)}."
+            )
 
-            for key, value in self.r2_map.items():
-                if not isinstance(key, str) or not key:
-                    raise ValueError(f"Invalid r2_map key: {key!r}")
-                if not isinstance(value, torch.Tensor):
-                    raise TypeError(
-                        f"r2_map[{key!r}] must be a torch.Tensor, got {type(value)}."
-                    )
+        if self.r2_map is not None:
+            self._validate_r2_map("r2_map", self.r2_map)
+
+        if self.vision_r2_map is not None:
+            self._validate_r2_map("vision_r2_map", self.vision_r2_map)
+
+        if not isinstance(self.vision_rotation_tolerance, (float, int)):
+            raise TypeError(
+                "`vision_rotation_tolerance` must be a float, "
+                f"got {type(self.vision_rotation_tolerance)}."
+            )
+        if self.vision_rotation_tolerance <= 0:
+            raise ValueError(
+                "`vision_rotation_tolerance` must be positive, "
+                f"got {self.vision_rotation_tolerance}."
+            )
 
         for field_name in (
             "language_model_attr",
             "text_layers_attr",
+            "visual_model_attr",
+            "vision_blocks_attr",
             "visual_deepstack_mergers_attr",
             "lm_head_attr",
         ):
@@ -155,6 +266,35 @@ class Qwen3VLSpinQuantConfig(BaseConfig):
             if not isinstance(field_value, str) or not field_value:
                 raise ValueError(
                     f"{field_name} must be a non-empty string, got {field_value!r}."
+                )
+
+    def _validate_r2_map(
+        self,
+        field_name: str,
+        value: Dict[str, torch.Tensor],
+    ) -> None:
+        """
+        Validate an R2 map field.
+
+        Parameters:
+            field_name: Configuration field name used in error messages.
+            value: Candidate mapping from module keys to tensors.
+
+        Raises:
+            TypeError: If the map or one of its values has an invalid type.
+            ValueError: If a key is invalid.
+        """
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"`{field_name}` must be a dict[str, torch.Tensor], got {type(value)}."
+            )
+
+        for key, tensor in value.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError(f"Invalid {field_name} key: {key!r}")
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(
+                    f"{field_name}[{key!r}] must be a torch.Tensor, got {type(tensor)}."
                 )
 
     @property

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
@@ -31,11 +31,19 @@ pipeline:
   - name: spinquant
     enabled: true
     init_method: random
-    disable_r1: false
-    disable_r2: false
-    disable_deepstack_fusion: false
     r1_path: null
     r2_map_path: null
+    enable_r1: true
+    enable_r2: true
+    fuse_deepstack_visual_outputs: true
+    vision_init_method: random
+    vision_r1_path: null
+    vision_r2_map_path: null
+    enable_vision_r1: true
+    enable_vision_r2: true
+    fuse_vision_layer_norms: true
+    require_vision_r1_layernorm_compatible: true
+    vision_rotation_tolerance: 1.0e-4
 
   - name: smoothquant
     enabled: false
@@ -76,6 +84,7 @@ pipeline:
     vision_patch_embed_weight: uint8
     embedding_weight: uint8
     lm_head_weight: uint8
+    spin_rotation_weight: int16
     norm: int16
     norm_weight: int16
     strict_wrap: true

--- a/tico/quantization/examples/configs/qwen3_vl_gptq_ptq.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_gptq_ptq.yaml
@@ -31,11 +31,19 @@ pipeline:
   - name: spinquant
     enabled: true
     init_method: random
-    disable_r1: false
-    disable_r2: false
-    disable_deepstack_fusion: false
     r1_path: null
     r2_map_path: null
+    enable_r1: true
+    enable_r2: true
+    fuse_deepstack_visual_outputs: true
+    vision_init_method: random
+    vision_r1_path: null
+    vision_r2_map_path: null
+    enable_vision_r1: true
+    enable_vision_r2: true
+    fuse_vision_layer_norms: true
+    require_vision_r1_layernorm_compatible: true
+    vision_rotation_tolerance: 1.0e-4
 
   - name: smoothquant
     enabled: false
@@ -76,6 +84,7 @@ pipeline:
     vision_patch_embed_weight: uint8
     embedding_weight: uint8
     lm_head_weight: uint8
+    spin_rotation_weight: int16
     norm: int16
     norm_weight: int16
     strict_wrap: true

--- a/tico/quantization/examples/configs/qwen3_vl_ptq_only.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_ptq_only.yaml
@@ -26,11 +26,19 @@ pipeline:
   - name: spinquant
     enabled: false
     init_method: random
-    disable_r1: false
-    disable_r2: false
-    disable_deepstack_fusion: false
     r1_path: null
     r2_map_path: null
+    enable_r1: true
+    enable_r2: true
+    fuse_deepstack_visual_outputs: true
+    vision_init_method: random
+    vision_r1_path: null
+    vision_r2_map_path: null
+    enable_vision_r1: false
+    enable_vision_r2: false
+    fuse_vision_layer_norms: false
+    require_vision_r1_layernorm_compatible: true
+    vision_rotation_tolerance: 1.0e-4
 
   - name: ptq
     enabled: true
@@ -39,6 +47,7 @@ pipeline:
     vision_patch_embed_weight: uint8
     embedding_weight: uint8
     lm_head_weight: uint8
+    spin_rotation_weight: int16
     norm: int16
     norm_weight: int16
     strict_wrap: true

--- a/tico/quantization/recipes/adapters/qwen3_vl.py
+++ b/tico/quantization/recipes/adapters/qwen3_vl.py
@@ -184,6 +184,9 @@ class Qwen3VLAdapter(ModelAdapter):
             ),
             embedding_weight=quant_spec_from_config(stage_cfg.get("embedding_weight")),
             lm_head_weight=quant_spec_from_config(stage_cfg.get("lm_head_weight")),
+            spin_rotation_weight=quant_spec_from_config(
+                stage_cfg.get("spin_rotation_weight")
+            ),
             norm=quant_spec_from_config(stage_cfg.get("norm")),
             norm_weight=quant_spec_from_config(stage_cfg.get("norm_weight")),
             strict_wrap=bool(stage_cfg.get("strict_wrap", True)),
@@ -222,21 +225,43 @@ class Qwen3VLAdapter(ModelAdapter):
 
         r1 = _load_torch_object(stage_cfg.get("r1_path"))
         r2_map = _load_torch_object(stage_cfg.get("r2_map_path"))
+        vision_r1 = _load_torch_object(stage_cfg.get("vision_r1_path"))
+        vision_r2_map = _load_torch_object(stage_cfg.get("vision_r2_map_path"))
+
+        enable_r1 = bool(stage_cfg.get("enable_r1", True))
+        enable_r2 = bool(stage_cfg.get("enable_r2", True))
+        enable_vision_r1 = bool(stage_cfg.get("enable_vision_r1", False))
+        enable_vision_r2 = bool(stage_cfg.get("enable_vision_r2", False))
+        fuse_vision_layer_norms = bool(
+            stage_cfg.get("fuse_vision_layer_norms", enable_vision_r1)
+        )
 
         spinquant_config = Qwen3VLSpinQuantConfig(
             init_method=stage_cfg.get("init_method", "random"),
             r1=r1,
             r2_map=r2_map,
-            apply_r1=not bool(stage_cfg.get("disable_r1", False)),
-            apply_r2=not bool(stage_cfg.get("disable_r2", False)),
-            fuse_deepstack_visual_outputs=not bool(
-                stage_cfg.get("disable_deepstack_fusion", False)
+            enable_r1=enable_r1,
+            enable_r2=enable_r2,
+            fuse_deepstack_visual_outputs=bool(
+                stage_cfg.get("fuse_deepstack_visual_outputs", True)
             ),
             show_progress=bool(
                 stage_cfg.get(
                     "show_progress",
                     ctx.cfg.get("runtime", {}).get("show_progress", True),
                 )
+            ),
+            fuse_vision_layer_norms=fuse_vision_layer_norms,
+            enable_vision_r1=enable_vision_r1,
+            enable_vision_r2=enable_vision_r2,
+            vision_init_method=stage_cfg.get("vision_init_method"),
+            vision_r1=vision_r1,
+            vision_r2_map=vision_r2_map,
+            require_vision_r1_layernorm_compatible=bool(
+                stage_cfg.get("require_vision_r1_layernorm_compatible", True)
+            ),
+            vision_rotation_tolerance=float(
+                stage_cfg.get("vision_rotation_tolerance", 1e-4)
             ),
         )
 

--- a/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_qwen3_vl_with_gptq.py
@@ -779,8 +779,8 @@ def apply_spinquant_if_enabled(
         init_method=args.spinquant_init_method,
         r1=r1,
         r2_map=r2_map,
-        apply_r1=not args.spinquant_disable_r1,
-        apply_r2=not args.spinquant_disable_r2,
+        enable_r1=not args.spinquant_disable_r1,
+        enable_r2=not args.spinquant_disable_r2,
         fuse_deepstack_visual_outputs=not args.spinquant_disable_deepstack_fusion,
         show_progress=not args.hide_progress,
     )


### PR DESCRIPTION
Extend Qwen3-VL SpinQuant with optional vision-side rotations and LayerNorm-compatible vision R1 fusion. Update recipe integration, PTQ builder overrides, tests, and example configs to use the new enable_* SpinQuant options.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>