### PR TITLE
[quantization] Align Gemma4 PTQ builder with HF module scope

### DIFF
--- a/test/quantization/config/test_builders.py
+++ b/test/quantization/config/test_builders.py
@@ -278,6 +278,18 @@ class TestBuildGemma4E2BPtqConfig(unittest.TestCase):
             cfg.overrides["vision_tower"]["patch_embedder"]["input_proj"]["weight"]["dtype"],  # type: ignore[index]
             DType.uint(8),
         )
+        self.assertEqual(
+            cfg.overrides["vision_tower"]["encoder"]["layers"]["0"]["self_attn"]["q_norm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["vision_tower"]["encoder"]["layers"]["0"]["input_layernorm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["embed_vision"]["embedding_pre_projection_norm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
 
         # Gemma4ForConditionalGeneration path: model is Gemma4Model.
         self.assertEqual(
@@ -290,6 +302,18 @@ class TestBuildGemma4E2BPtqConfig(unittest.TestCase):
         )
         self.assertEqual(
             cfg.overrides["model"]["embed_vision"]["embedding_projection"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["vision_tower"]["encoder"]["layers"]["0"]["self_attn"]["v_norm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["vision_tower"]["encoder"]["layers"]["0"]["post_feedforward_layernorm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["embed_vision"]["embedding_pre_projection_norm"]["weight"]["dtype"],  # type: ignore[index]
             DType.uint(4),
         )
         self.assertEqual(

--- a/test/quantization/config/test_builders.py
+++ b/test/quantization/config/test_builders.py
@@ -22,6 +22,7 @@ from tico.quantization.config.builders import (
     build_llm_ptq_config,
     build_qwen3_vl_ptq_config,
 )
+from tico.quantization.config.gemma4_builders import build_gemma4_e2b_ptq_config
 from tico.quantization.config.llama_attention import DEFAULT_EXECUTION_PROFILE
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.config.specs import affine, mx
@@ -223,6 +224,78 @@ class TestBuildQwen3VlPtqConfig(unittest.TestCase):
             cfg.overrides["model"]["language_model"],  # type: ignore[index]
         )
         self.assertNotIn("rotate_lm_head", cfg.overrides)  # type: ignore[operator]
+
+
+class TestBuildGemma4E2BPtqConfig(unittest.TestCase):
+    def test_build_gemma4_e2b_ptq_config_follows_hf_text_and_model_scopes(self):
+        cfg = build_gemma4_e2b_ptq_config(
+            num_text_layers=2,
+            num_vision_layers=1,
+            linear_weight=affine(DType.uint(4)),
+            embedding_weight=affine(DType.uint(8)),
+            lm_head_weight=affine(DType.uint(8)),
+            vision_patch_embed_weight=affine(DType.uint(8)),
+            norm_weight=affine(DType.uint(4)),
+            strict_wrap=False,
+        )
+
+        self.assertFalse(cfg.strict_wrap)
+
+        # Direct Gemma4TextModel path.
+        self.assertEqual(
+            cfg.overrides["embed_tokens"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(8),
+        )
+        self.assertEqual(
+            cfg.overrides["layers"]["1"]["self_attn"]["q_proj"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["layers"]["1"]["self_attn"]["q_norm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["norm"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+
+        # Gemma4ForCausalLM path: model is Gemma4TextModel.
+        self.assertEqual(
+            cfg.overrides["model"]["embed_tokens"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(8),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["layers"]["1"]["mlp"]["up_proj"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+
+        # Direct Gemma4Model path: language_model is Gemma4TextModel.
+        self.assertEqual(
+            cfg.overrides["language_model"]["layers"]["0"]["self_attn"]["o_proj"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["vision_tower"]["patch_embedder"]["input_proj"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(8),
+        )
+
+        # Gemma4ForConditionalGeneration path: model is Gemma4Model.
+        self.assertEqual(
+            cfg.overrides["model"]["language_model"]["layers"]["0"]["self_attn"]["k_proj"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["vision_tower"]["encoder"]["layers"]["0"]["mlp"]["down_proj"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["model"]["embed_vision"]["embedding_projection"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(4),
+        )
+        self.assertEqual(
+            cfg.overrides["lm_head"]["weight"]["dtype"],  # type: ignore[index]
+            DType.uint(8),
+        )
 
 
 if __name__ == "__main__":

--- a/tico/quantization/config/gemma4_builders.py
+++ b/tico/quantization/config/gemma4_builders.py
@@ -60,6 +60,17 @@ def _linear_tree_override(
     return root
 
 
+def _deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return ``base`` recursively merged with ``overlay``."""
+    out: Dict[str, Any] = copy.deepcopy(dict(base))
+    for key, value in overlay.items():
+        if isinstance(value, Mapping) and isinstance(out.get(key), Mapping):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = copy.deepcopy(value)
+    return out
+
+
 def _gemma4_text_attention_override(
     linear_weight: Optional[QuantSpec],
     norm_weight: Optional[QuantSpec],
@@ -176,11 +187,47 @@ def _gemma4_text_model_override(
     return text
 
 
+def _gemma4_vision_attention_override(
+    linear_weight: Optional[QuantSpec],
+    norm_weight: Optional[QuantSpec],
+) -> Dict[str, Any]:
+    """Build overrides for Gemma4VisionAttention."""
+    result = _linear_tree_override(
+        linear_weight,
+        ("q_proj", "k_proj", "v_proj", "o_proj"),
+    )
+
+    norm_override = _weight_override(norm_weight)
+    if norm_override:
+        for name in ("q_norm", "k_norm", "v_norm"):
+            result[name] = copy.deepcopy(norm_override)
+
+    return result
+
+
+def _gemma4_multimodal_embedder_override(
+    *,
+    linear_weight: Optional[QuantSpec],
+    norm_weight: Optional[QuantSpec],
+) -> Dict[str, Any]:
+    """Build overrides for Gemma4MultimodalEmbedder."""
+    result: Dict[str, Any] = {
+        "embedding_projection": _weight_override(linear_weight),
+    }
+
+    norm_override = _weight_override(norm_weight)
+    if norm_override:
+        result["embedding_pre_projection_norm"] = copy.deepcopy(norm_override)
+
+    return result
+
+
 def _gemma4_vision_model_override(
     *,
     num_vision_layers: int,
     linear_weight: Optional[QuantSpec],
     vision_patch_embed_weight: Optional[QuantSpec],
+    norm_weight: Optional[QuantSpec],
 ) -> Dict[str, Any]:
     """Build overrides for Gemma4VisionModel."""
     vision: Dict[str, Any] = {
@@ -189,17 +236,27 @@ def _gemma4_vision_model_override(
         },
         "encoder": {"layers": {}},
     }
+
+    norm_override = _weight_override(norm_weight)
     for idx in range(num_vision_layers):
-        vision["encoder"]["layers"][str(idx)] = {
-            "self_attn": _linear_tree_override(
-                linear_weight,
-                ("q_proj", "k_proj", "v_proj", "o_proj"),
-            ),
+        layer = {
+            "self_attn": _gemma4_vision_attention_override(linear_weight, norm_weight),
             "mlp": _linear_tree_override(
                 linear_weight,
                 ("gate_proj", "up_proj", "down_proj"),
             ),
         }
+
+        if norm_override:
+            for name in (
+                "input_layernorm",
+                "post_attention_layernorm",
+                "pre_feedforward_layernorm",
+                "post_feedforward_layernorm",
+            ):
+                layer[name] = copy.deepcopy(norm_override)
+
+        vision["encoder"]["layers"][str(idx)] = layer
     return vision
 
 
@@ -238,11 +295,13 @@ def build_gemma4_e2b_ptq_config(
         num_vision_layers=num_vision_layers,
         linear_weight=linear_weight,
         vision_patch_embed_weight=vision_patch_embed_weight,
+        norm_weight=norm_weight,
     )
 
-    multimodal_projection_overrides = {
-        "embedding_projection": _weight_override(linear_weight),
-    }
+    multimodal_embedder_overrides = _gemma4_multimodal_embedder_override(
+        linear_weight=linear_weight,
+        norm_weight=norm_weight,
+    )
 
     # Follow the original Hugging Face structures while keeping one public API:
     #
@@ -263,17 +322,17 @@ def build_gemma4_e2b_ptq_config(
     gemma4_model_overrides: Dict[str, Any] = {
         "language_model": copy.deepcopy(text_model_overrides),
         "vision_tower": copy.deepcopy(vision_model_overrides),
-        "embed_vision": copy.deepcopy(multimodal_projection_overrides),
+        "embed_vision": copy.deepcopy(multimodal_embedder_overrides),
     }
 
-    overrides: Dict[str, Any] = {
-        **copy.deepcopy(text_model_overrides),
-        **copy.deepcopy(gemma4_model_overrides),
-        "model": {
-            **copy.deepcopy(text_model_overrides),
-            **copy.deepcopy(gemma4_model_overrides),
-        },
-    }
+    model_like_overrides = _deep_merge(
+        text_model_overrides,
+        gemma4_model_overrides,
+    )
+    overrides: Dict[str, Any] = _deep_merge(
+        model_like_overrides,
+        {"model": model_like_overrides},
+    )
     overrides["lm_head"] = _weight_override(lm_head_weight or linear_weight)
 
     return PTQConfig(

--- a/tico/quantization/config/gemma4_builders.py
+++ b/tico/quantization/config/gemma4_builders.py
@@ -60,6 +60,149 @@ def _linear_tree_override(
     return root
 
 
+def _gemma4_text_attention_override(
+    linear_weight: Optional[QuantSpec],
+    norm_weight: Optional[QuantSpec],
+) -> Dict[str, Any]:
+    """Build overrides for Gemma4TextAttention.
+
+    HF structure:
+      q_proj, q_norm, k_proj, k_norm, v_proj, v_norm, o_proj
+
+    Some modules are absent for shared-KV or attention_k_eq_v variants. Extra
+    override keys are harmless because wrappers only consume matching children.
+    """
+    result = _linear_tree_override(
+        linear_weight,
+        ("q_proj", "k_proj", "v_proj", "o_proj"),
+    )
+
+    norm_override = _weight_override(norm_weight)
+    if norm_override:
+        for name in ("q_norm", "k_norm", "v_norm"):
+            result[name] = copy.deepcopy(norm_override)
+
+    return result
+
+
+def _gemma4_text_layer_override(
+    linear_weight: Optional[QuantSpec],
+    norm_weight: Optional[QuantSpec],
+) -> Dict[str, Any]:
+    """Build overrides for one Gemma4TextDecoderLayer.
+
+    Mirrors the dense/no-MoE E2B text layer structure in HF:
+      self_attn
+      mlp
+      input_layernorm
+      post_attention_layernorm
+      pre_feedforward_layernorm
+      post_feedforward_layernorm
+      optional PLE modules
+    """
+    layer: Dict[str, Any] = {
+        "self_attn": _gemma4_text_attention_override(linear_weight, norm_weight),
+        "mlp": _linear_tree_override(
+            linear_weight,
+            ("gate_proj", "up_proj", "down_proj"),
+        ),
+    }
+
+    norm_override = _weight_override(norm_weight)
+    if norm_override:
+        for name in (
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+            # Optional PLE norm. Ignored when PLE is disabled.
+            "post_per_layer_input_norm",
+        ):
+            layer[name] = copy.deepcopy(norm_override)
+
+    # Optional PLE linears. Ignored when hidden_size_per_layer_input == 0.
+    layer.update(
+        _linear_tree_override(
+            linear_weight,
+            ("per_layer_input_gate", "per_layer_projection"),
+        )
+    )
+
+    return layer
+
+
+def _gemma4_text_model_override(
+    *,
+    num_text_layers: int,
+    linear_weight: Optional[QuantSpec],
+    embedding_weight: Optional[QuantSpec],
+    norm_weight: Optional[QuantSpec],
+) -> Dict[str, Any]:
+    """Build overrides for Gemma4TextModel.
+
+    This tree is used directly by:
+      - Gemma4TextModel
+      - Gemma4ForCausalLM.model
+
+    It is also nested below ``language_model`` for Gemma4Model and
+    Gemma4ForConditionalGeneration.model.
+    """
+    text: Dict[str, Any] = {
+        "embed_tokens": _weight_override(embedding_weight),
+        "layers": {},
+        "norm": _weight_override(norm_weight),
+    }
+
+    for idx in range(num_text_layers):
+        text["layers"][str(idx)] = _gemma4_text_layer_override(
+            linear_weight,
+            norm_weight,
+        )
+
+    # Optional top-level PLE modules in Gemma4TextModel. These are ignored by
+    # wrappers when PLE is disabled, but let one builder follow the HF structure.
+    embedding_override = _weight_override(embedding_weight)
+    if embedding_override:
+        text["embed_tokens_per_layer"] = copy.deepcopy(embedding_override)
+
+    linear_override = _weight_override(linear_weight)
+    if linear_override:
+        text["per_layer_model_projection"] = copy.deepcopy(linear_override)
+
+    norm_override = _weight_override(norm_weight)
+    if norm_override:
+        text["per_layer_projection_norm"] = copy.deepcopy(norm_override)
+
+    return text
+
+
+def _gemma4_vision_model_override(
+    *,
+    num_vision_layers: int,
+    linear_weight: Optional[QuantSpec],
+    vision_patch_embed_weight: Optional[QuantSpec],
+) -> Dict[str, Any]:
+    """Build overrides for Gemma4VisionModel."""
+    vision: Dict[str, Any] = {
+        "patch_embedder": {
+            "input_proj": _weight_override(vision_patch_embed_weight or linear_weight)
+        },
+        "encoder": {"layers": {}},
+    }
+    for idx in range(num_vision_layers):
+        vision["encoder"]["layers"][str(idx)] = {
+            "self_attn": _linear_tree_override(
+                linear_weight,
+                ("q_proj", "k_proj", "v_proj", "o_proj"),
+            ),
+            "mlp": _linear_tree_override(
+                linear_weight,
+                ("gate_proj", "up_proj", "down_proj"),
+            ),
+        }
+    return vision
+
+
 def build_gemma4_e2b_ptq_config(
     *,
     num_text_layers: int,
@@ -85,46 +228,51 @@ def build_gemma4_e2b_ptq_config(
     weight = weight or _default_weight()
     linear_weight = linear_weight or weight
 
-    overrides: Dict[str, Any] = {"model": {}}
+    text_model_overrides = _gemma4_text_model_override(
+        num_text_layers=num_text_layers,
+        linear_weight=linear_weight,
+        embedding_weight=embedding_weight,
+        norm_weight=norm_weight,
+    )
+    vision_model_overrides = _gemma4_vision_model_override(
+        num_vision_layers=num_vision_layers,
+        linear_weight=linear_weight,
+        vision_patch_embed_weight=vision_patch_embed_weight,
+    )
 
-    model_overrides = overrides["model"]
-    model_overrides["language_model"] = {
-        "embed_tokens": _weight_override(embedding_weight),
-        "layers": {},
-        "norm": _weight_override(norm_weight),
-    }
-    for idx in range(num_text_layers):
-        model_overrides["language_model"]["layers"][str(idx)] = {
-            "self_attn": _linear_tree_override(
-                linear_weight,
-                ("q_proj", "k_proj", "v_proj", "o_proj"),
-            ),
-            "mlp": _linear_tree_override(
-                linear_weight,
-                ("gate_proj", "up_proj", "down_proj"),
-            ),
-        }
-
-    model_overrides["vision_tower"] = {
-        "patch_embedder": {
-            "input_proj": _weight_override(vision_patch_embed_weight or linear_weight)
-        },
-        "encoder": {"layers": {}},
-    }
-    for idx in range(num_vision_layers):
-        model_overrides["vision_tower"]["encoder"]["layers"][str(idx)] = {
-            "self_attn": _linear_tree_override(
-                linear_weight,
-                ("q_proj", "k_proj", "v_proj", "o_proj"),
-            ),
-            "mlp": _linear_tree_override(
-                linear_weight,
-                ("gate_proj", "up_proj", "down_proj"),
-            ),
-        }
-
-    model_overrides["embed_vision"] = {
+    multimodal_projection_overrides = {
         "embedding_projection": _weight_override(linear_weight),
+    }
+
+    # Follow the original Hugging Face structures while keeping one public API:
+    #
+    # Gemma4TextModel:
+    #   embed_tokens / layers / norm / ...
+    #
+    # Gemma4ForCausalLM:
+    #   model.(embed_tokens / layers / norm / ...)
+    #
+    # Gemma4Model:
+    #   language_model.(embed_tokens / layers / norm / ...)
+    #   vision_tower / embed_vision
+    #
+    # Gemma4ForConditionalGeneration:
+    #   model.language_model.(embed_tokens / layers / norm / ...)
+    #   model.vision_tower / model.embed_vision
+    #   lm_head
+    gemma4_model_overrides: Dict[str, Any] = {
+        "language_model": copy.deepcopy(text_model_overrides),
+        "vision_tower": copy.deepcopy(vision_model_overrides),
+        "embed_vision": copy.deepcopy(multimodal_projection_overrides),
+    }
+
+    overrides: Dict[str, Any] = {
+        **copy.deepcopy(text_model_overrides),
+        **copy.deepcopy(gemma4_model_overrides),
+        "model": {
+            **copy.deepcopy(text_model_overrides),
+            **copy.deepcopy(gemma4_model_overrides),
+        },
     }
     overrides["lm_head"] = _weight_override(lm_head_weight or linear_weight)
 


### PR DESCRIPTION
Previously, `build_gemma4_e2b_ptq_config()` always placed text overrides under
`model.language_model.*`, which matches `Gemma4ForConditionalGeneration` but not
`Gemma4ForCausalLM`. In Hugging Face `Gemma4ForCausalLM`, model is already a
`Gemma4TextModel`, so overrides such as embed_tokens, layers, and norm were not
reached when preparing the causal LM wrapper.

Update the Gemma4 PTQ override tree to follow the original HF module layout for both `CausalLM` and `ConditionalGeneration` paths, so the existing builder API can be reused without silently dropping custom text-model overrides.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>