### PR TITLE
[serialize] Support Gather as Circle GatherNd

### DIFF
--- a/test/unit_test/passes/test_convert_gather_to_gather_nd.py
+++ b/test/unit_test/passes/test_convert_gather_to_gather_nd.py
@@ -20,7 +20,7 @@ from test.support.pass_value_test import SinglePassValueTest
 
 
 class GatherBasic(torch.nn.Module):
-    """Basic gather """
+    """Basic gather"""
 
     def __init__(self, dim: int):
         super().__init__()
@@ -38,8 +38,7 @@ class GatherBasic(torch.nn.Module):
 class GatherBasicTest(SinglePassValueTest):
     def test_pass(self):
         self.setup(GatherBasic(dim=3))
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.gather), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.gather), 1)
         # Run conversion without actually running the model because after the
         # ConvertGatherToGatherNd pass the graph is not a valid PyTorch model
         # any more. Therefore we just check that the conversion is correct
@@ -48,15 +47,9 @@ class GatherBasicTest(SinglePassValueTest):
         # Check whether indices preprocessing nodes have been added. The number
         # of arange, reshape and expand ops should be equal to the rank of the
         # input tensor minus 1 (the original index is used for the gather dim).
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.arange), 3)
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.reshape), 3)
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.expand), 3)
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.unsqueeze), 4)
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.cat), 1)
-        self.assertEqual(num_of_ops(
-            self.exported_program(), ops.aten.gather), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.arange), 3)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.reshape), 3)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.expand), 3)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.unsqueeze), 4)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.cat), 1)
+        self.assertEqual(num_of_ops(self.exported_program(), ops.aten.gather), 1)

--- a/test/unit_test/passes/test_convert_gather_to_gather_nd.py
+++ b/test/unit_test/passes/test_convert_gather_to_gather_nd.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from tico.passes import ops
+from tico.passes.convert_gather_to_gather_nd import ConvertGatherToGatherNd
+
+from test.support.helper import num_of_ops
+from test.support.pass_value_test import SinglePassValueTest
+
+
+class GatherBasic(torch.nn.Module):
+    """Basic gather """
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, input, index):
+        return torch.gather(input, dim=self.dim, index=index)
+
+    def get_example_inputs(self):
+        input = torch.randn(5, 1, 3, 6)
+        index = torch.tensor([[[[0, 1, 2]]], [[[3, 4, 5]]]])
+        return (input, index), {}
+
+
+class GatherBasicTest(SinglePassValueTest):
+    def test_pass(self):
+        self.setup(GatherBasic(dim=3))
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.gather), 1)
+        # Run conversion without actually running the model because after the
+        # ConvertGatherToGatherNd pass the graph is not a valid PyTorch model
+        # any more. Therefore we just check that the conversion is correct
+        # based on the graph structure.
+        ConvertGatherToGatherNd().call(self.ep)
+        # Check whether indices preprocessing nodes have been added. The number
+        # of arange, reshape and expand ops should be equal to the rank of the
+        # input tensor minus 1 (the original index is used for the gather dim).
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.arange), 3)
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.reshape), 3)
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.expand), 3)
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.unsqueeze), 4)
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.cat), 1)
+        self.assertEqual(num_of_ops(
+            self.exported_program(), ops.aten.gather), 1)

--- a/tico/passes/convert_gather_to_gather_nd.py
+++ b/tico/passes/convert_gather_to_gather_nd.py
@@ -16,11 +16,11 @@ import torch
 from torch.export import ExportedProgram
 
 from tico.utils import logging
-from tico.utils.utils import is_target_node
 from tico.utils.graph import create_node
 from tico.utils.passes import PassBase, PassResult
-from tico.utils.validate_args_kwargs import GatherArgs
 from tico.utils.trace_decorators import trace_graph_diff_on_pass
+from tico.utils.utils import is_target_node
+from tico.utils.validate_args_kwargs import GatherArgs
 
 
 @trace_graph_diff_on_pass
@@ -56,15 +56,18 @@ class ConvertGatherToGatherNd(PassBase):
             if args.dim < 0:
                 args.dim = len(args_input_shape) + args.dim
 
-            logger.debug("%s: Lowering to GATHER_ND: input=%r dim=%d",
-                         node, args_input_shape, args.dim)
+            logger.debug(
+                "%s: Lowering to GATHER_ND: input=%r dim=%d",
+                node,
+                args_input_shape,
+                args.dim,
+            )
 
             with graph.inserting_before(node):
                 # Create coordinate grids for each dimension.
 
                 indices = []
                 for i in range(len(args_input_shape)):
