### PR TITLE
[evaluation] Qwen3 mx evaluation

### DIFF
--- a/tico/quantization/examples/configs/README.md
+++ b/tico/quantization/examples/configs/README.md
@@ -198,6 +198,55 @@ pipeline:
     linear_weight: uint4
 ```
 
+### Per-module activation overrides: `linear_activation` and `softmax_activation`
+
+In addition to the global `activation` default, the PTQ stage supports two
+optional overrides that can apply different quantization scheme to specific
+module categories:
+
+- **`linear_activation`** — Overrides the activation observer for all
+  `nn.Linear` layers' act_in and act_out. When set, these layers use the
+  specified quantization scheme(e.g. MX) instead of the global `activation` default.
+- **`softmax_activation`** — Overrides the activation observer for all
+  attention softmax outputs. When set, softmax outputs use the specified
+  quantization scheme instead of the global `activation` default.
+
+Both fields accept the same spec mapping as `activation`:
+
+```yaml
+pipeline:
+  - name: ptq
+    enabled: true
+    # Global default for ALL activation observers (int16).
+    activation: int16
+    # Override: all nn.Linear act_in/act_out observers use MXINT8.
+    # Set to null to disable (fall back to global ``activation``).
+    linear_activation:
+      kind: mx
+      elem_format: int8
+      axis: -1
+      shared_exp_method: max
+      round: nearest
+    # Override: all attention softmax observers use MXINT8.
+    # Set to null to disable (fall back to global ``activation``).
+    softmax_activation:
+      kind: mx
+      elem_format: int8
+      axis: -1
+      shared_exp_method: max
+      round: nearest
+    linear_weight: uint4
+```
+
+Rules:
+
+- When `linear_activation` or `softmax_activation` is `null` or absent, the
+  corresponding modules fall back to the global `activation` spec.
+- The `kind: mx` spec requires `elem_format`, `axis`, `shared_exp_method`,
+  and `round` fields.
+- These overrides only affect activation observers; weight quantization is
+  controlled by `linear_weight` and other weight fields.
+
 Preprocessing + GPTQ + PTQ:
 
 ```yaml

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite_mx.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite_mx.yaml
@@ -1,0 +1,188 @@
+model:
+  family: qwen3_vl
+  name_or_path: Qwen/Qwen3-VL-2B-Instruct
+  trust_remote_code: true
+  hf_token: null
+  cache_dir: null
+
+runtime:
+  device: cuda
+  dtype: float32
+  seed: 42
+  show_progress: true
+
+calibration:
+  datasets:
+    - dataset: vqav2
+      split: testdev
+      n_samples: 128
+    - dataset: wikitext2
+      split: train
+      n_samples: 128
+  seq_len: 2048
+
+model_args:
+  vision:
+    grid_thw: [8, 24, 24]
+    visual_start_idx: 0
+    spatial_merge_size: 2
+
+pipeline:
+  - name: spinquant
+    enabled: true
+    init_method: random
+    r1_path: null
+    r2_map_path: null
+    enable_r1: true
+    enable_r2: true
+    fuse_deepstack_visual_outputs: true
+    vision_init_method: random
+    vision_r1_path: null
+    vision_r2_map_path: null
+    enable_vision_r1: true
+    enable_vision_r2: true
+    fuse_vision_layer_norms: true
+    require_vision_r1_layernorm_compatible: true
+    vision_rotation_tolerance: 1.0e-4
+
+  - name: smoothquant
+    enabled: false
+    alpha: 0.5
+    components: both
+    custom_alpha_map: null
+
+  - name: gptq
+    enabled: true
+    weight_bits: 4
+    weight_bits_overrides: {}
+    perchannel: true
+    symmetric: false
+    mse: null
+    sensitivity:
+      mode: compute
+      path: null
+    percdamp: 0.01
+    groupsize: -1
+    actorder: true
+    static_groups: false
+    verbose: false
+    show_progress: true
+    quantize_vision: true
+    quantize_text: true
+    quantize_lm_head: false
+    quantize_vision_patch_embed: true
+    quantize_vision_blocks: true
+    quantize_vision_merger: true
+    quantize_vision_deepstack_mergers: true
+    quantize_text_layers: true
+    move_cache_to_cpu: false
+
+  - name: ptq
+    enabled: true
+    # Print the full model after PTQ prepare.
+    print_model: true
+    # Global default for ALL activation observers (int16).
+    # Observers not explicitly overridden below will use this.
+    activation: int16
+    # Override: all nn.Linear act_in/act_out observers.
+    # Set to null to disable (fall back to global ``activation``).
+    linear_activation:
+      kind: mx
+      elem_format: int8
+      axis: -1
+      shared_exp_method: max
+      round: nearest
+    # Override: all attention softmax observers.
+    # Set to null to disable (fall back to global ``activation``).
+    softmax_activation:
+      kind: mx
+      elem_format: int8
+      axis: -1
+      shared_exp_method: max
+      round: nearest
+    linear_weight: uint4
+    vision_patch_embed_weight: uint8
+    embedding_weight: uint8
+    lm_head_weight: uint8
+    spin_rotation_weight: int16
+    norm: int16
+    norm_weight: int16
+    strict_wrap: true
+
+evaluation:
+  enabled: true
+  vlm_tasks:
+    - vqav2
+    - textvqa
+  coco: true
+  # LLaVA-Bench is open-ended natural QA. The legacy CIDEr/BLEU path is not
+  # enabled by default here. Use mode=judge for benchmark-style scoring.
+  llava_bench:
+    enabled: false
+    mode: judge
+    dataset: lmms-lab/llava-bench-in-the-wild
+    split: train
+    n_samples: 50
+    start_index: 0
+    max_seq_len: 2048
+    max_new_tokens: 512
+    temperature: 0.0
+    candidate_label: Qwen/Qwen3-VL-2B-Instruct
+    baseline_label: reference
+    candidate_answers: null
+    baseline_answers: null
+    regenerate: false
+    output:
+      dir: ./out/llava_bench
+      answers: ./out/llava_bench/qwen3_vl_2b.answers.jsonl
+      reviews: ./out/llava_bench/qwen3_vl_2b.llama3_2_3b.reviews.jsonl
+      summary: ./out/llava_bench/qwen3_vl_2b.llama3_2_3b.summary.json
+    judge:
+      enabled: true
+      model_id: meta-llama/Llama-3.2-3B-Instruct
+      device: cuda
+      dtype: float16
+      max_new_tokens: 256
+      temperature: 0.0
+      swap_order: true
+  videomme:
+    enabled: true
+    batch_size: 1
+    max_new_tokens: 30
+    n_samples: -1
+    max_num_frames: 32
+    use_cache: null
+    verbose: false
+  mmlu:
+    enabled: true
+    subjects: null
+    n_shots: 5
+    n_samples: -1
+    batch_size: 1
+  hellaswag:
+    enabled: true
+    n_shots: 10
+    n_samples: -1
+    batch_size: 1
+  mmmu:
+    enabled: true
+    dataset: MMMU/MMMU
+    subjects: null
+    n_shots: 5
+    n_samples: -1
+    max_new_tokens: 16
+    temperature: 0.0
+    verbose: false
+  ppl:
+    enabled: true
+    dataset: wikitext2
+    split: test
+    stride: 512
+  n_samples: -1
+  max_seq_len: 2048
+
+export:
+  enabled: false
+  output_dir: ./out/qwen3_vl_eval_suite
+  artifacts:
+    - ptq_checkpoint

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite_mx.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite_mx.yaml
@@ -79,7 +79,7 @@ pipeline:
 
   - name: ptq
     enabled: true
