### PR TITLE
[quantization] Add Gemma4 text attention wrapper

### DIFF
--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_text_attention.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_text_attention.py
@@ -21,6 +21,7 @@ import torch
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.wrappers.gemma4.quant_text_attention import (
+    LayerKV,
     QuantGemma4TextAttention,
 )
 from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
@@ -267,8 +268,8 @@ class TestQuantGemma4TextAttention(unittest.TestCase):
         rope = self._rope(batch_size, seq_len, cfg.head_dim)
         mask = self._zero_mask(batch_size, seq_len, seq_len)
 
-        fp_shared = {}
-        q_shared = {}
+        fp_shared: dict[str, LayerKV] = {}
+        q_shared: dict[str, LayerKV] = {}
         with torch.no_grad():
             fp_attn0(
                 hidden,

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_text_attention.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_text_attention.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Gemma4 text attention PTQ wrapper."""
+
+import unittest
+
+import torch
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.gemma4.quant_text_attention import (
+    QuantGemma4TextAttention,
+)
+from tico.quantization.wrapq.wrappers.nn.quant_linear import QuantLinear
+
+
+_SKIP_MSG = "required transformers Gemma4 modules are not installed"
+
+
+def _has_gemma4() -> bool:
+    """Return whether the installed transformers package provides Gemma4."""
+    try:
+        from transformers.models.gemma4.configuration_gemma4 import (  # noqa: F401
+            Gemma4TextConfig,
+        )
+        from transformers.models.gemma4.modeling_gemma4 import (  # noqa: F401
+            Gemma4TextAttention,
+        )
+    except Exception:
+        return False
+    return True
+
+
+def _make_text_config(**overrides):
+    """Create a tiny dense Gemma4 text config for synthetic attention tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    kwargs = dict(
+        vocab_size=128,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=4,
+        global_head_dim=4,
+        attention_bias=False,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        sliding_window=8,
+        layer_types=["full_attention"],
+        hidden_size_per_layer_input=0,
+        attention_k_eq_v=False,
+        num_kv_shared_layers=0,
+        enable_moe_block=False,
+    )
+    kwargs.update(overrides)
+    cfg = Gemma4TextConfig(**kwargs)
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestQuantGemma4TextAttention(unittest.TestCase):
+    """Validate dense Gemma4 text attention wrapper behavior."""
+
+    def setUp(self):
+        """Create deterministic test inputs."""
+        torch.manual_seed(1234)
+
+    @staticmethod
+    def _rope(batch_size: int, seq_len: int, head_dim: int):
+        """Create synthetic RoPE tables shaped like Gemma4 text RoPE output."""
+        emb = torch.randn(batch_size, seq_len, head_dim)
+        return emb.cos(), emb.sin()
+
+    @staticmethod
+    def _zero_mask(batch_size: int, q_len: int, k_len: int) -> torch.Tensor:
+        """Return an additive attention mask that keeps every key."""
+        return torch.zeros(batch_size, 1, q_len, k_len)
+
+    def _make_attention(self, cfg=None, layer_idx: int = 0):
+        """Create a floating-point Gemma4 text attention module."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+
+        cfg = cfg if cfg is not None else _make_text_config()
+        return Gemma4TextAttention(cfg, layer_idx=layer_idx).eval()
+
+    def test_no_quant_forward_matches_hf_eager_attention(self):
+        """Check that the wrapper matches Hugging Face eager attention in NO_QUANT."""
+        cfg = _make_text_config()
+        fp_attn = self._make_attention(cfg)
+        qattn = QuantGemma4TextAttention(fp_attn).eval()
+
+        batch_size, seq_len = 2, 5
+        hidden = torch.randn(batch_size, seq_len, cfg.hidden_size)
+        rope = self._rope(batch_size, seq_len, cfg.head_dim)
+        mask = self._zero_mask(batch_size, seq_len, seq_len)
+
+        with torch.no_grad():
+            quant_out, quant_weights = qattn(
+                hidden,
+                rope,
+                attention_mask=mask,
+                shared_kv_states={},
+            )
+            fp_out, fp_weights = fp_attn(
+                hidden,
+                position_embeddings=rope,
+                attention_mask=mask,
+                shared_kv_states={},
+            )
+
+        self.assertEqual(quant_out.shape, fp_out.shape)
+        self.assertEqual(quant_weights.shape, fp_weights.shape)
+        self.assertTrue(torch.allclose(quant_out, fp_out, atol=1e-5, rtol=1e-5))
+        self.assertTrue(torch.allclose(quant_weights, fp_weights, atol=1e-5, rtol=1e-5))
+
+    def test_mode_transitions_and_projection_override(self):
+        """Check lifecycle transitions and a child projection quant override."""
+        from tico.quantization.wrapq.dtypes import DType
+
+        cfg = PTQConfig(
+            overrides={
+                "q_proj": {
+                    "act_in": {"dtype": DType.uint(4)},
+                    "act_out": {"dtype": DType.uint(4)},
+                }
+            }
+        )
+        qattn = QuantGemma4TextAttention(self._make_attention(), qcfg=cfg)
+
+        self.assertIs(qattn._mode, Mode.NO_QUANT)
+        qattn.enable_calibration()
+        self.assertIs(qattn._mode, Mode.CALIB)
+
+        hidden = torch.randn(1, 4, qattn.config.hidden_size)
+        rope = self._rope(1, 4, qattn.head_dim)
+        qattn(hidden, rope, attention_mask=self._zero_mask(1, 4, 4))
+        qattn.freeze_qparams()
+
+        self.assertIs(qattn._mode, Mode.QUANT)
+        self.assertIsInstance(qattn.q_proj.wrapped, QuantLinear)
+        self.assertEqual(qattn.q_proj.wrapped.obs_act_in.dtype, DType.uint(4))
+        self.assertEqual(qattn.q_proj.wrapped.obs_act_out.dtype, DType.uint(4))
+
+    def test_cache_delta_prefill_then_decode(self):
+        """Validate explicit tuple cache handling for prefill and decode."""
+        cfg = _make_text_config()
+        qattn = QuantGemma4TextAttention(self._make_attention(cfg)).eval()
+
+        batch_size, prefill_len = 1, 4
+        hidden = torch.randn(batch_size, prefill_len, cfg.hidden_size)
+        rope = self._rope(batch_size, prefill_len, cfg.head_dim)
+        mask = self._zero_mask(batch_size, prefill_len, prefill_len)
+
+        with torch.no_grad():
+            out0, weights0, kv0 = qattn(
+                hidden,
+                rope,
+                attention_mask=mask,
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        self.assertEqual(out0.shape, (batch_size, prefill_len, cfg.hidden_size))
+        self.assertEqual(
+            weights0.shape,
+            (batch_size, cfg.num_attention_heads, prefill_len, prefill_len),
+        )
+        self.assertIsInstance(kv0, tuple)
+        key0, value0 = kv0
+        self.assertEqual(
+            key0.shape, (batch_size, cfg.num_key_value_heads, prefill_len, cfg.head_dim)
+        )
+        self.assertEqual(value0.shape, key0.shape)
+
+        decode_len = 1
+        hidden1 = torch.randn(batch_size, decode_len, cfg.hidden_size)
+        rope1 = self._rope(batch_size, decode_len, cfg.head_dim)
+        mask1 = self._zero_mask(batch_size, decode_len, prefill_len + decode_len)
+        with torch.no_grad():
+            out1, weights1, kv1 = qattn(
+                hidden1,
+                rope1,
+                attention_mask=mask1,
+                past_key_value=kv0,
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        self.assertEqual(out1.shape, (batch_size, decode_len, cfg.hidden_size))
+        self.assertEqual(
+            weights1.shape,
+            (batch_size, cfg.num_attention_heads, decode_len, prefill_len + decode_len),
+        )
+        key1, value1 = kv1
+        self.assertEqual(
+            key1.shape, (batch_size, cfg.num_key_value_heads, decode_len, cfg.head_dim)
+        )
+        self.assertEqual(value1.shape, key1.shape)
+
+    def test_alternative_attention_k_equals_v_matches_hf(self):
+        """Check the Gemma4 full-attention path where V reuses raw K states."""
+        cfg = _make_text_config(attention_k_eq_v=True)
+        fp_attn = self._make_attention(cfg)
+        qattn = QuantGemma4TextAttention(fp_attn).eval()
+
+        self.assertTrue(qattn.use_alternative_attention)
+        self.assertIsNone(qattn.v_proj)
+
+        batch_size, seq_len = 1, 5
+        hidden = torch.randn(batch_size, seq_len, cfg.hidden_size)
+        rope = self._rope(batch_size, seq_len, cfg.head_dim)
+        mask = self._zero_mask(batch_size, seq_len, seq_len)
+
+        with torch.no_grad():
+            quant_out, _ = qattn(
+                hidden,
+                rope,
+                attention_mask=mask,
+                shared_kv_states={},
+            )
+            fp_out, _ = fp_attn(
+                hidden,
+                position_embeddings=rope,
+                attention_mask=mask,
+                shared_kv_states={},
+            )
+
+        self.assertTrue(torch.allclose(quant_out, fp_out, atol=1e-5, rtol=1e-5))
+
+    def test_shared_kv_layer_consumes_stored_states(self):
+        """Validate Gemma4 shared-KV producer and consumer layer behavior."""
+        cfg = _make_text_config(
+            num_hidden_layers=2,
+            layer_types=["full_attention", "full_attention"],
+            num_kv_shared_layers=1,
+        )
+        fp_attn0 = self._make_attention(cfg, layer_idx=0)
+        fp_attn1 = self._make_attention(cfg, layer_idx=1)
+        qattn0 = QuantGemma4TextAttention(fp_attn0).eval()
+        qattn1 = QuantGemma4TextAttention(fp_attn1).eval()
+
+        self.assertTrue(qattn0.store_full_length_kv)
+        self.assertTrue(qattn1.is_kv_shared_layer)
+
+        batch_size, seq_len = 1, 4
+        hidden = torch.randn(batch_size, seq_len, cfg.hidden_size)
+        rope = self._rope(batch_size, seq_len, cfg.head_dim)
+        mask = self._zero_mask(batch_size, seq_len, seq_len)
+
+        fp_shared = {}
+        q_shared = {}
+        with torch.no_grad():
+            fp_attn0(
+                hidden,
+                position_embeddings=rope,
+                attention_mask=mask,
+                shared_kv_states=fp_shared,
+            )
+            fp_out, fp_weights = fp_attn1(
+                hidden,
+                position_embeddings=rope,
+                attention_mask=mask,
+                shared_kv_states=fp_shared,
+            )
+
+            qattn0(
+                hidden,
+                rope,
+                attention_mask=mask,
+                shared_kv_states=q_shared,
+            )
+            quant_out, quant_weights = qattn1(
+                hidden,
+                rope,
+                attention_mask=mask,
+                shared_kv_states=q_shared,
+            )
+
+        self.assertIn("full_attention", q_shared)
+        self.assertEqual(quant_out.shape, fp_out.shape)
+        self.assertEqual(quant_weights.shape, fp_weights.shape)
+        self.assertTrue(torch.allclose(quant_out, fp_out, atol=1e-5, rtol=1e-5))
+
+    def test_bool_mask_is_combined_with_causal_mask(self):
+        """Check keep-mask conversion and causal-mask combination."""
+        qcfg = PTQConfig(attention_mask_fill_value=-100.0)
+        qattn = QuantGemma4TextAttention(self._make_attention(), qcfg=qcfg)
+
+        keep_mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.bool)
+        out = qattn._build_attention_mask(
+            attention_mask=keep_mask,
+            q_len=4,
+            k_len=4,
+            device=torch.device("cpu"),
+        )
+
+        self.assertEqual(tuple(out.shape), (1, 1, 4, 4))
+        self.assertEqual(out[0, 0, 0, 0].item(), 0.0)
+        self.assertEqual(out[0, 0, 0, 1].item(), -100.0)
+        self.assertEqual(out[0, 0, 0, 2].item(), -100.0)
+        self.assertTrue(torch.all(out[..., 3] == -100.0))
+        self.assertEqual(out[0, 0, 2, 0].item(), 0.0)
+        self.assertEqual(out[0, 0, 2, 1].item(), 0.0)
+        self.assertEqual(out[0, 0, 2, 2].item(), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/gemma4/test_quantize_text_attention.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quantize_text_attention.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for Gemma4 text attention prepare-calibrate-convert flow."""
+
+import copy
+import os
+import unittest
+
+import torch
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+
+IS_INTERNAL_TEST = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+_SKIP_MSG = "required transformers Gemma4 modules are not installed"
+
+
+def _has_gemma4() -> bool:
+    """Return whether the installed transformers package provides Gemma4."""
+    try:
+        from transformers.models.gemma4.configuration_gemma4 import (  # noqa: F401
+            Gemma4TextConfig,
+        )
+        from transformers.models.gemma4.modeling_gemma4 import (  # noqa: F401
+            Gemma4TextAttention,
+        )
+    except Exception:
+        return False
+    return True
+
+
+def _make_text_config():
+    """Create a tiny Gemma4 text config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    cfg = Gemma4TextConfig(
+        vocab_size=128,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=4,
+        global_head_dim=4,
+        attention_bias=False,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        sliding_window=8,
+        layer_types=["full_attention"],
+        hidden_size_per_layer_input=0,
+        attention_k_eq_v=False,
+        num_kv_shared_layers=0,
+        enable_moe_block=False,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _rope(batch_size: int, seq_len: int, head_dim: int):
+    """Create synthetic Gemma4 text RoPE tables."""
+    emb = torch.randn(batch_size, seq_len, head_dim)
+    return emb.cos(), emb.sin()
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestGemma4TextAttentionSmoke(unittest.TestCase):
+    """Exercise the prepare-calibrate-convert flow for Gemma4 text attention."""
+
+    def setUp(self):
+        """Create a deterministic tiny Gemma4 text attention module."""
+        torch.manual_seed(2026)
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+
+        self.cfg = _make_text_config()
+        self.fp_attn = Gemma4TextAttention(self.cfg, layer_idx=0).eval()
+        self.fp_ref = copy.deepcopy(self.fp_attn).eval()
+
+    def test_prepare_convert_text_attention_flow(self):
+        """Quantize Gemma4 text attention and validate a synthetic output."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_text_attention import (
+            QuantGemma4TextAttention,
+        )
+
+        prepared = prepare(self.fp_attn, PTQConfig())
+        self.assertIsInstance(prepared, PTQWrapper)
+        self.assertIsInstance(prepared.wrapped, QuantGemma4TextAttention)
+
+        batch_size, seq_len = 1, 8
+        mask = torch.zeros(batch_size, 1, seq_len, seq_len)
+        with torch.no_grad():
+            for _ in range(3):
+                hidden = torch.randn(batch_size, seq_len, self.cfg.hidden_size)
+                prepared(
+                    hidden,
+                    _rope(batch_size, seq_len, self.cfg.head_dim),
+                    attention_mask=mask,
+                    shared_kv_states={},
+                )
+
+        quantized = convert(prepared)
+        self.assertIs(quantized._mode, Mode.QUANT)
+
+        hidden = torch.randn(batch_size, seq_len, self.cfg.hidden_size)
+        position_embeddings = _rope(batch_size, seq_len, self.cfg.head_dim)
+        with torch.no_grad():
+            quant_out = quantized(
+                hidden,
+                position_embeddings,
+                attention_mask=mask,
+                shared_kv_states={},
+            )[0]
+            fp_out = self.fp_ref(
+                hidden,
+                position_embeddings=position_embeddings,
+                attention_mask=mask,
+                shared_kv_states={},
+            )[0]
+
+        self.assertEqual(quant_out.shape, fp_out.shape)
+        self.assertTrue(torch.isfinite(quant_out).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/quantization/examples/inspect.py
+++ b/tico/quantization/examples/inspect.py
@@ -128,6 +128,8 @@ def _wrapper_smoke_case_group(case_name: str) -> str:
         return "llama"
     if case_name.startswith("qwen3_vl_"):
         return "qwen3_vl"
+    if case_name.startswith("gemma4_"):
+        return "gemma4"
     return "other"
 
 
@@ -137,13 +139,14 @@ def _print_wrapper_smoke_cases() -> None:
         "nn": [],
         "llama": [],
         "qwen3_vl": [],
+        "gemma4": [],
         "other": [],
     }
     for case in list_cases():
         groups[_wrapper_smoke_case_group(case.name)].append(case.name)
 
     print("Available wrapper smoke cases:")