-
                     if i == args.dim:
                         # Use the original index tensor for the gather dimension.
                         indices.append(args.index)
@@ -93,12 +96,14 @@ class ConvertGatherToGatherNd(PassBase):
                     )
 
                     # Expand to match the output shape.
-                    indices.append(create_node(
-                        graph,
-                        torch.ops.aten.expand.default,
-                        args=(reshape_node, list(args_index_shape)),
-                        origin=node,
-                    ))
+                    indices.append(
+                        create_node(
+                            graph,
+                            torch.ops.aten.expand.default,
+                            args=(reshape_node, list(args_index_shape)),
+                            origin=node,
+                        )
+                    )
 
                 # Stack all indices along the last dimension. We have to do it
                 # manually because torch.stack is not supported for our case.

--- a/tico/passes/convert_gather_to_gather_nd.py
+++ b/tico/passes/convert_gather_to_gather_nd.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions of
+# limitations under the License.
+
+import torch
+from torch.export import ExportedProgram
+
+from tico.utils import logging
+from tico.utils.utils import is_target_node
+from tico.utils.graph import create_node
+from tico.utils.passes import PassBase, PassResult
+from tico.utils.validate_args_kwargs import GatherArgs
+from tico.utils.trace_decorators import trace_graph_diff_on_pass
+
+
+@trace_graph_diff_on_pass
+class ConvertGatherToGatherNd(PassBase):
+    """
+    This pass transforms torch.gather to operations compatible with Circle GATHER_ND.
+
+    This pass constructs multi-dimensional indices by:
+    1. Creating coordinate grids for all non-gather dimensions
+    2. Stacking them with the gather indices to form full coordinates
+    3. Replacing the original gather with an index operation using these coordinates
+    """
+
+    def call(self, exported_program: ExportedProgram) -> PassResult:
+        logger = logging.getLogger(__name__)
+
+        graph_module = exported_program.graph_module
+        graph = graph_module.graph
+
+        modified = False
+        for node in graph.nodes:
+            if not is_target_node(node, torch.ops.aten.gather.default):
+                continue
+            # Skip if this node was already processed.
+            if node.meta.get("gather-to-gather-nd-passed", False):
+                continue
+
+            args = GatherArgs(*node.args, **node.kwargs)  # type: ignore
+            args_input_shape = args.input.meta["val"].shape
+            args_index_shape = args.index.meta["val"].shape
+
+            # Normalize dimension index to be positive.
+            if args.dim < 0:
+                args.dim = len(args_input_shape) + args.dim
+
+            logger.debug("%s: Lowering to GATHER_ND: input=%r dim=%d",
+                         node, args_input_shape, args.dim)
+
+            with graph.inserting_before(node):
+                # Create coordinate grids for each dimension.
+
+                indices = []
+                for i in range(len(args_input_shape)):
+
+                    if i == args.dim:
+                        # Use the original index tensor for the gather dimension.
+                        indices.append(args.index)
+                        continue
+
+                    # For dimensions other than the gather dimension, create a
+                    # coordinate grid with shape [1, 1, ..., index_shape[i], ..., 1].
+
+                    # Create a range from 0 to the size of the n-th dimension.
+                    arange_node = create_node(
+                        graph,
+                        torch.ops.aten.arange.start_step,
+                        args=(0, args_index_shape[i], 1),
+                        kwargs={"dtype": torch.int32},
+                        origin=node,
+                    )
+
+                    # Use INDEX shape for the range.
+                    shape = [1] * len(args_index_shape)
+                    shape[i] = args_index_shape[i]
+                    reshape_node = create_node(
+                        graph,
+                        torch.ops.aten.reshape.default,
+                        args=(arange_node, shape),
+                        origin=node,
+                    )
+
+                    # Expand to match the output shape.
+                    indices.append(create_node(
+                        graph,
+                        torch.ops.aten.expand.default,
+                        args=(reshape_node, list(args_index_shape)),
+                        origin=node,
+                    ))
+
+                # Stack all indices along the last dimension. We have to do it
+                # manually because torch.stack is not supported for our case.
+                indices = [
+                    create_node(
+                        graph,
+                        torch.ops.aten.unsqueeze.default,
+                        args=(index, -1),
+                        origin=node,
+                    )
+                    for index in indices
+                ]
+                stacked_indices = create_node(
+                    graph,
+                    torch.ops.aten.cat.default,
+                    args=(indices, -1),
+                    origin=node,
+                )
+
+            # Replace the original index tensor with the stacked indices.
+            # The gather node will now use GATHER_ND with these indices
+
+            if len(node.args) > 2:
+                new_args = list(node.args)
+                new_args[2] = stacked_indices
+                node.args = tuple(new_args)
+
+            node.meta["gather-to-gather-nd-passed"] = True
+            modified = True
+
+        if modified:
+            graph.eliminate_dead_code()
+            graph.lint()
+            graph_module.recompile()
+
+        return PassResult(modified)

