### PR TITLE
[quantization] Add image prefill runtime for qwen3-vl

### DIFF
--- a/tico/quantization/recipes/debug/static_qwen3_vl_runtime.py
+++ b/tico/quantization/recipes/debug/static_qwen3_vl_runtime.py
@@ -13,19 +13,29 @@
 # limitations under the License.
 
 import argparse
+import inspect
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple
+from pathlib import Path
+from typing import Any, Optional, Sequence, Tuple
 
 import torch
 import torch.nn as nn
-from transformers import AutoModelForImageTextToText, AutoTokenizer
+from transformers import AutoModelForImageTextToText, AutoProcessor, AutoTokenizer
 
 from tico.quantization import prepare
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.wrapq.wrappers.qwen_vl.export_adapters import (
+    Qwen3VLVisionPrefillExportAdapter,
+    Qwen3VLVisualEmbeddingFusionAdapter,
+)
 from tico.quantization.wrapq.wrappers.qwen_vl.quant_text_decoder_layer import (
     QuantQwen3VLTextDecoderLayer,
 )
+
+
+DEFAULT_IMAGE_MAX_PIXELS = 1280 * 28 * 28
+DEFAULT_IMAGE_MIN_PIXELS = None
 
 
 @dataclass
@@ -38,13 +48,19 @@ class LayerCache:
 
 @dataclass
 class StaticQwen3VLRuntimeConfig:
-    """Configuration for the text-only static Qwen3-VL runtime smoke test."""
+    """Configuration for the static Qwen3-VL runtime smoke test."""
 
     model: str = "Qwen/Qwen3-VL-2B-Instruct"
     max_seq: int = 2048
     padding_side: str = "right"
     device: str = "cpu"
-    prompt: str = "The capital of France is"
+    prompt: str = "Describe this image."
+    image: Optional[str] = None
+    image_max_pixels: Optional[int] = DEFAULT_IMAGE_MAX_PIXELS
+    image_min_pixels: Optional[int] = DEFAULT_IMAGE_MIN_PIXELS
+    use_chat_template: bool = True
+    visual_start_idx: Optional[int] = None
+    enable_deepstack: bool = True
     verify_steps: int = 6
     gen_steps: int = 16
     trust_remote_code: bool = True
@@ -53,6 +69,26 @@ class StaticQwen3VLRuntimeConfig:
 def _clone_quant_layer(layer: nn.Module) -> nn.Module:
     """Build a quantized decoder layer wrapper for runtime simulation."""
     return prepare(layer, PTQConfig())
+
+
+def _make_qwen_model(
+    model_name: str, device: str, trust_remote_code: bool
+) -> nn.Module:
+    """Load a Qwen3-VL model with a transformers-version-compatible dtype argument."""
+    kwargs = {"trust_remote_code": trust_remote_code}
+    try:
+        model = AutoModelForImageTextToText.from_pretrained(
+            model_name,
+            dtype=torch.float32,
+            **kwargs,
+        )
+    except TypeError:
+        model = AutoModelForImageTextToText.from_pretrained(
+            model_name,
+            torch_dtype=torch.float32,
+            **kwargs,
+        )
+    return model.eval().to(device)
 
 
 def _set_text_max_position_embeddings(model: nn.Module, max_seq: int) -> None:
@@ -73,40 +109,6 @@ def _set_text_max_position_embeddings(model: nn.Module, max_seq: int) -> None:
             layer.self_attn.config.max_position_embeddings = max_seq
 
 
