### PR TITLE
[quantization] Complete QuantGemma4Model PTQ Wrapper

### DIFF
--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_model.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_model.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for QuantGemma4Model wrapper and _get_placeholder_mask helper."""
+
+import copy
+import os
+import unittest
+
+import torch
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.gemma4.quant_model import (
+    _get_placeholder_mask,
+    QuantGemma4Model,
+)
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+
+IS_INTERNAL_TEST = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+_SKIP_MSG = "required transformers Gemma4 modules are not installed"
+
+
+def _has_gemma4() -> bool:
+    """Return whether the installed transformers package provides Gemma4 support."""
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4Model  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _make_vision_config():
+    """Create a tiny Gemma4 vision config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+    cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        patch_size=4,
+        position_embedding_size=8,
+        pooling_kernel_size=2,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        use_clipped_linears=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 100.0},
+        standardize=True,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_text_config():
+    """Create a tiny Gemma4 text config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    cfg = Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=32,
+        global_head_dim=32,
+        max_position_embeddings=128,
+        layer_types=["full_attention"],
+        rope_parameters={
+            "full_attention": {"rope_type": "default", "rope_theta": 10000.0}
+        },
+        attention_bias=False,
+        attention_dropout=0.0,
+        use_cache=False,
+        enable_moe_block=False,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_gemma4_config():
+    """Create a tiny Gemma4 top-level config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4Config
+
+    return Gemma4Config(
+        text_config=_make_text_config(),
+        vision_config=_make_vision_config(),
+        audio_config=None,
+        image_token_id=10,
+        video_token_id=11,
+        audio_token_id=12,
+    )
+
+
+def _make_gemma4_model():
+    """Create a tiny Gemma4Model for testing."""
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
+
+    config = _make_gemma4_config()
+    return Gemma4Model(config).eval()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _get_placeholder_mask (no model required)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlaceholderMask(unittest.TestCase):
+    """Test the _get_placeholder_mask helper function."""
+
+    def _make_config(
+        self,
+        image_token_id: int | None = 10,
+        video_token_id: int | None = 11,
+        audio_token_id: int | None = 12,
+    ):
+        """Create a simple config-like object with token IDs."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            image_token_id=image_token_id,
+            video_token_id=video_token_id,
+            audio_token_id=audio_token_id,
+        )
+
+    def test_no_placeholders(self):
+        """All-text input should produce all-False masks."""
+        input_ids = torch.tensor([[1, 2, 3, 4, 5]])
+        cfg = self._make_config()
+        img, vid, aud = _get_placeholder_mask(input_ids, cfg)
+        self.assertFalse(img.any())
+        self.assertFalse(vid.any())
+        self.assertFalse(aud.any())
+
+    def test_image_placeholders(self):
+        """Image token IDs should be marked in the image mask only."""
+        input_ids = torch.tensor([[1, 10, 10, 4]])
+        cfg = self._make_config()
+        img, vid, aud = _get_placeholder_mask(input_ids, cfg)
+        self.assertTrue(torch.equal(img, torch.tensor([[False, True, True, False]])))
+        self.assertFalse(vid.any())
+        self.assertFalse(aud.any())
+
+    def test_mixed_placeholders(self):
+        """Each placeholder type should appear in its own mask only."""
+        input_ids = torch.tensor([[10, 11, 12, 1]])
+        cfg = self._make_config()
+        img, vid, aud = _get_placeholder_mask(input_ids, cfg)
+        self.assertTrue(torch.equal(img, torch.tensor([[True, False, False, False]])))
+        self.assertTrue(torch.equal(vid, torch.tensor([[False, True, False, False]])))
+        self.assertTrue(torch.equal(aud, torch.tensor([[False, False, True, False]])))
+
+    def test_missing_token_ids(self):
+        """When a token ID is None, the corresponding mask should be all-False."""
+        input_ids = torch.tensor([[1, 2, 3]])
+        cfg = self._make_config(
+            image_token_id=None, video_token_id=None, audio_token_id=None
+        )
+        img, vid, aud = _get_placeholder_mask(input_ids, cfg)
+        self.assertFalse(img.any())
+        self.assertFalse(vid.any())
+        self.assertFalse(aud.any())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for QuantGemma4Model input validation
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestQuantGemma4ModelValidation(unittest.TestCase):
+    """Test input validation in QuantGemma4Model.forward."""
+
+    def setUp(self):
+        """Create a tiny Gemma4Model and wrap it."""
+        torch.manual_seed(2026)
+        self.fp_model = _make_gemma4_model()
+        self.qcfg = PTQConfig(
+            model_args={
+                "vision": {
+                    "visual_start_idx": 0,
+                    "num_visual_tokens": 4,
+                }
+            }
+        )
+        self.qmodel = prepare(self.fp_model, self.qcfg).eval()
+
+    def test_reject_both_input_ids_and_inputs_embeds(self):
+        """Providing both input_ids and inputs_embeds should raise ValueError."""
+        input_ids = torch.tensor([[1, 2, 3]])
+        inputs_embeds = torch.randn(1, 3, 64)
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            self.qmodel(input_ids=input_ids, inputs_embeds=inputs_embeds)
+
+    def test_reject_neither_input_ids_nor_inputs_embeds(self):
+        """Providing neither input_ids nor inputs_embeds should raise ValueError."""
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            self.qmodel()
+
+    def test_reject_input_ids_with_per_layer_inputs(self):
+        """Providing both input_ids and per_layer_inputs should raise ValueError."""
+        input_ids = torch.tensor([[1, 2, 3]])
+        per_layer_inputs = torch.randn(1, 3, 1, 256)
+        with self.assertRaisesRegex(ValueError, "per_layer_inputs"):
+            self.qmodel(input_ids=input_ids, per_layer_inputs=per_layer_inputs)
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for QuantGemma4Model forward
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestQuantGemma4ModelSmoke(unittest.TestCase):
+    """Exercise QuantGemma4Model wrapper parity and PTQ flow."""
+
+    def setUp(self):
+        """Create deterministic tiny Gemma4Model modules."""
+        torch.manual_seed(2026)
+        self.fp_model = _make_gemma4_model()
+        self.fp_ref = copy.deepcopy(self.fp_model).eval()
+        self.config = self.fp_model.config
+        self.text_config = self.config.get_text_config()
+        self.seq_len = 8
+        self.batch_size = 1
+        self.qcfg = PTQConfig(
+            model_args={
+                "vision": {
+                    "visual_start_idx": 0,
+                    "num_visual_tokens": 4,
+                }
+            }
+        )
+
+    def _text_only_sample(self):
+        """Create a text-only sample (no image tokens)."""
+        return {
+            "input_ids": torch.randint(
+                0, self.text_config.vocab_size, (self.batch_size, self.seq_len)
+            ),
+        }
+
+    def _text_with_image_sample(self):
+        """Create a sample with image placeholder tokens at the start."""
+        input_ids = torch.randint(
+            0, self.text_config.vocab_size, (self.batch_size, self.seq_len)
+        )
+        # Place image tokens at positions 0..3
+        input_ids[0, :4] = self.config.image_token_id
+        return {
+            "input_ids": input_ids,
+        }
+
+    def test_text_only_forward_is_finite(self):
+        """Text-only forward through the wrapper should produce finite output."""
+        qmodel = prepare(self.fp_model, self.qcfg).eval()
+        sample = self._text_only_sample()
+
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+
+        quantized = convert(qmodel)
+        with torch.no_grad():
+            out = quantized(**sample)
+
+        # The output is a Gemma4TextModelOutputWithPast; check last_hidden_state
+        hidden = out.last_hidden_state
+        self.assertTrue(torch.isfinite(hidden).all())
+
+    def test_placeholder_replacement_produces_pad_embedding(self):
+        """Image placeholder tokens should be replaced with pad_token_id before embedding."""
+        qmodel = prepare(self.fp_model, self.qcfg).eval()
+        sample = self._text_with_image_sample()
+        input_ids = sample["input_ids"]
+
+        # Calibrate and convert
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+        quantized = convert(qmodel)
+
+        # After quantization, the forward should still work with image tokens
+        with torch.no_grad():
+            out = quantized(**sample)
+
+        hidden = out.last_hidden_state
+        self.assertTrue(torch.isfinite(hidden).all())
+
+    def test_prepare_convert_flow(self):
+        """Full prepare → calibrate → convert flow should succeed."""
+        qmodel = prepare(self.fp_model, self.qcfg)
+        self.assertIsInstance(qmodel, PTQWrapper)
+        self.assertIsInstance(qmodel.wrapped, QuantGemma4Model)
+
+        sample = self._text_only_sample()
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+
+        quantized = convert(qmodel)
+        self.assertIs(quantized._mode, Mode.QUANT)
+
+        with torch.no_grad():
+            out = quantized(**sample)
+
+        hidden = out.last_hidden_state
+        self.assertEqual(
+            hidden.shape,
+            (self.batch_size, self.seq_len, self.text_config.hidden_size),
+        )
+        self.assertTrue(torch.isfinite(hidden).all())
+
+    def test_inputs_embeds_without_per_layer_inputs_raises(self):
+        """When PLE is enabled and inputs_embeds is given without per_layer_inputs, it should raise."""
+        # This test only applies when hidden_size_per_layer_input > 0
+        if not self.text_config.hidden_size_per_layer_input:
+            self.skipTest("PLE not enabled for this config")
+
+        qmodel = prepare(self.fp_model, self.qcfg).eval()
+        sample = self._text_only_sample()
+
+        # Calibrate first
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+        quantized = convert(qmodel)
+
+        # Now call with inputs_embeds but no per_layer_inputs
+        inputs_embeds = torch.randn(
+            self.batch_size, self.seq_len, self.text_config.hidden_size
+        )
+        with self.assertRaises((ValueError, RuntimeError)):
+            with torch.no_grad():
+                quantized(inputs_embeds=inputs_embeds)
+
+    def test_inputs_embeds_with_per_layer_inputs_works(self):
+        """When PLE is enabled and both inputs_embeds and per_layer_inputs are given, it should work."""
+        if not self.text_config.hidden_size_per_layer_input:
+            self.skipTest("PLE not enabled for this config")
+
+        qmodel = prepare(self.fp_model, self.qcfg).eval()
+        sample = self._text_only_sample()
+
+        # Calibrate
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+        quantized = convert(qmodel)
+
+        # Call with both inputs_embeds and per_layer_inputs
+        inputs_embeds = torch.randn(
+            self.batch_size, self.seq_len, self.text_config.hidden_size
+        )
+        per_layer_inputs = torch.randn(
+            self.batch_size,
+            self.seq_len,
+            self.text_config.num_hidden_layers,
+            self.text_config.hidden_size_per_layer_input,
+        )
+        with torch.no_grad():
+            out = quantized(
+                inputs_embeds=inputs_embeds, per_layer_inputs=per_layer_inputs
+            )
+
+        hidden = out.last_hidden_state
+        self.assertTrue(torch.isfinite(hidden).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for Gemma4Model prepare-calibrate-convert flow."""
+
+import copy
+import os
+import unittest
+
+import torch
+
+from tico.quantization import convert, prepare
+from tico.quantization.config.gemma4_builders import build_gemma4_e2b_ptq_config
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
+
+
+IS_INTERNAL_TEST = os.environ.get("RUN_INTERNAL_TESTS", "0") == "1"
+_SKIP_MSG = "required transformers Gemma4 modules are not installed"
+
+
+def _has_gemma4() -> bool:
+    """Return whether the installed transformers package provides Gemma4 support."""
+    try:
+        from transformers.models.gemma4.configuration_gemma4 import (  # noqa: F401
+            Gemma4Config,
+            Gemma4TextConfig,
+            Gemma4VisionConfig,
+        )
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4Model  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _make_vision_config():
+    """Create a tiny Gemma4 vision config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+    cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        patch_size=4,
+        position_embedding_size=8,
+        pooling_kernel_size=2,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        use_clipped_linears=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 100.0},
+        standardize=True,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_text_config():
+    """Create a tiny Gemma4 text config for synthetic smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    cfg = Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=32,
+        global_head_dim=32,
+        max_position_embeddings=128,
+        layer_types=["full_attention"],
+        rope_parameters={
+            "full_attention": {"rope_type": "default", "rope_theta": 10000.0}
+        },
+        attention_bias=False,
+        attention_dropout=0.0,
+        use_cache=False,
+        enable_moe_block=False,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_gemma4_config():
+    """Create a tiny Gemma4 top-level config for smoke tests."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4Config
+
+    return Gemma4Config(
+        text_config=_make_text_config(),
+        vision_config=_make_vision_config(),
+        audio_config=None,
+        image_token_id=10,
+        video_token_id=11,
+        audio_token_id=12,
+    )
+
+
+def _pixel_position_ids(batch_size: int, num_patches: int) -> torch.Tensor:
+    """Create deterministic 2D pixel position ids for a patch grid."""
+    side = int(num_patches**0.5)
+    coords = torch.arange(num_patches)
+    xy = torch.stack((coords % side, coords // side), dim=-1)
+    return xy.unsqueeze(0).expand(batch_size, -1, -1).long()
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestGemma4ModelSmoke(unittest.TestCase):
+    """Exercise Gemma4Model wrapper parity and PTQ flow."""
+
+    def setUp(self):
+        """Create deterministic tiny Gemma4Model modules."""
+        torch.manual_seed(2026)
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
+
+        self.cfg = _make_gemma4_config()
+        self.text_cfg = self.cfg.get_text_config()
+        self.vision_cfg = self.cfg.vision_config
+        self.fp_model = Gemma4Model(self.cfg).eval()
+        self.fp_ref = copy.deepcopy(self.fp_model).eval()
+        self.batch_size = 1
+        self.seq_len = 16
+        self.num_patches = 16
+        self.patch_size = self.vision_cfg.patch_size
+        self.num_visual_tokens = 4
+
+    def _ptq_config(self):
+        """Build the PTQ config used by Gemma4Model smoke tests."""
+        return build_gemma4_e2b_ptq_config(
+            num_text_layers=int(self.text_cfg.num_hidden_layers),
+            num_vision_layers=int(self.vision_cfg.num_hidden_layers),
+            model_args={
+                "vision": {
+                    "visual_start_idx": 0,
+                    "num_visual_tokens": self.num_visual_tokens,
+                }
+            },
+        )
+
+    def _text_sample(self):
+        """Create one synthetic text-only input (no image placeholders).
+
+        Token IDs are kept in [0, 9] to avoid colliding with the image
+        placeholder token ID (10).
+        """
+        return {
+            "input_ids": torch.randint(0, 10, (self.batch_size, self.seq_len)),
+        }
+
+    def _image_text_sample(self):
+        """Create one synthetic image-text input with image placeholders."""
+        input_ids = torch.randint(0, 10, (self.batch_size, self.seq_len))
+        input_ids[0, : self.num_visual_tokens] = self.cfg.image_token_id
+        patch_dim = 3 * self.patch_size**2
+        return {
+            "input_ids": input_ids,
+            "pixel_values": torch.randn(self.batch_size, self.num_patches, patch_dim),
+            "image_position_ids": _pixel_position_ids(
+                self.batch_size, self.num_patches
+            ),
+        }
+
+    def test_no_quant_model_matches_reference(self):
+        """The wrapper should match the floating-point module before quantization."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_model import QuantGemma4Model
+
+        wrapped = QuantGemma4Model(self.fp_model, qcfg=self._ptq_config()).eval()
+        sample = self._text_sample()
+
+        with torch.no_grad():
+            quant_out = wrapped(**sample)
+            fp_out = self.fp_ref(**sample)
+
+        self.assertEqual(
+            quant_out.last_hidden_state.shape, fp_out.last_hidden_state.shape
+        )
+        self.assertTrue(
+            torch.allclose(
+                quant_out.last_hidden_state,
+                fp_out.last_hidden_state,
+                atol=1e-5,
+                rtol=1e-5,
+            )
+        )
+
+    def test_prepare_convert_model_flow(self):
+        """Quantize Gemma4Model and validate a synthetic output."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_model import QuantGemma4Model
+
+        prepared = prepare(self.fp_model, self._ptq_config())
+        self.assertIsInstance(prepared, PTQWrapper)
+        self.assertIsInstance(prepared.wrapped, QuantGemma4Model)
+
+        with torch.no_grad():
+            for _ in range(3):
+                prepared(**self._text_sample())
+
+        quantized = convert(prepared)
+        self.assertIs(quantized._mode, Mode.QUANT)
+
+        sample = self._text_sample()
+        with torch.no_grad():
+            quant_out = quantized(**sample)
+            fp_out = self.fp_ref(**sample)
+
+        self.assertEqual(
+            quant_out.last_hidden_state.shape, fp_out.last_hidden_state.shape
+        )
+        self.assertTrue(torch.isfinite(quant_out.last_hidden_state).all())
+
+    def test_prepare_convert_model_flow_with_image(self):
+        """Quantize Gemma4Model with image-text calibration data."""
+        prepared = prepare(self.fp_model, self._ptq_config())
+
+        with torch.no_grad():
+            for _ in range(3):
+                prepared(**self._image_text_sample())
+
+        quantized = convert(prepared)
+        self.assertIs(quantized._mode, Mode.QUANT)
+
+        sample = self._image_text_sample()
+        with torch.no_grad():
+            quant_out = quantized(**sample)
+            fp_out = self.fp_ref(**sample)
+
+        self.assertEqual(
+            quant_out.last_hidden_state.shape, fp_out.last_hidden_state.shape
+        )
+        self.assertTrue(torch.isfinite(quant_out.last_hidden_state).all())
+
+    def test_as_export_module_flow(self):
+        """Test the as_export_module flow for Circle export."""
+        from tico.quantization.wrapq.wrappers.gemma4.export_adapters import (
+            Gemma4ModelPrefillExportAdapter,
+        )
+
+        prepared = prepare(self.fp_model, self._ptq_config())
+
+        with torch.no_grad():
+            for _ in range(3):
+                prepared(**self._text_sample())
+
+        quantized = convert(prepared)
+
+        export_module = quantized.wrapped.as_export_module(mode="prefill")
+
+        # as_export_module returns Gemma4ModelPrefillExportAdapter
+        self.assertIsInstance(export_module, Gemma4ModelPrefillExportAdapter)
+
+        # Build precomputed export inputs (simulating CPU runtime output)
+        hidden_size = int(self.text_cfg.hidden_size)
+        head_dim = int(self.text_cfg.head_dim)
+        num_layers = int(self.text_cfg.num_hidden_layers)
+        ple_dim = int(getattr(self.text_cfg, "hidden_size_per_layer_input", 0) or 0)
+        layer_types = list(self.text_cfg.layer_types)
+
+        inputs_embeds = torch.randn(self.batch_size, self.seq_len, hidden_size)
+
+        per_layer_inputs = None
+        if ple_dim > 0:
+            per_layer_inputs = torch.randn(
+                self.batch_size, self.seq_len, num_layers, ple_dim
+            )
+
+        attention_masks = {}
+        position_embeddings = {}
+        for layer_type in layer_types:
+            attention_masks[layer_type] = torch.zeros(
+                self.batch_size, 1, self.seq_len, self.seq_len
+            )
+            cos = torch.ones(self.batch_size, self.seq_len, head_dim)
+            sin = torch.zeros(self.batch_size, self.seq_len, head_dim)
+            position_embeddings[layer_type] = (cos, sin)
+
+        with torch.no_grad():
+            output = export_module(
+                inputs_embeds=inputs_embeds,
+                per_layer_inputs=per_layer_inputs,
+                attention_masks=attention_masks,
+                position_embeddings=position_embeddings,
+            )
+
+        self.assertTrue(torch.isfinite(output).all())
+        self.assertEqual(output.shape, (self.batch_size, self.seq_len, hidden_size))
+
+    def test_get_placeholder_mask(self):
+        """Test the _get_placeholder_mask helper function."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_model import (
+            _get_placeholder_mask,
+        )
+
+        input_ids = torch.tensor([[1, 10, 11, 12, 5, 10]])
+        image_mask, video_mask, audio_mask = _get_placeholder_mask(input_ids, self.cfg)
+
+        self.assertTrue(image_mask[0, 1].item())
+        self.assertTrue(image_mask[0, 5].item())
+        self.assertFalse(image_mask[0, 0].item())
+        self.assertTrue(video_mask[0, 2].item())
+        self.assertTrue(audio_mask[0, 3].item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
@@ -1409,6 +1409,147 @@ class Gemma4VisionEncoderCase(Gemma4BaseCase):
         return ForwardInput((hidden,), {})
 
 
+class Gemma4ModelCase(Gemma4BaseCase):
+    """Smoke case for one tiny Gemma4Model (image-text)."""
+
+    name = "gemma4_model"
+    description = (
+        "Quantize one tiny Gemma4Model (vision tower + language model + fusion)."
+    )
+    tags = ("gemma4", "e2b", "model", "image-text")
+    max_mean_abs_diff = 5.0
+    seq_len = 16
+    num_visual_tokens = 4
+
+    def ptq_config(self, cfg: Mapping[str, Any]) -> Any:
+        """Build the PTQ config used by Gemma4Model smoke checks."""
+        from tico.quantization.config.gemma4_builders import build_gemma4_e2b_ptq_config
+
+        return build_gemma4_e2b_ptq_config(
+            num_text_layers=int(self.text_cfg.num_hidden_layers),
+            num_vision_layers=int(self.vision_cfg.num_hidden_layers),
+            model_args={
+                "vision": {
+                    "visual_start_idx": 0,
+                    "num_visual_tokens": self.num_visual_tokens,
+                }
+            },
+        )
+
+    def build(self, cfg: Mapping[str, Any]) -> tuple[torch.nn.Module, torch.nn.Module]:
+        """Build a tiny Gemma4Model and reference copy."""
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4Config
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
+
+        torch.manual_seed(123)
+        self.text_cfg = _make_text_config(layer_types=("full_attention",))
+        self.vision_cfg = _make_vision_config()
+
+        config = Gemma4Config(
+            text_config=self.text_cfg,
+            vision_config=self.vision_cfg,
+            audio_config=None,
+            image_token_id=10,
+            video_token_id=11,
+            audio_token_id=12,
+        )
+        module = Gemma4Model(config).eval()
+        return module, clone_module(module)
+
+    def _sample(self) -> ForwardInput:
+        """Create one synthetic Gemma4Model text-only input.
+
+        Token IDs are kept in [0, 9] to avoid colliding with the image
+        placeholder token ID (10).
+        """
+        input_ids = torch.randint(0, 10, (1, self.seq_len))
+        return ForwardInput(
+            (),
+            {
+                "input_ids": input_ids,
+            },
+        )
+
+    def calibration_inputs(
+        self,
+        prepared: torch.nn.Module,
+        cfg: Mapping[str, Any],
+    ) -> list[ForwardInput]:
+        """Create Gemma4Model calibration samples."""
+        return [self._sample() for _ in range(3)]
+
+    def eval_input(
+        self,
+        prepared: torch.nn.Module,
+        cfg: Mapping[str, Any],
+    ) -> ForwardInput:
+        """Create the Gemma4Model evaluation sample."""
+        return self._sample()
+
+    def forward(self, module: torch.nn.Module, sample: ForwardInput) -> Any:
+        """Run the Gemma4Model without sharing mutable sample state."""
+        cloned = _clone_forward_input(sample)
+        output = module(*cloned.args, **dict(cloned.kwargs))
+        if hasattr(output, "last_hidden_state"):
+            return output.last_hidden_state
+        return output
+
+    def reference_forward(
+        self, reference: torch.nn.Module, sample: ForwardInput
+    ) -> Any:
+        """Run the original Gemma4Model without sharing mutable sample state."""
+        cloned = _clone_forward_input(sample)
+        output = reference(*cloned.args, **dict(cloned.kwargs))
+        if hasattr(output, "last_hidden_state"):
+            return output.last_hidden_state
+        return output
+
+    def export_module(
+        self, quantized: torch.nn.Module, cfg: Mapping[str, Any]
+    ) -> torch.nn.Module:
+        """Export the wrapped Gemma4Model in prefill mode."""
+        wrapped = getattr(quantized, "wrapped", quantized)
+        if hasattr(wrapped, "as_export_module"):
+            return wrapped.as_export_module(mode="prefill").eval()
+        return quantized
+
+    def export_input(
+        self, eval_sample: ForwardInput, cfg: Mapping[str, Any]
+    ) -> ForwardInput:
+        """Create static export inputs expected by the Gemma4Model export adapter.
+
+        The export adapter's forward_export() takes precomputed inputs:
+        - inputs_embeds: (1, S, H)
+        - per_layer_inputs: (1, S, L, P) or None
+        - attention_masks: dict[layer_type -> mask]
+        - position_embeddings: dict[layer_type -> (cos, sin)]
+        """
+        hidden_size = int(self.text_cfg.hidden_size)
+        head_dim = int(self.text_cfg.head_dim)
+        num_layers = int(self.text_cfg.num_hidden_layers)
+        ple_dim = int(getattr(self.text_cfg, "hidden_size_per_layer_input", 0) or 0)
+        layer_types = list(self.text_cfg.layer_types)
+
+        inputs_embeds = torch.randn(1, self.seq_len, hidden_size)
+
+        per_layer_inputs = None
+        if ple_dim > 0:
+            per_layer_inputs = torch.randn(1, self.seq_len, num_layers, ple_dim)
+
+        attention_masks: dict[str, torch.Tensor] = {}
+        position_embeddings: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+        for layer_type in layer_types:
+            attention_masks[layer_type] = torch.zeros(1, 1, self.seq_len, self.seq_len)
+            cos = torch.ones(1, self.seq_len, head_dim)
+            sin = torch.zeros(1, self.seq_len, head_dim)
+            position_embeddings[layer_type] = (cos, sin)
+
+        return ForwardInput(
+            (inputs_embeds, per_layer_inputs, attention_masks, position_embeddings),
+            {},
+        )
+
+
 GEMMA4_CASES = (
     Gemma4TextMLPCase(),
     Gemma4TextAttentionCase(),
@@ -1428,4 +1569,5 @@ GEMMA4_CASES = (
     Gemma4VisionModelCase(),
     Gemma4MultimodalEmbedderCase(),
     Gemma4VisionEncoderCase(),
+    Gemma4ModelCase(),
 )

--- a/tico/quantization/wrapq/examples/gemma4/quantize_model.py
+++ b/tico/quantization/wrapq/examples/gemma4/quantize_model.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example: PTQ quantization of Gemma4Model (image-text).
+
+The Gemma4Model is the top-level multimodal model that combines a vision
+tower, a vision-to-text projection (embed_vision), and a text decoder
+(language_model).  It accepts:
+
+- ``input_ids``: Token IDs of shape ``(B, S)`` including optional image
+  placeholder tokens (``config.image_token_id``).
+- ``pixel_values``: Pre-flattened image patches of shape
+  ``(B, num_patches, 3*patch_size^2)``.
+- ``image_position_ids``: 2D patch coordinates of shape ``(B, num_patches, 2)``.
+
+The output is a ``Gemma4ModelOutputWithPast`` whose ``last_hidden_state``
+contains the decoder hidden states.
+
+This script demonstrates the full PTQ flow:
+
+1. Create a tiny Gemma4Model with random weights (no download needed).
+2. Prepare the model for quantization with Gemma4-specific PTQ config.
+3. Calibrate with synthetic text-only data (image placeholders replaced
+   with pad_token_id before embedding, matching the production path).
+4. Convert to a fake-quantized model.
+5. Compare FP vs. quantized outputs.
+"""
+
+import copy
+import sys
+
+import torch
+
+import tico
+import tico.quantization
+import tico.quantization.config.ptq
+from tico.quantization.config.gemma4_builders import build_gemma4_e2b_ptq_config
+from tico.quantization.evaluation.metric import compute_peir
+from tico.quantization.evaluation.utils import plot_two_outputs
+from tico.quantization.wrapq.utils.version import has_transformers_for
+
+torch.manual_seed(123)
+
+
+# Check if transformers is available
+if not has_transformers_for("gemma4"):
+    print(
+        "Error: transformers package with Gemma4 support not installed. "
+        "Cannot test Gemma4Model."
+    )
+    sys.exit(1)
+
+from transformers.models.gemma4.configuration_gemma4 import (
+    Gemma4Config,
+    Gemma4TextConfig,
+    Gemma4VisionConfig,
+)
+from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
+
+
+def _make_vision_config() -> Gemma4VisionConfig:
+    """Create a tiny Gemma4 vision config for the example."""
+    cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        patch_size=4,
+        position_embedding_size=8,
+        pooling_kernel_size=2,
+        attention_dropout=0.0,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        use_clipped_linears=False,
+        rope_parameters={"rope_type": "default", "rope_theta": 100.0},
+        standardize=True,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_text_config() -> Gemma4TextConfig:
+    """Create a tiny Gemma4 text config for the example."""
+    cfg = Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=32,
+        global_head_dim=32,
+        max_position_embeddings=128,
+        layer_types=["full_attention"],
+        rope_parameters={
+            "full_attention": {"rope_type": "default", "rope_theta": 10000.0}
+        },
+        attention_bias=False,
+        attention_dropout=0.0,
+        use_cache=False,
+        enable_moe_block=False,
+    )
+    if not hasattr(cfg, "_attn_implementation"):
+        setattr(cfg, "_attn_implementation", "eager")
+    else:
+        cfg._attn_implementation = "eager"
+    return cfg
+
+
+def _make_gemma4_config() -> Gemma4Config:
+    """Create a tiny Gemma4 top-level config for the example."""
+    return Gemma4Config(
+        text_config=_make_text_config(),
+        vision_config=_make_vision_config(),
+        audio_config=None,
+        # Use small token IDs that fit within vocab_size=256
+        image_token_id=10,
+        video_token_id=11,
+        audio_token_id=12,
+    )
+
+
+def _pixel_position_ids(batch_size: int, num_patches: int) -> torch.Tensor:
+    """Create deterministic 2D pixel position ids for a patch grid."""
+    side = int(num_patches**0.5)
+    coords = torch.arange(num_patches)
+    xy = torch.stack((coords % side, coords // side), dim=-1)
+    return xy.unsqueeze(0).expand(batch_size, -1, -1).long()
+
+
+def generate_text_only_calibration_data(
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    num_samples: int = 20,
+) -> list[dict]:
+    """Generate text-only calibration data for PTQ.
+
+    Each sample contains ``input_ids`` with no image placeholder tokens.
+    The QuantGemma4Model wrapper will embed them directly.
+    """
+    calibration_data = []
+    for _ in range(num_samples):
+        # Use token IDs in range [0, vocab_size) but avoid the image
+        # placeholder token ID to keep this text-only.
+        input_ids = torch.randint(0, vocab_size, (batch_size, seq_len))
+        # Ensure no accidental image placeholder tokens
+        input_ids = input_ids.clamp(0, 9)
+        sample = {
+            "input_ids": input_ids,
+        }
+        calibration_data.append(sample)
+    return calibration_data
+
+
+def generate_image_text_calibration_data(
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    num_patches: int,
+    patch_size: int,
+    image_token_id: int,
+    num_visual_tokens: int,
+    num_samples: int = 20,
+) -> list[dict]:
+    """Generate image-text calibration data for PTQ.
+
+    Each sample contains ``input_ids`` with image placeholder tokens at
+    fixed positions, plus ``pixel_values`` and ``image_position_ids`` for
+    the vision tower.
+    """
+    patch_dim = 3 * patch_size**2
+    calibration_data = []
+    for _ in range(num_samples):
+        input_ids = torch.randint(0, vocab_size, (batch_size, seq_len))
+        # Place image placeholder tokens at the start
+        input_ids[0, :num_visual_tokens] = image_token_id
+        sample = {
+            "input_ids": input_ids,
+            "pixel_values": torch.randn(batch_size, num_patches, patch_dim),
+            "image_position_ids": _pixel_position_ids(batch_size, num_patches),
+        }
+        calibration_data.append(sample)
+    return calibration_data
+
+
+def main():
+    # Create the model with a tiny config (no download needed).
+    config = _make_gemma4_config()
+    text_config = config.get_text_config()
+    vision_config = config.vision_config
+
+    model = Gemma4Model(config)
+    orig_model = copy.deepcopy(model)
+    model.eval()
+
+    # Dimensions
+    batch_size = 1
+    seq_len = 16
+    num_patches = 16
+    patch_size = vision_config.patch_size
+    num_visual_tokens = 4
+
+    # Build a Gemma4-specific PTQ config with proper overrides.
+    ptq_config = build_gemma4_e2b_ptq_config(
+        num_text_layers=int(text_config.num_hidden_layers),
+        num_vision_layers=int(vision_config.num_hidden_layers),
+        model_args={
+            "vision": {
+                "visual_start_idx": 0,
+                "num_visual_tokens": num_visual_tokens,
+            }
+        },
+    )
+
+    # Prepare the model for quantization
+    print("Preparing model for quantization...")
+    prepared_model = tico.quantization.prepare(model, ptq_config)
+
+    # Calibrate with text-only data
+    print("Calibrating (text-only)...")
+    calibration_data = generate_text_only_calibration_data(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        vocab_size=text_config.vocab_size,
+        num_samples=20,
+    )
+    with torch.no_grad():
+        for sample in calibration_data:
+            prepared_model(**sample)
+
+    # Convert to quantized model
+    print("Converting to quantized model...")
+    quantized_model = tico.quantization.convert(prepared_model)
+
+    # Compute PEIR between quantized model and original model
+    eval_sample = calibration_data[0]
+    with torch.no_grad():
+        quant_out = quantized_model(**eval_sample).last_hidden_state
+        fp_out = orig_model(**eval_sample).last_hidden_state
+
+    print(f"\n┌───────────── Quantization Error Summary ─────────────")
+    print(f"│ FP output shape    : {tuple(fp_out.shape)}")
+    print(f"│ Quant output shape : {tuple(quant_out.shape)}")
+    print(f"│ Mean |diff|        : {(quant_out - fp_out).abs().mean().item():.6f}")
+    print(f"│ PEIR               : {compute_peir(fp_out, quant_out) * 100:.6f} %")
+    print(f"└──────────────────────────────────────────────────────")
+    print(plot_two_outputs(fp_out, quant_out))
+
+    # Also test with image-text data
+    print("\nCalibrating with image-text data...")
+    model2 = Gemma4Model(_make_gemma4_config())
+    orig_model2 = copy.deepcopy(model2)
+    model2.eval()
+
+    ptq_config2 = build_gemma4_e2b_ptq_config(
+        num_text_layers=int(text_config.num_hidden_layers),
+        num_vision_layers=int(vision_config.num_hidden_layers),
+        model_args={
+            "vision": {
+                "visual_start_idx": 0,
+                "num_visual_tokens": num_visual_tokens,
+            }
+        },
+    )
+
+    prepared_model2 = tico.quantization.prepare(model2, ptq_config2)
+
+    image_text_data = generate_image_text_calibration_data(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        vocab_size=text_config.vocab_size,
+        num_patches=num_patches,
+        patch_size=patch_size,
+        image_token_id=config.image_token_id,
+        num_visual_tokens=num_visual_tokens,
+        num_samples=20,
+    )
+    with torch.no_grad():
+        for sample in image_text_data:
+            prepared_model2(**sample)
+
+    quantized_model2 = tico.quantization.convert(prepared_model2)
+
+    eval_sample2 = image_text_data[0]
+    with torch.no_grad():
+        quant_out2 = quantized_model2(**eval_sample2).last_hidden_state
+        fp_out2 = orig_model2(**eval_sample2).last_hidden_state
+
+    print(f"\n┌───────────── Image-Text Quantization Error ──────────")
+    print(f"│ FP output shape    : {tuple(fp_out2.shape)}")
+    print(f"│ Quant output shape : {tuple(quant_out2.shape)}")
+    print(f"│ Mean |diff|        : {(quant_out2 - fp_out2).abs().mean().item():.6f}")
+    print(f"│ PEIR               : {compute_peir(fp_out2, quant_out2) * 100:.6f} %")
+    print(f"└──────────────────────────────────────────────────────")
+
+    # ------------------------------------------------------------------
+    # Export and convert to Circle format.
+    #
+    # The QuantGemma4Model.as_export_module() returns an export adapter
+    # whose forward_export() takes precomputed inputs:
+    #   - inputs_embeds:  Pre-fused text+image embeddings (B, S, H)
+    #   - per_layer_inputs: PLE tensor (B, S, L, P) or None
+    #   - attention_masks:  Dict mapping layer type to additive mask
+    #   - position_embeddings: Dict mapping layer type to (cos, sin)
+    #
+    # In a real deployment the CPU runtime computes these; here we
+    # synthesize them to demonstrate the Circle conversion path.
+    # ------------------------------------------------------------------
+    print("\nExporting to Circle format...")
+    wrapped = getattr(quantized_model2, "wrapped", quantized_model2)
+    export_module = wrapped.as_export_module(mode="prefill").eval()
+
+    # Build precomputed example inputs (simulating CPU runtime output).
+    hidden_size = int(text_config.hidden_size)
+    head_dim = int(text_config.head_dim)
+    num_layers = int(text_config.num_hidden_layers)
+    ple_dim = int(getattr(text_config, "hidden_size_per_layer_input", 0) or 0)
+    layer_types = list(text_config.layer_types)
+
+    ex_inputs_embeds = torch.randn(batch_size, seq_len, hidden_size)
+
+    ex_per_layer_inputs = None
+    if ple_dim > 0:
+        ex_per_layer_inputs = torch.randn(batch_size, seq_len, num_layers, ple_dim)
+
+    # Static causal masks and identity-like RoPE for each layer type.
+    ex_attention_masks = {}
+    ex_position_embeddings = {}
+    for layer_type in layer_types:
+        ex_attention_masks[layer_type] = torch.zeros(batch_size, 1, seq_len, seq_len)
+        cos = torch.ones(batch_size, seq_len, head_dim)
+        sin = torch.zeros(batch_size, seq_len, head_dim)
+        ex_position_embeddings[layer_type] = (cos, sin)
+
+    # Verify the export module produces finite output.
+    with torch.no_grad():
+        export_out = export_module(
+            inputs_embeds=ex_inputs_embeds,
+            per_layer_inputs=ex_per_layer_inputs,
+            attention_masks=ex_attention_masks,
+            position_embeddings=ex_position_embeddings,
+        )
+    print(f"Export output shape: {tuple(export_out.shape)}")
+    assert torch.isfinite(export_out).all(), "Export output contains non-finite values!"
+
+    # Convert to Circle format.
+    example_inputs = (
+        ex_inputs_embeds,  # inputs_embeds
+        ex_per_layer_inputs,  # per_layer_inputs
+        ex_attention_masks,  # attention_masks
+        ex_position_embeddings,  # position_embeddings
+    )
+
+    print("Converting to Circle format...")
+    circle_model = tico.convert(export_module, example_inputs)
+
+    filename = "gemma4_model.q.circle"
+    circle_model.save(filename)
+    print(f"Circle model saved as '{filename}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tico/quantization/wrapq/wrappers/gemma4/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/export_adapters.py
@@ -348,6 +348,52 @@ class Gemma4LMHeadExportAdapter(nn.Module):
         return self.lm_head(self.norm(hidden_states))
 
 
+class Gemma4ModelPrefillExportAdapter(nn.Module):
+    """Export adapter for the Gemma4Model (image-text) with static-shape contract.
+
+    This adapter wraps a ``QuantGemma4Model`` that has been prepared for export
+    via ``as_export_module()``.  Calling ``forward()`` delegates to the wrapped
+    model's ``forward_export()`` method, which runs only the text decoder layers
+    and final norm on pre-fused ``inputs_embeds``.
+
+    The CPU runtime is responsible for:
+    - Token embedding (with placeholder replacement)
+    - Vision tower + projection
+    - Multimodal fusion (fixed-slot)
+    - PLE computation (if enabled)
+    - Mask and RoPE generation per layer type
+    - KV cache management
+
+    Input contract:
+        ``inputs_embeds`` has shape ``(1, S, hidden_size)`` — pre-fused.
+        ``per_layer_inputs`` has shape ``(1, S, num_layers, ple_dim)`` or None.
+        ``attention_masks`` is a dict mapping layer type to additive masks.
+        ``position_embeddings`` is a dict mapping layer type to (cos, sin).
+
+    Output contract:
+        Returns the final hidden states with shape ``(1, S, hidden_size)``.
+    """
+
+    def __init__(self, wrapped_model: nn.Module):
+        super().__init__()
+        self.wrapped_model = wrapped_model
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        attention_masks: Optional[dict] = None,
+        position_embeddings: Optional[dict] = None,
+    ) -> torch.Tensor:
+        """Run the model export path via the wrapped model's forward_export."""
+        return self.wrapped_model.forward_export(
+            inputs_embeds=inputs_embeds,
+            per_layer_inputs=per_layer_inputs,
+            attention_masks=attention_masks,
+            position_embeddings=position_embeddings,
+        )
+
+
 class Gemma4VisionModelPrefillExportAdapter(nn.Module):
     """Export adapter for the Gemma4 vision model with static-shape contract.
 

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.gemma4.utils import (
     assert_gemma4_e2b_no_moe,
@@ -26,6 +27,37 @@ from tico.quantization.wrapq.wrappers.gemma4.utils import (
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
+
+
+def _get_placeholder_mask(
+    input_ids: torch.Tensor,
+    config: object,
+) -> tuple[torch.BoolTensor, torch.BoolTensor, torch.BoolTensor]:
+    """Return boolean masks for image, video, and audio placeholder tokens.
+
+    Mirrors ``Gemma4Model.get_placeholder_mask`` but works on raw tensors
+    without requiring the full model reference.
+    """
+    image_token_id = getattr(config, "image_token_id", None)
+    video_token_id = getattr(config, "video_token_id", None)
+    audio_token_id = getattr(config, "audio_token_id", None)
+
+    image_mask = (
+        input_ids == image_token_id
+        if image_token_id is not None
+        else torch.zeros_like(input_ids, dtype=torch.bool)
+    )
+    video_mask = (
+        input_ids == video_token_id
+        if video_token_id is not None
+        else torch.zeros_like(input_ids, dtype=torch.bool)
+    )
+    audio_mask = (
+        input_ids == audio_token_id
+        if audio_token_id is not None
+        else torch.zeros_like(input_ids, dtype=torch.bool)
+    )
+    return image_mask, video_mask, audio_mask
 
 
 @try_register("transformers.models.gemma4.modeling_gemma4.Gemma4Model")
@@ -41,12 +73,15 @@ class QuantGemma4Model(QuantModuleBase):
     ):
         assert_gemma4_e2b_no_moe(fp_model)
         super().__init__(qcfg, fp_name=fp_name)
-        self.module = fp_model
         self.config = fp_model.config
-        self.vision_tower = PTQWrapper(
-            fp_model.vision_tower,
-            qcfg=qcfg.child("vision_tower") if qcfg else None,
-            fp_name=join_name(fp_name, "vision_tower"),
+        self.vision_tower = (
+            PTQWrapper(
+                fp_model.vision_tower,
+                qcfg=qcfg.child("vision_tower") if qcfg else None,
+                fp_name=join_name(fp_name, "vision_tower"),
+            )
+            if fp_model.vision_tower is not None
+            else None
         )
         self.language_model = PTQWrapper(
             fp_model.language_model,
@@ -70,6 +105,7 @@ class QuantGemma4Model(QuantModuleBase):
             self.qcfg.model_args.get("vision", {}).get("num_visual_tokens", 0)
         )
         self.obs_mm_fusion = self._make_obs("mm_fusion")
+        self.obs_per_layer_inputs = self._make_obs("per_layer_inputs")
 
     def get_image_features(
         self,
@@ -77,6 +113,7 @@ class QuantGemma4Model(QuantModuleBase):
         image_position_ids: Optional[torch.Tensor] = None,
     ):
         """Return projected image soft tokens."""
+        assert self.vision_tower is not None, "vision_tower is not available"
         vision_outputs = self.vision_tower(
             pixel_values=pixel_values,
             pixel_position_ids=image_position_ids,
@@ -97,21 +134,110 @@ class QuantGemma4Model(QuantModuleBase):
     ):
         """Run Gemma4 image-text forward with fixed-slot fusion.
 
+        Mirrors ``Gemma4Model.forward`` with the following adaptations for
+        quantized calibration:
+
+        * Multimodal placeholder token IDs (image / video / audio) are replaced
+          with ``pad_token_id`` before the token-embedding lookup so that the
+          embedding at those positions is a neutral pad embedding (the real
+          features will be fused in later).
+        * The dynamic ``masked_scatter`` used by the original model is replaced
+          by ``fixed_slot_fuse`` which writes image features into a static,
+          pre-determined position range.
+        * Per-Layer Embeddings (PLE) are computed when the text config has
+          ``hidden_size_per_layer_input > 0`` (E2B / E4B models).  The PLE
+          token-identity and context-projection paths are both exercised so
+          their observers collect statistics during calibration.
+        * Video and audio paths are not supported in the v0 scope.
+
         TODO: Implement full HF-compatible output objects after the static layer
         wrappers are complete.
         """
-        if inputs_embeds is None:
-            if input_ids is None:
-                raise ValueError(
-                    "input_ids must be provided when inputs_embeds is None."
-                )
-            llm_input_ids = input_ids.clone()
-            # TODO: Replace image token positions with pad_token_id on CPU before calling this wrapper.
-            inputs_embeds = self.language_model.wrapped.embed_tokens(llm_input_ids)
+        # --- Input validation (matches original Gemma4Model.forward) ------
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds."
+            )
+        if input_ids is not None and per_layer_inputs is not None:
+            raise ValueError(
+                "You cannot specify per_layer_inputs if input_ids is provided."
+            )
 
+        # --- Token embedding with placeholder replacement -----------------
+        # QuantGemma4TextModel is the concrete type behind the PTQWrapper.
+        text_model = self.language_model.wrapped  # QuantGemma4TextModel
+        llm_input_ids: Optional[torch.Tensor] = None
+
+        if inputs_embeds is None:
+            assert input_ids is not None  # guaranteed by validation above
+            # Replace multimodal placeholder token IDs with pad_token_id so
+            # the embedding lookup returns a neutral pad embedding at those
+            # positions.  The real features will be fused in by fixed_slot_fuse.
+            llm_input_ids = input_ids.clone()
+            image_mask, video_mask, audio_mask = _get_placeholder_mask(
+                input_ids, self.config
+            )
+            multimodal_mask = image_mask | video_mask | audio_mask
+            if multimodal_mask.any():
+                pad_token_id = self.config.text_config.pad_token_id
+                llm_input_ids = torch.where(
+                    multimodal_mask, pad_token_id, llm_input_ids
+                )
+            inputs_embeds = text_model.embed_tokens(llm_input_ids)
+
+        # --- Per-Layer Embeddings (PLE) -----------------------------------
+        # E2B / E4B models use PLE.  When input_ids was provided we compute
+        # PLE here; when inputs_embeds was provided the caller must also
+        # supply per_layer_inputs (validated by QuantGemma4TextModel).
+        text_config = self.config.get_text_config()
+        hidden_size_per_layer_input = int(
+            getattr(text_config, "hidden_size_per_layer_input", 0) or 0
+        )
+        if per_layer_inputs is None and hidden_size_per_layer_input:
+            # PLE needs llm_input_ids and a pad-replaced version of
+            # inputs_embeds.  When input_ids was provided we already have
+            # llm_input_ids.  When inputs_embeds was provided directly we
+            # cannot reliably recover input_ids, so the caller must supply
+            # per_layer_inputs explicitly.
+            if llm_input_ids is None:
+                raise ValueError(
+                    "per_layer_inputs must be provided when inputs_embeds is "
+                    "given and PLE is enabled (hidden_size_per_layer_input > 0)."
+                )
+            # Replace embeddings at multimodal positions with the pad embedding
+            # before computing PLE, matching the original Gemma4Model.forward.
+            embed_tokens_fp = text_model.embed_tokens.wrapped.module
+            pad_embedding = embed_tokens_fp.weight[text_config.pad_token_id, :]
+            image_mask_emb, video_mask_emb, audio_mask_emb = _get_placeholder_mask(
+                llm_input_ids, self.config
+            )
+            multimodal_mask_emb = image_mask_emb | video_mask_emb | audio_mask_emb
+            multimodal_mask_emb = multimodal_mask_emb.to(inputs_embeds.device)
+            llm_inputs_embeds = torch.where(
+                multimodal_mask_emb[..., None],
+                pad_embedding.view(1, 1, -1).to(inputs_embeds),
+                inputs_embeds,
+            )
+            per_layer_inputs = text_model.get_per_layer_inputs(
+                llm_input_ids, llm_inputs_embeds
+            )
+
+        # Collect PLE statistics for the export path.  The calibration path
+        # also exercises PLE inside each decoder layer's
+        # ``_apply_per_layer_input()``, but the export path receives PLE as
+        # an external input that must be fake-quantized at this level.
+        if per_layer_inputs is not None:
+            self.obs_per_layer_inputs.collect(per_layer_inputs)
+
+        # --- Multimodal fusion (image only for v0) -----------------------
         if pixel_values is not None:
             image_embeds = self.get_image_features(
                 pixel_values, image_position_ids=image_position_ids
+            )
+            assert inputs_embeds is not None  # guaranteed after embedding step
+            # Align dtype/device to match text embeddings before fusion.
+            image_embeds = image_embeds.to(
+                device=inputs_embeds.device, dtype=inputs_embeds.dtype
             )
             inputs_embeds = fixed_slot_fuse(
                 inputs_embeds,
@@ -121,6 +247,7 @@ class QuantGemma4Model(QuantModuleBase):
             )
             inputs_embeds = self._fq(inputs_embeds, self.obs_mm_fusion)
 
+        # --- Language model -----------------------------------------------
         return self.language_model(
             input_ids=None,
             inputs_embeds=inputs_embeds,
@@ -130,6 +257,142 @@ class QuantGemma4Model(QuantModuleBase):
             **kwargs,
         )
 
+    def forward_export(
+        self,
+        inputs_embeds: torch.Tensor,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        attention_masks: Optional[dict] = None,
+        position_embeddings: Optional[dict] = None,
+    ) -> torch.Tensor:
+        """Run Gemma4 text decoder with static shapes for torch.export.
+
+        This method assumes the CPU runtime has already performed:
+        - Token embedding (with placeholder replacement)
+        - Vision tower + projection
+        - Multimodal fusion (fixed-slot)
+        - PLE computation (if enabled)
+        - Mask and RoPE generation per layer type
+
+        This method IS exportable via torch.export — no dynamic control flow
+        on tensor values, no references to dynamic tensor shapes.
+
+        Args:
+            inputs_embeds: Pre-fused text+image embeddings, shape ``(1, S, H)``.
+            per_layer_inputs: PLE tensor, shape ``(1, S, L, P)`` or None.
+            attention_masks: Dict mapping layer type to additive mask tensors.
+            position_embeddings: Dict mapping layer type to ``(cos, sin)`` tuples.
+
+        Returns:
+            Final hidden states after the text decoder and final norm,
+            shape ``(1, S, H)``.
+        """
+        if not hasattr(self, "prefill_layers"):
+            raise RuntimeError(
+                "forward_export() requires as_export_module() to be called first."
+            )
+
+        text_model = self.language_model.wrapped  # QuantGemma4TextModel
+        text_config = self.config.get_text_config()
+
+        # mypy: attention_masks and position_embeddings are required when
+        # running decoder layers; narrow away None before the loop.
+        assert attention_masks is not None
+        assert position_embeddings is not None
+
+        hidden_states = inputs_embeds
+
+        # Fake-quantize PLE inputs so the exported graph carries qparam
+        # metadata on the placeholder and its derived slice nodes.
+        if per_layer_inputs is not None:
+            per_layer_inputs = self._fq(per_layer_inputs, self.obs_per_layer_inputs)
+
+        # Run text decoder layers with precomputed masks and RoPE.
+        for i, decoder_layer in enumerate(self.prefill_layers):
+            layer_type = text_config.layer_types[i]
+            per_layer_input = (
+                per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
+            )
+            output = decoder_layer(
+                hidden_states,
+                per_layer_input=per_layer_input,
+                attention_mask=attention_masks[layer_type],
+                position_embeddings=position_embeddings[layer_type],
+            )
+            # Layer output is (hidden_states,) or (hidden_states, kv).
+            if isinstance(output, tuple):
+                hidden_states = output[0]
+            else:
+                hidden_states = output
+
+        # Final norm.
+        hidden_states = text_model.norm(hidden_states)
+        return hidden_states
+
+    def as_export_module(
+        self,
+        mode: str = "prefill",
+        *,
+        pixel_position_ids: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> nn.Module:
+        """Prepare the model for torch.export by precomputing static tensors.
+
+        This method:
+        1. Asserts that the model is in QUANT mode
+        2. Verifies all observers are calibrated
+        3. Creates text decoder layer export adapters via ``as_export_module()``
+        4. Returns a ``Gemma4ModelPrefillExportAdapter`` wrapping this module
+
+        Args:
+            mode: Export mode (only "prefill" is supported).
+            pixel_position_ids: Accepted for API compatibility but not yet
+                used.  Vision tower precomputation is handled separately by
+                ``Gemma4VisionPrefillExportAdapter``.
+            **kwargs: Additional arguments (unused).
+
+        Returns:
+            ``Gemma4ModelPrefillExportAdapter`` wrapping this module.
+        """
+        assert self._mode is Mode.QUANT, "Must be in QUANT mode for export"
+
+        # Make sure that all observers are calibrated.
+        for obs in self._all_observers():
+            assert obs.has_qparams, f"Observer {obs.name} has not been calibrated"
+
+        text_model = self.language_model.wrapped  # QuantGemma4TextModel
+        text_config = self.config.get_text_config()
+
+        # Create text decoder layer export adapters.
+        if mode == "prefill":
+            self.prefill_layers = nn.ModuleList(
+                [
+                    layer.wrapped.as_export_module(mode="prefill", return_kv=True)
+                    for layer in text_model.layers
+                ]
+            )
+        elif mode == "decode":
+            self.prefill_layers = nn.ModuleList(
+                [
+                    layer.wrapped.as_export_module(mode="decode", return_kv=True)
+                    for layer in text_model.layers
+                ]
+            )
+        else:
+            raise ValueError(f"Unsupported export mode: {mode!r}")
+
+        # Register fake-quant meta kernels for dynamic export.
+        from tico.quantization.wrapq.wrappers.llama.export_adapters import (
+            register_fake_quant_meta_kernels_for_dynamic_export,
+        )
+
+        register_fake_quant_meta_kernels_for_dynamic_export()
+
+        from tico.quantization.wrapq.wrappers.gemma4.export_adapters import (
+            Gemma4ModelPrefillExportAdapter,
+        )
+
+        return Gemma4ModelPrefillExportAdapter(wrapped_model=self)
+
     def _all_observers(self) -> Iterable:
         """Return observers owned directly by this wrapper."""
-        return (self.obs_mm_fusion,)
+        return (self.obs_mm_fusion, self.obs_per_layer_inputs)

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -79,7 +79,7 @@ _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.gemma4.quant_vision_encoder",
     "tico.quantization.wrapq.wrappers.gemma4.quant_vision_model",
     "tico.quantization.wrapq.wrappers.gemma4.quant_multimodal_embedder",
-    # "tico.quantization.wrapq.wrappers.gemma4.quant_model",
+    "tico.quantization.wrapq.wrappers.gemma4.quant_model",
     # "tico.quantization.wrapq.wrappers.gemma4.quant_for_conditional_generation",
     # add future core wrappers here
 )


### PR DESCRIPTION
## What

This PR completes the `QuantGemma4Model` PTQ wrapper — the top-level multimodal (image-text) model for Gemma4 E2B. It implements the full calibration forward path with multimodal placeholder replacement, PLE computation, and fixed-slot fusion, plus an export-friendly `forward_export()` and `as_export_module()` for Circle conversion.

## Why

The `QuantGemma4Model` wrapper previously had a skeleton `forward()` that only handled the simplest text-only path — multimodal placeholder tokens (image/video/audio) were not replaced before embedding, PLE was not computed, and the wrapper was not registered for automatic discovery by `prepare()`. Without these, calibration through the full model was incorrect (wrong embeddings at image positions, no PLE statistics) and the wrapper was never instantiated. Additionally, there was no export path to convert the quantized model to Circle format, which is the final deliverable of the TICO pipeline.

## Key Design Decisions

1. **Placeholder replacement via `torch.where` instead of `masked_scatter`**: The original HuggingFace `Gemma4Model.forward` uses `masked_scatter` to insert image features, which is not export-friendly. We replace placeholder token IDs with `pad_token_id` before embedding and use `fixed_slot_fuse` to insert image features at a static position range. This matches the `StaticGemma4Runtime` design where CPU owns dynamic operations and NPU owns static compute.

2. **Two forward methods — `forward()` for calibration, `forward_export()` for export**: The calibration `forward()` contains dynamic control flow (`if pixel_values is not None`, `if multimodal_mask.any()`, conditional PLE) that cannot be exported. The export `forward_export()` takes pre-fused `inputs_embeds` and precomputed masks/RoPE/PLE, with no dynamic control flow — following the pattern established by `QuantGemma4VisionModel`.

3. **CPU/NPU split aligned with `StaticGemma4Runtime`**: The export path assumes the CPU runtime has already performed token embedding, vision tower, MM fusion, PLE computation, and mask/RoPE generation. The NPU subgraph runs only the text decoder layers and final norm.

## Changes

- `tico/quantization/wrapq/wrappers/gemma4/quant_model.py` — Added `_get_placeholder_mask()` helper; completed `forward()` with placeholder replacement, PLE computation, and input validation; added `forward_export()` (static-shape export path) and `as_export_module()` (export preparation)
- `tico/quantization/wrapq/wrappers/gemma4/export_adapters.py` — Added `Gemma4ModelPrefillExportAdapter` that delegates to `forward_export()`
- `tico/quantization/wrapq/wrappers/registry.py` — Enabled `quant_model` in `_CORE_MODULES` for automatic discovery
- `tico/quantization/wrapq/examples/gemma4/quantize_model.py` — New example script demonstrating full PTQ flow (text-only + image-text calibration, PEIR evaluation, Circle export)
- `test/quantization/wrapq/wrappers/gemma4/test_quant_model.py` — New unit tests for `_get_placeholder_mask` and `QuantGemma4Model` wrapper
- `test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py` — New smoke tests for prepare-calibrate-convert flow (text-only, image-text, export adapter)
- `tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py` — Added `Gemma4ModelCase` and registered it in `GEMMA4_CASES`

## Tests

- `test_quantize_model.py`: 5 smoke tests — no-quant parity, prepare-convert text-only flow, prepare-convert image-text flow, `as_export_module` flow, `_get_placeholder_mask` unit test
- `test_quant_model.py`: Unit tests for `QuantGemma4Model` wrapper and helper functions
- Wrapper smoke runner: `Gemma4ModelCase` passes with Mean |diff| = 0.006353, PEIR = 0.028361, and successful Circle export
- All 149 tests in `test/quantization/wrapq/wrappers/gemma4/` pass

### Unit Tests

```
$ python -m pytest test/quantization/wrapq/wrappers/gemma4/test_quant_model.py -v 2>&1
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 12 items                                                                                                                     

test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestGetPlaceholderMask::test_image_placeholders                                    PASSED [  8%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestGetPlaceholderMask::test_missing_token_ids                                     PASSED [ 16%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestGetPlaceholderMask::test_mixed_placeholders                                    PASSED [ 25%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestGetPlaceholderMask::test_no_placeholders                                       PASSED [ 33%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelValidation::test_reject_both_input_ids_and_inputs_embeds       PASSED [ 41%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelValidation::test_reject_input_ids_with_per_layer_inputs        PASSED [ 50%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelValidation::test_reject_neither_input_ids_nor_inputs_embeds    PASSED [ 58%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelSmoke::test_inputs_embeds_with_per_layer_inputs_works          PASSED [ 66%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelSmoke::test_inputs_embeds_without_per_layer_inputs_raises      PASSED [ 75%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelSmoke::test_placeholder_replacement_produces_pad_embedding     PASSED [ 83%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelSmoke::test_prepare_convert_flow                               PASSED [ 91%]
test/quantization/wrapq/wrappers/gemma4/test_quant_model.py::TestQuantGemma4ModelSmoke::test_text_only_forward_is_finite                        PASSED [100%]

=================================================================== 12 passed in 48.35s ===================================================================
```

### Internal Tests

```
$ RUN_INTERNAL_TESTS=1 python -m pytest test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py -v
=================================================================== test session starts ===================================================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 5 items                                                                                                                                         

test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py::TestGemma4ModelSmoke::test_as_export_module_flow                    PASSED [ 20%]
test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py::TestGemma4ModelSmoke::test_get_placeholder_mask                     PASSED [ 40%]
test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py::TestGemma4ModelSmoke::test_no_quant_model_matches_reference         PASSED [ 60%]
test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py::TestGemma4ModelSmoke::test_prepare_convert_model_flow               PASSED [ 80%]
test/quantization/wrapq/wrappers/gemma4/test_quantize_model.py::TestGemma4ModelSmoke::test_prepare_convert_model_flow_with_image    PASSED [100%]

=================================================================== 5 passed in 34.18s ====================================================================
```

### Smoke Test

```
$ python -m tico.quantization.examples.inspect \
    --config tico/quantization/examples/configs/wrapper_smoke.yaml \
    --mode wrapper-smoke \
    --case gemma4_model \
    --export circle \
    --output-dir ./out/wrapper_smoke
┌───────────── Wrapper Smoke Summary ─────────────
│ Case             : gemma4_model
│ Status           : PASS
│ Mean |diff|      : 0.006353
│ Max |diff|       : 0.169459
│ PEIR             : 0.028361
│ Shape match      : True
│ Quant finite     : True
└─────────────────────────────────────────────────
Artifacts:
  - circle: out/wrapper_smoke/gemma4_model.q.circle
    ┌────────────────────────────────────────────┐
 3.1┤                                            │
    │                                        ••  │
    │                                      •••   │
 2.0┤                                    •••     │
    │                                  •••       │
    │                               ••••         │
    │                             ••••           │
 0.9┤                            •••             │
    │                          •••               │
    │                      • •••                 │
-0.2┤                      •••                   │
    │                    ••                      │
    │                 •••                        │
    │               •••                          │
-1.3┤             •••                            │
    │           •••                              │
    │          ••                                │
-2.4┤       •••                                  │
    │      •                                     │
    │    ••                                      │
    │  •                                         │
-3.5┤                                            │
    └┬──────────┬──────────┬─────────┬──────────┬┘
   -3.5       -1.8       -0.2       1.5       3.1 
```

## Example Script

`tico/quantization/wrapq/examples/gemma4/quantize_model.py` demonstrates the complete workflow:
1. Creates a tiny `Gemma4Model` with random weights (no download)
2. Prepares with `build_gemma4_e2b_ptq_config()`
3. Calibrates with text-only data (20 samples) and image-text data (20 samples)
4. Converts to fake-quantized model and compares FP vs. quantized outputs (PEIR)
5. Exports via `as_export_module("prefill")` and converts to Circle format (`gemma4_model.q.circle`)

```
$ python tico/quantization/wrapq/examples/gemma4/quantize_model.py
Preparing model for quantization...
Calibrating (text-only)...
Converting to quantized model...

┌───────────── Quantization Error Summary ─────────────
│ FP output shape    : (1, 16, 64)
│ Quant output shape : (1, 16, 64)
│ Mean |diff|        : 0.000134
│ PEIR               : 0.009668 %
└──────────────────────────────────────────────────────
     ┌───────────────────────────────────────────┐
 2.25┤                                           │
     │                                        •  │
     │                                      •    │
 1.46┤                                    •      │
     │                                  •        │
     │                               ••          │
     │                             •••           │
 0.67┤                           •••             │
     │                         ••                │
     │                       •••                 │
-0.12┤                     ••                    │
     │                   •••                     │
     │                  •                        │
     │               •••                         │
-0.91┤              ••                           │
     │           •••                             │
     │                                           │
-1.70┤        ••                                 │
     │       •                                   │
     │    ••                                     │
     │  ••                                       │
-2.49┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -2.5       -1.3      -0.1        1.1      2.3 


Calibrating with image-text data...

┌───────────── Image-Text Quantization Error ──────────
│ FP output shape    : (1, 16, 64)
│ Quant output shape : (1, 16, 64)
│ Mean |diff|        : 0.000280
│ PEIR               : 0.028300 %
└──────────────────────────────────────────────────────

Exporting to Circle format...
Export output shape: (1, 16, 64)
Converting to Circle format...
[QuantCheck] WARNING: 2 nodes without qparam detected (see logs).
Circle model saved as 'gemma4_model.q.circle'
```
