### PR TITLE
[examples] Load evaluation checkpoints on runtime device

### DIFF
--- a/test/quantization/examples/test_examples_cli.py
+++ b/test/quantization/examples/test_examples_cli.py
@@ -135,7 +135,7 @@ class TestQuantizationExamplesCLI(unittest.TestCase):
         ), patch.object(
             evaluate_cli.torch,
             "load",
-            lambda path, weights_only=False: FakeCheckpoint(),
+            lambda path, **kwargs: FakeCheckpoint(),
         ), patch.object(
             sys, "argv", argv
         ):

--- a/tico/quantization/examples/evaluate.py
+++ b/tico/quantization/examples/evaluate.py
@@ -57,7 +57,11 @@ def main() -> None:
     ctx = adapter.load_model(ctx)
 
     if args.checkpoint:
-        ctx.model = torch.load(args.checkpoint, weights_only=False).eval()
+        ctx.model = (
+            torch.load(args.checkpoint, map_location=ctx.device, weights_only=False)
+            .to(ctx.device)
+            .eval()
+        )
 
     if args.tasks:
         if adapter.family == "llama":

--- a/tico/quantization/examples/evaluate.py
+++ b/tico/quantization/examples/evaluate.py
@@ -57,11 +57,14 @@ def main() -> None:
     ctx = adapter.load_model(ctx)
 
     if args.checkpoint:
-        ctx.model = (
-            torch.load(args.checkpoint, map_location=ctx.device, weights_only=False)
-            .to(ctx.device)
-            .eval()
+        checkpoint = torch.load(
+            args.checkpoint,
+            map_location=ctx.device,
+            weights_only=False,
         )
+        if hasattr(checkpoint, "to"):
+            checkpoint = checkpoint.to(ctx.device)
+        ctx.model = checkpoint.eval()
 
     if args.tasks:
         if adapter.family == "llama":


### PR DESCRIPTION
Ensure checkpoints loaded by evaluate.py are mapped to the configured runtime device before evaluation. This avoids CPU/CUDA mismatches when evaluating a checkpoint saved on a different device.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>