### PR TITLE
[quantization] Add Gemma4 vision attention wrapper

### DIFF
--- a/test/quantization/wrapq/wrappers/gemma4/test_quantize_vision_attention.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quantize_vision_attention.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for Gemma4 vision attention prepare-calibrate-convert flow."""
+
+import copy
+import os
+import unittest
+
+import torch
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+
+IS_INTERNAL_TEST = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+_SKIP_MSG = "required transformers Gemma4 modules are not installed"
+
+
+def _has_gemma4() -> bool:
+    """Return whether the installed transformers package provides Gemma4 vision."""
+    try:
+        from transformers.models.gemma4.configuration_gemma4 import (  # noqa: F401
+            Gemma4VisionConfig,
+        )
+        from transformers.models.gemma4.modeling_gemma4 import (  # noqa: F401
+            Gemma4VisionAttention,
+        )
+    except Exception:
+        return False
+    return True
+
+
+def _make_vision_config():
+    """Create a tiny Gemma4 vision config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+    cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        use_clipped_linears=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 100.0},
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _vision_rope(batch_size: int, seq_len: int, head_dim: int):
+    """Create synthetic Gemma4 vision RoPE tables."""
+    emb = torch.randn(batch_size, seq_len, head_dim)
+    return emb.cos(), emb.sin()
+
+
+def _vision_position_ids(batch_size: int, seq_len: int) -> torch.Tensor:
+    """Create deterministic 2-D pixel position ids for a tiny patch sequence."""
+    side = 4
+    coords = torch.arange(seq_len)
+    xy = torch.stack((coords % side, coords // side), dim=-1)
+    return xy.unsqueeze(0).expand(batch_size, -1, -1).long()
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestGemma4VisionAttentionSmoke(unittest.TestCase):
+    """Exercise Gemma4 vision attention wrapper parity and PTQ flow."""
+
+    def setUp(self):
+        """Create deterministic tiny Gemma4 vision attention modules."""
+        torch.manual_seed(2026)
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionAttention
+
+        self.cfg = _make_vision_config()
+        self.fp_attn = Gemma4VisionAttention(self.cfg, layer_idx=0).eval()
+        self.fp_ref = copy.deepcopy(self.fp_attn).eval()
+
+    def _sample(self):
+        """Create one synthetic Gemma4 vision attention sample."""
+        batch_size, seq_len = 1, 8
+        return {
+            "hidden_states": torch.randn(batch_size, seq_len, self.cfg.hidden_size),
+            "position_embeddings": _vision_rope(
+                batch_size,
+                seq_len,
+                self.cfg.head_dim,
+            ),
+            "attention_mask": torch.zeros(batch_size, 1, seq_len, seq_len),
+            "position_ids": _vision_position_ids(batch_size, seq_len),
+        }
+
+    def test_no_quant_vision_attention_matches_reference(self):
+        """The wrapper should match the floating-point module before quantization."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_clippable_linear import (  # noqa: F401
+            QuantGemma4ClippableLinear,
+        )
+        from tico.quantization.wrapq.wrappers.gemma4.quant_vision_attention import (
+            QuantGemma4VisionAttention,
+        )
+
+        wrapped = QuantGemma4VisionAttention(self.fp_attn, qcfg=PTQConfig()).eval()
+        sample = self._sample()
+
+        with torch.no_grad():
+            quant_out = wrapped(**sample)[0]
+            fp_out = self.fp_ref(**sample)[0]
+
+        self.assertEqual(quant_out.shape, fp_out.shape)
+        self.assertTrue(torch.allclose(quant_out, fp_out, atol=1e-5, rtol=1e-5))
+
+    def test_prepare_convert_vision_attention_flow(self):
+        """Quantize Gemma4 vision attention and validate a synthetic output."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_clippable_linear import (  # noqa: F401
+            QuantGemma4ClippableLinear,
+        )
+        from tico.quantization.wrapq.wrappers.gemma4.quant_vision_attention import (
+            QuantGemma4VisionAttention,
+        )
+
+        prepared = prepare(self.fp_attn, PTQConfig())
+        self.assertIsInstance(prepared, PTQWrapper)
+        self.assertIsInstance(prepared.wrapped, QuantGemma4VisionAttention)
+
+        with torch.no_grad():
+            for _ in range(3):
+                prepared(**self._sample())
+
+        quantized = convert(prepared)
+        self.assertIs(quantized._mode, Mode.QUANT)
+
+        sample = self._sample()
+        with torch.no_grad():
+            quant_out = quantized(**sample)[0]
+            fp_out = self.fp_ref(**sample)[0]
+
+        self.assertEqual(quant_out.shape, fp_out.shape)
+        self.assertTrue(torch.isfinite(quant_out).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
@@ -322,10 +322,104 @@ class Gemma4TextAttentionSharedKVCase(Gemma4TextAttentionBaseCase):
         )
 
 
+def _make_vision_config() -> Any:
+    """Create a tiny Gemma4 vision config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+    cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        use_clipped_linears=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 100.0},
+    )
+    return _set_eager_attention(cfg)
+
+
+def _vision_rope(
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Create synthetic Gemma4 vision RoPE embeddings."""
+    emb = torch.randn(batch_size, seq_len, head_dim)
+    return emb.cos(), emb.sin()
+
+
+def _vision_position_ids(batch_size: int, seq_len: int) -> torch.Tensor:
+    """Create deterministic 2-D pixel position ids for a tiny patch sequence."""
+    side = 4
+    coords = torch.arange(seq_len)
+    xy = torch.stack((coords % side, coords // side), dim=-1)
+    return xy.unsqueeze(0).expand(batch_size, -1, -1).long()
+
+
+class Gemma4VisionAttentionCase(Gemma4BaseCase):
+    """Smoke case for one tiny Gemma4 vision attention module."""
+
+    name = "gemma4_vision_attention"
+    description = "Quantize one tiny Gemma4 vision attention module."
+    tags = ("gemma4", "e2b", "vision", "attention")
+    max_mean_abs_diff = 2.0
+    seq_len = 8
+
+    def build(self, cfg: Mapping[str, Any]) -> tuple[torch.nn.Module, torch.nn.Module]:
+        """Build a tiny Gemma4 vision attention module and reference copy."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionAttention
+
+        torch.manual_seed(123)
+        self.vision_cfg = _make_vision_config()
+        module = Gemma4VisionAttention(self.vision_cfg, layer_idx=0).eval()
+        return module, clone_module(module)
+
+    def _sample(self) -> ForwardInput:
+        """Create one synthetic Gemma4 vision attention input."""
+        batch_size = 1
+        hidden = torch.randn(batch_size, self.seq_len, self.vision_cfg.hidden_size)
+        return ForwardInput(
+            (),
+            {
+                "hidden_states": hidden,
+                "position_embeddings": _vision_rope(
+                    batch_size,
+                    self.seq_len,
+                    self.vision_cfg.head_dim,
+                ),
+                "attention_mask": torch.zeros(
+                    batch_size, 1, self.seq_len, self.seq_len
+                ),
+                "position_ids": _vision_position_ids(batch_size, self.seq_len),
+            },
+        )
+
+    def calibration_inputs(
+        self,
+        prepared: torch.nn.Module,
+        cfg: Mapping[str, Any],
+    ) -> list[ForwardInput]:
+        """Create Gemma4 vision attention calibration samples."""
+        return [self._sample() for _ in range(3)]
+
+    def eval_input(
+        self,
+        prepared: torch.nn.Module,
+        cfg: Mapping[str, Any],
+    ) -> ForwardInput:
+        """Create the Gemma4 vision attention evaluation sample."""
+        return self._sample()
+
+
 GEMMA4_CASES = (
     Gemma4TextMLPCase(),
     Gemma4TextAttentionCase(),
     Gemma4TextSlidingAttentionCase(),
     Gemma4TextAttentionKEqVCase(),
     Gemma4TextAttentionSharedKVCase(),
+    Gemma4VisionAttentionCase(),
 )

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_vision_attention.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_vision_attention.py
@@ -16,6 +16,7 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
@@ -26,7 +27,17 @@ from tico.quantization.wrapq.wrappers.registry import try_register
 
 @try_register("transformers.models.gemma4.modeling_gemma4.Gemma4VisionAttention")
 class QuantGemma4VisionAttention(QuantModuleBase):
-    """PTQ wrapper skeleton for Gemma4 vision attention."""
+    """PTQ wrapper for Gemma4 E2B vision attention.
+
+    The wrapper mirrors Hugging Face ``Gemma4VisionAttention`` while keeping
+    projection, RMSNorm, multidimensional RoPE, mask addition, softmax, and the
+    output projection explicit. This makes the module suitable for activation
+    observation, fake-quantized PTQ simulation, and later static-shape export.
+
+    Dynamic image preprocessing and mask construction should stay outside this
+    wrapper. The wrapper expects already static tensors, especially a fixed patch
+    sequence length and fixed 2-D pixel position ids.
+    """
 
     def __init__(
         self,
@@ -39,9 +50,24 @@ class QuantGemma4VisionAttention(QuantModuleBase):
         self.module = fp_attn
         self.config = fp_attn.config
         self.layer_idx = fp_attn.layer_idx
-        self.head_dim = fp_attn.head_dim
-        self.num_key_value_groups = fp_attn.num_key_value_groups
+        self.layer_type = getattr(fp_attn, "layer_type", None)
+        self.head_dim = int(fp_attn.head_dim)
+        self.num_heads = int(
+            getattr(fp_attn, "num_heads", self.config.num_attention_heads)
+        )
+        self.num_key_value_heads = int(
+            getattr(
+                fp_attn,
+                "num_key_value_heads",
+                self.config.num_key_value_heads,
+            )
+        )
+        self.num_key_value_groups = int(fp_attn.num_key_value_groups)
         self.scaling = float(getattr(fp_attn, "scaling", 1.0))
+        self.attention_dropout = float(
+            getattr(fp_attn, "attention_dropout", 0.0) or 0.0
+        )
+        self.is_causal = bool(getattr(fp_attn, "is_causal", False))
 
         self.q_proj = PTQWrapper(
             fp_attn.q_proj,
@@ -79,9 +105,341 @@ class QuantGemma4VisionAttention(QuantModuleBase):
             fp_name=join_name(fp_name, "v_norm"),
         )
 
-        self.obs_logits = self._make_obs("logits")
-        self.obs_softmax = self._make_obs("softmax")
-        self.obs_attn_out = self._make_obs("attn_out")
+        mk = self._make_obs
+        self.obs_hidden = mk("hidden")
+
+        # RoPE tables.
+        self.obs_cos = mk("cos")
+        self.obs_sin = mk("sin")
+
+        # rotate_half sub-steps for Q.
+        self.obs_q_x1 = mk("q_x1")
+        self.obs_q_x2 = mk("q_x2")
+        self.obs_q_neg = mk("q_neg")
+        self.obs_q_cat = mk("q_cat")
+
+        # rotate_half sub-steps for K.
+        self.obs_k_x1 = mk("k_x1")
+        self.obs_k_x2 = mk("k_x2")
+        self.obs_k_neg = mk("k_neg")
+        self.obs_k_cat = mk("k_cat")
+
+        # RoPE combine points.
+        self.obs_q_cos = mk("q_cos")
+        self.obs_q_sin = mk("q_sin")
+        self.obs_q_rot = mk("q_rot")
+        self.obs_k_cos = mk("k_cos")
+        self.obs_k_sin = mk("k_sin")
+        self.obs_k_rot = mk("k_rot")
+
+        # Masking and attention math.
+        self.obs_attn_mask = mk("attn_mask")
+        self.obs_logits_raw = mk("logits_raw")
+        self.obs_scale = mk("scale")
+        self.obs_logits = mk("logits")
+        self.obs_mask_add = mk("mask_add")
+        self.obs_softmax = mk("softmax")
+        self.obs_attn_out = mk("attn_out")
+        self.obs_attn_weights = mk("attn_weights")
+        self.obs_attn_out_h = mk("attn_out_h")
+
+    @staticmethod
+    def _expand_rope_table(table: torch.Tensor) -> torch.Tensor:
+        """Return a RoPE table shaped as ``(B, S, 1, H)`` for vision attention."""
+        if table.dim() == 2:
+            table = table.unsqueeze(0)
+        if table.dim() == 3:
+            table = table.unsqueeze(2)
+        if table.dim() != 4:
+            raise RuntimeError(
+                "Gemma4 vision RoPE table must have rank 2, 3, or 4, "
+                f"got shape={tuple(table.shape)}."
+            )
+        return table
+
+    @staticmethod
+    def _rope_ndim(position_ids: Optional[torch.Tensor]) -> int:
+        """Return the number of spatial RoPE dimensions for pixel position ids."""
+        if position_ids is None:
+            # Vision attention is 2-D by construction. This fallback keeps export
+            # adapters usable when they precompute cos/sin and omit position ids.
+            return 2
+        if position_ids.dim() < 3:
+            raise RuntimeError(
+                "Gemma4 vision position_ids must be shaped as ``(B, S, ndim)``, "
+                f"got shape={tuple(position_ids.shape)}."
+            )
+        return int(position_ids.shape[-1])
+
+    def _rot(
+        self,
+        tensor: torch.Tensor,
+        obs_x1,
+        obs_x2,
+        obs_neg,
+        obs_cat,
+    ) -> torch.Tensor:
+        """Apply Gemma4/Hugging Face ``rotate_half`` as ``[-x2, x1]``."""
+        x1, x2 = torch.chunk(tensor, 2, dim=-1)
+        x1 = self._fq(x1, obs_x1)
+        x2 = self._fq(x2, obs_x2)
+        neg_x2 = self._fq(-x2, obs_neg)
+        return self._fq(torch.cat((neg_x2, x1), dim=-1), obs_cat)
+
+    def _apply_rope_part(
+        self,
+        tensor: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        obs_x1,
+        obs_x2,
+        obs_neg,
+        obs_cat,
+        obs_cos,
+        obs_sin,
+        obs_rot,
+    ) -> torch.Tensor:
+        """Apply one spatial RoPE partition to Q or K before head transposition."""
+        half = self._rot(tensor, obs_x1, obs_x2, obs_neg, obs_cat)
+        cos_part = self._fq(tensor * cos, obs_cos)
+        sin_part = self._fq(half * sin, obs_sin)
+        return self._fq(cos_part + sin_part, obs_rot)
+
+    def _apply_multidimensional_rope(
+        self,
+        tensor: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: Optional[torch.Tensor],
+        obs_x1,
+        obs_x2,
+        obs_neg,
+        obs_cat,
+        obs_cos,
+        obs_sin,
+        obs_rot,
+    ) -> torch.Tensor:
+        """Apply Gemma4 multidimensional RoPE to Q or K.
+
+        ``Gemma4VisionRotaryEmbedding`` builds cos/sin tables by concatenating
+        one RoPE table per spatial dimension. The attention input is split using
+        the same partitioning rule and each part receives normal 1-D RoPE.
+        """
+        ndim = self._rope_ndim(position_ids)
+        num_input_channels = int(tensor.shape[-1])
+        num_rotated_channels_per_dim = 2 * (num_input_channels // (2 * ndim))
+
+        if num_rotated_channels_per_dim <= 0:
+            raise ValueError(
+                "Invalid Gemma4 vision RoPE configuration: "
+                "num_rotated_channels_per_dim must be positive, got "
+                f"{num_rotated_channels_per_dim} "
+                f"(head_dim={num_input_channels}, ndim={ndim})."
+            )
+        if num_rotated_channels_per_dim * ndim != num_input_channels:
+            raise ValueError(
+                "Gemma4 vision head_dim must be divisible by ``2 * ndim`` for "
+                "multidimensional RoPE: "
+                f"head_dim={num_input_channels}, ndim={ndim}."
+            )
+
+        split_sizes = [num_rotated_channels_per_dim] * ndim
+        cos = self._expand_rope_table(cos)
+        sin = self._expand_rope_table(sin)
+
+        tensor_parts = torch.split(tensor, split_sizes, dim=-1)
+        cos_parts = torch.split(cos, split_sizes, dim=-1)
+        sin_parts = torch.split(sin, split_sizes, dim=-1)
+
+        rotated_parts = [
+            self._apply_rope_part(
+                tensor_parts[idx],
+                cos_parts[idx],
+                sin_parts[idx],
+                obs_x1,
+                obs_x2,
+                obs_neg,
+                obs_cat,
+                obs_cos,
+                obs_sin,
+                obs_rot,
+            )
+            for idx in range(ndim)
+        ]
+        return torch.cat(rotated_parts, dim=-1)
+
+    @staticmethod
+    def _normalize_attention_mask_shape(
+        mask: torch.Tensor,
+        *,
+        q_len: int,
+        k_len: int,
+    ) -> torch.Tensor:
+        """Normalize a vision attention mask to broadcast over ``(B, heads, Q, K)``.
+
+        Supported input shapes are ``(B, K)``, ``(B, Q, K)``, and
+        ``(B, 1, Q, K)``. Longer preallocated masks are sliced to the active
+        query and key lengths.
+        """
+        if mask.dim() not in (2, 3, 4):
+            raise RuntimeError(
+                "Unsupported attention_mask rank for Gemma4 vision attention: "
+                f"rank={mask.dim()}, shape={tuple(mask.shape)}."
+            )
+
+        if mask.size(-1) != k_len:
+            if mask.size(-1) > k_len:
+                mask = mask[..., :k_len]
+            else:
+                raise RuntimeError(
+                    "attention_mask key length is shorter than key states: "
+                    f"mask_k={mask.size(-1)}, k_len={k_len}, "
+                    f"shape={tuple(mask.shape)}."
+                )
+
+        if mask.dim() == 2:
+            return mask[:, None, None, :]
+
+        if mask.size(-2) not in (1, q_len):
+            if mask.size(-2) > q_len:
+                mask = mask[..., -q_len:, :]
+            else:
+                raise RuntimeError(
+                    "attention_mask query length is incompatible with query states: "
+                    f"mask_q={mask.size(-2)}, q_len={q_len}, "
+                    f"shape={tuple(mask.shape)}."
+                )
+
+        if mask.dim() == 3:
+            return mask[:, None, :, :]
+
+        if mask.size(1) != 1:
+            raise RuntimeError(
+                "Per-head attention masks are not supported by the Gemma4 vision "
+                "attention wrapper. Expected mask shape ``(B, 1, Q, K)``, "
+                f"got shape={tuple(mask.shape)}."
+            )
+        return mask
+
+    def _build_attention_mask(
+        self,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        batch_size: int,
+        q_len: int,
+        k_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Build an additive attention mask for vision attention logits."""
+        if attention_mask is None:
+            mask = torch.zeros(
+                (batch_size, 1, q_len, k_len),
+                device=device,
+                dtype=dtype,
+            )
+            return self._fq(mask, self.obs_attn_mask)
+
+        attention_mask = attention_mask.to(device)
+        if attention_mask.dtype in (
+            torch.bool,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+        ):
+            keep_mask = self._normalize_attention_mask_shape(
+                attention_mask.bool(),
+                q_len=q_len,
+                k_len=k_len,
+            )
+            additive = torch.zeros(
+                keep_mask.shape,
+                dtype=dtype,
+                device=device,
+            )
+            additive = additive.masked_fill(
+                ~keep_mask,
+                float(self.qcfg.attention_mask_fill_value),
+            )
+            return self._fq(additive, self.obs_attn_mask)
+
+        if torch.is_floating_point(attention_mask):
+            additive = self._normalize_attention_mask_shape(
+                attention_mask,
+                q_len=q_len,
+                k_len=k_len,
+            ).to(dtype=dtype)
+            return self._fq(additive, self.obs_attn_mask)
+
+        raise RuntimeError(
+            "Unsupported attention_mask dtype for Gemma4 vision attention: "
+            f"dtype={attention_mask.dtype}."
+        )
+
+    def _attention_forward(
+        self,
+        *,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run grouped-query vision attention without materializing repeated K/V."""
+        batch_size, num_heads, q_len, _ = query_states.shape
+        num_kv_heads = key_states.size(1)
+        kv_rep = self.num_key_value_groups
+
+        attn_weights_parts: list[torch.Tensor] = []
+        attn_out_parts: list[torch.Tensor] = []
+
+        for kv_idx in range(num_kv_heads):
+            key_i = key_states[:, kv_idx : kv_idx + 1, :, :]
+            value_i = value_states[:, kv_idx : kv_idx + 1, :, :]
+            head_start = kv_idx * kv_rep
+            head_end = min(head_start + kv_rep, num_heads)
+            query_i = query_states[:, head_start:head_end, :, :]
+            if query_i.size(1) == 0:
+                continue
+
+            logits_i = query_i @ key_i.transpose(-2, -1)
+            logits_i = self._fq(logits_i, self.obs_logits_raw)
+            scale = self._fq(
+                torch.tensor(
+                    self.scaling,
+                    device=logits_i.device,
+                    dtype=logits_i.dtype,
+                ),
+                self.obs_scale,
+            )
+            logits_i = self._fq(logits_i * scale, self.obs_logits)
+            logits_i = self._fq(logits_i + attention_mask, self.obs_mask_add)
+
+            attn_i = torch.softmax(logits_i, dim=-1, dtype=torch.float32).to(
+                query_states.dtype
+            )
+            if self.training and self.attention_dropout > 0.0:
+                attn_i = F.dropout(attn_i, p=self.attention_dropout, training=True)
+            attn_i = self._fq(attn_i, self.obs_softmax)
+
+            out_i = self._fq(attn_i @ value_i, self.obs_attn_out)
+            attn_weights_parts.append(attn_i)
+            attn_out_parts.append(out_i)
+
+        if not attn_out_parts:
+            raise RuntimeError("Gemma4 vision attention produced no head outputs.")
+
+        attn_weights = self._fq(
+            torch.cat(attn_weights_parts, dim=1),
+            self.obs_attn_weights,
+        )
+        attn_out_h = self._fq(
+            torch.cat(attn_out_parts, dim=1),
+            self.obs_attn_out_h,
+        )
+        attn_output = attn_out_h.transpose(1, 2).reshape(batch_size, q_len, -1)
+        return self.o_proj(attn_output), attn_weights
 
     def forward(
         self,
@@ -91,15 +449,117 @@ class QuantGemma4VisionAttention(QuantModuleBase):
         position_ids: Optional[torch.Tensor] = None,
         **kwargs,
     ):
-        """Run Gemma4 vision attention.
+        """Run Gemma4 vision attention with explicit PTQ observation points.
 
-        TODO: Implement decomposed multidimensional RoPE and attention math for
-        Circle/NPU-friendly export.
+        Args:
+            hidden_states: Input patch states shaped ``(B, S, hidden_size)``.
+            position_embeddings: Tuple ``(cos, sin)`` produced by
+                ``Gemma4VisionRotaryEmbedding``. Each table is expected to be
+                shaped ``(B, S, head_dim)``.
+            attention_mask: Optional additive or keep mask broadcastable to
+                ``(B, heads, S, S)``.
+            position_ids: Pixel position ids shaped ``(B, S, 2)``. Static export
+                adapters may omit this argument when they always use 2-D RoPE.
+
+        Returns:
+            Tuple ``(attn_output, attn_weights)`` following the Hugging Face
+            vision attention contract.
         """
-        raise NotImplementedError(
-            "Gemma4 vision attention static implementation is not wired yet."
+        if position_embeddings is None:
+            raise RuntimeError(
+                "Gemma4 vision attention requires ``position_embeddings=(cos, sin)``."
+            )
+
+        hidden = self._fq(hidden_states, self.obs_hidden)
+        batch_size, seq_len, _ = hidden.shape
+        query_shape = (batch_size, seq_len, self.num_heads, self.head_dim)
+        kv_shape = (batch_size, seq_len, self.num_key_value_heads, self.head_dim)
+
+        cos, sin = position_embeddings
+        cos = self._fq(cos, self.obs_cos)
+        sin = self._fq(sin, self.obs_sin)
+
+        query_states = self.q_proj(hidden).view(query_shape)
+        query_states = self.q_norm(query_states)
+        query_states = self._apply_multidimensional_rope(
+            query_states,
+            cos,
+            sin,
+            position_ids,
+            self.obs_q_x1,
+            self.obs_q_x2,
+            self.obs_q_neg,
+            self.obs_q_cat,
+            self.obs_q_cos,
+            self.obs_q_sin,
+            self.obs_q_rot,
+        )
+        query_states = query_states.transpose(1, 2)
+
+        key_states = self.k_proj(hidden).view(kv_shape)
+        key_states = self.k_norm(key_states)
+        key_states = self._apply_multidimensional_rope(
+            key_states,
+            cos,
+            sin,
+            position_ids,
+            self.obs_k_x1,
+            self.obs_k_x2,
+            self.obs_k_neg,
+            self.obs_k_cat,
+            self.obs_k_cos,
+            self.obs_k_sin,
+            self.obs_k_rot,
+        )
+        key_states = key_states.transpose(1, 2)
+
+        value_states = self.v_proj(hidden).view(kv_shape)
+        value_states = self.v_norm(value_states)
+        value_states = value_states.transpose(1, 2)
+
+        attn_mask = self._build_attention_mask(
+            attention_mask=attention_mask,
+            batch_size=batch_size,
+            q_len=query_states.size(-2),
+            k_len=key_states.size(-2),
+            device=query_states.device,
+            dtype=query_states.dtype,
+        )
+
+        return self._attention_forward(
+            query_states=query_states,
+            key_states=key_states,
+            value_states=value_states,
+            attention_mask=attn_mask,
         )
 
     def _all_observers(self) -> Iterable:
         """Return observers owned directly by this wrapper."""
-        return (self.obs_logits, self.obs_softmax, self.obs_attn_out)
+        return (
+            self.obs_hidden,
+            self.obs_cos,
+            self.obs_sin,
+            self.obs_q_x1,
+            self.obs_q_x2,
+            self.obs_q_neg,
+            self.obs_q_cat,
+            self.obs_k_x1,
+            self.obs_k_x2,
+            self.obs_k_neg,
+            self.obs_k_cat,
+            self.obs_q_cos,
+            self.obs_q_sin,
+            self.obs_q_rot,
+            self.obs_k_cos,
+            self.obs_k_sin,
+            self.obs_k_rot,
+            self.obs_attn_mask,
+            self.obs_logits_raw,
+            self.obs_scale,
+            self.obs_logits,
+            self.obs_mask_add,
+            self.obs_softmax,
+            self.obs_attn_out,
+            self.obs_attn_weights,
+            self.obs_attn_out_h,
+        )

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -63,7 +63,7 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_model",
     "tico.quantization.wrapq.wrappers.qwen_vl.quant_for_conditional_generation",
     ## gemma4 ##
-    # "tico.quantization.wrapq.wrappers.gemma4.quant_clippable_linear",
+    "tico.quantization.wrapq.wrappers.gemma4.quant_clippable_linear",
     "tico.quantization.wrapq.wrappers.gemma4.quant_rmsnorm",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_text_scaled_word_embedding",
     "tico.quantization.wrapq.wrappers.gemma4.quant_text_mlp",
@@ -74,7 +74,7 @@ _CORE_MODULES = (
     # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_patch_embedder",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_pooler",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_mlp",
-    # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_attention",
+    "tico.quantization.wrapq.wrappers.gemma4.quant_vision_attention",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_encoder_layer",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_encoder",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_vision_model",


### PR DESCRIPTION
This commit adds Gemma4 vision attention wrapper.

```bash
python -m tico.quantization.examples.inspect \
  --mode wrapper-smoke \
  --case gemma4_vision_attention \
  --strict \
  --no-plot \
  --calibration-iters 3 \
  --output-dir ./out/wrapper_smoke/gemma4_vision_attention
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_vision_attention
│ Status           : PASS
│ Mean |diff|      : 0.017682
│ Max |diff|       : 0.070248
│ PEIR             : 0.029431
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>