### PR TITLE
[quantization] avoid import-time optional eval dependencies

### DIFF
--- a/tico/quantization/evaluation/hellaswag_eval_utils.py
+++ b/tico/quantization/evaluation/hellaswag_eval_utils.py
@@ -30,9 +30,25 @@ from typing import Any
 
 import torch
 
-from lm_eval import evaluator
-from lm_eval.models.huggingface import HFLM
-from lm_eval.utils import make_table
+from tico.quantization.evaluation.optional_deps import require_attr, require_module
+
+_LM_EVAL_INSTALL_HINT = "pip install lm-eval"
+
+
+def _load_lm_eval_runtime() -> tuple[Any, Any]:
+    """Load ``lm_eval`` runtime pieces lazily."""
+    evaluator = require_module(
+        "lm_eval.evaluator",
+        feature="HellaSwag evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+    HFLM = require_attr(
+        "lm_eval.models.huggingface",
+        "HFLM",
+        feature="HellaSwag evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+    return evaluator, HFLM
 
 
 def evaluate_hellaswag(
@@ -65,6 +81,8 @@ def evaluate_hellaswag(
         - acc: Accuracy
         - acc_norm: Normalized accuracy (length-normalized)
     """
+    evaluator, HFLM = _load_lm_eval_runtime()
+
     # Unwrap if needed (handles PTQWrapper)
     if hasattr(model, "wrapped"):
         model = model.wrapped
@@ -98,6 +116,12 @@ def print_hellaswag_results(results: dict[str, Any]) -> None:
     Args:
         results: Results dictionary from evaluate_hellaswag().
     """
+    make_table = require_attr(
+        "lm_eval.utils",
+        "make_table",
+        feature="HellaSwag result printing",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
     print(make_table(results))
 
 

--- a/tico/quantization/evaluation/mmlu_eval_utils.py
+++ b/tico/quantization/evaluation/mmlu_eval_utils.py
@@ -1,13 +1,27 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any
 
 import torch
 
-from lm_eval import evaluator
-from lm_eval.models.huggingface import HFLM
-from lm_eval.utils import make_table
+from tico.quantization.evaluation.optional_deps import require_attr, require_module
+
+_LM_EVAL_INSTALL_HINT = "pip install lm-eval"
 
 
-def _normalize_subject(subject: str) -> str:
+def _normalize_subject(subject: str | None) -> str | None:
     if subject is None:
         return None
 
@@ -15,6 +29,22 @@ def _normalize_subject(subject: str) -> str:
         return subject
 
     return f"mmlu_{subject}"
+
+
+def _load_lm_eval_runtime() -> tuple[Any, Any]:
+    """Load ``lm_eval`` runtime pieces lazily."""
+    evaluator = require_module(
+        "lm_eval.evaluator",
+        feature="MMLU evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+    HFLM = require_attr(
+        "lm_eval.models.huggingface",
+        "HFLM",
+        feature="MMLU evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+    return evaluator, HFLM
 
 
 def evaluate_mmlu(
@@ -47,6 +77,8 @@ def evaluate_mmlu(
     Returns:
         Aggregated results dictionary with per-subject, per-domain, and overall accuracy.
     """
+    evaluator, HFLM = _load_lm_eval_runtime()
+
     # Unwrap if needed (handles PTQWrapper)
     if hasattr(model, "wrapped"):
         model = model.wrapped
@@ -63,7 +95,9 @@ def evaluate_mmlu(
 
     # Convert subjects to lm_eval task names
     tasks: list[str] = (
-        [_normalize_subject(subject) for subject in subjects] if subjects else ["mmlu"]
+        [task for task in (_normalize_subject(subject) for subject in subjects) if task]
+        if subjects
+        else ["mmlu"]
     )
 
     # Run lm_eval evaluation
@@ -79,4 +113,10 @@ def evaluate_mmlu(
 
 
 def print_mmlu_results(results: dict[str, Any]) -> None:
+    make_table = require_attr(
+        "lm_eval.utils",
+        "make_table",
+        feature="MMLU result printing",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
     print(make_table(results))

--- a/tico/quantization/evaluation/optional_deps.py
+++ b/tico/quantization/evaluation/optional_deps.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for optional evaluation dependencies.
+
+Evaluation backends such as ``lm_eval``, ``datasets`` and ``transformers`` are
+not required for every quantization recipe.  Import them only from the evaluation
+function that actually needs them, and use these helpers to produce a clear
+runtime error when an optional package is missing.
+"""
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+
+def require_module(
+    module_name: str,
+    *,
+    feature: str,
+    install_hint: str,
+) -> ModuleType:
+    """Import an optional module or raise a clear RuntimeError.
+
+    Args:
+        module_name: Fully-qualified module name to import.
+        feature: Human-readable feature name that requires the module.
+        install_hint: Installation hint shown to the user.
+
+    Returns:
+        The imported module.
+
+    Raises:
+        RuntimeError: If the module cannot be imported.
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"{module_name!r} is required for {feature}. "
+            f"Install the optional evaluation dependency with: {install_hint}"
+        ) from exc
+
+
+def require_attr(
+    module_name: str,
+    attr_name: str,
+    *,
+    feature: str,
+    install_hint: str,
+) -> Any:
+    """Import an optional module and return one attribute from it.
+
+    Args:
+        module_name: Fully-qualified module name to import.
+        attr_name: Attribute expected in the imported module.
+        feature: Human-readable feature name that requires the attribute.
+        install_hint: Installation hint shown to the user.
+
+    Returns:
+        The requested attribute.
+
+    Raises:
+        RuntimeError: If the module cannot be imported or lacks the attribute.
+    """
+    module = require_module(
+        module_name,
+        feature=feature,
+        install_hint=install_hint,
+    )
+    try:
+        return getattr(module, attr_name)
+    except AttributeError as exc:
+        raise RuntimeError(
+            f"{module_name!r} was imported, but it does not provide "
+            f"{attr_name!r}, which is required for {feature}. "
+            f"Check the installed package version or reinstall with: {install_hint}"
+        ) from exc

--- a/tico/quantization/evaluation/script/llm_tasks_eval.py
+++ b/tico/quantization/evaluation/script/llm_tasks_eval.py
@@ -12,36 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import argparse
 from typing import Any
 
-from lm_eval import evaluator
-from lm_eval.models.huggingface import HFLM
-from lm_eval.utils import make_table
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from tico.quantization.evaluation.optional_deps import require_attr, require_module
+
+_LM_EVAL_INSTALL_HINT = "pip install lm-eval"
+_TRANSFORMERS_INSTALL_HINT = "pip install transformers"
 
 
 def evaluate_llm_on_tasks(
-    model: AutoModelForCausalLM,
-    tokenizer: AutoTokenizer,
+    model: Any,
+    tokenizer: Any,
     tasks: str,
     max_length: int | None = None,
 ) -> dict[str, Any]:
+    """Evaluate a Hugging Face causal LM on one or more ``lm_eval`` tasks.
+
+    Optional third-party dependencies are loaded only when this function runs,
+    keeping recipe imports lightweight for users who only run quantization.
+    """
+    evaluator = require_module(
+        "lm_eval.evaluator",
+        feature="lm_eval task evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+    HFLM = require_attr(
+        "lm_eval.models.huggingface",
+        "HFLM",
+        feature="lm_eval task evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+
     if hasattr(model, "wrapped"):
         model = model.wrapped
+
     model_to_evaluate = HFLM(
-        model,
-        "causal",
+        pretrained=model,
+        backend="causal",
         tokenizer=tokenizer,
         max_length=max_length,
         truncation=True,
     )
-    tasks_list: list[str] = tasks.split(",")
+    tasks_list: list[str] = [task.strip() for task in tasks.split(",") if task.strip()]
     return evaluator.simple_evaluate(model_to_evaluate, tasks=tasks_list)
 
 
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument(
         "--model",
@@ -53,7 +70,10 @@ def main():
         "--eval_tasks",
         type=str,
         default="arc_easy",
-        help="tasks to run evaluation, e.g `winogrande,arc_easy,arc_challenge,openbookqa,mmlu_pro,ifeval,bbh",
+        help=(
+            "Tasks to run evaluation, e.g. "
+            "`winogrande,arc_easy,arc_challenge,openbookqa,mmlu_pro,ifeval,bbh`"
+        ),
     )
     ap.add_argument(
         "--device",
@@ -79,6 +99,25 @@ def main():
     )
 
     args = ap.parse_args()
+
+    AutoTokenizer = require_attr(
+        "transformers",
+        "AutoTokenizer",
+        feature="standalone LLM evaluation script",
+        install_hint=_TRANSFORMERS_INSTALL_HINT,
+    )
+    AutoModelForCausalLM = require_attr(
+        "transformers",
+        "AutoModelForCausalLM",
+        feature="standalone LLM evaluation script",
+        install_hint=_TRANSFORMERS_INSTALL_HINT,
+    )
+    make_table = require_attr(
+        "lm_eval.utils",
+        "make_table",
+        feature="standalone LLM evaluation script",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
 
     print("Loading FP model …")
     tokenizer = AutoTokenizer.from_pretrained(

--- a/tico/quantization/recipes/evaluation/llm.py
+++ b/tico/quantization/recipes/evaluation/llm.py
@@ -14,11 +14,10 @@
 
 from typing import Any
 
-from datasets import load_dataset
-from lm_eval.utils import make_table
+from tico.quantization.evaluation.optional_deps import require_attr
 
-from tico.quantization.evaluation.script.llm_tasks_eval import evaluate_llm_on_tasks
-from tico.quantization.wrapq.utils.metrics import perplexity
+_DATASETS_INSTALL_HINT = "pip install datasets"
+_LM_EVAL_INSTALL_HINT = "pip install lm-eval"
 
 
 def evaluate_perplexity(
@@ -32,8 +31,26 @@ def evaluate_perplexity(
     dataset_config: str = "wikitext-2-raw-v1",
     split: str = "test",
 ) -> float:
+    """Evaluate text perplexity on a Hugging Face dataset.
+
+    The ``datasets`` package is imported lazily so that importing recipe modules
+    does not require optional evaluation dependencies unless this function is
+    actually used.
+    """
+    load_dataset = require_attr(
+        "datasets",
+        "load_dataset",
+        feature="LLM perplexity evaluation",
+        install_hint=_DATASETS_INSTALL_HINT,
+    )
+
+    from tico.quantization.wrapq.utils.metrics import perplexity
+
     dataset = load_dataset(
-        dataset_name, dataset_config, split=split, cache_dir=cache_dir
+        dataset_name,
+        dataset_config,
+        split=split,
+        cache_dir=cache_dir,
     )
     enc = tokenizer("\n\n".join(dataset["text"]), return_tensors="pt")
     return float(
@@ -48,6 +65,20 @@ def evaluate_lm_tasks(
     tasks: str,
     max_seq_len: int,
 ) -> Any:
+    """Evaluate text-only LM tasks through ``lm_eval``.
+
+    ``lm_eval`` is imported lazily and reports a clear error only when this
+    evaluation path is requested.
+    """
+    make_table = require_attr(
+        "lm_eval.utils",
+        "make_table",
+        feature="lm_eval task evaluation",
+        install_hint=_LM_EVAL_INSTALL_HINT,
+    )
+
+    from tico.quantization.evaluation.script.llm_tasks_eval import evaluate_llm_on_tasks
+
     results = evaluate_llm_on_tasks(model, tokenizer, tasks, max_length=max_seq_len)
     print(make_table(results))
     return results


### PR DESCRIPTION
Move datasets, lm_eval, and transformers imports behind the evaluation entry points so recipe modules remain importable without optional benchmark packages installed.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>