### PR TITLE
[quantization] Fix gemma4_text_attention Circle export

### DIFF
--- a/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
@@ -253,6 +253,21 @@ class Gemma4TextAttentionBaseCase(Gemma4BaseCase):
         """Create the Gemma4 text attention evaluation sample."""
         return self._sample()
 
+    def export_input(
+        self, eval_sample: ForwardInput, cfg: Mapping[str, Any]
+    ) -> ForwardInput:
+        """Return export input without shared_kv_states.
+
+        shared_kv_states is a mutable dict used to pass KV tensors between
+        layers at runtime. torch.export strict mode fails when an empty dict
+        is included in kwargs because pytree traversal produces a tensor-count
+        mismatch.  The export path doesn't need this side-channel.
+        """
+        kwargs = {
+            k: v for k, v in eval_sample.kwargs.items() if k != "shared_kv_states"
+        }
+        return ForwardInput(eval_sample.args, kwargs)
+
 
 class Gemma4TextAttentionCase(Gemma4TextAttentionBaseCase):
     """Smoke case for one tiny full-attention Gemma4 text attention module."""

--- a/tico/quantization/recipes/debug/wrapper_smoke/utils.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/utils.py
@@ -128,9 +128,14 @@ def suppress_tico_warnings() -> Iterator[None]:
     try:
         from tico.utils.utils import SuppressWarning
 
-        with SuppressWarning(UserWarning, ".*"):
-            yield
+        suppressor = SuppressWarning(UserWarning, ".*")
     except Exception:
+        suppressor = None
+
+    if suppressor is not None:
+        with suppressor:
+            yield
+    else:
         yield
 
 


### PR DESCRIPTION
- suppress_tico_warnings: yield inside try/except caught export exceptions and re-yielded, triggering "generator didn't stop after throw()". Separated import guard from yield to fix propagation.

- Gemma4TextAttentionBaseCase: shared_kv_states={} in export kwargs caused IndexError in torch.export strict mode (pytree tensor-count mismatch). Override export_input to strip it before export.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>