### PR TITLE
[quantization] Fix Qwen3-VL text attention smoke test

### DIFF
--- a/tico/quantization/recipes/debug/wrapper_smoke/cases/qwen3_vl.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/cases/qwen3_vl.py
@@ -292,6 +292,11 @@ def _create_image_input(
     return example
 
 
+def _causal_mask(seq_len: int, fill_value: float = -120.0) -> torch.Tensor:
+    mask = torch.full((1, 1, seq_len, seq_len), fill_value)
+    return torch.triu(mask, diagonal=1)
+
+
 class QwenBaseCase(WrapperSmokeCase):
     """Base class for Qwen3-VL wrapper smoke cases."""
 
@@ -341,7 +346,7 @@ class QwenTextAttentionCase(QwenBaseCase):
     ) -> Any:
         """Run the original text attention signature with an explicit mask."""
         hidden, rope = sample.args
-        mask = torch.zeros(1, 1, hidden.shape[1], hidden.shape[1])
+        mask = _causal_mask(hidden.shape[1])
         return reference(hidden, position_embeddings=rope, attention_mask=mask)[0]
 
     def export_input(


### PR DESCRIPTION
Align the Qwen3-VL text attention smoke reference path with the wrapper behavior by using a causal additive mask instead of an all-zero mask.

### Before

```bash
     ┌───────────────────────────────────────────┐
 0.90┤                                           │
     │                    •   •                  │
     │                    • •  •   •             │
 0.60┤                    •                      │
     │                   ••    • •               │
     │                             •  •          │
     │                    • • •• •••             │
 0.30┤         •       •••••• ••••••             │
     │                  ••••••••••• •            │
     │                ••••••••••••••             │
-0.00┤                • •••••••••••              │
     │               • •••••••••• •              │
     │               ••••••••• •  • •            │
     │              ••••••••• • •                │
-0.30┤           •  ••••••• ••• •                │
     │                ••• • •      •             │
     │           •  •  • ••••                    │
-0.60┤           •    • ••                       │
     │                                           │
     │                •                          │
     │                       • •                 │
-0.91┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -0.91      -0.45     -0.00      0.45     0.90
```

### After

```bash
     ┌───────────────────────────────────────────┐
 1.04┤                                           │
     │                                           │
     │                                      •••  │
 0.69┤                                   ••      │
     │                                  •        │
     │                               •••         │
     │                             ••            │
 0.34┤                           •••             │
     │                        ••••               │
     │                       •••                 │
-0.01┤                     ••••                  │
     │                   •••                     │
     │                •••••                      │
     │               •••                         │
-0.36┤             •••                           │
     │           •••                             │
     │         •••                               │
-0.71┤                                           │
     │        •                                  │
     │  • •                                      │
     │                                           │
-1.06┤                                           │
     └┬──────────┬─────────┬──────────┬─────────┬┘
    -1.06      -0.54     -0.01      0.52     1.04 
```

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>