### PR TITLE
[quantization] Add text-only static runtime path for Qwen3-VL

### DIFF
--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_attention.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_attention.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import types
+import inspect
 import unittest
 
 import torch
-import torch.nn as nn
-from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.version import has_transformers_for
@@ -72,11 +70,59 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
         cls.num_kv_heads = cfg.num_key_value_heads
 
     def _rand_rope(self, B: int, S: int):
-        # Build dummy RoPE tables with shape (B, S, head_dim),
-        # consistent with HF apply_rotary_pos_emb() expectations.
+        """Create synthetic RoPE tables with Qwen text-attention shapes."""
         h = self.head_dim
         emb = torch.randn(B, S, h)
         return emb.cos(), emb.sin()
+
+    def _collect_cache_calibration(self, qattn: QuantQwen3VLTextAttention) -> None:
+        """Collect observer statistics for static KV cache tensors."""
+        batch_size = 2
+        past_len = 2
+        q_len = 1
+        past_k = torch.randn(batch_size, self.num_kv_heads, past_len, self.head_dim)
+        past_v = torch.randn_like(past_k)
+        hidden = torch.randn(batch_size, q_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, q_len)
+        mask = torch.zeros(batch_size, 1, q_len, past_len + q_len)
+        _ = qattn(
+            hidden,
+            pos,
+            attention_mask=mask,
+            past_key_values=(past_k, past_v),
+            use_cache=True,
+            cache_output_mode="present",
+        )
+
+    def _calibrate_cache_paths(self, qattn: QuantQwen3VLTextAttention) -> None:
+        """Calibrate the no-cache and static tuple-cache execution paths."""
+        qattn.enable_calibration()
+
+        batch_size, prefill_len, decode_len = 2, 4, 1
+        for _ in range(2):
+            x0 = torch.randn(batch_size, prefill_len, self.hidden_size)
+            pos0 = self._rand_rope(batch_size, prefill_len)
+            _, _, delta0 = qattn(
+                x0,
+                pos0,
+                attention_mask=None,
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+            past_k, past_v = delta0
+            x1 = torch.randn(batch_size, decode_len, self.hidden_size)
+            pos1 = self._rand_rope(batch_size, decode_len)
+            _ = qattn(
+                x1,
+                pos1,
+                attention_mask=None,
+                past_key_values=(past_k, past_v),
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        qattn.freeze_qparams()
 
     def test_mode_transitions(self):
         qattn = QuantQwen3VLTextAttention(self.fp_attn)
@@ -88,6 +134,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
         x = torch.randn(2, 5, self.hidden_size)
         pos = self._rand_rope(2, 5)
         _ = qattn(x, pos)
+        self._collect_cache_calibration(qattn)
 
         qattn.freeze_qparams()
         self.assertIs(qattn._mode, Mode.QUANT)
@@ -99,6 +146,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
             inp = torch.randn(2, 6, self.hidden_size)
             pos = self._rand_rope(2, 6)
             _ = qattn(inp, pos)
+        self._collect_cache_calibration(qattn)
         qattn.freeze_qparams()
 
         x = torch.randn(2, 6, self.hidden_size)
@@ -143,6 +191,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
             x = torch.randn(B, S, self.hidden_size)
             pos = self._rand_rope(B, S)
             _ = qattn(x, pos, attention_mask=float_mask)
+        self._collect_cache_calibration(qattn)
         qattn.freeze_qparams()
 
         # Forward should not raise, and shapes should match
@@ -161,12 +210,122 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
         self.assertEqual(attn_w.shape, (B, self.num_heads, S, S))
         self.assertEqual(fp_attn_w.shape, (B, self.num_heads, S, S))
 
+    def test_public_cache_argument_is_past_key_values(self):
+        """Verify that the public static-runtime cache argument is plural only."""
+        params = inspect.signature(QuantQwen3VLTextAttention.forward).parameters
+        self.assertIn("past_key_values", params)
+        self.assertNotIn("past_key_value", params)
+
+    def test_static_tuple_cache_returns_delta_kv_for_prefill_and_decode(self):
+        """Validate delta-only KV outputs for the static tuple-cache path."""
+        torch.manual_seed(7)
+        qattn = QuantQwen3VLTextAttention(self.fp_attn)
+        self._calibrate_cache_paths(qattn)
+
+        B, S0 = 2, 4
+        x0 = torch.randn(B, S0, self.hidden_size)
+        pos0 = self._rand_rope(B, S0)
+
+        with torch.no_grad():
+            out0, attn0, delta0 = qattn(
+                x0,
+                pos0,
+                attention_mask=None,
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        new_k0, new_v0 = delta0
+        self.assertEqual(out0.shape, (B, S0, self.hidden_size))
+        self.assertEqual(attn0.shape, (B, self.num_heads, S0, S0))
+        self.assertEqual(new_k0.shape, (B, self.num_kv_heads, S0, self.head_dim))
+        self.assertEqual(new_v0.shape, (B, self.num_kv_heads, S0, self.head_dim))
+
+        x1 = torch.randn(B, 1, self.hidden_size)
+        pos1 = self._rand_rope(B, 1)
+        with torch.no_grad():
+            out1, attn1, delta1 = qattn(
+                x1,
+                pos1,
+                attention_mask=None,
+                past_key_values=(new_k0, new_v0),
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        new_k1, new_v1 = delta1
+        self.assertEqual(out1.shape, (B, 1, self.hidden_size))
+        self.assertEqual(attn1.shape, (B, self.num_heads, 1, S0 + 1))
+        self.assertEqual(new_k1.shape, (B, self.num_kv_heads, 1, self.head_dim))
+        self.assertEqual(new_v1.shape, (B, self.num_kv_heads, 1, self.head_dim))
+
+    def test_static_tuple_cache_returns_present_kv_when_requested(self):
+        """Validate full present KV outputs for the static tuple-cache path."""
+        torch.manual_seed(9)
+        qattn = QuantQwen3VLTextAttention(self.fp_attn)
+        self._calibrate_cache_paths(qattn)
+
+        B, S0 = 1, 3
+        x0 = torch.randn(B, S0, self.hidden_size)
+        pos0 = self._rand_rope(B, S0)
+
+        with torch.no_grad():
+            _, _, present0 = qattn(
+                x0,
+                pos0,
+                attention_mask=None,
+                use_cache=True,
+                cache_output_mode="present",
+            )
+
+        present_k0, present_v0 = present0
+        self.assertEqual(present_k0.shape, (B, self.num_kv_heads, S0, self.head_dim))
+        self.assertEqual(present_v0.shape, (B, self.num_kv_heads, S0, self.head_dim))
+
+        x1 = torch.randn(B, 1, self.hidden_size)
+        pos1 = self._rand_rope(B, 1)
+        with torch.no_grad():
+            _, attn1, present1 = qattn(
+                x1,
+                pos1,
+                attention_mask=None,
+                past_key_values=(present_k0, present_v0),
+                use_cache=True,
+                cache_output_mode="present",
+            )
+
+        present_k1, present_v1 = present1
+        self.assertEqual(attn1.shape, (B, self.num_heads, 1, S0 + 1))
+        self.assertEqual(
+            present_k1.shape,
+            (B, self.num_kv_heads, S0 + 1, self.head_dim),
+        )
+        self.assertEqual(
+            present_v1.shape,
+            (B, self.num_kv_heads, S0 + 1, self.head_dim),
+        )
+
+    def test_invalid_cache_output_mode_raises(self):
+        """Reject unsupported cache output policies."""
+        qattn = QuantQwen3VLTextAttention(self.fp_attn)
+        x = torch.randn(1, 2, self.hidden_size)
+        pos = self._rand_rope(1, 2)
+
+        with self.assertRaises(ValueError):
+            _ = qattn(
+                x,
+                pos,
+                attention_mask=None,
+                use_cache=True,
+                cache_output_mode="full",  # type: ignore[arg-type]
+            )
+
     def test_cache_mock_object_update_prefill_then_decode(self):
         """
-        `QuantQwen3VLTextAttention` uses HF Cache-like update().
-        This test validates:
-          - cache grows along sequence dim (dim=2)
-          - attention weights use the grown key length
+        Validate HF Cache-like update semantics for eager wrapper execution.
+
+        The exported static runtime uses tuple caches, but full-model eager
+        execution may still pass a Cache-like object with an update method.
         """
 
         class MockCache:
@@ -193,6 +352,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
             x = torch.randn(2, 3, self.hidden_size)
             pos = self._rand_rope(2, 3)
             _ = qattn(x, pos, attention_mask=None)
+        self._collect_cache_calibration(qattn)
         qattn.freeze_qparams()
 
         cache = MockCache()
@@ -238,8 +398,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
 
     def test_mask_slicing_with_cache_q_len_lt_k_len(self):
         """
-        Validate causal mask slicing when q_len < k_len due to cache growth.
-        This specifically checks that attention weights have shape (..., q_len, k_len).
+        Validate causal mask slicing when q_len is smaller than cached key length.
         """
         torch.manual_seed(2)
         qattn = QuantQwen3VLTextAttention(self.fp_attn)
@@ -250,6 +409,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
             x = torch.randn(1, 5, self.hidden_size)
             pos = self._rand_rope(1, 5)
             _ = qattn(x, pos, attention_mask=None)
+        self._collect_cache_calibration(qattn)
         qattn.freeze_qparams()
 
         class MockCache:
@@ -281,7 +441,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
                 cache_position=torch.arange(3),
             )
 
-        # Now decode with q_len=2 => k_len should be 5
+        # Now decode with q_len=2, so k_len should be 5.
         x1 = torch.randn(B, 2, self.hidden_size)
         pos1 = self._rand_rope(B, 2)
         with torch.no_grad():
@@ -319,7 +479,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
 
         assert out.shape == (1, 1, 4, 4)
 
-        # Causal mask: query 0 cannot attend to keys 1,2,3.
+        # Causal mask: query 0 cannot attend to keys 1, 2, and 3.
         assert out[0, 0, 0, 0].item() == 0.0
         assert out[0, 0, 0, 1].item() == -100.0
         assert out[0, 0, 0, 2].item() == -100.0
@@ -327,7 +487,7 @@ class TestQuantQwen3VLTextAttention(unittest.TestCase):
         # Padding mask: key 3 is masked for all queries.
         assert torch.all(out[..., 3] == -100.0)
 
-        # Query 2 can attend to keys 0,1,2, but not key 3.
+        # Query 2 can attend to keys 0, 1, and 2, but not key 3.
         assert out[0, 0, 2, 0].item() == 0.0
         assert out[0, 0, 2, 1].item() == 0.0
         assert out[0, 0, 2, 2].item() == 0.0

--- a/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py
+++ b/test/quantization/wrapq/wrappers/qwen_vl/test_quant_text_decoder_layer.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pathlib
-import tempfile
+import inspect
 import unittest
-import warnings
-
-import tico
 
 import torch
-from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.version import has_transformers_for
-from tico.quantization.wrapq.wrappers.nn.quant_layernorm import QuantLayerNorm
+from tico.quantization.wrapq.wrappers.qwen_vl.export_adapters import (
+    Qwen3VLTextDecoderLayerDecodeExportAdapter,
+    Qwen3VLTextDecoderLayerPrefillExportAdapter,
+)
 from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer import (
     QuantQwen3VLTextDecoderLayer,
 )
@@ -42,6 +40,7 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
     fp_model: torch.nn.Module
     hidden_size: int
     num_attention_heads: int
+    num_key_value_heads: int
     head_dim: int
 
     @classmethod
@@ -53,7 +52,7 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
             Qwen3VLTextDecoderLayer,
         )
 
-        # Use smaller sizes for testing
+        # Use smaller sizes for testing.
         cfg = Qwen3VLTextConfig(
             hidden_size=64,
             num_attention_heads=2,
@@ -74,32 +73,72 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
         cls.fp_model = Qwen3VLTextDecoderLayer(cfg, layer_idx=0)
         cls.hidden_size = cfg.hidden_size
         cls.num_attention_heads = cfg.num_attention_heads
-        cls.head_dim = cls.hidden_size // cls.num_attention_heads
+        cls.num_key_value_heads = cfg.num_key_value_heads
+        cls.head_dim = cfg.head_dim
 
     def _rand_position_embeddings(self, batch_size, seq_len):
-        """Helper to create dummy rotary position embeddings"""
+        """Create dummy rotary position embeddings."""
         cos = torch.randn(batch_size, seq_len, self.head_dim)
         sin = torch.randn(batch_size, seq_len, self.head_dim)
         return cos, sin
 
     def _create_test_inputs(self, batch_size=2, seq_len=16):
-        """Helper to create test inputs for TextDecoderLayer."""
+        """Create synthetic inputs for Qwen3-VL text decoder-layer tests."""
         hidden_states = torch.randn(batch_size, seq_len, self.hidden_size)
         position_embeddings = self._rand_position_embeddings(batch_size, seq_len)
         attention_mask = torch.ones(batch_size, 1, seq_len, seq_len)
         position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
         return hidden_states, position_embeddings, attention_mask, position_ids
 
-    def test_mode_transitions(self):
-        """Test quantization mode transitions: NO_QUANT → CALIB → QUANT"""
+    def _create_decode_inputs(self, batch_size=2, past_len=4):
+        """Create synthetic single-token decode inputs and static tuple caches."""
+        hidden_states = torch.randn(batch_size, 1, self.hidden_size)
+        position_embeddings = self._rand_position_embeddings(batch_size, 1)
+        attention_mask = torch.zeros(batch_size, 1, 1, past_len + 1)
+        position_ids = torch.full((batch_size, 1), past_len, dtype=torch.long)
+        past_key = torch.randn(
+            batch_size,
+            self.num_key_value_heads,
+            past_len,
+            self.head_dim,
+        )
+        past_value = torch.randn_like(past_key)
+        return (
+            hidden_states,
+            position_embeddings,
+            attention_mask,
+            position_ids,
+            (
+                past_key,
+                past_value,
+            ),
+        )
 
+    def _collect_cache_calibration(self, q_model: QuantQwen3VLTextDecoderLayer) -> None:
+        """Collect observer statistics for the static KV-cache path."""
+        hidden_states, pos_emb, attn_mask, pos_ids, past = self._create_decode_inputs(
+            batch_size=2,
+            past_len=2,
+        )
+        _ = q_model(
+            hidden_states=hidden_states,
+            position_embeddings=pos_emb,
+            attention_mask=attn_mask,
+            position_ids=pos_ids,
+            past_key_values=past,
+            use_cache=True,
+            cache_output_mode="present",
+        )
+
+    def test_mode_transitions(self):
+        """Test quantization mode transitions: NO_QUANT -> CALIB -> QUANT."""
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
         self.assertIs(q_model._mode, Mode.NO_QUANT)
 
         q_model.enable_calibration()
         self.assertIs(q_model._mode, Mode.CALIB)
 
-        # Run forward pass during calibration
+        # Run forward pass during calibration.
         hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
         _ = q_model(
             hidden_states=hidden_states,
@@ -108,18 +147,17 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
             position_ids=pos_ids,
         )
 
+        self._collect_cache_calibration(q_model)
         q_model.freeze_qparams()
         self.assertIs(q_model._mode, Mode.QUANT)
 
     def test_forward_diff(self):
-        """
-        Test that quantized output is acceptably close to FP32 reference.
-        """
+        """Test that quantized output is acceptably close to the FP32 reference."""
         torch.manual_seed(42)
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
         q_model.enable_calibration()
 
-        # Calibrate with multiple inputs
+        # Calibrate with multiple inputs.
         for _ in range(4):
             hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
             _ = q_model(
@@ -129,6 +167,7 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
                 position_ids=pos_ids,
             )
 
+        self._collect_cache_calibration(q_model)
         q_model.freeze_qparams()
 
         hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs()
@@ -152,12 +191,7 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
         self.assertLess(diff, 0.7)  # acceptably close
 
     def test_registration_in_registry(self):
-        """
-        Test that Qwen3VLTextDecoderLayer is properly registered.
-        """
-        from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer import (
-            QuantQwen3VLTextDecoderLayer,
-        )
+        """Test that Qwen3VLTextDecoderLayer is properly registered."""
         from tico.quantization.wrapq.wrappers.registry import lookup
         from transformers.models.qwen3_vl.modeling_qwen3_vl import (
             Qwen3VLTextDecoderLayer,
@@ -167,11 +201,7 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
         self.assertIs(wrapper_cls, QuantQwen3VLTextDecoderLayer)
 
     def test_output_shape(self):
-        """
-        Test that output shape is preserved.
-        Input: (batch_size, seq_len, hidden_size)
-        Output: (batch_size, seq_len, hidden_size)
-        """
+        """Test that the decoder layer preserves hidden-state shape."""
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
         q_model.enable_calibration()
 
@@ -187,6 +217,7 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
             position_ids=pos_ids,
         )
 
+        self._collect_cache_calibration(q_model)
         q_model.freeze_qparams()
 
         with torch.no_grad():
@@ -207,10 +238,170 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
         self.assertEqual(q_out.shape, expected_shape)
         self.assertEqual(fp_out.shape, expected_shape)
 
+    def test_public_cache_argument_is_past_key_values(self):
+        """Verify that decoder-layer cache APIs use only the plural argument."""
+        layer_params = inspect.signature(
+            QuantQwen3VLTextDecoderLayer.forward
+        ).parameters
+        self.assertIn("past_key_values", layer_params)
+        self.assertNotIn("past_key_value", layer_params)
+
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        decode_adapter = q_model.as_export_module("decode")
+        adapter_params = inspect.signature(decode_adapter.forward).parameters
+        self.assertIn("past_key_values", adapter_params)
+        self.assertNotIn("past_key_value", adapter_params)
+
+    def test_forward_with_cache_returns_delta_kv_tuple(self):
+        """Validate decoder-layer delta KV output in tuple-return mode."""
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model, return_type="tuple")
+        q_model.enable_calibration()
+
+        hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs(
+            batch_size=2,
+            seq_len=4,
+        )
+        _ = q_model(
+            hidden_states=hidden_states,
+            position_embeddings=pos_emb,
+            attention_mask=attn_mask,
+            position_ids=pos_ids,
+            use_cache=True,
+            cache_output_mode="delta",
+        )
+        self._collect_cache_calibration(q_model)
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            outputs = q_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        hidden_out, cache_delta = outputs
+        new_k, new_v = cache_delta
+        self.assertEqual(hidden_out.shape, (2, 4, self.hidden_size))
+        self.assertEqual(new_k.shape, (2, self.num_key_value_heads, 4, self.head_dim))
+        self.assertEqual(new_v.shape, (2, self.num_key_value_heads, 4, self.head_dim))
+
+    def test_decode_with_static_tuple_cache_returns_delta_kv(self):
+        """Validate static tuple-cache decode with delta-only cache output."""
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model, return_type="tuple")
+        hidden_states, pos_emb, attn_mask, pos_ids, past = self._create_decode_inputs(
+            batch_size=2,
+            past_len=3,
+        )
+
+        q_model.enable_calibration()
+        _ = q_model(
+            hidden_states=hidden_states,
+            position_embeddings=pos_emb,
+            attention_mask=attn_mask,
+            position_ids=pos_ids,
+            past_key_values=past,
+            use_cache=True,
+            cache_output_mode="delta",
+        )
+        self._collect_cache_calibration(q_model)
+        q_model.freeze_qparams()
+
+        with torch.no_grad():
+            outputs = q_model(
+                hidden_states=hidden_states,
+                position_embeddings=pos_emb,
+                attention_mask=attn_mask,
+                position_ids=pos_ids,
+                past_key_values=past,
+                use_cache=True,
+                cache_output_mode="delta",
+            )
+
+        hidden_out, cache_delta = outputs
+        new_k, new_v = cache_delta
+        self.assertEqual(hidden_out.shape, (2, 1, self.hidden_size))
+        self.assertEqual(new_k.shape, (2, self.num_key_value_heads, 1, self.head_dim))
+        self.assertEqual(new_v.shape, (2, self.num_key_value_heads, 1, self.head_dim))
+
+    def test_as_export_module_prefill_and_decode_contracts(self):
+        """Validate the static runtime adapter input and output contracts."""
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+
+        prefill_adapter = q_model.as_export_module("prefill", return_kv=True)
+        self.assertIsInstance(
+            prefill_adapter,
+            Qwen3VLTextDecoderLayerPrefillExportAdapter,
+        )
+
+        B, S = 1, 4
+        hidden_states = torch.randn(B, S, self.hidden_size)
+        pos_emb = self._rand_position_embeddings(B, S)
+        attn_mask = torch.zeros(B, 1, S, S)
+
+        with torch.no_grad():
+            hidden_out, new_k, new_v = prefill_adapter(
+                hidden_states=hidden_states,
+                attention_mask=attn_mask,
+                position_embeddings=pos_emb,
+            )
+
+        self.assertEqual(hidden_out.shape, (B, S, self.hidden_size))
+        self.assertEqual(new_k.shape, (B, self.num_key_value_heads, S, self.head_dim))
+        self.assertEqual(new_v.shape, (B, self.num_key_value_heads, S, self.head_dim))
+
+        decode_adapter = q_model.as_export_module("decode", return_kv=True)
+        self.assertIsInstance(
+            decode_adapter,
+            Qwen3VLTextDecoderLayerDecodeExportAdapter,
+        )
+
+        hidden_decode = torch.randn(B, 1, self.hidden_size)
+        pos_decode = self._rand_position_embeddings(B, 1)
+        attn_decode = torch.zeros(B, 1, 1, S + 1)
+
+        with torch.no_grad():
+            hidden_next, delta_k, delta_v = decode_adapter(
+                hidden_states=hidden_decode,
+                attention_mask=attn_decode,
+                position_embeddings=pos_decode,
+                past_key_values=(new_k, new_v),
+            )
+
+        self.assertEqual(hidden_next.shape, (B, 1, self.hidden_size))
+        self.assertEqual(delta_k.shape, (B, self.num_key_value_heads, 1, self.head_dim))
+        self.assertEqual(delta_v.shape, (B, self.num_key_value_heads, 1, self.head_dim))
+
+    def test_as_export_module_return_kv_false_returns_hidden_only(self):
+        """Validate hidden-only adapter output when KV return is disabled."""
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        prefill_adapter = q_model.as_export_module("prefill", return_kv=False)
+
+        B, S = 1, 3
+        hidden_states = torch.randn(B, S, self.hidden_size)
+        pos_emb = self._rand_position_embeddings(B, S)
+        attn_mask = torch.zeros(B, 1, S, S)
+
+        with torch.no_grad():
+            hidden_out = prefill_adapter(
+                hidden_states=hidden_states,
+                attention_mask=attn_mask,
+                position_embeddings=pos_emb,
+            )
+
+        self.assertIsInstance(hidden_out, torch.Tensor)
+        self.assertEqual(hidden_out.shape, (B, S, self.hidden_size))
+
+    def test_as_export_module_rejects_unknown_mode(self):
+        """Reject unsupported export adapter modes."""
+        q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
+        with self.assertRaises(ValueError):
+            _ = q_model.as_export_module("train")  # type: ignore[arg-type]
+
     def test_residual_connection_preservation(self):
-        """
-        Test that residual connections are preserved (output close to input + transformation).
-        """
+        """Test that residual connections preserve shape and transform values."""
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
         q_model.enable_calibration()
 
@@ -222,13 +413,11 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
             position_ids=pos_ids,
         )
 