-    # Print the full model after PTQ prepare.
+    # Print the full model after PTQ.
     print_model: true
     # Global default for ALL activation observers (int16).
     # Observers not explicitly overridden below will use this.

--- a/tico/quantization/recipes/adapters/qwen3_vl.py
+++ b/tico/quantization/recipes/adapters/qwen3_vl.py
@@ -21,7 +21,9 @@ from transformers import AutoProcessor
 
 from tico.quantization import convert, prepare
 from tico.quantization.config.builders import build_qwen3_vl_ptq_config
+from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.config.qwen3_vl_spinquant import Qwen3VLSpinQuantConfig
+from tico.quantization.config.specs import QuantSpec
 from tico.quantization.recipes.adapters.base import ModelAdapter
 from tico.quantization.recipes.config import get_by_path
 from tico.quantization.recipes.context import RecipeContext
@@ -42,10 +44,7 @@ from tico.quantization.recipes.evaluation.vlm import (
     print_vqa_results,
 )
 from tico.quantization.recipes.export.checkpoint import save_checkpoint
-from tico.quantization.config.ptq import PTQConfig
-from tico.quantization.config.specs import QuantSpec
 from tico.quantization.recipes.utils import (
-
     move_to_device,
     quant_spec_from_config,
     quant_specs_equivalent,
@@ -210,7 +209,6 @@ class Qwen3VLAdapter(ModelAdapter):
             )
 
         return ptq_config
