### PR TITLE
[quantization] Fail fast on missing COCO eval dependencies

### DIFF
--- a/test/quantization/recipes/test_vlm_evaluation.py
+++ b/test/quantization/recipes/test_vlm_evaluation.py
@@ -26,6 +26,7 @@ import io
 import unittest
 from unittest.mock import patch
 
+import tico.quantization.evaluation.vlm_eval_utils as vlm_eval_utils
 import tico.quantization.recipes.evaluation.vlm as vlm
 
 
@@ -72,6 +73,39 @@ class TestVlmEvaluation(unittest.TestCase):
         self.assertIn("total_count    2", output)
         self.assertIn("skipped_count  1", output)
         self.assertNotIn("total_count    2.000", output)
+
+    def test_coco_eval_dependencies_checked_before_consuming_dataset(self):
+        """Missing COCO eval dependencies should fail before samples run."""
+        consumed = False
+
+        def dataset():
+            nonlocal consumed
+            consumed = True
+            yield {}
+
+        def fake_import_module(module_name):
+            if module_name == "pycocotools.coco":
+                raise ModuleNotFoundError(
+                    "No module named 'pycocotools'", name="pycocotools"
+                )
+            return object()
+
+        with patch.object(
+            vlm_eval_utils.importlib,
+            "import_module",
+            side_effect=fake_import_module,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "pycocotools\\.coco"):
+                vlm_eval_utils.get_coco_scores_on_dataset(
+                    model=object(),
+                    processor=object(),
+                    dataset_name="coco",
+                    ds=dataset(),
+                    device="cpu",
+                    metrics=["CIDEr"],
+                )
+
+        self.assertFalse(consumed)
 
 
 if __name__ == "__main__":

--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
 import os
 import random
@@ -546,6 +547,54 @@ class CocoImage(TypedDict):
 # - Each function computes a specific captioning metric
 # - These can be used independently or via get_coco_scores_on_dataset
 # ============================================================
+def _get_required_coco_eval_modules(metrics: Iterable[str]) -> list[str]:
+    """Return optional Python modules needed for requested COCO metrics."""
+    modules = ["pycocotools.coco"]
+    metric_modules = {
+        "CIDEr": "pycocoevalcap.cider.cider",
+        "METEOR": "pycocoevalcap.meteor.meteor",
+        "ROUGE_L": "pycocoevalcap.rouge.rouge",
+    }
+
+    for metric in metrics:
+        if metric.startswith("Bleu_"):
+            modules.append("pycocoevalcap.bleu.bleu")
+        elif metric in metric_modules:
+            modules.append(metric_modules[metric])
+
+    return list(dict.fromkeys(modules))
+
+
+def _require_coco_eval_dependencies(metrics: Iterable[str]) -> None:
+    """
+    Validate optional COCO evaluation dependencies before running inference.
+
+    COCO scoring is executed after all samples have been generated. Importing
+    the optional evaluation modules up front lets a missing dependency fail fast
+    before expensive benchmark samples are processed.
+    """
+    missing: list[str] = []
+    first_error: ImportError | None = None
+
+    for module_name in _get_required_coco_eval_modules(metrics):
+        try:
+            importlib.import_module(module_name)
+        except ImportError as exc:
+            if first_error is None:
+                first_error = exc
+            missing.append(f"{module_name}: {exc}")
+
+    if missing:
+        missing_lines = "\n".join(f"- {item}" for item in missing)
+        raise RuntimeError(
+            "COCO evaluation dependencies are missing for the requested metrics. "
+            "Install the optional COCO evaluation packages before running the "
+            "benchmark, for example: "
+            "`pip install pycocotools pycocoevalcap`.\n"
+            f"Missing imports:\n{missing_lines}"
+        ) from first_error
+
+
 def compute_bleu_scores(
     ground_truths: dict[str, list[str]],
     predictions: dict[str, list[str]],
@@ -639,6 +688,9 @@ def get_coco_scores_on_dataset(
             raise ValueError(
                 f"Unsupported metric '{m}'. Supported metrics: {supported_metrics}"
             )
+
+    _require_coco_eval_dependencies(metrics)
+
     # Collect predictions and ground truth
     results: list[CocoResult] = []
     images: list[CocoImage] = []


### PR DESCRIPTION
This commit fails fast on missing COCO eval dependencies
 before inference.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>