+        self._collect_cache_calibration(q_model)
         q_model.freeze_qparams()
 
         with torch.no_grad():
-            # Save input
             input_copy = hidden_states.clone()
-
-            # Run forward pass
             output = q_model(
                 hidden_states=hidden_states,
                 position_embeddings=pos_emb,
@@ -236,26 +425,24 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
                 position_ids=pos_ids,
             )
 
-        # Output should be different from input (transformation applied)
+        # Output should be different from input because transformations are applied.
         self.assertFalse(torch.equal(output, input_copy))
 
-        # But shape should be preserved
+        # Shape should be preserved.
         self.assertEqual(output.shape, input_copy.shape)
 
     def test_observer_count(self):
         """
-        Test that the wrapper has the correct number of observers.
-        - 3 local observers (input, post_attn, output)
+        Test that the wrapper has the correct number of local observers.
+
+        The attention and MLP submodules own their own observers.
         """
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
         observers = list(q_model._all_observers())
-        # Should have 3 local observers
         self.assertEqual(len(observers), 3)
 
     def test_per_module_override(self):
-        """
-        Test that PTQConfig overrides propagate correctly to submodules.
-        """
+        """Test that PTQConfig overrides propagate correctly to submodules."""
         cfg = make_affine_ptq_config(
             dtype=DType.uint(8),
             overrides={
@@ -266,17 +453,15 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
         )
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model, qcfg=cfg)
 
