### PR TITLE
[utils] Suppress "isinstance(treespec, LeafSpec) is deprecated" warning

### DIFF
--- a/test/pt2_to_circle_test/test_pt2_to_circle.py
+++ b/test/pt2_to_circle_test/test_pt2_to_circle.py
@@ -93,7 +93,7 @@ def convert_pt2_to_circle(
     circle_model_path: str,
     config: Optional[CompileConfigBase] = None,
 ):
-    with SuppressWarning(FutureWarning, ".*LeafSpec*"):
+    with SuppressWarning(FutureWarning, ".*LeafSpec"):
         tico.pt2_to_circle.convert(pt2_model_path, circle_model_path, config=config)
 
 
@@ -113,7 +113,7 @@ def convert_nnmodule_to_circle(
             kwargs=forward_kwargs,
             dynamic_shapes=dynamic_shapes,
         )
-    with SuppressWarning(FutureWarning, ".*LeafSpec*"):
+    with SuppressWarning(FutureWarning, ".*LeafSpec"):
         circle_program = convert_exported_module_to_circle(exported_program, config)
     circle_binary = circle_program
     with open(circle_model_path, "wb") as f:

--- a/test/unit_test/quantization/test_evaluate.py
+++ b/test/unit_test/quantization/test_evaluate.py
@@ -63,7 +63,7 @@ class EvaluateTest(unittest.TestCase):
         convert(q_m.m)
 
         # Export circle
-        with SuppressWarning(FutureWarning, ".*LeafSpec*"):
+        with SuppressWarning(FutureWarning, ".*LeafSpec"):
             ep = torch.export.export(q_m, args, kwargs)
             cm = tico.convert_from_exported_program(ep)
         results = evaluate(q_m, cm, BACKEND.TRIV24, mode="return")
@@ -78,7 +78,7 @@ class EvaluateTest(unittest.TestCase):
         inputs may produce spikes in error, and a stricter threshold might
         result in unncessary test failures.
 
-        Setting the threshold at 10 ensures robustness while still maintaining 
+        Setting the threshold at 10 ensures robustness while still maintaining
          a reasonable level of accuracy for the test.
         """
         self.assertLess(results["peir"][0], 10)

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -143,7 +143,7 @@ def traced_run_decompositions(exported_program: ExportedProgram):
             if op in _decomp_table:
                 del _decomp_table[op]
 
-        with SuppressWarning(FutureWarning, ".*LeafSpec*"):
+        with SuppressWarning(FutureWarning, ".*LeafSpec"):
             ep = ep.run_decompositions(decomp_table=_decomp_table)
         return ep
 
@@ -361,7 +361,7 @@ def convert(
             mod, args, kwargs, dynamic_shapes=dynamic_shapes, strict=strict
         )
 
-    with SuppressWarning(FutureWarning, ".*LeafSpec*"):
+    with SuppressWarning(FutureWarning, ".*LeafSpec"):
         circle_binary = convert_exported_module_to_circle(
             exported_program, config=config
         )

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -143,7 +143,8 @@ def traced_run_decompositions(exported_program: ExportedProgram):
             if op in _decomp_table:
                 del _decomp_table[op]
 
-        ep = ep.run_decompositions(decomp_table=_decomp_table)
+        with SuppressWarning(FutureWarning, ".*LeafSpec*"):
+            ep = ep.run_decompositions(decomp_table=_decomp_table)
         return ep
 
     if torch.__version__.startswith("2.5"):

--- a/tico/utils/utils.py
+++ b/tico/utils/utils.py
@@ -41,19 +41,18 @@ def get_fake_mode(exported_program: ExportedProgram):
 
 
 class SuppressWarning:
-    def __init__(self, warning_category: type[Warning], regex):
-        self.warning_category = warning_category
+    def __init__(self, category: type[Warning], regex):
+        self.ctx = warnings.catch_warnings()
+        self.category = category
         self.regex = regex
 
     def __enter__(self):
-        warnings.filterwarnings(
-            "ignore", category=self.warning_category, message=self.regex
-        )
+        self.ctx.__enter__()
+        warnings.filterwarnings("ignore", self.regex, category=self.category)
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        warnings.filterwarnings(
-            "default", category=self.warning_category, message=self.regex
-        )
+        self.ctx.__exit__(exc_type, exc_val, exc_tb)
 
 
 class ArgTypeError(Exception):


### PR DESCRIPTION
This PR suppresses warning caused by PyTorch:

```
/usr/lib/python3.14/copyreg.py:104: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return cls.__new__(cls, *args)
```