### PR TITLE
[quantization] Warn when plotext is missing

### DIFF
--- a/tico/quantization/recipes/debug/wrapper_smoke/runner.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/runner.py
@@ -15,6 +15,7 @@
 """Runner for wrapper-level quantization smoke checks."""
 
 import json
+import sys
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -71,8 +72,20 @@ def _print_plot(
         from tico.quantization.evaluation.utils import plot_two_outputs
 
         plot = plot_two_outputs(fp_tensor, quant_tensor)
+    except ModuleNotFoundError as exc:
+        if exc.name == "plotext":
+            print(
+                "WARNING: plot requested, but optional dependency 'plotext' is not "
+                "installed; skipping plot. Install it with `pip install plotext` "
+                "or pass `--no-plot`.",
+                file=sys.stderr,
+            )
+            return
+
+        print(f"WARNING: plot_two_outputs failed: {exc}", file=sys.stderr)
+        return
     except Exception as exc:
-        result.messages.append(f"plot_two_outputs failed: {exc}")
+        print(f"WARNING: plot_two_outputs failed: {exc}", file=sys.stderr)
         return
 
     print(plot)


### PR DESCRIPTION
This commit warns when plotext is missing.

### Before

```bash
python -m tico.quantization.examples.inspect \
  --config tico/quantization/examples/configs/wrapper_smoke.yaml \
  --mode wrapper-smoke \
  --case gemma4_vision_encoder_layer
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_vision_encoder_layer
│ Status           : PASS
│ Mean |diff|      : 0.094157
│ Max |diff|       : 1.843177
│ PEIR             : 0.177133
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
```

### After

```bash
python -m tico.quantization.examples.inspect \
  --config tico/quantization/examples/configs/wrapper_smoke.yaml \
  --mode wrapper-smoke \
  --case gemma4_vision_encoder_layer
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_vision_encoder_layer
│ Status           : PASS
│ Mean |diff|      : 0.094157
│ Max |diff|       : 1.843177
│ PEIR             : 0.177133
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
WARNING: plot requested, but optional dependency 'plotext' is not installed; skipping plot. Install it with `pip install plotext` or pass `--no-plot`.
```

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>