-        # Check that override is applied to local observer
+        # The local input observer keeps the top-level dtype override.
         self.assertEqual(q_model.obs_act_in.dtype, DType.uint(8))
 
     def test_different_batch_sizes(self):
-        """
-        Test that quantization works correctly with different batch sizes.
-        """
+        """Test that quantization works correctly with different batch sizes."""
         q_model = QuantQwen3VLTextDecoderLayer(self.fp_model)
         q_model.enable_calibration()
 
-        # Calibrate with one batch size
+        # Calibrate with one batch size.
         calibrate_hidden, pos_emb, attn_mask, pos_ids = self._create_test_inputs(
             batch_size=2
         )
@@ -287,9 +472,10 @@ class TestQuantQwen3VLTextDecoderLayer(unittest.TestCase):
                 attention_mask=attn_mask,
                 position_ids=pos_ids,
             )
+        self._collect_cache_calibration(q_model)
         q_model.freeze_qparams()
 
-        # Test with different batch sizes
+        # Test with different batch sizes.
         for batch_size in [1, 2, 4]:
             hidden_states, pos_emb, attn_mask, pos_ids = self._create_test_inputs(
                 batch_size=batch_size

--- a/tico/quantization/recipes/debug/static_qwen3_vl_runtime.py
+++ b/tico/quantization/recipes/debug/static_qwen3_vl_runtime.py
@@ -1,0 +1,765 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+from transformers import AutoModelForImageTextToText, AutoTokenizer
+
+from tico.quantization import prepare
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer import (
+    QuantQwen3VLTextDecoderLayer,
+)
+
+
+@dataclass
+class LayerCache:
+    """Store one decoder layer's static KV cache tensors."""
+
+    past_k: torch.Tensor
+    past_v: torch.Tensor
+
+
+@dataclass
+class StaticQwen3VLRuntimeConfig:
+    """Configuration for the text-only static Qwen3-VL runtime smoke test."""
+
+    model: str = "Qwen/Qwen3-VL-2B-Instruct"
+    max_seq: int = 2048
+    padding_side: str = "right"
+    device: str = "cpu"
+    prompt: str = "The capital of France is"
+    verify_steps: int = 6
+    gen_steps: int = 16
+    trust_remote_code: bool = True
+
+
+def _clone_quant_layer(layer: nn.Module) -> nn.Module:
+    """Build a quantized decoder layer wrapper for runtime simulation."""
+    return prepare(layer, PTQConfig())
+
+
+def _set_text_max_position_embeddings(model: nn.Module, max_seq: int) -> None:
+    """Set Qwen3-VL text-position capacity before quant wrappers are created."""
+    config = getattr(model, "config", None)
+    text_config = getattr(config, "text_config", None)
+    if text_config is not None:
+        text_config.max_position_embeddings = max_seq
+
+    qwen_model = getattr(model, "model", None)
+    language_model = getattr(qwen_model, "language_model", None)
+    if language_model is None:
+        raise RuntimeError("Expected model.model.language_model for Qwen3-VL.")
+
+    language_model.config.max_position_embeddings = max_seq
+    for layer in language_model.layers:
+        if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "config"):
+            layer.self_attn.config.max_position_embeddings = max_seq
+
+
+def _build_qwen_text_rope_templates(
+    text_model: nn.Module,
+    max_seq: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.float32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Build text-only Qwen3-VL RoPE tables for static runtime positions.
+
+    The returned tensors use shape `(1, max_seq, head_dim)` and can be gathered
+    by compact text position IDs for padded prefill inputs.
+    """
+    hidden_size = int(text_model.config.hidden_size)
+    dummy = torch.empty(1, max_seq, hidden_size, device=device, dtype=dtype)
+    position_ids = (
+        torch.arange(max_seq, device=device, dtype=torch.long)
+        .view(1, 1, -1)
+        .expand(3, 1, -1)
+    )
+    cos, sin = text_model.rotary_emb(dummy, position_ids)
+
+    if cos.dim() == 2:
+        cos = cos.unsqueeze(0)
+    if sin.dim() == 2:
+        sin = sin.unsqueeze(0)
+
+    if cos.size(0) != 1:
+        cos = cos[:1]
+    if sin.size(0) != 1:
+        sin = sin[:1]
+
+    return cos.to(dtype=dtype), sin.to(dtype=dtype)
+
+
+def _normalize_valid_token_mask(
+    input_ids: torch.LongTensor,
+    attention_mask: Optional[torch.Tensor],
+    *,
+    pad_token_id: Optional[int],
+    device: torch.device,
+) -> torch.Tensor:
+    """
+    Build a boolean mask where True marks real prompt tokens.
+
+    Callers should pass `attention_mask` explicitly when the pad token can also
+    appear as a real token.
+    """
+    if attention_mask is None:
+        if pad_token_id is None:
+            valid = torch.ones(input_ids.shape, device=device, dtype=torch.bool)
+        else:
+            valid = input_ids.to(device).ne(int(pad_token_id))
+    else:
+        if tuple(attention_mask.shape) != tuple(input_ids.shape):
+            raise ValueError(
+                "attention_mask must have the same shape as input_ids. "
+                f"Got attention_mask={tuple(attention_mask.shape)}, "
+                f"input_ids={tuple(input_ids.shape)}."
+            )
+        valid = attention_mask.to(device=device).bool()
+
+    if torch.any(valid.sum(dim=1) == 0):
+        raise ValueError("Each batch row must contain at least one real token.")
+
+    return valid
+
+
+def _validate_padding_layout(valid_token_mask: torch.Tensor, padding_side: str) -> None:
+    """Validate that each batch row uses contiguous left or right padding."""
+    batch_size, seq_len = valid_token_mask.shape
+    valid_lengths = valid_token_mask.sum(dim=1)
+    positions = torch.arange(seq_len, device=valid_token_mask.device).unsqueeze(0)
+
+    if padding_side == "right":
+        expected = positions < valid_lengths.unsqueeze(1)
+    elif padding_side == "left":
+        expected = positions >= (seq_len - valid_lengths).unsqueeze(1)
+    else:
+        raise ValueError(
+            f"padding_side must be 'left' or 'right'. got {padding_side!r}"
+        )
+
+    if not torch.equal(valid_token_mask, expected):
+        raise ValueError(
+            "Input padding layout does not match padding_side. "
+            f"Expected contiguous {padding_side} padding for shape "
+            f"(B={batch_size}, S={seq_len})."
+        )
+
+
+def _build_position_ids_from_valid_token_mask(
+    valid_token_mask: torch.Tensor,
+) -> torch.LongTensor:
+    """
+    Build compact absolute position IDs for padded text-only prefill inputs.
+
+    Real tokens receive positions `0..valid_length-1`. Padding slots receive
+    position 0 because their logits and K/V values are ignored by the runtime.
+    """
+    position_ids = valid_token_mask.to(torch.long).cumsum(dim=1) - 1
+    position_ids = torch.clamp(position_ids, min=0)
+    return position_ids.masked_fill(~valid_token_mask, 0)
+
+
+def _last_valid_token_indices(valid_token_mask: torch.Tensor) -> torch.LongTensor:
+    """Return the input index of the last real token for each batch row."""
+    batch_size, seq_len = valid_token_mask.shape
+    positions = torch.arange(seq_len, device=valid_token_mask.device)
+    positions = positions.unsqueeze(0).expand(batch_size, -1)
+    return positions.masked_fill(~valid_token_mask, 0).max(dim=1).values
+
+
+def _gather_last_token_logits(
+    logits: torch.Tensor,
+    valid_token_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Gather logits at the last real token index of each padded prefill row."""
+    last_indices = _last_valid_token_indices(valid_token_mask).to(logits.device)
+    batch_indices = torch.arange(logits.size(0), device=logits.device)
+    return logits[batch_indices, last_indices, :]
+
+
+def _gather_rope_by_position_ids(
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
+    position_ids: torch.LongTensor,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Gather static RoPE tensors by per-token absolute position IDs.
+
+    Args:
+        rope_cos: RoPE cosine table with shape `(1, max_seq, head_dim)`.
+        rope_sin: RoPE sine table with shape `(1, max_seq, head_dim)`.
+        position_ids: Absolute position IDs with shape `(B, S)`.
+        device: Destination device.
+        dtype: Destination dtype.
+
+    Returns:
+        A tuple `(cos, sin)` with shape `(B, S, head_dim)`.
+    """
+    position_ids = position_ids.to(device=device, dtype=torch.long)
+    batch_size, seq_len = position_ids.shape
+    flat_positions = position_ids.reshape(-1)
+
+    cos_table = rope_cos[0].to(device=device, dtype=dtype)
+    sin_table = rope_sin[0].to(device=device, dtype=dtype)
+
+    cos = cos_table.index_select(0, flat_positions).reshape(batch_size, seq_len, -1)
+    sin = sin_table.index_select(0, flat_positions).reshape(batch_size, seq_len, -1)
+    return cos, sin
+
+
+def _slice_rope(
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
+    position: int,
+    batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Slice one absolute-position RoPE entry for static decode."""
+    if position < 0 or position >= rope_cos.size(1):
+        raise ValueError(
+            f"position must be within [0, {rope_cos.size(1)}), got {position}."
+        )
+
+    cos = rope_cos[:, position : position + 1, :].to(device=device, dtype=dtype)
+    sin = rope_sin[:, position : position + 1, :].to(device=device, dtype=dtype)
+    if batch_size != 1:
+        cos = cos.expand(batch_size, -1, -1).contiguous()
+        sin = sin.expand(batch_size, -1, -1).contiguous()
+    return cos, sin
+
+
+def _build_prefill_attention_mask(
+    valid_token_mask: torch.Tensor,
+    device: torch.device,
+    dtype: torch.dtype,
+    mask_value: float = -120.0,
+) -> torch.Tensor:
+    """
+    Build a static additive causal + padding mask for prefill.
+
+    Returns a tensor with shape `(B, 1, S, S)`.
+    """
+    batch_size, seq_len = valid_token_mask.shape
+    causal = torch.ones(seq_len, seq_len, device=device, dtype=torch.bool)
+    causal = torch.tril(causal).unsqueeze(0).expand(batch_size, -1, -1)
+    key_valid = valid_token_mask.to(device).unsqueeze(1).expand(-1, seq_len, -1)
+    query_valid = valid_token_mask.to(device).unsqueeze(2).expand(-1, -1, seq_len)
+    valid = causal & key_valid & query_valid
+    mask = torch.zeros(batch_size, 1, seq_len, seq_len, device=device, dtype=dtype)
+    return mask.masked_fill(~valid.unsqueeze(1), mask_value)
+
+
+def _build_decode_attention_mask(
+    batch_size: int,
+    past_len: int,
+    max_seq: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    mask_value: float = -120.0,
+) -> torch.Tensor:
+    """
+    Build a static additive decode mask for a `(max_seq - 1) + 1` KV layout.
+
+    The CPU cache stores valid past tokens at the beginning of the fixed cache.
+    The decode adapter appends the current token after the fixed past tensor, so
+    the current key is located at index `max_seq - 1` inside the attention matmul.
+    """
+    if past_len < 0 or past_len >= max_seq:
+        raise ValueError(f"past_len must be within [0, {max_seq}), got {past_len}.")
+
+    mask = torch.full(
+        (batch_size, 1, 1, max_seq),
+        mask_value,
+        device=device,
+        dtype=dtype,
+    )
+    if past_len > 0:
+        mask[:, :, :, :past_len] = 0.0
+    mask[:, :, :, max_seq - 1] = 0.0
+    return mask
+
+
+class StaticQwen3VLTextLayerRuntime:
+    """
+    Static-shape text-only runtime over separately wrapped Qwen3-VL decoder layers.
+
+    CPU responsibilities:
+      - token embedding,
+      - RoPE lookup,
+      - attention-mask construction,
+      - KV-cache allocation and updates,
+      - final norm and LM head.
+
+    NPU-simulated responsibilities:
+      - dense decoder-layer prefill and decode adapters.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        tokenizer,
+        max_seq: int,
+        device: str = "cpu",
+        padding_side: str = "right",
+        layers: Optional[Sequence[nn.Module]] = None,
+    ):
+        self.model = model.eval().to(device)
+        self.tokenizer = tokenizer
+        self.max_seq = max_seq
+        self.device = torch.device(device)
+        self.padding_side = padding_side
+
+        self.qwen_model = self.model.model
+        self.text_model = self.qwen_model.language_model
+        self.embed_tokens = self.text_model.embed_tokens
+        self.final_norm = self.text_model.norm
+        self.lm_head = self.model.lm_head
+        self.rotate_lm_head = getattr(self.model, "rotate_lm_head", None)
+        self.layers_ref = self.text_model.layers
+
+        if layers is None:
+            self.layers = nn.ModuleList(
+                [_clone_quant_layer(layer) for layer in self.layers_ref]
+            ).to(self.device)
+        else:
+            self.layers = nn.ModuleList(layers).to(self.device)
+
+        for layer in self.layers:
+            assert hasattr(layer, "wrapped")
+            assert isinstance(layer.wrapped, QuantQwen3VLTextDecoderLayer)
+
+        self.prefill_layers = nn.ModuleList(
+            [
+                layer.wrapped.as_export_module("prefill", return_kv=True)
+                for layer in self.layers
+            ]
+        ).to(self.device)
+        self.decode_layers = nn.ModuleList(
+            [
+                layer.wrapped.as_export_module("decode", return_kv=True)
+                for layer in self.layers
+            ]
+        ).to(self.device)
+
+        self.config = self.text_model.config
+        self.hidden_size = self.config.hidden_size
+        self.num_hidden_layers = self.config.num_hidden_layers
+        self.num_kv_heads = self.config.num_key_value_heads
+        self.head_dim = getattr(self.config, "head_dim", None) or (
+            self.hidden_size // self.config.num_attention_heads
+        )
+
+        self.rope_cos, self.rope_sin = _build_qwen_text_rope_templates(
+            self.text_model,
+            max_seq=self.max_seq,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        self.layer_caches: list[LayerCache] = []
+        self.past_len = 0
+
+    def reset_cache(self) -> None:
+        """Clear CPU-managed KV caches."""
+        self.layer_caches = []
+        self.past_len = 0
+
+    def _allocate_empty_cache(
+        self,
+        batch_size: int,
+        dtype: torch.dtype,
+    ) -> list[LayerCache]:
+        """Allocate static `(max_seq - 1)` past-cache tensors for every layer."""
+        caches = []
+        for _ in range(self.num_hidden_layers):
+            past_k = torch.zeros(
+                batch_size,
+                self.num_kv_heads,
+                self.max_seq - 1,
+                self.head_dim,
+                device=self.device,
+                dtype=dtype,
+            )
+            caches.append(LayerCache(past_k=past_k, past_v=torch.zeros_like(past_k)))
+        return caches
+
+    @torch.no_grad()
+    def prefill(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Run static prefill and return last-real-token logits."""
+        assert (
+            input_ids.dim() == 2
+        ), f"Expected input_ids as (B, S), got {tuple(input_ids.shape)}"
+        batch_size, seq_len = input_ids.shape
+        assert seq_len == self.max_seq, (
+            f"Static prefill expects padded length == max_seq. "
+            f"Got seq_len={seq_len}, max_seq={self.max_seq}."
+        )
+
+        valid = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        _validate_padding_layout(valid, self.padding_side)
+
+        position_ids = _build_position_ids_from_valid_token_mask(valid)
+        hidden_states = self.embed_tokens(input_ids.to(self.device))
+        runtime_dtype = hidden_states.dtype
+
+        self.layer_caches = self._allocate_empty_cache(batch_size, runtime_dtype)
+
+        attn_mask = _build_prefill_attention_mask(valid, self.device, runtime_dtype)
+        pos_embeds = _gather_rope_by_position_ids(
+            self.rope_cos,
+            self.rope_sin,
+            position_ids,
+            self.device,
+            runtime_dtype,
+        )
+
+        for layer_idx, layer in enumerate(self.prefill_layers):
+            out = layer(
+                hidden_states=hidden_states,
+                attention_mask=attn_mask,
+                position_embeddings=pos_embeds,
+            )
+            if not isinstance(out, tuple) or len(out) != 3:
+                raise RuntimeError(
+                    "Expected prefill adapter output as (hidden_states, new_k, new_v)."
+                )
+            hidden_states, new_k, new_v = out
+
+            valid_lengths = valid.sum(dim=1)
+            for b in range(batch_size):
+                length = int(valid_lengths[b].item())
+                src_start = 0 if self.padding_side == "right" else self.max_seq - length
+                src_end = src_start + length
+                self.layer_caches[layer_idx].past_k[b, :, :length, :] = new_k[
+                    b, :, src_start:src_end, :
+                ]
+                self.layer_caches[layer_idx].past_v[b, :, :length, :] = new_v[
+                    b, :, src_start:src_end, :
+                ]
+
+        if torch.unique(valid.sum(dim=1)).numel() != 1:
+            raise ValueError(
+                "Static decode currently requires equal valid prompt length for all batch rows."
+            )
+        self.past_len = int(valid.sum(dim=1)[0].item())
+
+        hidden_states = self.final_norm(hidden_states)
+        if self.rotate_lm_head is not None:
+            hidden_states = self.rotate_lm_head(hidden_states)
+        logits = self.lm_head(hidden_states)
+        return _gather_last_token_logits(logits, valid)
+
+    @torch.no_grad()
+    def decode_one(self, input_ids: torch.LongTensor) -> torch.Tensor:
+        """Run one static decode step and return logits for the current token."""
+        assert input_ids.dim() == 2 and input_ids.size(1) == 1
+        assert len(self.layer_caches) == self.num_hidden_layers, "Call prefill() first."
+        assert self.past_len < self.max_seq
+
+        batch_size = input_ids.size(0)
+        hidden_states = self.embed_tokens(input_ids.to(self.device))
+
+        attention_mask = _build_decode_attention_mask(
+            batch_size,
+            self.past_len,
+            self.max_seq,
+            self.device,
+            hidden_states.dtype,
+        )
+        position_embeddings = _slice_rope(
+            self.rope_cos,
+            self.rope_sin,
+            position=self.past_len,
+            batch_size=batch_size,
+            device=self.device,
+            dtype=hidden_states.dtype,
+        )
+
+        for layer_idx, layer in enumerate(self.decode_layers):
+            cache = self.layer_caches[layer_idx]
+            out = layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_embeddings=position_embeddings,
+                past_key_values=(cache.past_k, cache.past_v),
+            )
+            if not isinstance(out, tuple) or len(out) != 3:
+                raise RuntimeError(
+                    "Expected decode adapter output as (hidden_states, new_k, new_v)."
+                )
+            hidden_states, new_k, new_v = out
+            cache.past_k[:, :, self.past_len : self.past_len + 1, :] = new_k
+            cache.past_v[:, :, self.past_len : self.past_len + 1, :] = new_v
+
+        self.past_len += 1
+        hidden_states = self.final_norm(hidden_states)
+        if self.rotate_lm_head is not None:
+            hidden_states = self.rotate_lm_head(hidden_states)
+        logits = self.lm_head(hidden_states)
+        return logits[:, -1, :]
+
+    @torch.no_grad()
+    def generate_greedy(
+        self,
+        prompt: str,
+        max_new_tokens: int,
+        eos_token_id: Optional[int] = None,
+    ) -> torch.LongTensor:
+        """Generate tokens greedily with the static prefill/decode runtime."""
+        batch = self.tokenizer(
+            prompt,
+            return_tensors="pt",
+            add_special_tokens=True,
+            padding="max_length",
+            truncation=True,
+            max_length=self.max_seq,
+        )
+        input_ids = batch["input_ids"].to(self.device)
+        attention_mask = batch.get("attention_mask")
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(self.device)
+
+        if eos_token_id is None:
+            eos_token_id = self.tokenizer.eos_token_id
+
+        self.reset_cache()
+        logits = self.prefill(input_ids, attention_mask)
+        valid = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        prompt_len = int(valid.sum(dim=1)[0].item())
+        generated = input_ids[valid].reshape(1, prompt_len).clone()
+
+        for _ in range(max_new_tokens):
+            next_token = torch.argmax(logits, dim=-1, keepdim=True)
+            generated = torch.cat([generated, next_token], dim=1)
+            if eos_token_id is not None and torch.all(next_token == eos_token_id):
+                break
+            logits = self.decode_one(next_token)
+        return generated
+
+    @torch.no_grad()
+    def verify_against_reference(
+        self,
+        prompt: str,
+        steps: int = 8,
+        verbose: bool = True,
+    ) -> None:
+        """Compare static runtime logits with the HF reference model."""
+        batch = self.tokenizer(
+            prompt,
+            return_tensors="pt",
+            add_special_tokens=True,
+            padding="max_length",
+            truncation=True,
+            max_length=self.max_seq,
+        )
+        input_ids = batch["input_ids"].to(self.device)
+        attention_mask = batch.get("attention_mask")
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(self.device)
+
+        self.reset_cache()
+        logits_rt = self.prefill(input_ids, attention_mask)
+        valid = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        compact_input_ids = input_ids[valid].reshape(input_ids.size(0), -1)
+        ref_out = self.model(input_ids=compact_input_ids)
+        logits_ref = ref_out.logits[:, -1, :]
+
+        self._print_diff(
+            "Step 0: prefill last-token logits",
+            logits_rt,
+            logits_ref,
+            verbose,
+        )
+
+        generated = compact_input_ids.clone()
+        next_token = torch.argmax(logits_rt, dim=-1, keepdim=True)
+        generated = torch.cat([generated, next_token], dim=1)
+
+        for step in range(1, steps + 1):
+            logits_rt = self.decode_one(next_token)
+            ref_out = self.model(input_ids=generated)
+            logits_ref = ref_out.logits[:, -1, :]
+            self._print_diff(
+                f"Step {step}: decode logits",
+                logits_rt,
+                logits_ref,
+                verbose,
+            )
+
+            next_token = torch.argmax(logits_rt, dim=-1, keepdim=True)
+            generated = torch.cat([generated, next_token], dim=1)
+            if generated.size(1) >= self.max_seq:
+                if verbose:
+                    print("Stopped because the static decode window is full.")
+                break
+
+    @staticmethod
+    def _print_diff(
+        title: str,
+        actual: torch.Tensor,
+        expected: torch.Tensor,
+        verbose: bool,
+    ) -> None:
+        """Print absolute-difference and PEIR metrics for two logits tensors."""
+        if not verbose:
+            return
+        diff = (actual - expected).abs()
+        print("=" * 100)
+        print(title)
+        print(f"mean|diff| = {diff.mean().item():.8f}")
+        print(f" max|diff| = {diff.max().item():.8f}")
+        print(f"PEIR       = {compute_peir(actual, expected) * 100:.6f} %")
+
+
+def run_static_qwen3_vl_runtime(cfg: StaticQwen3VLRuntimeConfig) -> None:
+    """Load a Qwen3-VL model and run the text-only static runtime smoke test."""
+    torch.set_grad_enabled(False)
+
+    model = AutoModelForImageTextToText.from_pretrained(
+        cfg.model,
+        dtype=torch.float32,
+        trust_remote_code=cfg.trust_remote_code,
+    ).to(cfg.device)
+    _set_text_max_position_embeddings(model, cfg.max_seq)
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        cfg.model,
+        trust_remote_code=cfg.trust_remote_code,
+    )
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = cfg.padding_side
+
+    runtime = StaticQwen3VLTextLayerRuntime(
+        model=model,
+        tokenizer=tokenizer,
+        max_seq=cfg.max_seq,
+        device=cfg.device,
+        padding_side=cfg.padding_side,
+    )
+
+    runtime.verify_against_reference(
+        prompt=cfg.prompt,
+        steps=cfg.verify_steps,
+        verbose=True,
+    )
+
+    out_ids = runtime.generate_greedy(
+        prompt=cfg.prompt,
+        max_new_tokens=cfg.gen_steps,
+        eos_token_id=tokenizer.eos_token_id,
+    )
+
+    print("=" * 100)
+    print("Generated text:")
+    print(tokenizer.decode(out_ids[0], skip_special_tokens=True))
+
+
+def _parse_args() -> StaticQwen3VLRuntimeConfig:
+    """Parse command-line arguments for the static runtime smoke test."""
+    parser = argparse.ArgumentParser(
+        description="Run the text-only static Qwen3-VL layer runtime."
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=StaticQwen3VLRuntimeConfig.model,
+        help="HF model name or local model path.",
+    )
+    parser.add_argument(
+        "--max-seq",
+        type=int,
+        default=StaticQwen3VLRuntimeConfig.max_seq,
+        help="Static sequence length used by prefill and decode.",
+    )
+    parser.add_argument(
+        "--padding-side",
+        type=str,
+        choices=("left", "right"),
+        default=StaticQwen3VLRuntimeConfig.padding_side,
+        help="Padding direction for static prefill inputs.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=StaticQwen3VLRuntimeConfig.device,
+        help="Execution device, such as cpu or cuda.",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=StaticQwen3VLRuntimeConfig.prompt,
+        help="Prompt used for verification and greedy generation.",
+    )
+    parser.add_argument(
+        "--verify-steps",
+        type=int,
+        default=StaticQwen3VLRuntimeConfig.verify_steps,
+        help="Number of decode steps for reference verification.",
+    )
+    parser.add_argument(
+        "--gen-steps",
+        type=int,
+        default=StaticQwen3VLRuntimeConfig.gen_steps,
+        help="Maximum number of generated tokens.",
+    )
+    parser.add_argument(
+        "--no-trust-remote-code",
+        action="store_true",
+        help="Disable trust_remote_code when loading the model and tokenizer.",
+    )
+    args = parser.parse_args()
+
+    return StaticQwen3VLRuntimeConfig(
+        model=args.model,
+        max_seq=args.max_seq,
+        padding_side=args.padding_side,
+        device=args.device,
+        prompt=args.prompt,
+        verify_steps=args.verify_steps,
+        gen_steps=args.gen_steps,
+        trust_remote_code=not args.no_trust_remote_code,
+    )
+
+
+if __name__ == "__main__":
+    run_static_qwen3_vl_runtime(_parse_args())