-
 
     @staticmethod
     def get_num_vision_blocks(model: Any) -> int:
@@ -623,4 +621,3 @@ def _apply_type_based_activation_overrides(
             cls_name = type(module).__name__
             if cls_name in _ATTENTION_CLASS_NAMES:
                 ptq_config.set_override(f"{name}.softmax", softmax_spec)
-

--- a/tico/quantization/recipes/adapters/qwen3_vl.py
+++ b/tico/quantization/recipes/adapters/qwen3_vl.py
@@ -42,7 +42,10 @@ from tico.quantization.recipes.evaluation.vlm import (
     print_vqa_results,
 )
 from tico.quantization.recipes.export.checkpoint import save_checkpoint
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import QuantSpec
 from tico.quantization.recipes.utils import (
+
     move_to_device,
     quant_spec_from_config,
     quant_specs_equivalent,
@@ -173,7 +176,7 @@ class Qwen3VLAdapter(ModelAdapter):
         if "grid_thw" in vision_args:
             vision_args["grid_thw"] = tuple(vision_args["grid_thw"])
 
-        return build_qwen3_vl_ptq_config(
+        ptq_config = build_qwen3_vl_ptq_config(
             num_vision_blocks=num_vision_blocks,
             num_text_layers=num_text_layers,
             num_deepstack_mergers=num_deepstack_mergers,
@@ -192,6 +195,22 @@ class Qwen3VLAdapter(ModelAdapter):
             norm_weight=quant_spec_from_config(stage_cfg.get("norm_weight")),
             strict_wrap=bool(stage_cfg.get("strict_wrap", True)),
         )
+
+        # --- Type-based activation overrides ---
+        # The YAML ``activation`` field sets a global default for all activation
+        # observers.  ``linear_activation`` and ``softmax_activation`` allow
+        # overriding the quant spec for *all* Linear-layer activations and *all*
+        # attention softmax outputs respectively.
+        linear_act_spec = quant_spec_from_config(stage_cfg.get("linear_activation"))
+        softmax_spec = quant_spec_from_config(stage_cfg.get("softmax_activation"))
+
+        if linear_act_spec is not None or softmax_spec is not None:
+            _apply_type_based_activation_overrides(
+                ctx.model, ptq_config, linear_act_spec, softmax_spec
+            )
+
+        return ptq_config
+
 
     @staticmethod
     def get_num_vision_blocks(model: Any) -> int:
@@ -560,3 +579,48 @@ def _find_stage(cfg: dict[str, Any], stage_name: str) -> Mapping[str, Any] | Non
         if isinstance(stage, Mapping) and stage.get("name") == stage_name:
             return stage
     return None
+
+
+def _apply_type_based_activation_overrides(
+    model: torch.nn.Module,
+    ptq_config: "PTQConfig",
+    linear_act_spec: "QuantSpec | None",
+    softmax_spec: "QuantSpec | None",
+) -> None:
+    """Set per-module activation overrides based on module *type*.
+
+    This helper walks the model, finds every ``nn.Linear`` and every attention module,
+    and registers an explicit override for the relevant observer names so
+    that the desired ``QuantSpec`` is used regardless of the global default.
+
+    Parameters
+    ----------
+    model
+        The (possibly already-prepared) model to inspect.
+    ptq_config
+        The ``PTQConfig`` whose overrides will be extended in-place.
+    linear_act_spec
+        If not ``None``, applied to ``act_in`` and ``act_out`` of every
+        ``nn.Linear`` in the model.
+    softmax_spec
+        If not ``None``, applied to the ``softmax`` observer of every
+        ``Qwen3VLTextAttention`` and ``Qwen3VLVisionAttention`` module.
+    """
+    # Class names that contain a ``softmax`` observer.
+    _ATTENTION_CLASS_NAMES = {
+        "Qwen3VLTextAttention",
+        "Qwen3VLVisionAttention",
+    }
+
+    for name, module in model.named_modules():
+        # --- Linear-layer activation overrides ---
+        if linear_act_spec is not None and isinstance(module, torch.nn.Linear):
+            for obs_name in ("act_in", "act_out"):
+                ptq_config.set_override(f"{name}.{obs_name}", linear_act_spec)
+
+        # --- Softmax activation overrides ---
+        if softmax_spec is not None:
+            cls_name = type(module).__name__
+            if cls_name in _ATTENTION_CLASS_NAMES:
+                ptq_config.set_override(f"{name}.softmax", softmax_spec)
+

--- a/tico/quantization/recipes/runner.py
+++ b/tico/quantization/recipes/runner.py
@@ -216,6 +216,16 @@ def _print_config_summary(cfg: Mapping[str, Any]) -> None:
     _print_config_row("SpinQuant enabled", spinquant_enabled)
     _print_config_row("CLE enabled", _is_stage_enabled(cle_stage))
     _print_config_row("Activation", _stage_quant_spec(ptq_stage, "activation"))
+    linear_activation = _stage_value(ptq_stage, "linear_activation", None)
+    if linear_activation is not None:
+        _print_config_row(
+            "Linear activation", _format_quant_spec(linear_activation)
+        )
+    softmax_activation = _stage_value(ptq_stage, "softmax_activation", None)
+    if softmax_activation is not None:
+        _print_config_row(
+            "Softmax activation", _format_quant_spec(softmax_activation)
+        )
     _print_config_row("Linear weight", linear_weight)
     if vision_patch_embed_weight is not None:
         _print_config_row("Vision patch weight", vision_patch_embed_weight)
@@ -271,6 +281,11 @@ class QuantizationRunner:
                 continue
             stage = get_stage(stage_cfg["name"])
             ctx = stage.run(ctx, stage_cfg)
+
+            if stage_cfg.get("name") == "ptq":
+                if stage_cfg.get("print_model", False):
+                    print("=== Model after PTQ prepare ===")
+                    print(ctx.model)
 
         print("=== Evaluation ===")
         adapter.evaluate(ctx)

--- a/tico/quantization/recipes/runner.py
+++ b/tico/quantization/recipes/runner.py
@@ -218,14 +218,10 @@ def _print_config_summary(cfg: Mapping[str, Any]) -> None:
     _print_config_row("Activation", _stage_quant_spec(ptq_stage, "activation"))
     linear_activation = _stage_value(ptq_stage, "linear_activation", None)
     if linear_activation is not None:
-        _print_config_row(
-            "Linear activation", _format_quant_spec(linear_activation)
-        )
+        _print_config_row("Linear activation", _format_quant_spec(linear_activation))
     softmax_activation = _stage_value(ptq_stage, "softmax_activation", None)
     if softmax_activation is not None:
-        _print_config_row(
-            "Softmax activation", _format_quant_spec(softmax_activation)
-        )
+        _print_config_row("Softmax activation", _format_quant_spec(softmax_activation))
     _print_config_row("Linear weight", linear_weight)
     if vision_patch_embed_weight is not None:
         _print_config_row("Vision patch weight", vision_patch_embed_weight)

--- a/tico/quantization/recipes/runner.py
+++ b/tico/quantization/recipes/runner.py
@@ -280,7 +280,7 @@ class QuantizationRunner:
 
             if stage_cfg.get("name") == "ptq":
                 if stage_cfg.get("print_model", False):
-                    print("=== Model after PTQ prepare ===")
+                    print("=== Model after PTQ ===")
                     print(ctx.model)
 
         print("=== Evaluation ===")


### PR DESCRIPTION
This PR evaluates Qwen3 quant solution with MXINT8 activations for Linear and Softmax layers

 Evaluation `Qwen/Qwen3-VL-4B-Instruct`

| Config ID| PPL | mmlu | vqav2 | COCO (CIDEr/Bleu_4) | hellaswag| MMMU_Pro (vision) | Llava-Bench Rel. | videomme (32 frames) |
|--|--|--|--|--|--|--|--|--|
| FP32                       | 9.46 | 0.735     | 0.895   | 0.335 / 0.079 | 0.642 | 0.286 |104.7| 65 |
| **MX_GPTQ_MSE_spinquant_w4A16**  <br> MXINT8 for linear and softmax <br>_token embedding, lm_head: 8bit_ <br> _patch embedding (Conv3D): 8bit_ | 9.99  |   0.686    |  0.881  | 0.228/0.082  |  0.629  | 0.238  | 100.72 | 61   |
| % degradation        | 5%  |   5%      | 1%     |  32%/4%   |    2%  |  5%    | 4%  | 4% |

  



TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>