-def _build_qwen_text_rope_templates(
-    text_model: nn.Module,
-    max_seq: int,
-    device: torch.device,
-    dtype: torch.dtype = torch.float32,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Build text-only Qwen3-VL RoPE tables for static runtime positions.
-
-    The returned tensors use shape `(1, max_seq, head_dim)` and can be gathered
-    by compact text position IDs for padded prefill inputs.
-    """
-    hidden_size = int(text_model.config.hidden_size)
-    dummy = torch.empty(1, max_seq, hidden_size, device=device, dtype=dtype)
-    position_ids = (
-        torch.arange(max_seq, device=device, dtype=torch.long)
-        .view(1, 1, -1)
-        .expand(3, 1, -1)
-    )
-    cos, sin = text_model.rotary_emb(dummy, position_ids)
-
-    if cos.dim() == 2:
-        cos = cos.unsqueeze(0)
-    if sin.dim() == 2:
-        sin = sin.unsqueeze(0)
-
-    if cos.size(0) != 1:
-        cos = cos[:1]
-    if sin.size(0) != 1:
-        sin = sin[:1]
-
-    return cos.to(dtype=dtype), sin.to(dtype=dtype)
-
-
 def _normalize_valid_token_mask(
     input_ids: torch.LongTensor,
     attention_mask: Optional[torch.Tensor],
@@ -114,12 +116,7 @@ def _normalize_valid_token_mask(
     pad_token_id: Optional[int],
     device: torch.device,
 ) -> torch.Tensor:
-    """
-    Build a boolean mask where True marks real prompt tokens.
-
-    Callers should pass `attention_mask` explicitly when the pad token can also
-    appear as a real token.
-    """
+    """Build a boolean mask where True marks real prompt tokens."""
     if attention_mask is None:
         if pad_token_id is None:
             valid = torch.ones(input_ids.shape, device=device, dtype=torch.bool)
@@ -163,15 +160,10 @@ def _validate_padding_layout(valid_token_mask: torch.Tensor, padding_side: str) 
         )
 
 
-def _build_position_ids_from_valid_token_mask(
+def _build_text_position_ids_from_valid_token_mask(
     valid_token_mask: torch.Tensor,
 ) -> torch.LongTensor:
-    """
-    Build compact absolute position IDs for padded text-only prefill inputs.
-
-    Real tokens receive positions `0..valid_length-1`. Padding slots receive
-    position 0 because their logits and K/V values are ignored by the runtime.
-    """
+    """Build compact text-only position IDs for padded prefill inputs."""
     position_ids = valid_token_mask.to(torch.long).cumsum(dim=1) - 1
     position_ids = torch.clamp(position_ids, min=0)
     return position_ids.masked_fill(~valid_token_mask, 0)
@@ -195,71 +187,13 @@ def _gather_last_token_logits(
     return logits[batch_indices, last_indices, :]
 
 
-def _gather_rope_by_position_ids(
-    rope_cos: torch.Tensor,
-    rope_sin: torch.Tensor,
-    position_ids: torch.LongTensor,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Gather static RoPE tensors by per-token absolute position IDs.
-
-    Args:
-        rope_cos: RoPE cosine table with shape `(1, max_seq, head_dim)`.
-        rope_sin: RoPE sine table with shape `(1, max_seq, head_dim)`.
-        position_ids: Absolute position IDs with shape `(B, S)`.
-        device: Destination device.
-        dtype: Destination dtype.
-
-    Returns:
-        A tuple `(cos, sin)` with shape `(B, S, head_dim)`.
-    """
-    position_ids = position_ids.to(device=device, dtype=torch.long)
-    batch_size, seq_len = position_ids.shape
-    flat_positions = position_ids.reshape(-1)
-
-    cos_table = rope_cos[0].to(device=device, dtype=dtype)
-    sin_table = rope_sin[0].to(device=device, dtype=dtype)
-
-    cos = cos_table.index_select(0, flat_positions).reshape(batch_size, seq_len, -1)
-    sin = sin_table.index_select(0, flat_positions).reshape(batch_size, seq_len, -1)
-    return cos, sin
-
-
-def _slice_rope(
-    rope_cos: torch.Tensor,
-    rope_sin: torch.Tensor,
-    position: int,
-    batch_size: int,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Slice one absolute-position RoPE entry for static decode."""
-    if position < 0 or position >= rope_cos.size(1):
-        raise ValueError(
-            f"position must be within [0, {rope_cos.size(1)}), got {position}."
-        )
-
-    cos = rope_cos[:, position : position + 1, :].to(device=device, dtype=dtype)
-    sin = rope_sin[:, position : position + 1, :].to(device=device, dtype=dtype)
-    if batch_size != 1:
-        cos = cos.expand(batch_size, -1, -1).contiguous()
-        sin = sin.expand(batch_size, -1, -1).contiguous()
-    return cos, sin
-
-
 def _build_prefill_attention_mask(
     valid_token_mask: torch.Tensor,
     device: torch.device,
     dtype: torch.dtype,
     mask_value: float = -120.0,
 ) -> torch.Tensor:
-    """
-    Build a static additive causal + padding mask for prefill.
-
-    Returns a tensor with shape `(B, 1, S, S)`.
-    """
+    """Build a static additive causal + padding mask for prefill."""
     batch_size, seq_len = valid_token_mask.shape
     causal = torch.ones(seq_len, seq_len, device=device, dtype=torch.bool)
     causal = torch.tril(causal).unsqueeze(0).expand(batch_size, -1, -1)
@@ -300,18 +234,281 @@ def _build_decode_attention_mask(
     return mask
 
 
+def _pad_token_batch(
+    batch: dict[str, Any],
+    *,
+    max_seq: int,
+    pad_token_id: int,
+    padding_side: str,
+) -> dict[str, Any]:
+    """Pad or validate processor/tokenizer outputs to the static sequence length."""
+    input_ids = batch["input_ids"]
+    if input_ids.dim() != 2:
+        raise ValueError(f"Expected input_ids rank 2, got {tuple(input_ids.shape)}.")
+
+    batch_size, seq_len = input_ids.shape
+    if seq_len > max_seq:
+        raise ValueError(
+            f"Input sequence length {seq_len} exceeds static max_seq {max_seq}."
+        )
+    if seq_len == max_seq:
+        return batch
+
+    pad_len = max_seq - seq_len
+    pad_ids = torch.full(
+        (batch_size, pad_len),
+        int(pad_token_id),
+        dtype=input_ids.dtype,
+        device=input_ids.device,
+    )
+    attention_mask = batch.get("attention_mask")
+    if attention_mask is None:
+        attention_mask = torch.ones_like(input_ids)
+    pad_mask = torch.zeros(
+        (batch_size, pad_len),
+        dtype=attention_mask.dtype,
+        device=attention_mask.device,
+    )
+
+    out = dict(batch)
+    if padding_side == "right":
+        out["input_ids"] = torch.cat([input_ids, pad_ids], dim=1)
+        out["attention_mask"] = torch.cat([attention_mask, pad_mask], dim=1)
+    elif padding_side == "left":
+        out["input_ids"] = torch.cat([pad_ids, input_ids], dim=1)
+        out["attention_mask"] = torch.cat([pad_mask, attention_mask], dim=1)
+    else:
+        raise ValueError(f"Unsupported padding_side: {padding_side!r}")
+
+    for key in ("position_ids", "mm_token_type_ids"):
+        if key in out and isinstance(out[key], torch.Tensor) and out[key].dim() == 2:
+            value = out[key]
+            pad_value = torch.zeros(
+                (batch_size, pad_len), dtype=value.dtype, device=value.device
+            )
+            if padding_side == "right":
+                out[key] = torch.cat([value, pad_value], dim=1)
+            else:
+                out[key] = torch.cat([pad_value, value], dim=1)
+
+    return out
+
+
+def _move_batch_to_device(
+    batch: dict[str, Any], device: torch.device
+) -> dict[str, Any]:
+    """Move tensor values in a processor/tokenizer batch to the target device."""
+    out: dict[str, Any] = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor):
+            out[key] = value.to(device)
+        else:
+            out[key] = value
+    return out
+
+
+def _processor_accepts_kwarg(callable_obj, name: str) -> bool:
+    """Return whether a callable appears to accept a keyword argument."""
+    try:
+        signature = inspect.signature(callable_obj)
+    except (TypeError, ValueError):
+        return True
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return name in signature.parameters
+
+
+def _set_processor_image_budget(
+    processor,
+    *,
+    image_min_pixels: Optional[int],
+    image_max_pixels: Optional[int],
+) -> None:
+    """Best-effort update of processor image pixel-budget attributes."""
+    targets = [processor, getattr(processor, "image_processor", None)]
+    for target in targets:
+        if target is None:
+            continue
+        if image_min_pixels is not None and hasattr(target, "min_pixels"):
+            setattr(target, "min_pixels", int(image_min_pixels))
+        if image_max_pixels is not None and hasattr(target, "max_pixels"):
+            setattr(target, "max_pixels", int(image_max_pixels))
+
+
+def _resize_image_to_pixel_budget(image, image_max_pixels: Optional[int]):
+    """Downscale a PIL image so its area does not exceed a pixel budget."""
+    if image_max_pixels is None:
+        return image
+    image_max_pixels = int(image_max_pixels)
+    if image_max_pixels <= 0:
+        raise ValueError(f"image_max_pixels must be positive, got {image_max_pixels}.")
+    width, height = image.size
+    if width * height <= image_max_pixels:
+        return image
+
+    scale = (float(image_max_pixels) / float(width * height)) ** 0.5
+    target_size = (max(1, int(width * scale)), max(1, int(height * scale)))
+    try:
+        from PIL import Image
+
+        resample = Image.Resampling.LANCZOS
+    except Exception:  # pragma: no cover - Pillow compatibility fallback.
+        resample = 1
+
+    resized = image.copy()
+    resized.thumbnail(target_size, resample=resample)
+    return resized
+
+
+def _processor_call_kwargs_for_image_budget(
+    processor,
+    *,
+    image_min_pixels: Optional[int],
+    image_max_pixels: Optional[int],
+) -> dict[str, int]:
+    """Return processor call kwargs accepted by the installed processor version."""
+    kwargs: dict[str, int] = {}
+    if image_min_pixels is not None and _processor_accepts_kwarg(
+        processor.__call__, "min_pixels"
+    ):
+        kwargs["min_pixels"] = int(image_min_pixels)
+    if image_max_pixels is not None and _processor_accepts_kwarg(
+        processor.__call__, "max_pixels"
+    ):
+        kwargs["max_pixels"] = int(image_max_pixels)
+    return kwargs
+
+
+def _image_budget_candidates(
+    *,
+    image_min_pixels: Optional[int],
+    image_max_pixels: Optional[int],
+) -> list[Optional[int]]:
+    """Build descending image pixel-budget candidates for static sequence fitting."""
+    if image_max_pixels is None:
+        return [None]
+
+    floor = int(image_min_pixels) if image_min_pixels is not None else 4 * 28 * 28
+    floor = max(1, floor)
+    current = int(image_max_pixels)
+    if current < floor:
+        return [current]
+
+    candidates: list[Optional[int]] = []
+    while current >= floor:
+        candidates.append(current)
+        next_current = current // 2
+        if next_current == current:
+            break
+        current = next_current
+    if candidates[-1] != floor:
+        candidates.append(floor)
+    return candidates
+
+
+def _format_optional_tensor(value: Any) -> str:
+    """Format a tensor shape/value summary for diagnostics."""
+    if isinstance(value, torch.Tensor):
+        if value.numel() <= 16:
+            return f"shape={tuple(value.shape)}, value={value.detach().cpu().tolist()}"
+        return f"shape={tuple(value.shape)}"
+    return str(value)
+
+
+def _validate_unpadded_static_length(
+    batch: dict[str, Any],
+    *,
+    max_seq: int,
+    image_budget: Optional[int],
+) -> None:
+    """Raise a detailed error if the unpadded processor output exceeds max_seq."""
+    seq_len = int(batch["input_ids"].shape[1])
+    if seq_len <= max_seq:
+        return
+
+    grid = _format_optional_tensor(batch.get("image_grid_thw"))
+    pixel_values = _format_optional_tensor(batch.get("pixel_values"))
+    raise ValueError(
+        f"Input sequence length {seq_len} exceeds static max_seq {max_seq}. "
+        f"image_grid_thw={grid}; pixel_values={pixel_values}; "
+        f"image_budget={image_budget}. Lower --image-max-pixels or increase --max-seq."
+    )
+
+
+def _compact_token_batch(batch: dict[str, Any], valid: torch.Tensor) -> dict[str, Any]:
+    """Remove static padding from token-like tensors for reference execution."""
+    if valid.size(0) != 1:
+        raise ValueError("Reference compaction currently supports batch_size=1 only.")
+    compact: dict[str, Any] = {}
+    token_keys = {"input_ids", "attention_mask", "mm_token_type_ids"}
+    for key, value in batch.items():
+        if key in token_keys and isinstance(value, torch.Tensor) and value.dim() == 2:
+            compact[key] = value[:, valid[0]]
+        else:
+            compact[key] = value
+    if "attention_mask" in compact:
+        compact["attention_mask"] = torch.ones_like(compact["input_ids"])
+    return compact
+
+
+def _append_token_type_zero(
+    mm_token_type_ids: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Append a text-token type value for one generated token."""
+    if mm_token_type_ids is None:
+        return None
+    zeros = torch.zeros(
+        (mm_token_type_ids.size(0), 1),
+        dtype=mm_token_type_ids.dtype,
+        device=mm_token_type_ids.device,
+    )
+    return torch.cat([mm_token_type_ids, zeros], dim=1)
+
+
+def _image_grid_tuple(image_grid_thw: torch.Tensor) -> tuple[int, int, int]:
+    """Convert a single-image grid tensor to a Python tuple."""
+    if image_grid_thw is None:
+        raise ValueError("image_grid_thw is required for image prefill.")
+    if (
+        image_grid_thw.dim() != 2
+        or image_grid_thw.size(0) != 1
+        or image_grid_thw.size(1) != 3
+    ):
+        raise ValueError(
+            "Only one fixed image is supported. Expected image_grid_thw shape `(1, 3)`, "
+            f"got {tuple(image_grid_thw.shape)}."
+        )
+    return tuple(int(x) for x in image_grid_thw[0].tolist())
+
+
+def _processor_input_keys(batch: dict[str, Any]) -> dict[str, Any]:
+    """Select model-forward keys from a tokenizer or processor batch."""
+    keys = {
+        "input_ids",
+        "attention_mask",
+        "pixel_values",
+        "image_grid_thw",
+        "mm_token_type_ids",
+    }
+    return {key: value for key, value in batch.items() if key in keys}
+
+
 class StaticQwen3VLTextLayerRuntime:
     """
-    Static-shape text-only runtime over separately wrapped Qwen3-VL decoder layers.
+    Static-shape Qwen3-VL runtime over separately wrapped decoder layers.
 
     CPU responsibilities:
+      - tokenizer/processor padding,
       - token embedding,
-      - RoPE lookup,
+      - image embedding fusion,
+      - mRoPE lookup,
       - attention-mask construction,
       - KV-cache allocation and updates,
       - final norm and LM head.
 
     NPU-simulated responsibilities:
+      - fixed-grid vision prefill adapter,
       - dense decoder-layer prefill and decode adapters.
     """
 
@@ -323,12 +520,16 @@ class StaticQwen3VLTextLayerRuntime:
         device: str = "cpu",
         padding_side: str = "right",
         layers: Optional[Sequence[nn.Module]] = None,
+        visual_start_idx: Optional[int] = None,
+        enable_deepstack: bool = True,
     ):
         self.model = model.eval().to(device)
         self.tokenizer = tokenizer
         self.max_seq = max_seq
         self.device = torch.device(device)
         self.padding_side = padding_side
+        self.visual_start_idx = visual_start_idx
+        self.enable_deepstack = enable_deepstack
 
         self.qwen_model = self.model.model
         self.text_model = self.qwen_model.language_model
@@ -370,19 +571,18 @@ class StaticQwen3VLTextLayerRuntime:
             self.hidden_size // self.config.num_attention_heads
         )
 