--- a/tico/passes/ops.py
+++ b/tico/passes/ops.py
@@ -27,6 +27,7 @@ class AtenOps:
         # In alphabetical order
         self.add = [torch.ops.aten.add.Tensor]
         self.alias = [torch.ops.aten.alias.default, torch.ops.aten.alias_copy.default]
+        self.arange = [torch.ops.aten.arange.start_step]
         self.cat = [torch.ops.aten.cat.default]
         self.clamp = [torch.ops.aten.clamp.default, torch.ops.aten.clamp.Tensor]
         self.clone = [torch.ops.aten.clone.default]
@@ -50,6 +51,7 @@ class AtenOps:
             torch.ops.aten.expand.default,
             torch.ops.aten.expand_copy.default,
         ]
+        self.gather = [torch.ops.aten.gather.default]
         self.index_select = [torch.ops.aten.index_select.default]
         self.mean = [torch.ops.aten.mean.dim]
         self.mul_scalar = [torch.ops.aten.mul.Scalar]

--- a/tico/serialize/operators/op_gather.py
+++ b/tico/serialize/operators/op_gather.py
@@ -69,10 +69,11 @@ class GatherVisitor(NodeVisitor):
         inputs = [input_tensor, index_tensor]
         outputs = [node]
 
-        operator = create_builtin_operator(
-            self.graph, op_index, inputs, outputs)
+        operator = create_builtin_operator(self.graph, op_index, inputs, outputs)
 
-        operator.builtinOptionsType = circle.BuiltinOptions.BuiltinOptions.GatherNdOptions
+        operator.builtinOptionsType = (
+            circle.BuiltinOptions.BuiltinOptions.GatherNdOptions
+        )
         operator.builtinOptions = circle.GatherNdOptions.GatherNdOptionsT()
 
         return operator

--- a/tico/serialize/operators/op_gather.py
+++ b/tico/serialize/operators/op_gather.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch._ops
+    import torch.fx
+import torch
+from circle_schema import circle
+
+from tico.serialize.operators.node_visitor import NodeVisitor, register_node_visitor
+from tico.serialize.operators.utils import create_builtin_operator, get_op_index
+from tico.utils.validate_args_kwargs import GatherArgs
+
+
+@register_node_visitor
+class GatherVisitor(NodeVisitor):
+    target: List[torch._ops.OpOverload] = [
+        torch.ops.aten.gather.default,
+        torch.ops.aten.gather.out,
+    ]
+
+    def define_node(self, node: torch.fx.Node) -> circle.Operator.OperatorT:
+        """
+        Convert PyTorch gather to Circle GATHER_ND.
+
+        PyTorch: out[i,j,k] = input[i,j,indices[i,j,k],k] for dim=2
+
+        We construct indices that specify full coordinates:
+        - For each output position, create coordinates [i0, i1, ..., index_value, ..., iN]
+        - The index tensor provides the gather dimension values
+        - Other dimensions use arange-based coordinate grids
+
+        Note: The ConvertGatherToGatherNdPass preprocesses the graph to construct
+        multi-dimensional indices. This serializer then uses those pre-constructed
+        indices.
+        """
+        args = GatherArgs(*node.args, **node.kwargs)  # type: ignore[arg-type]
+
+        input_tensor = args.input
+        index_tensor = args.index
+
+        # Verify that the pass has already transformed the graph to provide
+        # multi-dimensional indices for GATHER_ND.
+        if not node.meta.get("gather-to-gather-nd-passed", False):
+            raise ValueError(
+                f"GatherVisitor expected node {node} to have been preprocessed by "
+                f"ConvertGatherToGatherNdPass, but it was not. Ensure that the pass "
+                f"is enabled and correctly modifies the graph before serialization."
+            )
+
+        op_index = get_op_index(
+            circle.BuiltinOperator.BuiltinOperator.GATHER_ND,
+            self._op_codes,
+        )
+
+        inputs = [input_tensor, index_tensor]
+        outputs = [node]
+
+        operator = create_builtin_operator(
+            self.graph, op_index, inputs, outputs)
+
+        operator.builtinOptionsType = circle.BuiltinOptions.BuiltinOptions.GatherNdOptions
+        operator.builtinOptions = circle.GatherNdOptions.GatherNdOptionsT()
+
+        return operator

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -51,6 +51,7 @@ from tico.passes.legalize_predefined_layout_operators import (
     LegalizePreDefinedLayoutOperators,
 )
 from tico.passes.lower_copy import LowerCopy