--- a/tico/quantization/wrapq/wrappers/qwen_vl/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/export_adapters.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+
+class Qwen3VLTextDecoderLayerPrefillExportAdapter(nn.Module):
+    """
+    Export adapter for the Qwen3-VL text decoder-layer prefill path.
+
+    Input contract:
+        hidden_states:
+            Tensor with shape `(B, S, hidden_size)`.
+        attention_mask:
+            Additive mask with shape broadcastable to `(B, 1, S, S)`.
+        position_embeddings:
+            Tuple `(cos, sin)` where each tensor has shape `(B, S, head_dim)`.
+
+    Return contract when `return_kv=True`:
+        `(hidden_states, new_key, new_value)`, where:
+            hidden_states has shape `(B, S, hidden_size)`;
+            new_key and new_value have shape `(B, num_kv_heads, S, head_dim)`.
+
+    Return contract when `return_kv=False`:
+        `hidden_states`.
+    """
+
+    def __init__(self, wrapped: nn.Module, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
+        self.wrapped.return_type = "tuple"
+        self.return_kv = return_kv
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        **kwargs,
+    ):
+        """Run prefill and optionally return the newly produced KV tensors."""
+        outputs = self.wrapped(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
+        )
+
+        hidden = outputs[0]
+
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[1]
+        return hidden, new_k, new_v
+
+
+class Qwen3VLTextDecoderLayerDecodeExportAdapter(nn.Module):
+    """
+    Export adapter for the Qwen3-VL text decoder-layer decode path.
+
+    Input contract:
+        hidden_states:
+            Tensor with shape `(B, 1, hidden_size)`.
+        attention_mask:
+            Additive mask with shape broadcastable to `(B, 1, 1, K)`.
+        position_embeddings:
+            Tuple `(cos, sin)` where each tensor has shape `(B, 1, head_dim)`.
+        past_key_values:
+            Tuple `(past_key, past_value)` where each tensor has shape
+            `(B, num_kv_heads, K - 1, head_dim)`.
+
+    Return contract when `return_kv=True`:
+        `(hidden_states, new_key, new_value)`, where new_key and new_value are
+        the KV delta for the current token with shape
+        `(B, num_kv_heads, 1, head_dim)`.
+
+    Return contract when `return_kv=False`:
+        `hidden_states`.
+    """
+
+    def __init__(self, wrapped: nn.Module, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
+        self.wrapped.return_type = "tuple"
+        self.return_kv = return_kv
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        past_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        **kwargs,
+    ):
+        """Run decode and optionally return the current-token KV delta."""
+        outputs = self.wrapped(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            past_key_values=past_key_values,
+            use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
+        )
+
+        hidden = outputs[0]
+
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[1]
+        return hidden, new_k, new_v

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attention.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attention.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -23,6 +23,10 @@ from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+LayerKV = Tuple[torch.Tensor, torch.Tensor]
+CacheOutputMode = Literal["present", "delta"]
 
 
 @try_register(
@@ -86,11 +90,11 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
             fp_name=join_name(fp_name, "k_norm"),
         )
 