-    for group_name in ("nn", "llama", "qwen3_vl", "other"):
+    for group_name in ("nn", "llama", "qwen3_vl", "gemma4", "other"):
         case_names = groups[group_name]
         if not case_names:
             continue

--- a/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Smoke cases for Gemma4 wrapper checks."""
+
 from typing import Any, Mapping
 
 import torch
@@ -24,6 +26,17 @@ from tico.quantization.recipes.debug.wrapper_smoke.case import (
 from tico.quantization.recipes.debug.wrapper_smoke.utils import clone_module
 
 
+_GEMMA4_FULL_ROPE_PARAMETERS: dict[str, Any] = {
+    "rope_type": "proportional",
+    "partial_rotary_factor": 0.25,
+    "rope_theta": 1_000_000.0,
+}
+_GEMMA4_SLIDING_ROPE_PARAMETERS: dict[str, Any] = {
+    "rope_type": "default",
+    "rope_theta": 10_000.0,
+}
+
+
 def _has_gemma4() -> CaseAvailability:
     """Return availability for Hugging Face Gemma4 modules."""
     try:
@@ -34,6 +47,106 @@ def _has_gemma4() -> CaseAvailability:
         return CaseAvailability(True)
     except Exception as exc:
         return CaseAvailability(False, f"Gemma4 modules are unavailable: {exc}")
+
+
+def _set_eager_attention(cfg: Any) -> Any:
+    """Set eager attention on configs that expose a configurable implementation."""
+    if hasattr(cfg, "_attn_implementation"):
+        cfg._attn_implementation = "eager"
+    else:
+        setattr(cfg, "_attn_implementation", "eager")
+    return cfg
+
+
+def _rope_parameters_for_layer_types(
+    layer_types: tuple[str, ...]
+) -> dict[str, dict[str, Any]]:
+    """Return RoPE parameters whose keys exactly match the requested layer types.
+
+    Hugging Face validates Gemma4 RoPE parameters as a nested layer-type mapping
+    only when every top-level RoPE key is present in ``config.layer_types``. Tiny
+    smoke configs often use a subset of real Gemma4 layer types, so the default
+    Gemma4 RoPE dict can trigger warnings when it contains unused keys.
+    """
+    rope_parameters: dict[str, dict[str, Any]] = {}
+    if "sliding_attention" in layer_types:
+        rope_parameters["sliding_attention"] = dict(_GEMMA4_SLIDING_ROPE_PARAMETERS)
+    if "full_attention" in layer_types:
+        rope_parameters["full_attention"] = dict(_GEMMA4_FULL_ROPE_PARAMETERS)
+    return rope_parameters
+
+
+def _make_text_config(
+    *,
+    layer_types: tuple[str, ...] = ("full_attention",),
+    attention_k_eq_v: bool = False,
+    num_kv_shared_layers: int = 0,
+) -> Any:
+    """Create a warning-free tiny Gemma4 text config for synthetic smoke tests.
+
+    The helper intentionally provides ``layer_types`` and ``rope_parameters`` as
+    a matched pair. This prevents Hugging Face from treating nested Gemma4 RoPE
+    parameters as one global default-RoPE config, which otherwise emits
+    ``Unrecognized keys in rope_parameters`` warnings in one-layer smoke cases.
+    """
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    cfg = Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=len(layer_types),
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=32,
+        global_head_dim=32,
+        max_position_embeddings=128,
+        layer_types=list(layer_types),
+        rope_parameters=_rope_parameters_for_layer_types(layer_types),
+        attention_bias=False,
+        attention_dropout=0.0,
+        use_cache=False,
+        enable_moe_block=False,
+        attention_k_eq_v=attention_k_eq_v,
+        num_kv_shared_layers=num_kv_shared_layers,
+    )
+    return _set_eager_attention(cfg)
+
+
+def _text_rope(
+    batch_size: int, seq_len: int, head_dim: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Create synthetic Gemma4 text RoPE embeddings."""
+    emb = torch.randn(batch_size, seq_len, head_dim)
+    return emb.cos(), emb.sin()
+
+
+def _attention_mask(seq_len: int, kv_len: int | None = None) -> torch.Tensor:
+    """Create an additive attention mask for synthetic Gemma4 attention tests."""
+    kv_len = seq_len if kv_len is None else kv_len
+    return torch.zeros(1, 1, seq_len, kv_len)
+
+
+def _clone_value(value: Any) -> Any:
+    """Clone tensors nested inside a small smoke-test value."""
+    if isinstance(value, torch.Tensor):
+        return value.clone()
+    if isinstance(value, tuple):
+        return tuple(_clone_value(item) for item in value)
+    if isinstance(value, list):
+        return [_clone_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _clone_value(item) for key, item in value.items()}
+    return value
+
+
+def _clone_forward_input(sample: ForwardInput) -> ForwardInput:
+    """Clone a smoke input so reference and quantized runs do not share mutable state."""
+    return ForwardInput(
+        tuple(_clone_value(arg) for arg in sample.args),
+        {key: _clone_value(value) for key, value in sample.kwargs.items()},
+    )
 
 
 class Gemma4BaseCase(WrapperSmokeCase):