+from tico.passes.convert_gather_to_gather_nd import ConvertGatherToGatherNd
 from tico.passes.lower_pow2_to_mul import LowerPow2ToMul
 from tico.passes.lower_to_resize_nearest_neighbor import LowerToResizeNearestNeighbor
 from tico.passes.lower_to_slice import passes as LowerToSlicePasses
@@ -248,6 +249,7 @@ def convert_exported_module_to_circle(
             ExtractDtypeKwargsPass(),
             RemoveNop(),
             LowerCopy(),
+            ConvertGatherToGatherNd(),
             ConvertSymSizeToCircleShape(),
             ConvertLayoutOpToReshape(),
             RestoreLinear(),

--- a/tico/utils/convert.py
+++ b/tico/utils/convert.py
@@ -27,6 +27,7 @@ from tico.passes.const_prop_pass import ConstPropPass
 from tico.passes.convert_conv1d_to_conv2d import ConvertConv1dToConv2d
 from tico.passes.convert_conv3d_to_conv2d import ConvertConv3dToConv2d
 from tico.passes.convert_expand_to_slice_cat import ConvertExpandToSliceCat
+from tico.passes.convert_gather_to_gather_nd import ConvertGatherToGatherNd
 from tico.passes.convert_layout_op_to_reshape import ConvertLayoutOpToReshape
 from tico.passes.convert_matmul_to_linear import ConvertMatmulToLinear
 from tico.passes.convert_repeat_to_expand_copy import ConvertRepeatToExpandCopy
@@ -51,7 +52,6 @@ from tico.passes.legalize_predefined_layout_operators import (
     LegalizePreDefinedLayoutOperators,
 )
 from tico.passes.lower_copy import LowerCopy
-from tico.passes.convert_gather_to_gather_nd import ConvertGatherToGatherNd
 from tico.passes.lower_pow2_to_mul import LowerPow2ToMul
 from tico.passes.lower_to_resize_nearest_neighbor import LowerToResizeNearestNeighbor
 from tico.passes.lower_to_slice import passes as LowerToSlicePasses

--- a/tico/utils/validate_args_kwargs.py
+++ b/tico/utils/validate_args_kwargs.py
@@ -520,6 +520,18 @@ class FullLikeArgs:
 
 @enforce_type
 @dataclass
+class GatherArgs:
+    """
+    gather(Tensor self, int dim, Tensor index) -> Tensor
+    """
+
+    input: torch.fx.Node
+    dim: int
+    index: Union[torch.fx.Node, torch.Tensor]
+
+
+@enforce_type
+@dataclass
 class FullArgs:
     """
     full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor


### PR DESCRIPTION
Add support for PyTorch gather operator by converting it into Circle GATHER_ND.

Since the `torch.gather` and `circle.gather_nd` semantics are different, the conversion involves creating full indices matrix for `circle.gather_nd` based on the `index` and `dim` `torch.gather` arguments. The final conversion looks like this (for different gathering dimension in the torch semantic):

Gathering over 0 axis:
<img width="1000" height="400" alt="circle-0" src="https://github.com/user-attachments/assets/a8f97fa9-d6d0-4b8f-9e75-ad41242a349a" />

Gathering over 1st axis:
<img width="1000" height="400" alt="circle-1" src="https://github.com/user-attachments/assets/56c5543f-b605-4807-bcae-777950253783" />

Gathering over 2nd axis:
<img width="1000" height="400" alt="circle-2" src="https://github.com/user-attachments/assets/5c6dbb76-b16c-4e75-8750-291176dd075e" />

Gathering over 3rd axis:
<img width="1000" height="400" alt="circle-3" src="https://github.com/user-attachments/assets/df6fcddb-e89a-43fd-a295-ea0dce768d98" />