-        # Constant scale (1/√d)
+        # Constant scale (1/sqrt(d)).
         scale_t = torch.tensor(
             float(getattr(fp_attn, "scaling", self.head_dim**-0.5))
         )
-        # Merge scale_t to k_norm, (otherwise merge it to q_norm)
+        # Merge scale_t to k_norm, otherwise it would need to be applied to logits.
         with torch.no_grad():
             self.k_norm.wrapped.module.weight.mul_(scale_t)
 
@@ -121,7 +125,7 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         self.obs_k_sin = mk("k_sin")
         self.obs_k_rot = mk("k_rot")
 
-        # Masking & attention math
+        # Masking and attention math
         self.obs_causal_mask = mk("causal_mask")
         self.obs_logits = mk("logits")
         self.obs_mask_add = mk("mask_add")
@@ -129,6 +133,14 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         self.obs_attn_out = mk("attn_out")
         self.obs_attn_weights = mk("attn_weights")
         self.obs_attn_out_h = mk("attn_out_h")
+
+        # Cache tensors
+        self.obs_past_key = mk("past_key")
+        self.obs_past_value = mk("past_value")
+        self.obs_new_k = mk("new_k")
+        self.obs_new_v = mk("new_v")
+        self.obs_present_key = mk("present_key")
+        self.obs_present_value = mk("present_value")
 
         # Static causal mask template
         assert hasattr(cfg, "max_position_embeddings")