@@ -55,21 +168,11 @@ class Gemma4TextMLPCase(Gemma4BaseCase):
 
     def build(self, cfg: Mapping[str, Any]) -> tuple[torch.nn.Module, torch.nn.Module]:
         """Build a tiny Gemma4 text MLP and reference copy."""
-        from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextMLP
 
-        text_cfg = Gemma4TextConfig(
-            vocab_size=256,
-            hidden_size=64,
-            intermediate_size=128,
-            num_hidden_layers=1,
-            num_attention_heads=2,
-            num_key_value_heads=2,
-            head_dim=32,
-            enable_moe_block=False,
-        )
-        self.text_cfg = text_cfg
-        module = Gemma4TextMLP(text_cfg, layer_idx=0).eval()
+        torch.manual_seed(123)
+        self.text_cfg = _make_text_config(layer_types=("full_attention",))
+        module = Gemma4TextMLP(self.text_cfg, layer_idx=0).eval()
         return module, clone_module(module)
 
     def calibration_inputs(
@@ -86,3 +189,143 @@ class Gemma4TextMLPCase(Gemma4BaseCase):
     ) -> ForwardInput:
         """Create an evaluation sample."""
         return ForwardInput((torch.randn(1, 8, self.text_cfg.hidden_size),))
+
+
+class Gemma4TextAttentionBaseCase(Gemma4BaseCase):
+    """Base class for tiny Gemma4 text attention smoke cases."""
+
+    tags = ("gemma4", "e2b", "text", "attention")
+    max_mean_abs_diff = 2.0
+    seq_len = 8
+    layer_idx = 0
+    layer_types: tuple[str, ...] = ("full_attention",)
+    attention_k_eq_v = False
+    num_kv_shared_layers = 0
+
+    def build(self, cfg: Mapping[str, Any]) -> tuple[torch.nn.Module, torch.nn.Module]:
+        """Build a tiny Gemma4 text attention module and reference copy."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+
+        torch.manual_seed(123)
+        self.text_cfg = _make_text_config(
+            layer_types=self.layer_types,
+            attention_k_eq_v=self.attention_k_eq_v,
+            num_kv_shared_layers=self.num_kv_shared_layers,
+        )
+        module = Gemma4TextAttention(self.text_cfg, layer_idx=self.layer_idx).eval()
+        return module, clone_module(module)
+
+    def _base_kwargs(self) -> dict[str, Any]:
+        """Create keyword arguments shared by non-shared attention samples."""
+        hidden = torch.randn(1, self.seq_len, self.text_cfg.hidden_size)
+        return {
+            "hidden_states": hidden,
+            "position_embeddings": _text_rope(1, self.seq_len, self.text_cfg.head_dim),
+            "attention_mask": _attention_mask(self.seq_len),
+            "shared_kv_states": {},
+        }
+
+    def _sample(self) -> ForwardInput:
+        """Create one synthetic Gemma4 text attention input."""
+        return ForwardInput((), self._base_kwargs())
+
+    def forward(self, module: torch.nn.Module, sample: ForwardInput) -> Any:
+        """Run a Gemma4 attention wrapper without sharing mutable sample state."""
+        cloned = _clone_forward_input(sample)
+        return module(*cloned.args, **dict(cloned.kwargs))
+
+    def reference_forward(
+        self, reference: torch.nn.Module, sample: ForwardInput
+    ) -> Any:
+        """Run the original Gemma4 attention module without sharing mutable sample state."""
+        cloned = _clone_forward_input(sample)
+        return reference(*cloned.args, **dict(cloned.kwargs))
+
+    def calibration_inputs(
+        self, prepared: torch.nn.Module, cfg: Mapping[str, Any]
+    ) -> list[ForwardInput]:
+        """Create Gemma4 text attention calibration samples."""
+        return [self._sample() for _ in range(3)]
+
+    def eval_input(
+        self, prepared: torch.nn.Module, cfg: Mapping[str, Any]
+    ) -> ForwardInput:
+        """Create the Gemma4 text attention evaluation sample."""
+        return self._sample()
+
+
+class Gemma4TextAttentionCase(Gemma4TextAttentionBaseCase):
+    """Smoke case for one tiny full-attention Gemma4 text attention module."""
+
+    name = "gemma4_text_attention"
+    description = "Quantize one tiny full-attention Gemma4 text attention module."
+    layer_types = ("sliding_attention", "full_attention")
+    layer_idx = 1
+
+
+class Gemma4TextSlidingAttentionCase(Gemma4TextAttentionBaseCase):
+    """Smoke case for one tiny sliding Gemma4 text attention module."""
+
+    name = "gemma4_text_attention_sliding"
+    description = "Quantize one tiny sliding Gemma4 text attention module."
+    layer_types = ("sliding_attention", "full_attention")
+    layer_idx = 0
+
+
+class Gemma4TextAttentionKEqVCase(Gemma4TextAttentionBaseCase):
+    """Smoke case for Gemma4 full attention with K-equals-V alternative attention."""
+
+    name = "gemma4_text_attention_k_eq_v"
+    description = (
+        "Quantize one tiny Gemma4 text attention module with attention_k_eq_v=True."
+    )
+    layer_types = ("full_attention",)
+    layer_idx = 0
+    attention_k_eq_v = True
+
+
+class Gemma4TextAttentionSharedKVCase(Gemma4TextAttentionBaseCase):
+    """Smoke case for a Gemma4 shared-KV consumer attention layer."""
+
+    name = "gemma4_text_attention_shared_kv"
+    description = (
+        "Quantize one tiny Gemma4 text attention module that consumes shared KV states."
+    )
+    layer_types = ("full_attention", "full_attention")
+    layer_idx = 1
+    num_kv_shared_layers = 1
+
+    def _sample(self) -> ForwardInput:
+        """Create one synthetic shared-KV attention input."""
+        hidden = torch.randn(1, self.seq_len, self.text_cfg.hidden_size)
+        key_states = torch.randn(
+            1,
+            self.text_cfg.num_key_value_heads,
+            self.seq_len,
+            self.text_cfg.head_dim,
+        )
+        value_states = torch.randn_like(key_states)
+        shared_key_value = (key_states, value_states)
+        return ForwardInput(
+            (),
+            {
+                "hidden_states": hidden,
+                "position_embeddings": _text_rope(
+                    1, self.seq_len, self.text_cfg.head_dim
+                ),
+                "attention_mask": _attention_mask(self.seq_len),
+                "shared_kv_states": {"full_attention": shared_key_value},
+                # QuantGemma4TextAttention implementations may also accept this
+                # explicit tuple form for static-runtime export paths.
+                "shared_key_value": shared_key_value,
+            },
+        )
+
+
+GEMMA4_CASES = (
+    Gemma4TextMLPCase(),
+    Gemma4TextAttentionCase(),
+    Gemma4TextSlidingAttentionCase(),
+    Gemma4TextAttentionKEqVCase(),
+    Gemma4TextAttentionSharedKVCase(),
+)

--- a/tico/quantization/recipes/debug/wrapper_smoke/registry.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/registry.py
@@ -61,11 +61,12 @@ def _register_builtin_cases() -> None:
     """Register all built-in cases exactly once."""
     if _REGISTRY:
         return
+    from .cases.gemma4 import GEMMA4_CASES
     from .cases.llama import LLAMA_CASES
     from .cases.nn import NN_CASES
     from .cases.qwen3_vl import QWEN3_VL_CASES
 
-    for case in (*NN_CASES, *LLAMA_CASES, *QWEN3_VL_CASES):
+    for case in (*NN_CASES, *LLAMA_CASES, *QWEN3_VL_CASES, *GEMMA4_CASES):
         register_case(case)
 
 

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_text_attention.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_text_attention.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional, Tuple
+from collections.abc import MutableMapping
+from typing import Any, Iterable, Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
@@ -24,17 +26,27 @@ from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
 
 
+LayerKV = Tuple[torch.Tensor, torch.Tensor]
+CacheOutputMode = Literal["delta", "present", "full"]
+
+
 @try_register("transformers.models.gemma4.modeling_gemma4.Gemma4TextAttention")
 class QuantGemma4TextAttention(QuantModuleBase):
-    """PTQ wrapper skeleton for dense Gemma4 text attention.
+    """PTQ wrapper for dense Gemma4 E2B text attention.
 
-    The wrapper must support two layer modes:
+    This wrapper keeps the Hugging Face Gemma4 attention semantics while making
+    the arithmetic explicit enough for post-training quantization and static
+    export. It supports the dense E2B path only:
 
-    - Non-shared KV layers with q/k/v/o projections.
-    - Shared-KV layers that reuse key/value tensors produced by an earlier layer.
+    - regular non-shared KV layers with q/k/v/o projections,
+    - global layers with ``attention_k_eq_v=True`` where V reuses raw K states,
+    - shared-KV layers that consume key/value tensors produced by an earlier
+      non-shared layer of the same ``layer_type``.
 
-    The first production implementation should avoid HF ``Cache`` objects in
-    export mode and accept explicit static key/value tensors instead.
+    CPU runtime code should own dynamic orchestration such as cache writes,
+    shared-KV bookkeeping, mask generation, and sampling. This wrapper only
+    performs fixed-shape tensor compute and returns optional K/V deltas when
+    requested.
     """
 
     def __init__(
@@ -60,6 +72,10 @@ class QuantGemma4TextAttention(QuantModuleBase):
         self.head_dim = int(fp_attn.head_dim)
         self.num_key_value_groups = int(fp_attn.num_key_value_groups)
         self.scaling = float(getattr(fp_attn, "scaling", 1.0))
+        self.attention_dropout = float(
+            getattr(fp_attn, "attention_dropout", 0.0) or 0.0
+        )
+        self.max_seq = int(getattr(self.config, "max_position_embeddings"))
 
         self.q_proj = PTQWrapper(
             fp_attn.q_proj,
@@ -87,7 +103,7 @@ class QuantGemma4TextAttention(QuantModuleBase):
                 qcfg=qcfg.child("v_norm") if qcfg else None,
                 fp_name=join_name(fp_name, "v_norm"),
             )
-            self.v_proj = None
+            self.v_proj: Optional[PTQWrapper] = None
             if fp_attn.v_proj is not None:
                 self.v_proj = PTQWrapper(
                     fp_attn.v_proj,
@@ -101,41 +117,560 @@ class QuantGemma4TextAttention(QuantModuleBase):
             fp_name=join_name(fp_name, "o_proj"),
         )
 
-        self.obs_hidden = self._make_obs("hidden")
-        self.obs_cos = self._make_obs("cos")
-        self.obs_sin = self._make_obs("sin")
-        self.obs_logits = self._make_obs("logits")
-        self.obs_softmax = self._make_obs("softmax")
-        self.obs_attn_out = self._make_obs("attn_out")
+        mk = self._make_obs
+        self.obs_hidden = mk("hidden")
+
+        # RoPE tables.
+        self.obs_cos = mk("cos")
+        self.obs_sin = mk("sin")
+
+        # rotate_half sub-steps for Q.
+        self.obs_q_x1 = mk("q_x1")
+        self.obs_q_x2 = mk("q_x2")
+        self.obs_q_neg = mk("q_neg")
+        self.obs_q_cat = mk("q_cat")
+
+        # rotate_half sub-steps for K.
+        self.obs_k_x1 = mk("k_x1")
+        self.obs_k_x2 = mk("k_x2")
+        self.obs_k_neg = mk("k_neg")
+        self.obs_k_cat = mk("k_cat")
+
+        # RoPE combine points.
+        self.obs_q_cos = mk("q_cos")
+        self.obs_q_sin = mk("q_sin")
+        self.obs_q_rot = mk("q_rot")
+        self.obs_k_cos = mk("k_cos")
+        self.obs_k_sin = mk("k_sin")
+        self.obs_k_rot = mk("k_rot")
+
+        # Cache and attention math.
+        self.obs_new_k = mk("new_k")
+        self.obs_new_v = mk("new_v")
+        self.obs_present_key = mk("present_key")
+        self.obs_present_value = mk("present_value")
+        self.obs_attn_mask = mk("attn_mask")
+        self.obs_logits_raw = mk("logits_raw")
+        self.obs_scale = mk("scale")
+        self.obs_logits = mk("logits")
+        self.obs_mask_add = mk("mask_add")
+        self.obs_softmax = mk("softmax")
+        self.obs_attn_out = mk("attn_out")
+        self.obs_attn_weights = mk("attn_weights")
+        self.obs_attn_out_h = mk("attn_out_h")
+
+        mask = torch.full(
+            (1, 1, self.max_seq, self.max_seq),
+            float(self.qcfg.attention_mask_fill_value),
+        )
+        mask.triu_(1)
+        self.register_buffer("causal_mask_template", mask, persistent=False)
+
+    @staticmethod
+    def _expand_rope_table(table: torch.Tensor) -> torch.Tensor:
+        """Return a RoPE table shaped as ``(B, S, 1, H)`` for Gemma4 text."""
+        if table.dim() == 2:
+            table = table.unsqueeze(0)
+        if table.dim() == 3:
+            table = table.unsqueeze(2)
+        if table.dim() != 4:
+            raise RuntimeError(
+                "RoPE table must have rank 2, 3, or 4 for Gemma4 text attention, "
+                f"got shape={tuple(table.shape)}."
+            )
+        return table
+
+    def _rot(
+        self,
+        tensor: torch.Tensor,
+        obs_x1,
+        obs_x2,
+        obs_neg,
+        obs_cat,
+    ) -> torch.Tensor:
+        """Apply Gemma4/HF ``rotate_half`` as ``[-x2, x1]``."""
+        x1, x2 = torch.chunk(tensor, 2, dim=-1)
+        x1 = self._fq(x1, obs_x1)
+        x2 = self._fq(x2, obs_x2)
+        neg_x2 = self._fq(-x2, obs_neg)
+        return self._fq(torch.cat((neg_x2, x1), dim=-1), obs_cat)
+
+    def _apply_rope(
+        self,
+        tensor: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        obs_x1,
+        obs_x2,
+        obs_neg,
+        obs_cat,
+        obs_cos,
+        obs_sin,
+        obs_rot,
+    ) -> torch.Tensor:
+        """Apply rotary position embedding to Q or K before head transposition."""
+        cos = self._expand_rope_table(cos)
+        sin = self._expand_rope_table(sin)
+        half = self._rot(tensor, obs_x1, obs_x2, obs_neg, obs_cat)
+        cos_part = self._fq(tensor * cos, obs_cos)
+        sin_part = self._fq(half * sin, obs_sin)
+        return self._fq(cos_part + sin_part, obs_rot)
+
+    @staticmethod
+    def _normalize_attention_mask_shape(
+        mask: torch.Tensor,
+        *,
+        q_len: int,
+        k_len: int,
+    ) -> torch.Tensor:
+        """Normalize an attention mask so it broadcasts to ``(B, heads, Q, K)``.
+
+        Supported input shapes are ``(B, K)``, ``(B, Q, K)``, and
+        ``(B, 1, Q, K)``. Longer preallocated masks are sliced from the right
+        query range and from the left key range to match the actual attention
+        tensors.
+        """
+        if mask.dim() not in (2, 3, 4):
+            raise RuntimeError(
+                "Unsupported attention_mask rank for Gemma4 text attention: "
+                f"rank={mask.dim()}, shape={tuple(mask.shape)}."
+            )
+
+        if mask.size(-1) != k_len:
+            if mask.size(-1) > k_len:
+                mask = mask[..., :k_len]
+            else:
+                raise RuntimeError(
+                    "attention_mask key length is shorter than key states: "
+                    f"mask_k={mask.size(-1)}, k_len={k_len}, "
+                    f"shape={tuple(mask.shape)}."
+                )
+
+        if mask.dim() == 2:
+            return mask[:, None, None, :]
+
+        if mask.size(-2) not in (1, q_len):
+            if mask.size(-2) > q_len:
+                mask = mask[..., -q_len:, :]
+            else:
+                raise RuntimeError(
+                    "attention_mask query length is incompatible with query states: "
+                    f"mask_q={mask.size(-2)}, q_len={q_len}, "
+                    f"shape={tuple(mask.shape)}."
+                )
+
+        if mask.dim() == 3:
+            return mask[:, None, :, :]
+
+        if mask.size(1) != 1:
+            raise RuntimeError(
+                "Per-head attention masks are not supported by the Gemma4 text "
+                "attention wrapper. Expected mask shape (B, 1, Q, K), "
+                f"got shape={tuple(mask.shape)}."
+            )
+        return mask
+
+    def _build_attention_mask(
+        self,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        q_len: int,
+        k_len: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Build an additive attention mask for per-head attention logits."""
+        fill_val = float(self.qcfg.attention_mask_fill_value)
+        assert isinstance(self.causal_mask_template, torch.Tensor)
+
+        if k_len > self.causal_mask_template.size(-1):
+            raise RuntimeError(
+                "Key length exceeds causal mask capacity: "
+                f"k_len={k_len}, capacity={self.causal_mask_template.size(-1)}."
+            )
+
+        q_start = max(k_len - q_len, 0)
+        q_end = q_start + q_len
+        if q_end > self.causal_mask_template.size(-2):
+            raise RuntimeError(
+                "Query range exceeds causal mask capacity: "
+                f"q_start={q_start}, q_end={q_end}, "
+                f"capacity={self.causal_mask_template.size(-2)}."
+            )
+
+        causal_mask = self.causal_mask_template[..., q_start:q_end, :k_len].to(device)
+
+        if attention_mask is None:
+            return self._fq(causal_mask, self.obs_attn_mask)
+
+        attention_mask = attention_mask.to(device)
+        if attention_mask.dtype in (
+            torch.bool,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+        ):
+            keep_mask = attention_mask.bool()
+            keep_mask = self._normalize_attention_mask_shape(
+                keep_mask,
+                q_len=q_len,
+                k_len=k_len,
+            )
+            additive = torch.zeros(
+                keep_mask.shape,
+                dtype=torch.float32,
+                device=device,
+            )
+            additive = additive.masked_fill(~keep_mask, fill_val)
+            mask = torch.clamp(causal_mask + additive, min=fill_val)
+            return self._fq(mask, self.obs_attn_mask)
+
+        if torch.is_floating_point(attention_mask):
+            attention_mask = self._normalize_attention_mask_shape(
+                attention_mask,
+                q_len=q_len,
+                k_len=k_len,
+            )
+            return self._fq(attention_mask, self.obs_attn_mask)
+
+        raise RuntimeError(
+            "Unsupported attention_mask dtype for Gemma4 text attention: "
+            f"dtype={attention_mask.dtype}, shape={tuple(attention_mask.shape)}."
+        )
+
+    def _resolve_shared_key_value(
+        self,
+        shared_key_value: Optional[LayerKV],
+        shared_kv_states: Optional[MutableMapping[str, LayerKV]],
+    ) -> LayerKV:
+        """Return shared K/V tensors for a shared-KV layer."""
+        if shared_key_value is not None:
+            return shared_key_value
+        if shared_kv_states is not None and self.layer_type in shared_kv_states:
+            return shared_kv_states[self.layer_type]
+        raise RuntimeError(
+            "Gemma4 shared-KV attention requires shared_key_value or "
+            f"shared_kv_states[{self.layer_type!r}]."
+        )
+
+    def _project_current_key_value(
+        self,
+        hidden_states: torch.Tensor,
+        hidden_shape: tuple[int, ...],
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> LayerKV:
+        """Project and rotate the current non-shared K/V tensors."""
+        key_states_raw = self.k_proj(hidden_states).view(hidden_shape)
+        if self.v_proj is None:
+            value_states = key_states_raw
+        else:
+            value_states = self.v_proj(hidden_states).view(hidden_shape)
+
+        key_states = self.k_norm(key_states_raw)
+        key_states = self._apply_rope(
+            key_states,
+            cos,
+            sin,
+            self.obs_k_x1,
+            self.obs_k_x2,
+            self.obs_k_neg,
+            self.obs_k_cat,
+            self.obs_k_cos,
+            self.obs_k_sin,
+            self.obs_k_rot,
+        )
+        key_states = key_states.transpose(1, 2)
+
+        value_states = self.v_norm(value_states)
+        value_states = value_states.transpose(1, 2)
+
+        key_states = self._fq(key_states, self.obs_new_k)
+        value_states = self._fq(value_states, self.obs_new_v)
+        return key_states, value_states
+
+    def _build_present_key_value(
+        self,
+        *,
+        new_key_value: LayerKV,
+        past_key_value: Optional[Any],
+    ) -> tuple[LayerKV, Optional[Any]]:
+        """Build the K/V tensors used by attention and optional cache output."""
+        new_k, new_v = new_key_value
+        cache_object_out = None
+
+        if past_key_value is None:
+            present_k = self._fq(new_k, self.obs_present_key)
+            present_v = self._fq(new_v, self.obs_present_value)
+            return (present_k, present_v), cache_object_out
+
+        if isinstance(past_key_value, tuple):
+            past_k, past_v = past_key_value
+            past_k = self._fq(past_k, self.obs_present_key)
+            past_v = self._fq(past_v, self.obs_present_value)
+            present_k = self._fq(
+                torch.cat([past_k, new_k], dim=2), self.obs_present_key
+            )
+            present_v = self._fq(
+                torch.cat([past_v, new_v], dim=2),
+                self.obs_present_value,
+            )
+            return (present_k, present_v), cache_object_out
+
+        update = getattr(past_key_value, "update", None)
+        if callable(update):
+            present_k, present_v = update(new_k, new_v, self.layer_idx)
+            present_k = self._fq(present_k, self.obs_present_key)
+            present_v = self._fq(present_v, self.obs_present_value)
+            cache_object_out = past_key_value
+            return (present_k, present_v), cache_object_out
+
+        raise RuntimeError(
+            "Unsupported past_key_value type for Gemma4 text attention: "
+            f"{type(past_key_value).__name__}."
+        )
+
+    @staticmethod
+    def _normalize_cache_output_mode(cache_output_mode: str) -> CacheOutputMode:
+        """Normalize the cache output mode accepted by static runtime adapters."""
+        if cache_output_mode == "full":
+            return "present"
+        if cache_output_mode not in ("delta", "present"):
+            raise ValueError(f"Unsupported cache_output_mode: {cache_output_mode!r}.")
+        return cache_output_mode  # type: ignore[return-value]
+
+    def _cache_output(
+        self,
+        *,
+        mode: CacheOutputMode,
+        new_key_value: Optional[LayerKV],
+        present_key_value: Optional[LayerKV],
+        cache_object_out: Optional[Any],
+    ) -> Optional[Any]:
+        """Return cache data according to the requested cache output mode."""
+        if new_key_value is None:
+            return None
+        if mode == "delta":
+            return new_key_value
+        if cache_object_out is not None:
+            return cache_object_out
+        return present_key_value
+
+    def _attention_forward(
+        self,
+        *,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run grouped-query attention without materializing repeated K/V tensors."""
+        batch_size, num_heads, q_len, _ = query_states.shape
+        num_kv_heads = key_states.size(1)
+        kv_rep = self.num_key_value_groups
+
+        attn_weights_parts: list[torch.Tensor] = []
+        attn_out_parts: list[torch.Tensor] = []
+
+        for kv_idx in range(num_kv_heads):
+            key_i = key_states[:, kv_idx : kv_idx + 1, :, :]
+            value_i = value_states[:, kv_idx : kv_idx + 1, :, :]
+            head_start = kv_idx * kv_rep
+            head_end = min(head_start + kv_rep, num_heads)
+            query_i = query_states[:, head_start:head_end, :, :]
+            if query_i.size(1) == 0:
+                continue
+
+            logits_i = query_i @ key_i.transpose(-2, -1)
+            logits_i = self._fq(logits_i, self.obs_logits_raw)
+            scale = self._fq(
+                torch.tensor(
+                    self.scaling,
+                    device=logits_i.device,
+                    dtype=logits_i.dtype,
+                ),
+                self.obs_scale,
+            )
+            logits_i = self._fq(logits_i * scale, self.obs_logits)
+            logits_i = self._fq(logits_i + attention_mask, self.obs_mask_add)
+
+            attn_i = torch.softmax(logits_i, dim=-1, dtype=torch.float32).to(
+                query_states.dtype
+            )
+            if self.training and self.attention_dropout > 0.0:
+                attn_i = F.dropout(attn_i, p=self.attention_dropout, training=True)
+            attn_i = self._fq(attn_i, self.obs_softmax)
+
+            out_i = self._fq(attn_i @ value_i, self.obs_attn_out)
+            attn_weights_parts.append(attn_i)
+            attn_out_parts.append(out_i)
+
+        attn_weights = self._fq(
+            torch.cat(attn_weights_parts, dim=1),
+            self.obs_attn_weights,
+        )
+        attn_out_h = self._fq(
+            torch.cat(attn_out_parts, dim=1),
+            self.obs_attn_out_h,
+        )
+        attn_output = attn_out_h.transpose(1, 2).reshape(batch_size, q_len, -1)
+        return self.o_proj(attn_output), attn_weights
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
-        attention_mask: Optional[torch.Tensor],
-        shared_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        shared_key_value: Optional[LayerKV] = None,
+        past_key_value: Optional[Any] = None,
         use_cache: bool = False,
         cache_output_mode: str = "delta",
         **kwargs,
     ):
-        """Run Gemma4 text attention.
+        """Run Gemma4 text attention with explicit static-friendly K/V handling.
 
-        TODO: Implement the decomposed static attention math. The implementation
-        should return ``(attn_output, attn_weights, present_key_value)`` when
-        ``use_cache=True`` and return only hidden states otherwise.
+        Args:
+            hidden_states: Input tensor shaped ``(B, S, hidden_size)``.
+            position_embeddings: Tuple ``(cos, sin)`` shaped ``(B, S, head_dim)``.
+            attention_mask: Optional additive or keep mask broadcastable to
+                attention logits. Static runtime should provide this tensor.
+            shared_key_value: Optional full K/V tensors for shared-KV layers.
+            past_key_value: Optional tuple or HF-like cache object for non-shared
+                layers. Tuple caches must be shaped ``(B, num_kv_heads, K, H)``.
+            use_cache: When ``True``, append cache data to the output tuple.
+            cache_output_mode: ``"delta"`` returns only newly projected K/V;
+                ``"present"`` or ``"full"`` returns full K/V or the updated
+                cache object when a cache object is supplied.
+
+        Returns:
+            ``(attn_output, attn_weights)`` when ``use_cache=False``. When
+            ``use_cache=True``, returns ``(attn_output, attn_weights, cache)``.
+            Shared-KV layers return ``cache=None`` because they do not own K/V
+            projection weights.
         """
-        raise NotImplementedError(
-            "Gemma4 text attention static implementation is not wired yet."
+        past_key_value = kwargs.pop("past_key_values", past_key_value)
+        shared_kv_states = kwargs.pop("shared_kv_states", None)
+        cache_output_mode_normalized = self._normalize_cache_output_mode(
+            cache_output_mode
         )
+
+        hidden = self._fq(hidden_states, self.obs_hidden)
+        batch_size, seq_len, _ = hidden.shape
+        hidden_shape = (batch_size, seq_len, -1, self.head_dim)
+
+        cos, sin = position_embeddings
+        cos = self._fq(cos, self.obs_cos)
+        sin = self._fq(sin, self.obs_sin)
+
+        query_states = self.q_proj(hidden).view(hidden_shape)
+        query_states = self.q_norm(query_states)
+        query_states = self._apply_rope(
+            query_states,
+            cos,
+            sin,
+            self.obs_q_x1,
+            self.obs_q_x2,
+            self.obs_q_neg,
+            self.obs_q_cat,
+            self.obs_q_cos,
+            self.obs_q_sin,
+            self.obs_q_rot,
+        )
+        query_states = query_states.transpose(1, 2)
+
+        new_key_value: Optional[LayerKV]
+        cache_object_out: Optional[Any] = None
+        if self.is_kv_shared_layer:
+            key_states, value_states = self._resolve_shared_key_value(
+                shared_key_value,
+                shared_kv_states,
+            )
+            key_states = self._fq(
+                key_states.to(device=query_states.device, dtype=query_states.dtype),
+                self.obs_present_key,
+            )
+            value_states = self._fq(
+                value_states.to(device=query_states.device, dtype=query_states.dtype),
+                self.obs_present_value,
+            )
+            new_key_value = None
+            present_key_value: Optional[LayerKV] = (key_states, value_states)
+        else:
+            new_key_value = self._project_current_key_value(
+                hidden, hidden_shape, cos, sin
+            )
+            present_key_value, cache_object_out = self._build_present_key_value(
+                new_key_value=new_key_value,
+                past_key_value=past_key_value,
+            )
+            key_states, value_states = present_key_value
+            if self.store_full_length_kv and shared_kv_states is not None:
+                shared_kv_states[self.layer_type] = (key_states, value_states)
+
+        attn_mask = self._build_attention_mask(
+            attention_mask=attention_mask,
+            q_len=query_states.size(-2),
+            k_len=key_states.size(-2),
+            device=query_states.device,
+        )
+
+        attn_output, attn_weights = self._attention_forward(
+            query_states=query_states,
+            key_states=key_states,
+            value_states=value_states,
+            attention_mask=attn_mask,
+        )
+
+        outputs = (attn_output, attn_weights)
+        if use_cache:
+            outputs += (
+                self._cache_output(
+                    mode=cache_output_mode_normalized,
+                    new_key_value=new_key_value,
+                    present_key_value=present_key_value,
+                    cache_object_out=cache_object_out,
+                ),
+            )
+        return outputs
 
     def _all_observers(self) -> Iterable:
         """Return observers owned directly by this wrapper."""
-        return (
+        common = [
             self.obs_hidden,
             self.obs_cos,
             self.obs_sin,
+            self.obs_q_x1,
+            self.obs_q_x2,
+            self.obs_q_neg,
+            self.obs_q_cat,
+            self.obs_q_cos,
+            self.obs_q_sin,
+            self.obs_q_rot,
+            self.obs_present_key,
+            self.obs_present_value,
+            self.obs_attn_mask,
+            self.obs_logits_raw,
+            self.obs_scale,
             self.obs_logits,
+            self.obs_mask_add,
             self.obs_softmax,
             self.obs_attn_out,
-        )
+            self.obs_attn_weights,
+            self.obs_attn_out_h,
+        ]
+        if not self.is_kv_shared_layer:
+            common.extend(
+                [
+                    self.obs_k_x1,
+                    self.obs_k_x2,
+                    self.obs_k_neg,
+                    self.obs_k_cat,
+                    self.obs_k_cos,
+                    self.obs_k_sin,
+                    self.obs_k_rot,
+                    self.obs_new_k,
+                    self.obs_new_v,
+                ]
+            )
+        return tuple(common)

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_text_attention.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_text_attention.py
@@ -622,9 +622,10 @@ class QuantGemma4TextAttention(QuantModuleBase):
             attention_mask=attn_mask,
         )
 
-        outputs = (attn_output, attn_weights)
         if use_cache:
-            outputs += (
+            return (
+                attn_output,
+                attn_weights,
                 self._cache_output(
                     mode=cache_output_mode_normalized,
                     new_key_value=new_key_value,
@@ -632,7 +633,7 @@ class QuantGemma4TextAttention(QuantModuleBase):
                     cache_object_out=cache_object_out,
                 ),
             )
-        return outputs
+        return attn_output, attn_weights
 
     def _all_observers(self) -> Iterable:
         """Return observers owned directly by this wrapper."""

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -64,10 +64,10 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_for_conditional_generation",
     ## gemma4 ##
     # "tico.quantization.wrapq.wrappers.gemma4.quant_clippable_linear",
-    # "tico.quantization.wrapq.wrappers.gemma4.quant_rmsnorm",
+    "tico.quantization.wrapq.wrappers.gemma4.quant_rmsnorm",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_text_scaled_word_embedding",
-    # "tico.quantization.wrapq.wrappers.gemma4.quant_text_mlp",
-    # "tico.quantization.wrapq.wrappers.gemma4.quant_text_attention",
+    "tico.quantization.wrapq.wrappers.gemma4.quant_text_mlp",
+    "tico.quantization.wrapq.wrappers.gemma4.quant_text_attention",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_text_decoder_layer",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_text_model",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_for_causal_lm",


### PR DESCRIPTION
This commit adds Gemma4 text attention wrapper.

```bash
for case in \
  gemma4_text_attention \
  gemma4_text_attention_k_eq_v \
  gemma4_text_attention_shared_kv \
  gemma4_text_mlp
 do
  python -m tico.quantization.examples.inspect \
    --config tico/quantization/examples/configs/wrapper_smoke.yaml \
    --mode wrapper-smoke \
    --case "$case" \
    --strict \
    --no-plot
 done
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_text_attention
│ Status           : PASS
│ Mean |diff|      : 0.031640
│ Max |diff|       : 0.273058
│ PEIR             : 0.094067
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_text_attention_k_eq_v
│ Status           : PASS
│ Mean |diff|      : 0.026936
│ Max |diff|       : 0.115920
│ PEIR             : 0.039867
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_text_attention_shared_kv
│ Status           : PASS
│ Mean |diff|      : 0.019046
│ Max |diff|       : 0.222501
│ PEIR             : 0.073998
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_text_mlp
│ Status           : PASS
│ Mean |diff|      : 0.003317
│ Max |diff|       : 0.017069
│ PEIR             : 0.021938
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>