-        self.rope_cos, self.rope_sin = _build_qwen_text_rope_templates(
-            self.text_model,
-            max_seq=self.max_seq,
-            device=self.device,
-            dtype=torch.float32,
-        )
         self.layer_caches: list[LayerCache] = []
         self.past_len = 0
+        self.rope_delta = torch.zeros(1, 1, dtype=torch.long, device=self.device)
+        self.vision_prefill_adapter: Optional[Qwen3VLVisionPrefillExportAdapter] = None
+        self.vision_grid_thw: Optional[tuple[int, int, int]] = None
+        self.visual_fusion_adapter: Optional[Qwen3VLVisualEmbeddingFusionAdapter] = None
 
     def reset_cache(self) -> None:
         """Clear CPU-managed KV caches."""
         self.layer_caches = []
         self.past_len = 0
+        self.rope_delta = torch.zeros(1, 1, dtype=torch.long, device=self.device)
 
     def _allocate_empty_cache(
         self,
@@ -403,11 +603,333 @@ class StaticQwen3VLTextLayerRuntime:
             caches.append(LayerCache(past_k=past_k, past_v=torch.zeros_like(past_k)))
         return caches
 
+    def _position_embeddings(
+        self,
+        hidden_states: torch.Tensor,
+        position_ids: torch.LongTensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Compute Qwen3-VL mRoPE embeddings on CPU/runtime side."""
+        cos, sin = self.text_model.rotary_emb(hidden_states, position_ids)
+        return cos.to(dtype=hidden_states.dtype), sin.to(dtype=hidden_states.dtype)
+
+    def _text_position_ids(self, valid: torch.Tensor) -> torch.LongTensor:
+        """Build text-only 3D-compatible position IDs."""
+        ids_2d = _build_text_position_ids_from_valid_token_mask(valid)
+        return ids_2d.unsqueeze(0).expand(3, -1, -1).to(self.device)
+
+    def _compute_rope_delta(
+        self,
+        position_ids: torch.LongTensor,
+        valid: torch.Tensor,
+    ) -> torch.LongTensor:
+        """Compute the decode rope delta from compact cache length and mRoPE max index."""
+        deltas = []
+        for b in range(valid.size(0)):
+            row_valid = valid[b]
+            max_pos = position_ids[:, b, row_valid].max()
+            valid_len = row_valid.sum()
+            deltas.append(max_pos + 1 - valid_len)
+        return torch.stack(deltas).view(-1, 1).to(device=self.device, dtype=torch.long)
+
+    def _compute_multimodal_position_ids(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+        mm_token_type_ids: Optional[torch.Tensor],
+    ) -> torch.LongTensor:
+        """Compute Qwen3-VL 3D position IDs for a padded single-image prompt."""
+        get_rope_index = getattr(self.qwen_model, "get_rope_index", None)
+        if callable(get_rope_index):
+            kwargs: dict[str, Any] = {
+                "image_grid_thw": image_grid_thw,
+                "video_grid_thw": None,
+                "attention_mask": attention_mask,
+            }
+            if (
+                mm_token_type_ids is not None
+                and "mm_token_type_ids" in inspect.signature(get_rope_index).parameters
+            ):
+                kwargs["mm_token_type_ids"] = mm_token_type_ids
+            position_ids, _ = get_rope_index(input_ids, **kwargs)
+            return position_ids.to(device=self.device, dtype=torch.long)
+
+        return self._compute_single_image_position_ids_fallback(
+            input_ids,
+            attention_mask,
+            image_grid_thw,
+        )
+
+    def _compute_single_image_position_ids_fallback(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+    ) -> torch.LongTensor:
+        """Fallback single-image mRoPE position ID builder."""
+        if input_ids.size(0) != 1:
+            raise ValueError("Fallback mRoPE builder supports batch_size=1 only.")
+        grid_t, grid_h, grid_w = _image_grid_tuple(image_grid_thw)
+        spatial_merge_size = int(self.qwen_model.visual.spatial_merge_size)
+        llm_grid_t = grid_t
+        llm_grid_h = grid_h // spatial_merge_size
+        llm_grid_w = grid_w // spatial_merge_size
+        image_token_id = int(self.model.config.image_token_id)
+        valid_ids = input_ids[0][attention_mask[0].bool()]
+        image_positions = torch.nonzero(valid_ids == image_token_id, as_tuple=True)[0]
+        if image_positions.numel() == 0:
+            return self._text_position_ids(attention_mask.bool())
+        visual_start = int(image_positions[0].item())
+        num_visual_tokens = llm_grid_t * llm_grid_h * llm_grid_w
+        visual_end = visual_start + num_visual_tokens
+
+        segments: list[torch.Tensor] = []
+        if visual_start > 0:
+            segments.append(
+                torch.arange(visual_start, device=self.device).view(1, -1).expand(3, -1)
+            )
+
+        t_index = (
+            torch.arange(llm_grid_t, device=self.device)
+            .view(-1, 1)
+            .expand(-1, llm_grid_h * llm_grid_w)
+            .flatten()
+        )
+        h_index = (
+            torch.arange(llm_grid_h, device=self.device)
+            .view(1, -1, 1)
+            .expand(llm_grid_t, -1, llm_grid_w)
+            .flatten()
+        )
+        w_index = (
+            torch.arange(llm_grid_w, device=self.device)
+            .view(1, 1, -1)
+            .expand(llm_grid_t, llm_grid_h, -1)
+            .flatten()
+        )
+        st_idx = segments[-1].max() + 1 if segments else 0
+        segments.append(torch.stack([t_index, h_index, w_index]) + st_idx)
+
+        valid_len = int(attention_mask[0].sum().item())
+        if visual_end < valid_len:
+            st_idx = segments[-1].max() + 1
+            text_len = valid_len - visual_end
+            segments.append(
+                torch.arange(text_len, device=self.device).view(1, -1).expand(3, -1)
+                + st_idx
+            )
+
+        valid_positions = torch.cat(segments, dim=1)
+        position_ids = torch.zeros(
+            3,
+            1,
+            input_ids.size(1),
+            dtype=torch.long,
+            device=self.device,
+        )
+        position_ids[:, 0, attention_mask[0].bool()] = valid_positions
+        return position_ids
+
+    def _create_vision_prefill_adapter(
+        self,
+        image_grid_thw: torch.Tensor,
+        visual_start_idx: int,
+    ) -> None:
+        """Create or refresh the fixed-grid vision prefill adapter."""
+        grid_tuple = _image_grid_tuple(image_grid_thw)
+        if (
+            self.vision_prefill_adapter is not None
+            and self.vision_grid_thw == grid_tuple
+        ):
+            return
+
+        spatial_merge_size = int(self.qwen_model.visual.spatial_merge_size)
+        qcfg = PTQConfig(
+            model_args={
+                "vision": {
+                    "grid_thw": grid_tuple,
+                    "visual_start_idx": visual_start_idx,
+                    "spatial_merge_size": spatial_merge_size,
+                }
+            }
+        )
+        wrapped_visual = prepare(self.qwen_model.visual, qcfg).to(self.device)
+        self.vision_prefill_adapter = Qwen3VLVisionPrefillExportAdapter(wrapped_visual)
+        self.vision_grid_thw = grid_tuple
+
+    def _find_visual_span(
+        self,
+        input_ids: torch.LongTensor,
+        valid: torch.Tensor,
+        image_embeds: torch.Tensor,
+    ) -> tuple[int, int]:
+        """Find and validate the contiguous image placeholder span."""
+        if input_ids.size(0) != 1:
+            raise ValueError("Milestone 2 supports batch_size=1 for image prefill.")
+        image_token_id = int(self.model.config.image_token_id)
+        image_mask = input_ids[0].eq(image_token_id) & valid[0]
+        image_positions = torch.nonzero(image_mask, as_tuple=True)[0]
+        if image_positions.numel() == 0:
+            raise ValueError("No image placeholder tokens were found in input_ids.")
+
+        start = int(image_positions[0].item())
+        visual_len = int(image_embeds.size(0))
+        expected = torch.arange(start, start + visual_len, device=input_ids.device)
+        if image_positions.numel() != visual_len or not torch.equal(
+            image_positions, expected
+        ):
+            raise ValueError(
+                "Image placeholder tokens must be one contiguous span matching image_embeds. "
+                f"placeholder_count={image_positions.numel()}, image_embeds={visual_len}, "
+                f"start={start}."
+            )
+
+        if self.visual_start_idx is not None and self.visual_start_idx != start:
+            raise ValueError(
+                "Configured visual_start_idx does not match processor output. "
+                f"configured={self.visual_start_idx}, actual={start}."
+            )
+        self.visual_start_idx = start
+        return start, visual_len
+
+    def _make_deepstack_deltas(
+        self,
+        deepstack_features: Sequence[torch.Tensor],
+        *,
+        batch_size: int,
+        seq_len: int,
+        hidden_size: int,
+        visual_start_idx: int,
+        dtype: torch.dtype,
+    ) -> Optional[list[torch.Tensor]]:
+        """Convert sparse DeepStack visual features to dense static deltas."""
+        if not self.enable_deepstack or not deepstack_features:
+            return None
+
+        deltas = []
+        for feature in deepstack_features:
+            if feature.dim() != 2:
+                raise ValueError(
+                    "DeepStack feature must have shape `(V, H)`, "
+                    f"got {tuple(feature.shape)}."
+                )
+            visual_len = feature.size(0)
+            delta = torch.zeros(
+                batch_size,
+                seq_len,
+                hidden_size,
+                device=self.device,
+                dtype=dtype,
+            )
+            delta[:, visual_start_idx : visual_start_idx + visual_len, :] = feature.to(
+                device=self.device,
+                dtype=dtype,
+            ).unsqueeze(0)
+            deltas.append(delta)
+        return deltas
+
+    def _run_vision_prefill(
+        self,
+        pixel_values: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+        visual_start_idx: int,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, ...]]:
+        """Run the fixed-grid vision adapter and return image/DeepStack features."""
+        self._create_vision_prefill_adapter(image_grid_thw, visual_start_idx)
+        assert self.vision_prefill_adapter is not None
+        image_embeds, deepstack_features = self.vision_prefill_adapter(
+            pixel_values.to(self.device),
+            image_grid_thw.to(self.device),
+        )
+        return image_embeds.to(self.device), tuple(
+            feature.to(self.device) for feature in deepstack_features
+        )
+
+    def _prepare_inputs_embeds_and_positions(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: torch.Tensor,
+        pixel_values: Optional[torch.Tensor],
+        image_grid_thw: Optional[torch.Tensor],
+        mm_token_type_ids: Optional[torch.Tensor],
+        valid: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.LongTensor, Optional[list[torch.Tensor]],]:
+        """Prepare fused embeddings, position IDs, and optional DeepStack deltas."""
+        input_ids = input_ids.to(self.device)
+        inputs_embeds = self.embed_tokens(input_ids)
+        deepstack_deltas = None
+
+        if pixel_values is None:
+            position_ids = self._text_position_ids(valid)
+            self.rope_delta = self._compute_rope_delta(position_ids, valid)
+            return inputs_embeds, position_ids, deepstack_deltas
+
+        if image_grid_thw is None:
+            raise ValueError(
+                "image_grid_thw is required when pixel_values is provided."
+            )
+
+        # Bootstrap visual_start_idx from input IDs if the caller did not fix it.
+        image_token_id = int(self.model.config.image_token_id)
+        bootstrap_mask = input_ids[0].eq(image_token_id) & valid[0]
+        if bootstrap_mask.sum().item() == 0:
+            raise ValueError(
+                "pixel_values were provided but no image tokens were found."
+            )
+        bootstrap_start = int(torch.nonzero(bootstrap_mask, as_tuple=True)[0][0].item())
+        configured_start = (
+            self.visual_start_idx
+            if self.visual_start_idx is not None
+            else bootstrap_start
+        )
+
+        image_embeds, deepstack_features = self._run_vision_prefill(
+            pixel_values,
+            image_grid_thw,
+            configured_start,
+        )
+        visual_start_idx, visual_len = self._find_visual_span(
+            input_ids,
+            valid,
+            image_embeds,
+        )
+        del visual_len
+
+        if (
+            self.visual_fusion_adapter is None
+            or self.visual_fusion_adapter.visual_start_idx != visual_start_idx
+        ):
+            self.visual_fusion_adapter = Qwen3VLVisualEmbeddingFusionAdapter(
+                visual_start_idx
+            )
+        inputs_embeds = self.visual_fusion_adapter(inputs_embeds, image_embeds)
+
+        position_ids = self._compute_multimodal_position_ids(
+            input_ids,
+            attention_mask,
+            image_grid_thw.to(self.device),
+            mm_token_type_ids,
+        )
+        self.rope_delta = self._compute_rope_delta(position_ids, valid)
+
+        deepstack_deltas = self._make_deepstack_deltas(
+            deepstack_features,
+            batch_size=input_ids.size(0),
+            seq_len=input_ids.size(1),
+            hidden_size=inputs_embeds.size(-1),
+            visual_start_idx=visual_start_idx,
+            dtype=inputs_embeds.dtype,
+        )
+        return inputs_embeds, position_ids, deepstack_deltas
+
     @torch.no_grad()
     def prefill(
         self,
         input_ids: torch.LongTensor,
         attention_mask: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.Tensor] = None,
+        mm_token_type_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run static prefill and return last-real-token logits."""
         assert (
@@ -419,6 +941,18 @@ class StaticQwen3VLTextLayerRuntime:
             f"Got seq_len={seq_len}, max_seq={self.max_seq}."
         )
 
+        input_ids = input_ids.to(self.device)
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
+        else:
+            attention_mask = attention_mask.to(self.device)
+        if mm_token_type_ids is not None:
+            mm_token_type_ids = mm_token_type_ids.to(self.device)
+        if image_grid_thw is not None:
+            image_grid_thw = image_grid_thw.to(self.device)
+        if pixel_values is not None:
+            pixel_values = pixel_values.to(self.device)
+
         valid = _normalize_valid_token_mask(
             input_ids,
             attention_mask,
@@ -427,26 +961,29 @@ class StaticQwen3VLTextLayerRuntime:
         )
         _validate_padding_layout(valid, self.padding_side)
 
-        position_ids = _build_position_ids_from_valid_token_mask(valid)
-        hidden_states = self.embed_tokens(input_ids.to(self.device))
+        (
+            hidden_states,
+            position_ids,
+            deepstack_deltas,
+        ) = self._prepare_inputs_embeds_and_positions(
+            input_ids,
+            attention_mask,
+            pixel_values,
+            image_grid_thw,
+            mm_token_type_ids,
+            valid,
+        )
         runtime_dtype = hidden_states.dtype
 
         self.layer_caches = self._allocate_empty_cache(batch_size, runtime_dtype)
-
         attn_mask = _build_prefill_attention_mask(valid, self.device, runtime_dtype)
-        pos_embeds = _gather_rope_by_position_ids(
-            self.rope_cos,
-            self.rope_sin,
-            position_ids,
-            self.device,
-            runtime_dtype,
-        )
+        position_embeddings = self._position_embeddings(hidden_states, position_ids)
 
         for layer_idx, layer in enumerate(self.prefill_layers):
             out = layer(
                 hidden_states=hidden_states,
                 attention_mask=attn_mask,
-                position_embeddings=pos_embeds,
+                position_embeddings=position_embeddings,
             )
             if not isinstance(out, tuple) or len(out) != 3:
                 raise RuntimeError(
@@ -466,6 +1003,9 @@ class StaticQwen3VLTextLayerRuntime:
                     b, :, src_start:src_end, :
                 ]
 
+            if deepstack_deltas is not None and layer_idx < len(deepstack_deltas):
+                hidden_states = hidden_states + deepstack_deltas[layer_idx]
+
         if torch.unique(valid.sum(dim=1)).numel() != 1:
             raise ValueError(
                 "Static decode currently requires equal valid prompt length for all batch rows."
@@ -477,6 +1017,22 @@ class StaticQwen3VLTextLayerRuntime:
             hidden_states = self.rotate_lm_head(hidden_states)
         logits = self.lm_head(hidden_states)
         return _gather_last_token_logits(logits, valid)
+
+    def _decode_position_ids(self, batch_size: int) -> torch.LongTensor:
+        """Build mRoPE decode position IDs for one generated token."""
+        delta = self.rope_delta.to(self.device)
+        if delta.size(0) != batch_size:
+            delta = delta.expand(batch_size, -1)
+        pos = (
+            torch.full(
+                (batch_size, 1),
+                int(self.past_len),
+                dtype=torch.long,
+                device=self.device,
+            )
+            + delta
+        )
+        return pos.unsqueeze(0).expand(3, -1, -1)
 
     @torch.no_grad()
     def decode_one(self, input_ids: torch.LongTensor) -> torch.Tensor:
@@ -495,14 +1051,8 @@ class StaticQwen3VLTextLayerRuntime:
             self.device,
             hidden_states.dtype,
         )
-        position_embeddings = _slice_rope(
-            self.rope_cos,
-            self.rope_sin,
-            position=self.past_len,
-            batch_size=batch_size,
-            device=self.device,
-            dtype=hidden_states.dtype,
-        )
+        position_ids = self._decode_position_ids(batch_size)
+        position_embeddings = self._position_embeddings(hidden_states, position_ids)
 
         for layer_idx, layer in enumerate(self.decode_layers):
             cache = self.layer_caches[layer_idx]
@@ -528,21 +1078,24 @@ class StaticQwen3VLTextLayerRuntime:
         return logits[:, -1, :]
 
     @torch.no_grad()
-    def generate_greedy(
+    def prefill_batch(self, batch: dict[str, Any]) -> torch.Tensor:
+        """Run prefill from a padded tokenizer/processor batch."""
+        return self.prefill(
+            input_ids=batch["input_ids"],
+            attention_mask=batch.get("attention_mask"),
+            pixel_values=batch.get("pixel_values"),
+            image_grid_thw=batch.get("image_grid_thw"),
+            mm_token_type_ids=batch.get("mm_token_type_ids"),
+        )
+
+    @torch.no_grad()
+    def generate_greedy_from_batch(
         self,
-        prompt: str,
+        batch: dict[str, Any],
         max_new_tokens: int,
         eos_token_id: Optional[int] = None,
     ) -> torch.LongTensor:
-        """Generate tokens greedily with the static prefill/decode runtime."""
-        batch = self.tokenizer(
-            prompt,
-            return_tensors="pt",
-            add_special_tokens=True,
-            padding="max_length",
-            truncation=True,
-            max_length=self.max_seq,
-        )
+        """Generate tokens greedily with a preprocessed static batch."""
         input_ids = batch["input_ids"].to(self.device)
         attention_mask = batch.get("attention_mask")
         if attention_mask is not None:
@@ -552,7 +1105,7 @@ class StaticQwen3VLTextLayerRuntime:
             eos_token_id = self.tokenizer.eos_token_id
 
         self.reset_cache()
-        logits = self.prefill(input_ids, attention_mask)
+        logits = self.prefill_batch(batch)
         valid = _normalize_valid_token_mask(
             input_ids,
             attention_mask,
@@ -571,38 +1124,26 @@ class StaticQwen3VLTextLayerRuntime:
         return generated
 
     @torch.no_grad()
-    def verify_against_reference(
+    def verify_batch_against_reference(
         self,
-        prompt: str,
+        batch: dict[str, Any],
         steps: int = 8,
         verbose: bool = True,
     ) -> None:
         """Compare static runtime logits with the HF reference model."""
-        batch = self.tokenizer(
-            prompt,
-            return_tensors="pt",
-            add_special_tokens=True,
-            padding="max_length",
-            truncation=True,
-            max_length=self.max_seq,
-        )
-        input_ids = batch["input_ids"].to(self.device)
-        attention_mask = batch.get("attention_mask")
-        if attention_mask is not None:
-            attention_mask = attention_mask.to(self.device)
-
-        self.reset_cache()
-        logits_rt = self.prefill(input_ids, attention_mask)
+        batch = _move_batch_to_device(batch, self.device)
         valid = _normalize_valid_token_mask(
-            input_ids,
-            attention_mask,
+            batch["input_ids"],
+            batch.get("attention_mask"),
             pad_token_id=self.tokenizer.pad_token_id,
             device=self.device,
         )
-        compact_input_ids = input_ids[valid].reshape(input_ids.size(0), -1)
-        ref_out = self.model(input_ids=compact_input_ids)
-        logits_ref = ref_out.logits[:, -1, :]
+        compact_batch = _compact_token_batch(batch, valid)
 
+        self.reset_cache()
+        logits_rt = self.prefill_batch(batch)
+        ref_out = self.model(**_processor_input_keys(compact_batch))
+        logits_ref = ref_out.logits[:, -1, :]
         self._print_diff(
             "Step 0: prefill last-token logits",
             logits_rt,
@@ -610,13 +1151,28 @@ class StaticQwen3VLTextLayerRuntime:
             verbose,
         )
 
-        generated = compact_input_ids.clone()
+        generated_input_ids = compact_batch["input_ids"].clone()
+        generated_mm_types = compact_batch.get("mm_token_type_ids")
         next_token = torch.argmax(logits_rt, dim=-1, keepdim=True)
-        generated = torch.cat([generated, next_token], dim=1)
+        generated_input_ids = torch.cat([generated_input_ids, next_token], dim=1)
+        generated_mm_types = _append_token_type_zero(generated_mm_types)
+
+        static_image_payload = {
+            key: compact_batch[key]
+            for key in ("pixel_values", "image_grid_thw")
+            if key in compact_batch
+        }
 
         for step in range(1, steps + 1):
             logits_rt = self.decode_one(next_token)
-            ref_out = self.model(input_ids=generated)
+            ref_batch = {
+                "input_ids": generated_input_ids,
+                "attention_mask": torch.ones_like(generated_input_ids),
+                **static_image_payload,
+            }
+            if generated_mm_types is not None:
+                ref_batch["mm_token_type_ids"] = generated_mm_types
+            ref_out = self.model(**ref_batch)
             logits_ref = ref_out.logits[:, -1, :]
             self._print_diff(
                 f"Step {step}: decode logits",
@@ -626,8 +1182,9 @@ class StaticQwen3VLTextLayerRuntime:
             )
 
             next_token = torch.argmax(logits_rt, dim=-1, keepdim=True)
-            generated = torch.cat([generated, next_token], dim=1)
-            if generated.size(1) >= self.max_seq:
+            generated_input_ids = torch.cat([generated_input_ids, next_token], dim=1)
+            generated_mm_types = _append_token_type_zero(generated_mm_types)
+            if generated_input_ids.size(1) >= self.max_seq:
                 if verbose:
                     print("Stopped because the static decode window is full.")
                 break
@@ -650,21 +1207,148 @@ class StaticQwen3VLTextLayerRuntime:
         print(f"PEIR       = {compute_peir(actual, expected) * 100:.6f} %")
 
 
+def _build_text_only_batch(
+    tokenizer,
+    prompt: str,
+    *,
+    max_seq: int,
+    padding_side: str,
+) -> dict[str, Any]:
+    """Build a padded text-only batch for static runtime verification."""
+    tokenizer.padding_side = padding_side
+    batch = tokenizer(
+        prompt,
+        return_tensors="pt",
+        add_special_tokens=True,
+        padding=False,
+        truncation=False,
+    )
+    return _pad_token_batch(
+        dict(batch),
+        max_seq=max_seq,
+        pad_token_id=int(tokenizer.pad_token_id),
+        padding_side=padding_side,
+    )
+
+
+def _build_image_batch(
+    processor,
+    prompt: str,
+    image_path: str,
+    *,
+    max_seq: int,
+    padding_side: str,
+    use_chat_template: bool,
+    image_min_pixels: Optional[int],
+    image_max_pixels: Optional[int],
+) -> dict[str, Any]:
+    """Build a padded single-image Qwen3-VL processor batch within max_seq."""
+    from PIL import Image
+
+    original_image = Image.open(Path(image_path)).convert("RGB")
+
+    text = prompt
+    if use_chat_template and hasattr(processor, "apply_chat_template"):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ]
+        text = processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None:
+        raise RuntimeError("Qwen3-VL processor is expected to expose `.tokenizer`.")
+
+    last_batch: Optional[dict[str, Any]] = None
+    last_budget: Optional[int] = None
+    for candidate_max_pixels in _image_budget_candidates(
+        image_min_pixels=image_min_pixels,
+        image_max_pixels=image_max_pixels,
+    ):
+        _set_processor_image_budget(
+            processor,
+            image_min_pixels=image_min_pixels,
+            image_max_pixels=candidate_max_pixels,
+        )
+        image = _resize_image_to_pixel_budget(original_image, candidate_max_pixels)
+        processor_kwargs = _processor_call_kwargs_for_image_budget(
+            processor,
+            image_min_pixels=image_min_pixels,
+            image_max_pixels=candidate_max_pixels,
+        )
+        batch = dict(
+            processor(
+                text=[text],
+                images=[image],
+                return_tensors="pt",
+                padding=False,
+                **processor_kwargs,
+            )
+        )
+        last_batch = batch
+        last_budget = candidate_max_pixels
+        if int(batch["input_ids"].shape[1]) <= max_seq:
+            break
+    else:
+        assert last_batch is not None
+        _validate_unpadded_static_length(
+            last_batch,
+            max_seq=max_seq,
+            image_budget=last_budget,
+        )
+
+    assert last_batch is not None
+    _validate_unpadded_static_length(
+        last_batch,
+        max_seq=max_seq,
+        image_budget=last_budget,
+    )
+
+    seq_len = int(last_batch["input_ids"].shape[1])
+    grid = _format_optional_tensor(last_batch.get("image_grid_thw"))
+    print(
+        "Static image batch: "
+        f"unpadded_seq_len={seq_len}, image_grid_thw={grid}, "
+        f"image_max_pixels={last_budget}"
+    )
+
+    return _pad_token_batch(
+        last_batch,
+        max_seq=max_seq,
+        pad_token_id=int(tokenizer.pad_token_id),
+        padding_side=padding_side,
+    )
+
+
 def run_static_qwen3_vl_runtime(cfg: StaticQwen3VLRuntimeConfig) -> None:
-    """Load a Qwen3-VL model and run the text-only static runtime smoke test."""
+    """Load a Qwen3-VL model and run static runtime smoke tests."""
     torch.set_grad_enabled(False)
 
-    model = AutoModelForImageTextToText.from_pretrained(
-        cfg.model,
-        dtype=torch.float32,
-        trust_remote_code=cfg.trust_remote_code,
-    ).to(cfg.device)
+    model = _make_qwen_model(cfg.model, cfg.device, cfg.trust_remote_code)
     _set_text_max_position_embeddings(model, cfg.max_seq)
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        cfg.model,
-        trust_remote_code=cfg.trust_remote_code,
-    )
+    if cfg.image:
+        processor = AutoProcessor.from_pretrained(
+            cfg.model,
+            trust_remote_code=cfg.trust_remote_code,
+        )
+        tokenizer = processor.tokenizer
+    else:
+        processor = None
+        tokenizer = AutoTokenizer.from_pretrained(
+            cfg.model,
+            trust_remote_code=cfg.trust_remote_code,
+        )
+
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = cfg.padding_side
@@ -675,16 +1359,39 @@ def run_static_qwen3_vl_runtime(cfg: StaticQwen3VLRuntimeConfig) -> None:
         max_seq=cfg.max_seq,
         device=cfg.device,
         padding_side=cfg.padding_side,
+        visual_start_idx=cfg.visual_start_idx,
+        enable_deepstack=cfg.enable_deepstack,
     )
 
-    runtime.verify_against_reference(
-        prompt=cfg.prompt,
+    if cfg.image:
+        assert processor is not None
+        batch = _build_image_batch(
+            processor,
+            cfg.prompt,
+            cfg.image,
+            max_seq=cfg.max_seq,
+            padding_side=cfg.padding_side,
+            use_chat_template=cfg.use_chat_template,
+            image_min_pixels=cfg.image_min_pixels,
+            image_max_pixels=cfg.image_max_pixels,
+        )
+    else:
+        batch = _build_text_only_batch(
+            tokenizer,
+            cfg.prompt,
+            max_seq=cfg.max_seq,
+            padding_side=cfg.padding_side,
+        )
+
+    batch = _move_batch_to_device(batch, torch.device(cfg.device))
+    runtime.verify_batch_against_reference(
+        batch=batch,
         steps=cfg.verify_steps,
         verbose=True,
     )
 
-    out_ids = runtime.generate_greedy(
-        prompt=cfg.prompt,
+    out_ids = runtime.generate_greedy_from_batch(
+        batch=batch,
         max_new_tokens=cfg.gen_steps,
         eos_token_id=tokenizer.eos_token_id,
     )
@@ -697,7 +1404,7 @@ def run_static_qwen3_vl_runtime(cfg: StaticQwen3VLRuntimeConfig) -> None:
 def _parse_args() -> StaticQwen3VLRuntimeConfig:
     """Parse command-line arguments for the static runtime smoke test."""
     parser = argparse.ArgumentParser(
-        description="Run the text-only static Qwen3-VL layer runtime."
+        description="Run the static Qwen3-VL text/image-prefill runtime."
     )
     parser.add_argument(
         "--model",
@@ -731,6 +1438,43 @@ def _parse_args() -> StaticQwen3VLRuntimeConfig:
         help="Prompt used for verification and greedy generation.",
     )
     parser.add_argument(
+        "--image",
+        type=str,
+        default=None,
+        help="Optional image path. When provided, single-image prefill is used.",
+    )
+    parser.add_argument(
+        "--visual-start-idx",
+        type=int,
+        default=None,
+        help="Optional fixed visual token start index. If omitted, the processor output is used.",
+    )
+    parser.add_argument(
+        "--image-max-pixels",
+        type=int,
+        default=StaticQwen3VLRuntimeConfig.image_max_pixels,
+        help=(
+            "Maximum image pixel budget before processor tokenization. "
+            "The default keeps typical single-image prompts under max_seq=2048."
+        ),
+    )
+    parser.add_argument(
+        "--image-min-pixels",
+        type=int,
+        default=StaticQwen3VLRuntimeConfig.image_min_pixels,
+        help="Optional minimum image pixel budget passed to the processor.",
+    )
+    parser.add_argument(
+        "--no-chat-template",
+        action="store_true",
+        help="Do not wrap the image prompt with the processor chat template.",
+    )
+    parser.add_argument(
+        "--no-deepstack",
+        action="store_true",
+        help="Disable dense DeepStack delta injection during image prefill.",
+    )
+    parser.add_argument(
         "--verify-steps",
         type=int,
         default=StaticQwen3VLRuntimeConfig.verify_steps,
@@ -745,7 +1489,7 @@ def _parse_args() -> StaticQwen3VLRuntimeConfig:
     parser.add_argument(
         "--no-trust-remote-code",
         action="store_true",
-        help="Disable trust_remote_code when loading the model and tokenizer.",
+        help="Disable trust_remote_code when loading the model and tokenizer/processor.",
     )
     args = parser.parse_args()
 
@@ -755,6 +1499,12 @@ def _parse_args() -> StaticQwen3VLRuntimeConfig:
         padding_side=args.padding_side,
         device=args.device,
         prompt=args.prompt,
+        image=args.image,
+        image_max_pixels=args.image_max_pixels,
+        image_min_pixels=args.image_min_pixels,
+        use_chat_template=not args.no_chat_template,
+        visual_start_idx=args.visual_start_idx,
+        enable_deepstack=not args.no_deepstack,
         verify_steps=args.verify_steps,
         gen_steps=args.gen_steps,
         trust_remote_code=not args.no_trust_remote_code,

--- a/tico/quantization/recipes/debug/static_qwen3_vl_runtime.py
+++ b/tico/quantization/recipes/debug/static_qwen3_vl_runtime.py
@@ -479,7 +479,8 @@ def _image_grid_tuple(image_grid_thw: torch.Tensor) -> tuple[int, int, int]:
             "Only one fixed image is supported. Expected image_grid_thw shape `(1, 3)`, "
             f"got {tuple(image_grid_thw.shape)}."
         )
-    return tuple(int(x) for x in image_grid_thw[0].tolist())
+    values = [int(x) for x in image_grid_thw[0].tolist()]
+    return (values[0], values[1], values[2])
 
 
 def _processor_input_keys(batch: dict[str, Any]) -> dict[str, Any]:

--- a/tico/quantization/wrapq/wrappers/qwen_vl/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/export_adapters.py
@@ -57,6 +57,7 @@ class Qwen3VLTextDecoderLayerPrefillExportAdapter(nn.Module):
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_embeddings=position_embeddings,
+            past_key_values=None,
             use_cache=self.return_kv,
             cache_output_mode="delta",
             **kwargs,
@@ -127,3 +128,103 @@ class Qwen3VLTextDecoderLayerDecodeExportAdapter(nn.Module):
 
         new_k, new_v = outputs[1]
         return hidden, new_k, new_v
+
+
+class Qwen3VLVisionPrefillExportAdapter(nn.Module):
+    """
+    Export adapter for the fixed-grid Qwen3-VL vision prefill path.
+
+    Input contract:
+        pixel_values:
+            Flattened image patch tensor produced by the Qwen3-VL processor.
+        image_grid_thw:
+            Static image grid tensor with shape `(1, 3)`.
+
+    Return contract:
+        `(image_embeds, deepstack_features)`, where `image_embeds` is the merged
+        visual token tensor used to replace image placeholder tokens and
+        `deepstack_features` is a tuple of merged DeepStack tensors. Each tensor
+        is statically sized by the fixed `image_grid_thw` used during export.
+    """
+
+    def __init__(self, wrapped: nn.Module):
+        super().__init__()
+        self.wrapped = wrapped
+
+    @staticmethod
+    def _unwrap_vision_output(vision_output):
+        """Normalize Qwen3-VL vision outputs into image embeds and DeepStack features."""
+        if hasattr(vision_output, "pooler_output"):
+            image_embeds = vision_output.pooler_output
+            deepstack_features = getattr(vision_output, "deepstack_features", None)
+        elif isinstance(vision_output, (tuple, list)) and len(vision_output) >= 2:
+            image_embeds, deepstack_features = vision_output[0], vision_output[1]
+        else:
+            image_embeds = vision_output
+            deepstack_features = None
+
+        if deepstack_features is None:
+            deepstack_features = ()
+        elif isinstance(deepstack_features, list):
+            deepstack_features = tuple(deepstack_features)
+
+        return image_embeds, deepstack_features
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+        **kwargs,
+    ):
+        """Run fixed-grid vision prefill and return merged visual features."""
+        vision_output = self.wrapped(pixel_values, grid_thw=image_grid_thw, **kwargs)
+        return self._unwrap_vision_output(vision_output)
+
+
+class Qwen3VLVisualEmbeddingFusionAdapter(nn.Module):
+    """
+    Static adapter that fuses single-image embeddings into text embeddings.
+
+    This adapter intentionally assumes one contiguous visual-token span. The
+    visual span start is fixed at construction time so the exported graph avoids
+    dynamic `nonzero`, boolean indexing, or scatter operators.
+    """
+
+    def __init__(self, visual_start_idx: int):
+        super().__init__()
+        if visual_start_idx < 0:
+            raise ValueError("visual_start_idx must be non-negative.")
+        self.visual_start_idx = int(visual_start_idx)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        image_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        """Replace the fixed visual-token slice with image embeddings."""
+        if inputs_embeds.dim() != 3:
+            raise RuntimeError(
+                "inputs_embeds must have shape `(B, S, H)`, "
+                f"got {tuple(inputs_embeds.shape)}."
+            )
+        if image_embeds.dim() != 2:
+            raise RuntimeError(
+                "image_embeds must have shape `(V, H)`, "
+                f"got {tuple(image_embeds.shape)}."
+            )
+
+        visual_len = image_embeds.size(0)
+        visual_end = self.visual_start_idx + visual_len
+        if visual_end > inputs_embeds.size(1):
+            raise RuntimeError(
+                "The visual embedding span exceeds the input sequence length: "
+                f"start={self.visual_start_idx}, len={visual_len}, "
+                f"seq_len={inputs_embeds.size(1)}."
+            )
+
+        fused = inputs_embeds.clone()
+        fused[:, self.visual_start_idx : visual_end, :] = image_embeds.unsqueeze(0).to(
+            device=fused.device,
+            dtype=fused.dtype,
+        )
+        return fused


### PR DESCRIPTION
This commit adds static Qwen3-VL image prefill runtime.

```bash
python tico/quantization/recipes/debug/static_qwen3_vl_runtime.py \
  --model /home/seongwoo.chae/models/Qwen3-VL-4B-Instruct         \
  --image /home/seongwoo.chae/models/DOG-WIKI.jfif                \
  --prompt "Describe the image."   --max-seq 2048   --device cuda
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 713/713 [00:00<00:00, 772.09it/s]
Static image batch: unpadded_seq_len=986, image_grid_thw=shape=(1, 3), value=[[1, 72, 54]], image_max_pixels=1003520
====================================================================================================
Step 0: prefill last-token logits
mean|diff| = 0.00002233
 max|diff| = 0.00010872
PEIR       = 0.000219 %
====================================================================================================
Step 1: decode logits
mean|diff| = 0.00001260
 max|diff| = 0.00007915
PEIR       = 0.000154 %
====================================================================================================
Step 2: decode logits
mean|diff| = 0.00000771
 max|diff| = 0.00005913
PEIR       = 0.000111 %
====================================================================================================
Step 3: decode logits
mean|diff| = 0.00000840
 max|diff| = 0.00005817
PEIR       = 0.000116 %
====================================================================================================
Step 4: decode logits
mean|diff| = 0.00000752
 max|diff| = 0.00005341
PEIR       = 0.000101 %
====================================================================================================
Step 5: decode logits
mean|diff| = 0.00000960
 max|diff| = 0.00007343
PEIR       = 0.000154 %
====================================================================================================
Step 6: decode logits
mean|diff| = 0.00000875
 max|diff| = 0.00007820
PEIR       = 0.000138 %
====================================================================================================
Generated text:
user
Describe the image.
assistant
This is a charming, candid photograph of a young black and white puppy sitting on
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>