@@ -140,7 +152,7 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         self.register_buffer("causal_mask_template", mask, persistent=False)
 
     def _rot(self, t, o_x1, o_x2, o_neg, o_cat):
-        """rotate_half(t): [-x2, x1] along the last dimension."""
+        """Return rotate_half(t) as [-x2, x1] along the last dimension."""
         x1, x2 = torch.chunk(t, 2, dim=-1)
         x1 = self._fq(x1, o_x1)
         x2 = self._fq(x2, o_x2)
@@ -148,6 +160,7 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         return self._fq(torch.cat((x2n, x1), dim=-1), o_cat)
 
     def _apply_rope(self, q, k, cos, sin, unsqueeze_dim: int = 1):
+        """Apply rotary position embeddings to query and key states."""
         cos_u = cos.unsqueeze(unsqueeze_dim)
         sin_u = sin.unsqueeze(unsqueeze_dim)
 
@@ -175,7 +188,7 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         k_len: int,
     ) -> torch.Tensor:
         """
-        Normalize attention mask shape so it is broadcastable to per-head logits.
+        Normalize an attention mask to a shape broadcastable to per-head logits.
 
         Supported input shapes:
           - (B, K)
@@ -187,10 +200,8 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
           - (B, 1, Q, K)
           - (B, 1, Q, K)
 
-        Note:
-          This decomposed attention loop adds the same mask to each KV-head group.
-          Therefore, per-head masks with shape (B, H, Q, K), H != 1, are rejected
-          to avoid silently applying the wrong head-specific mask.
+        Per-head masks with H != 1 are rejected because this decomposed
+        attention path applies the same mask to every KV-head group.
         """
         if mask.dim() not in (2, 3, 4):
             raise RuntimeError(
@@ -248,14 +259,10 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         Build an additive attention mask for logits shaped `(B, heads, Q, K)`.
 
         Cases:
-          - None:
-              Use only the causal mask.
-          - bool/int:
-              Interpret True/non-zero as "keep", False/zero as "mask".
-              Convert to additive mask and combine with causal mask.
-          - floating point:
-              Assume caller already provided an additive mask. Shape is normalized
-              for broadcasting, but values are preserved.
+          - None: use only the causal mask.
+          - bool/int: interpret non-zero values as keep values and combine the
+            resulting padding mask with the causal mask.
+          - floating point: assume the caller already provided an additive mask.
         """
         fill_val = float(self.qcfg.attention_mask_fill_value)
 
@@ -330,15 +337,230 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
             f"dtype={attention_mask.dtype}, shape={tuple(attention_mask.shape)}"
         )
 
+    @staticmethod
+    def _is_static_kv_tuple(past_key_values) -> bool:
+        """Return True when the input is a per-layer `(key, value)` cache tuple."""
+        if not isinstance(past_key_values, (tuple, list)):
+            return False
+        if len(past_key_values) < 2:
+            return False
+        first, second = past_key_values[0], past_key_values[1]
+        tensor_or_none = (torch.Tensor, type(None))
+        return isinstance(first, tensor_or_none) and isinstance(second, tensor_or_none)
+
+    def _normalize_static_past_key_values(
+        self,
+        past_key_values,
+    ) -> Optional[LayerKV]:
+        """Quantize and return a per-layer static KV tuple when one is provided."""
+        if not self._is_static_kv_tuple(past_key_values):
+            return None
+
+        past_k, past_v = past_key_values[0], past_key_values[1]
+        if past_k is None or past_v is None:
+            return None
+
+        past_k = self._fq(past_k, self.obs_past_key)
+        past_v = self._fq(past_v, self.obs_past_value)
+        return past_k, past_v
+
+    def _extract_layer_kv_from_cache(self, cache) -> Optional[LayerKV]:
+        """
+        Extract the current layer KV tensors from common HF cache layouts.
+
+        This is a fallback path for cache implementations whose `update()`
+        method returns the cache object itself instead of the updated tensors.
+        """
+        if hasattr(cache, "k") and hasattr(cache, "v"):
+            k = getattr(cache, "k")
+            v = getattr(cache, "v")
+            if isinstance(k, torch.Tensor) and isinstance(v, torch.Tensor):
+                return k, v
+
+        layer_idx = self.layer_idx
+        if layer_idx is None:
+            return None
+
+        key_cache = getattr(cache, "key_cache", None)
+        value_cache = getattr(cache, "value_cache", None)
+        if key_cache is not None and value_cache is not None:
+            if layer_idx < len(key_cache) and layer_idx < len(value_cache):
+                k = key_cache[layer_idx]
+                v = value_cache[layer_idx]
+                if isinstance(k, torch.Tensor) and isinstance(v, torch.Tensor):
+                    return k, v
+
+        layers = getattr(cache, "layers", None)
+        if layers is not None and layer_idx < len(layers):
+            layer_cache = layers[layer_idx]
+            if isinstance(layer_cache, (tuple, list)) and len(layer_cache) >= 2:
+                k, v = layer_cache[0], layer_cache[1]
+                if isinstance(k, torch.Tensor) and isinstance(v, torch.Tensor):
+                    return k, v
+            for k_name, v_name in (
+                ("keys", "values"),
+                ("key", "value"),
+                ("k", "v"),
+            ):
+                k = getattr(layer_cache, k_name, None)
+                v = getattr(layer_cache, v_name, None)
+                if isinstance(k, torch.Tensor) and isinstance(v, torch.Tensor):
+                    return k, v
+
+        return None
+
+    def _update_cache_like(
+        self,
+        cache,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        *,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cache_position: Optional[torch.LongTensor],
+    ) -> LayerKV:
+        """
+        Update an HF Cache-like object and return the full present KV tensors.
+
+        The exported runtime uses tuple caches, but HF-compatible eager tests and
+        full-model execution may still pass a Cache-like object with `update()`.
+        """
+        update = getattr(cache, "update", None)
+        if not callable(update):
+            raise RuntimeError(
+                "past_key_values must be a static KV tuple or expose update(). "
+                f"Got type={type(cache)!r}."
+            )
+
+        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+
+        try:
+            updated = update(new_k, new_v, self.layer_idx, cache_kwargs)
+        except TypeError:
+            try:
+                updated = update(
+                    new_k,
+                    new_v,
+                    self.layer_idx,
+                    cache_kwargs=cache_kwargs,
+                )
+            except TypeError:
+                updated = update(new_k, new_v)
+
+        if isinstance(updated, (tuple, list)) and len(updated) >= 2:
+            present_k, present_v = updated[0], updated[1]
+            if isinstance(present_k, torch.Tensor) and isinstance(
+                present_v, torch.Tensor
+            ):
+                return present_k, present_v
+
+        extracted = self._extract_layer_kv_from_cache(cache)
+        if extracted is not None:
+            return extracted
+
+        raise RuntimeError(
+            "Cache update did not return key/value tensors and the updated cache "
+            f"layout could not be inspected. type={type(cache)!r}"
+        )
+
+    def _build_present_key_values(
+        self,
+        *,
+        past_key_values,
+        normalized_static_past: Optional[LayerKV],
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cache_position: Optional[torch.LongTensor],
+    ) -> LayerKV:
+        """Build the full present KV tensors used by the attention matmul."""
+        if normalized_static_past is not None:
+            past_k, past_v = normalized_static_past
+            present_k = self._fq(
+                torch.cat([past_k, new_k], dim=2),
+                self.obs_present_key,
+            )
+            present_v = self._fq(
+                torch.cat([past_v, new_v], dim=2),
+                self.obs_present_value,
+            )
+            return present_k, present_v
+
+        if past_key_values is not None and not self._is_static_kv_tuple(
+            past_key_values
+        ):
+            present_k, present_v = self._update_cache_like(
+                past_key_values,
+                new_k,
+                new_v,
+                cos=cos,
+                sin=sin,
+                cache_position=cache_position,
+            )
+            present_k = self._fq(present_k, self.obs_present_key)
+            present_v = self._fq(present_v, self.obs_present_value)
+            return present_k, present_v
+
+        present_k = self._fq(new_k, self.obs_present_key)
+        present_v = self._fq(new_v, self.obs_present_value)
+        return present_k, present_v
+
+    def _finalize_cache_output(
+        self,
+        *,
+        past_key_values,
+        new_k: torch.Tensor,
+        new_v: torch.Tensor,
+        present_k: torch.Tensor,
+        present_v: torch.Tensor,
+        cache_output_mode: CacheOutputMode,
+    ):
+        """Return cache tensors according to the requested cache output policy."""
+        if cache_output_mode not in ("present", "delta"):
+            raise ValueError(f"Unsupported cache_output_mode: {cache_output_mode!r}")
+
+        if cache_output_mode == "delta":
+            return new_k, new_v
+
+        if past_key_values is None or self._is_static_kv_tuple(past_key_values):
+            return present_k, present_v
+
+        # Cache-like objects are updated in-place, so returning the original
+        # object keeps HF-style semantics.
+        return past_key_values
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
         attention_mask: Optional[torch.Tensor] = None,
-        past_key_values=None,  # HF Cache-like object or None
+        past_key_values=None,
+        use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        cache_output_mode: CacheOutputMode = "present",
         **kwargs,
     ):
+        """
+        Run quantized Qwen3-VL text attention.
+
+        Args:
+            hidden_states: Input states with shape `(B, S, hidden_size)`.
+            position_embeddings: RoPE cosine and sine tensors with shape
+                `(B, S, head_dim)`.
+            attention_mask: Optional additive or boolean mask.
+            past_key_values: Optional per-layer static KV tuple or HF Cache-like object.
+            use_cache: Whether to return cache tensors.
+            cache_position: Optional absolute cache positions for HF caches.
+            cache_output_mode: Return full present KV tensors or only the new KV
+                delta tensors when `use_cache=True`.
+
+        Returns:
+            A tuple `(attn_output, attn_weights)` and, when `use_cache=True`, a
+            third cache output item.
+        """
+        del kwargs
+
         hidden = self._fq(hidden_states, self.obs_hidden)
         B, S, _ = hidden.shape
         H = self.head_dim
@@ -358,31 +580,40 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         sin = self._fq(sin, self.obs_sin)
         q_rot, k_rot = self._apply_rope(q, k, cos, sin, unsqueeze_dim=1)
 
-        # TODO Reivist cache logic
-        # Cache update (HF Cache path)
-        if past_key_values is not None:
-            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-            k_rot, v = past_key_values.update(k_rot, v, self.layer_idx, cache_kwargs)
+        normalized_static_past = self._normalize_static_past_key_values(past_key_values)
+
+        new_k = self._fq(k_rot, self.obs_new_k)
+        new_v = self._fq(v, self.obs_new_v)
+
+        present_k, present_v = self._build_present_key_values(
+            past_key_values=past_key_values,
+            normalized_static_past=normalized_static_past,
+            new_k=new_k,
+            new_v=new_v,
+            cos=cos,
+            sin=sin,
+            cache_position=cache_position,
+        )
 
         # Build additive attention mask.
         attention_mask = self._build_attention_mask(
             attention_mask=attention_mask,
             q_len=q_rot.size(-2),
-            k_len=k_rot.size(-2),
+            k_len=present_k.size(-2),
             device=hidden.device,
         )
 
         attn_weights_parts = []
         attn_out_parts = []
 
-        n_kv = k_rot.size(1)  # num_key_value_heads
+        n_kv = present_k.size(1)  # num_key_value_heads
         kv_rep = self.kv_rep
 
-        # TODO Consider attaching a separate observer to each computation.
+        # Process one KV-head group at a time to keep the export graph NPU-friendly.
         for i in range(n_kv):
             # (B, 1, K, H)
-            k_i = k_rot[:, i : i + 1, :, :]
-            v_i = v[:, i : i + 1, :, :]
+            k_i = present_k[:, i : i + 1, :, :]
+            v_i = present_v[:, i : i + 1, :, :]
 
             # (B, G, S, H) where G=kv_rep
             h0 = i * kv_rep
@@ -407,7 +638,7 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
             attn_weights_parts.append(attn_i)
             attn_out_parts.append(out_i)
 
-        # concat heads back: (B, n_h, S, K) / (B, n_h, S, H)
+        # Concatenate heads back: (B, n_h, S, K) / (B, n_h, S, H)
         attn_weights = self._fq(
             torch.cat(attn_weights_parts, dim=1), self.obs_attn_weights
         )
@@ -419,7 +650,19 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         # Final projection
         out = self.o_proj(attn_out)
 
-        return out, attn_weights
+        outputs = (out, attn_weights)
+        if use_cache:
+            cache_out = self._finalize_cache_output(
+                past_key_values=past_key_values,
+                new_k=new_k,
+                new_v=new_v,
+                present_k=present_k,
+                present_v=present_v,
+                cache_output_mode=cache_output_mode,
+            )
+            outputs += (cache_out,)
+
+        return outputs
 
     def _all_observers(self) -> Iterable:
         yield from (
@@ -447,4 +690,10 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
             self.obs_attn_out,
             self.obs_attn_weights,
             self.obs_attn_out_h,
+            self.obs_past_key,
+            self.obs_past_value,
+            self.obs_new_k,
+            self.obs_new_v,
+            self.obs_present_key,
+            self.obs_present_value,
         )

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attention.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_attention.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import Iterable, Literal, Optional, Tuple
+from typing import Any, Iterable, Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -650,7 +650,7 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
         # Final projection
         out = self.o_proj(attn_out)
 
-        outputs = (out, attn_weights)
+        outputs: list[Any] = [out, attn_weights]
         if use_cache:
             cache_out = self._finalize_cache_output(
                 past_key_values=past_key_values,
@@ -660,9 +660,9 @@ class QuantQwen3VLTextAttention(QuantModuleBase):
                 present_v=present_v,
                 cache_output_mode=cache_output_mode,
             )
-            outputs += (cache_out,)
+            outputs.append(cache_out)
 
-        return outputs
+        return tuple(outputs)
 
     def _all_observers(self) -> Iterable:
         yield from (

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional
+from typing import Iterable, Literal, Optional
 
 import torch
 import torch.nn as nn
 
-from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.qwen_vl.export_adapters import (
+    Qwen3VLTextDecoderLayerDecodeExportAdapter,
+    Qwen3VLTextDecoderLayerPrefillExportAdapter,
+)
 from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+ReturnType = Literal["tensor", "tuple"]
 
 
 @try_register(
@@ -29,13 +36,11 @@ from tico.quantization.wrapq.wrappers.registry import try_register
 )
 class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
     """
-    Quantization wrapper for Qwen3VLTextDecoderLayer module.
+    Quantization wrapper for Qwen3VLTextDecoderLayer.
 
-    This is a Transformer decoder layer for text processing, containing:
-    - 2 RMSNorm layers (pre-norm architecture)
-    - 1 Self-Attention module
-    - 1 MLP (Feed-Forward Network)
-    - 2 Residual connections
+    The wrapper keeps the eager Qwen3-VL text-layer behavior compatible with the
+    existing full-model wrapper while also exposing static prefill/decode export
+    adapters for a CPU-managed KV-cache runtime.
     """
 
     def __init__(
@@ -44,6 +49,7 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         *,
         qcfg: Optional[PTQConfig] = None,
         fp_name: Optional[str] = None,
+        return_type: Optional[ReturnType] = None,
     ):
         super().__init__(qcfg, fp_name=fp_name)
 
@@ -51,6 +57,8 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         assert hasattr(fp_layer, "mlp")
         assert hasattr(fp_layer, "input_layernorm")
         assert hasattr(fp_layer, "post_attention_layernorm")
+
+        self.return_type: ReturnType = return_type or "tensor"
 
         # --- Wrap submodules via PTQWrapper ----------------------------------
         self_attn_cfg = qcfg.child("self_attn") if qcfg else None
@@ -84,11 +92,24 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
             fp_name=join_name(fp_name, "post_attention_layernorm"),
         )
 
-        # --- Observers for residual additions ----------------------------------
+        # --- Observers for residual additions --------------------------------
         mk = self._make_obs
         self.obs_act_in = mk("act_in")
         self.obs_post_attn = mk("post_attn")
         self.obs_act_out = mk("act_out")
+
+    @staticmethod
+    def _unpack_attn_outputs(attn_out):
+        """
+        Normalize attention outputs into hidden states, attention weights, and cache.
+        """
+        if not isinstance(attn_out, tuple):
+            return attn_out, None, None
+
+        hidden_states_attn = attn_out[0]
+        attn_weights = attn_out[1] if len(attn_out) > 1 else None
+        present_key_value = attn_out[2] if len(attn_out) > 2 else None
+        return hidden_states_attn, attn_weights, present_key_value
 
     def forward(
         self,
@@ -96,26 +117,32 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
-        past_key_values: torch.Tensor | None = None,
+        past_key_values=None,
         use_cache: bool | None = False,
+        output_attentions: bool | None = False,
         cache_position: torch.LongTensor | None = None,
+        cache_output_mode: Literal["present", "delta"] = "present",
         **kwargs,
-    ) -> torch.Tensor:
+    ):
         """
-        Forward pass with fake quantization.
+        Run the quantized Qwen3-VL text decoder layer.
 
         Args:
-            hidden_states: Input tensor of shape (batch_size, seq_len, hidden_size)
-            position_embeddings: (cos, sin) position embeddings tuple
-            attention_mask: Attention mask tensor (optional)
-            position_ids: Position indices tensor (optional)
-            past_key_values: Cached key-value pairs for attention (optional)
-            use_cache: Whether to use key-value caching (optional)
-            cache_position: Cache position indices (optional)
-            **kwargs: Additional keyword arguments
+            hidden_states: Input tensor with shape `(batch_size, seq_len, hidden_size)`.
+            position_embeddings: RoPE cosine and sine tensors.
+            attention_mask: Optional attention mask tensor.
+            position_ids: Optional position indices kept for HF compatibility.
+            past_key_values: Optional per-layer static KV tuple or HF Cache-like object.
+            use_cache: Whether to return cache tensors.
+            output_attentions: Whether to include attention weights when returning a tuple.
+            cache_position: Optional cache positions for HF Cache-like objects.
+            cache_output_mode: Return either full present KV tensors or only the KV delta.
+            **kwargs: Additional keyword arguments passed to attention.
 
         Returns:
-            Transformed hidden states of shape (batch_size, seq_len, hidden_size)
+            By default, the transformed hidden states. When `return_type` is set
+            to `"tuple"`, returns `(hidden_states, ...)` with optional attention
+            weights and cache tensors.
         """
         # Quantize input activation
         hidden_states = self._fq(hidden_states, self.obs_act_in)
@@ -127,19 +154,24 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         hidden_states = self.input_layernorm(hidden_states)
 
         # Self-attention
-        hidden_states, _ = self.self_attn(
+        attn_out = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_ids=position_ids,
             past_key_values=past_key_values,
             use_cache=use_cache,
             cache_position=cache_position,
+            cache_output_mode=cache_output_mode,
             position_embeddings=position_embeddings,
             **kwargs,
         )
 
+        hidden_states_attn, attn_weights, present_key_value = self._unpack_attn_outputs(
+            attn_out
+        )
+
         # Post-attention residual connection
-        hidden_states = hidden_states + residual
+        hidden_states = hidden_states_attn + residual
         hidden_states = self._fq(hidden_states, self.obs_post_attn)
 
         # Save for MLP residual connection
@@ -148,7 +180,7 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         # Pre-MLP normalization
         hidden_states = self.post_attention_layernorm(hidden_states)
 
-        # Feed-Forward Network (MLP)
+        # Feed-forward network
         hidden_states = self.mlp(hidden_states)
 
         # Post-MLP residual connection
@@ -157,13 +189,38 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         # Quantize output activation
         hidden_states = self._fq(hidden_states, self.obs_act_out)
 
-        return hidden_states
+        outputs = (hidden_states,)
+        if output_attentions:
+            outputs += (attn_weights,)
+        if use_cache:
+            outputs += (present_key_value,)
+
+        if self.return_type == "tuple":
+            return outputs
+        if self.return_type == "tensor":
+            return hidden_states
+        raise RuntimeError(f"Invalid return_type: {self.return_type!r}")
 
     def _all_observers(self) -> Iterable:
         """Yield all observers from this module."""
-        # Local observers for residual connections
         yield from (
             self.obs_act_in,
             self.obs_post_attn,
             self.obs_act_out,
         )
+
+    def as_export_module(self, mode: ExportMode = "prefill", *, return_kv: bool = True):
+        """
+        Return a static-runtime export adapter for the requested execution mode.
+        """
+        if mode == "prefill":
+            return Qwen3VLTextDecoderLayerPrefillExportAdapter(
+                self,
+                return_kv=return_kv,
+            )
+        if mode == "decode":
+            return Qwen3VLTextDecoderLayerDecodeExportAdapter(
+                self,
+                return_kv=return_kv,
+            )
+        raise ValueError(f"Unsupported export mode: {mode!r}")

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_text_decoder_layer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Literal, Optional
+from typing import Any, Iterable, Literal, Optional
 
 import torch
 import torch.nn as nn
@@ -189,14 +189,14 @@ class QuantQwen3VLTextDecoderLayer(QuantModuleBase):
         # Quantize output activation
         hidden_states = self._fq(hidden_states, self.obs_act_out)
 
-        outputs = (hidden_states,)
+        outputs: list[Any] = [hidden_states]
         if output_attentions:
-            outputs += (attn_weights,)
+            outputs.append(attn_weights)
         if use_cache:
-            outputs += (present_key_value,)
+            outputs.append(present_key_value)
 
         if self.return_type == "tuple":
-            return outputs
+            return tuple(outputs)
         if self.return_type == "tensor":
             return hidden_states
         raise RuntimeError(f"Invalid return_type: {self.return_type!r}")


### PR DESCRIPTION
- Add prefill/decode export adapters for Qwen3-VL text decoder layers
- Expose static prefill/decode adapter hooks from QuantQwen3VLTextDecoderLayer
- Add text-only static_qwen3_vl_runtime.py

```bash
python -m tico.quantization.recipes.debug.static_qwen3_vl_runtime \
  --model /home/seongwoo.chae/models/Qwen3-VL-4B-Instruct/ \
  --max-seq 2048 \
  --padding-side right \
  --device cuda \
  --prompt "The capital of France is" \
  --verify-steps 6 \
  --gen-steps 16
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.01s/it]
The module name  (originally ) is not a valid Python identifier. Please rename the original module to avoid import issues.
====================================================================================================
Step 0: prefill last-token logits
mean|diff| = 0.00000805
 max|diff| = 0.00005627
PEIR       = 0.000174 %
====================================================================================================
Step 1: decode logits
mean|diff| = 0.00001196
 max|diff| = 0.00004387
PEIR       = 0.000130 %
====================================================================================================
Step 2: decode logits
mean|diff| = 0.00000750
 max|diff| = 0.00003433
PEIR       = 0.000124 %
====================================================================================================
Step 3: decode logits
mean|diff| = 0.00000335
 max|diff| = 0.00002575
PEIR       = 0.000088 %
====================================================================================================
Step 4: decode logits
mean|diff| = 0.00000431
 max|diff| = 0.00002098
PEIR       = 0.000059 %
====================================================================================================
Step 5: decode logits
mean|diff| = 0.00000648
 max|diff| = 0.00003052
PEIR       = 0.000096 %
====================================================================================================
Step 6: decode logits
mean|diff| = 0.00000315
 max|diff| = 0.00002480
PEIR       = 0.000067 %
====================================================================================================
Generated text:
The capital of France is Paris. The capital of Spain is Madrid. The capital of Italy is Rome.
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>