### PR TITLE
[recipes] Support named pipeline stage overrides

### DIFF
--- a/test/quantization/recipes/test_config.py
+++ b/test/quantization/recipes/test_config.py
@@ -30,8 +30,8 @@ from tico.quantization.recipes.config import (
 
 
 class TestRecipeConfig(unittest.TestCase):
-    def test_load_recipe_config_applies_nested_and_list_overrides(self):
-        """Recipe config loading should support dotted paths and list indices."""
+    def test_load_recipe_config_applies_nested_list_and_named_overrides(self):
+        """Recipe config loading should support dotted paths and list item names."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "recipe.yaml"
             config_path.write_text(
@@ -57,8 +57,8 @@ evaluation:
                 overrides=[
                     "model.name_or_path=new-model",
                     "runtime.device=cpu",
-                    "pipeline.0.enabled=false",
-                    "pipeline.1.linear_weight_bits=4",
+                    "pipeline.gptq.enabled=false",
+                    "pipeline.ptq.linear_weight_bits=4",
                     "evaluation.enabled=true",
                     "created.items.0.name=first",
                     "created.items.1.name=second",
@@ -111,18 +111,46 @@ evaluation:
         with self.assertRaises(ValueError):
             parse_override("runtime.device")
 
-    def test_set_by_path_requires_list_index_when_current_value_is_list(self):
-        """List traversal should reject non-numeric path segments."""
-        cfg: Config = {"pipeline": []}
+    def test_set_by_path_supports_named_list_items(self):
+        """List traversal should support unique mapping items addressed by name."""
+        cfg: Config = {
+            "pipeline": [
+                {"name": "gptq", "enabled": True},
+                {"name": "ptq", "enabled": True},
+            ]
+        }
 
-        with self.assertRaises(TypeError):
-            set_by_path(cfg, ["pipeline", "enabled"], False)
+        set_by_path(cfg, ["pipeline", "gptq", "mse"], "mse")
+        set_by_path(cfg, ["pipeline", "ptq", "linear_weight"], "uint4")
+
+        self.assertEqual(cfg["pipeline"][0]["mse"], "mse")
+        self.assertEqual(cfg["pipeline"][1]["linear_weight"], "uint4")
+
+    def test_set_by_path_rejects_missing_named_list_item(self):
+        """Named list traversal should fail when no item has the requested name."""
+        cfg: Config = {"pipeline": [{"name": "ptq"}]}
+
+        with self.assertRaises(KeyError):
+            set_by_path(cfg, ["pipeline", "gptq", "enabled"], False)
+
+    def test_set_by_path_rejects_ambiguous_named_list_item(self):
+        """Named list traversal should reject duplicate item names."""
+        cfg: Config = {
+            "pipeline": [
+                {"name": "ptq", "enabled": True},
+                {"name": "ptq", "enabled": False},
+            ]
+        }
+
+        with self.assertRaises(ValueError):
+            set_by_path(cfg, ["pipeline", "ptq", "enabled"], False)
 
     def test_get_by_path_returns_default_for_missing_values(self):
         """Nested path lookup should return the provided default when traversal fails."""
         cfg: Config = {"pipeline": [{"name": "ptq"}]}
 
         self.assertEqual(get_by_path(cfg, "pipeline.0.name"), "ptq")
+        self.assertEqual(get_by_path(cfg, "pipeline.ptq.name"), "ptq")
         self.assertEqual(get_by_path(cfg, "pipeline.1.name", "missing"), "missing")
         self.assertEqual(get_by_path(cfg, "pipeline.name", "missing"), "missing")
 
@@ -134,6 +162,26 @@ evaluation:
 
         self.assertEqual(cfg["runtime"]["device"], "cpu")
         self.assertEqual(cfg["pipeline"][0]["name"], "ptq")
+
+    def test_apply_overrides_supports_named_list_items(self):
+        """Applying overrides should support named list item traversal."""
+        cfg: Config = {
+            "pipeline": [
+                {"name": "gptq", "mse": None},
+                {"name": "ptq", "lm_head_weight": "uint8"},
+            ]
+        }
+
+        apply_overrides(
+            cfg,
+            [
+                "pipeline.gptq.mse=mse",
+                "pipeline.ptq.lm_head_weight=uint4",
+            ],
+        )
+
+        self.assertEqual(cfg["pipeline"][0]["mse"], "mse")
+        self.assertEqual(cfg["pipeline"][1]["lm_head_weight"], "uint4")
 
     def test_save_effective_config_serializes_non_yaml_values(self):
         """Effective config saving should serialize tuples and non-plain values."""

--- a/tico/quantization/recipes/config.py
+++ b/tico/quantization/recipes/config.py
@@ -82,7 +82,9 @@ def to_plain_data(value: Any) -> Any:
 def apply_overrides(cfg: Any, overrides: Iterable[str]) -> None:
     """Apply overrides of the form ``a.b.c=value``.
 
-    List indices are supported, e.g. ``pipeline.0.enabled=false``.
+    List indices are supported, e.g. ``pipeline.0.enabled=false``. Lists whose
+    items are mappings with a ``name`` field can also be addressed by name, e.g.
+    ``pipeline.gptq.mse=mse``.
     """
     for raw in overrides:
         path, value = parse_override(raw)
@@ -123,24 +125,105 @@ def _is_index(part: str) -> bool:
     return part.isdigit()
 
 
+def _format_location(path: Sequence[str]) -> str:
+    """Return a readable dotted path for diagnostics."""
+    return ".".join(path) if path else "<root>"
+
+
+def _available_item_names(items: Sequence[Any]) -> list[str]:
+    """Return stringified names from mapping items in a list."""
+    names: list[str] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        if "name" not in item:
+            continue
+        names.append(str(item["name"]))
+    return names
+
+
+def _find_named_list_item(
+    items: list[Any],
+    name: str,
+    *,
+    location: Sequence[str],
+) -> tuple[int, Mapping[str, Any]]:
+    """Find a unique mapping item whose ``name`` field matches ``name``."""
+    matches: list[tuple[int, Mapping[str, Any]]] = []
+    for idx, item in enumerate(items):
+        if isinstance(item, Mapping) and item.get("name") == name:
+            matches.append((idx, item))
+
+    loc = _format_location(location)
+    if not matches:
+        available = _available_item_names(items)
+        suffix = f" Available names: {available}." if available else ""
+        raise KeyError(f"No list item named {name!r} at {loc}.{suffix}")
+
+    if len(matches) > 1:
+        indices = ", ".join(str(idx) for idx, _ in matches)
+        raise ValueError(
+            f"Multiple list items named {name!r} at {loc} "
+            f"(indices: {indices}). Use a numeric index instead."
+        )
+
+    return matches[0]
+
+
+def _find_mutable_named_list_item(
+    items: list[Any],
+    name: str,
+    *,
+    location: Sequence[str],
+) -> tuple[int, MutableMapping[str, Any]]:
+    """Find a unique mutable mapping item whose ``name`` field matches ``name``."""
+    idx, item = _find_named_list_item(items, name, location=location)
+    if not isinstance(item, MutableMapping):
+        loc = _format_location(location)
+        raise TypeError(
+            f"List item named {name!r} at {loc} is not mutable. got {type(item)}"
+        )
+    return idx, item
+
+
 def get_by_path(cfg: Any, path: str, default: Any = None) -> Any:
+    """Read a value from a dotted path.
+
+    Mapping keys, list indices, and named list items are supported. Named list
+    items are mappings with a ``name`` field, so ``pipeline.gptq.enabled`` reads
+    the ``enabled`` field from the unique pipeline stage named ``gptq``.
+    """
     cur: Any = cfg
-    for part in path.split("."):
+    parts = path.split(".")
+    for i, part in enumerate(parts):
         if isinstance(cur, Mapping):
             if part not in cur:
                 return default
             cur = cur[part]
-        elif isinstance(cur, list) and _is_index(part):
-            idx = int(part)
-            if idx >= len(cur):
-                return default
-            cur = cur[idx]
+        elif isinstance(cur, list):
+            if _is_index(part):
+                idx = int(part)
+                if idx >= len(cur):
+                    return default
+                cur = cur[idx]
+            else:
+                try:
+                    _, cur = _find_named_list_item(cur, part, location=parts[:i])
+                except (KeyError, ValueError):
+                    return default
         else:
             return default
     return cur
 
 
 def set_by_path(cfg: Any, path: Sequence[str], value: Any) -> None:
+    """Set a value at a dotted override path.
+
+    Mapping keys and numeric list indices preserve the original override
+    semantics. Existing lists can also be traversed by matching mapping item
+    names, e.g. ``pipeline.gptq.mse=mse`` updates the unique list item with
+    ``name: gptq``.
+    """
     if not path:
         raise ValueError("Override path must not be empty.")
 
@@ -149,16 +232,15 @@ def set_by_path(cfg: Any, path: Sequence[str], value: Any) -> None:
         nxt_part = path[i + 1]
 
         if isinstance(cur, list):
-            if not _is_index(part):
-                raise TypeError(
-                    f"Expected list index at {'.'.join(path[:i+1])}, got {part!r}"
-                )
-            idx = int(part)
-            while len(cur) <= idx:
-                cur.append({} if not _is_index(nxt_part) else [])
-            if cur[idx] is None:
-                cur[idx] = {} if not _is_index(nxt_part) else []
-            cur = cur[idx]
+            if _is_index(part):
+                idx = int(part)
+                while len(cur) <= idx:
+                    cur.append({} if not _is_index(nxt_part) else [])
+                if cur[idx] is None:
+                    cur[idx] = {} if not _is_index(nxt_part) else []
+                cur = cur[idx]
+            else:
+                _, cur = _find_mutable_named_list_item(cur, part, location=path[:i])
             continue
 
         if not isinstance(cur, MutableMapping):
@@ -175,7 +257,11 @@ def set_by_path(cfg: Any, path: Sequence[str], value: Any) -> None:
     leaf = path[-1]
     if isinstance(cur, list):
         if not _is_index(leaf):
-            raise TypeError(f"Expected list index at {'.'.join(path)}, got {leaf!r}")
+            raise TypeError(
+                f"Cannot assign list item {leaf!r} directly at {'.'.join(path)}. "
+                "Use a numeric index or set a named item field such as "
+                f"{'.'.join((*path, '<field>'))}."
+            )
         idx = int(leaf)
         while len(cur) <= idx:
             cur.append(None)


### PR DESCRIPTION
Allow dotted config overrides to address list items by their `name` field,
such as `pipeline.gptq.mse=mse` and `pipeline.ptq.lm_head_weight=uint4`,
while preserving the existing numeric index form.

This makes recipe CLI overrides less fragile than relying on pipeline stage
indices, especially when stages are reordered or optional stages are added.

Also update config tests to cover named list lookup, named override mutation,
missing stage errors, and duplicate stage-name ambiguity.

### Before

```bash
python -m tico.quantization.examples.quantize \
  --config tico/quantization/examples/configs/llama_gptq_ptq.yaml \
  --model unsloth/Llama-3.2-3B-Instruct \
  --device cuda \
  --set pipeline.0.enabled=false \
  --set pipeline.2.mse=mse \
  --set pipeline.3.lm_head_weight=uint4 \
  --set pipeline.3.decode_calibration_steps=8 \
  --set evaluation.lm_eval_tasks=mmlu,hellaswag,piqa,truthfulqa \
  --set export.enabled=true \
  --set export.artifacts=[ptq_checkpoint]
```

### After

```bash
python -m tico.quantization.examples.quantize \
  --config tico/quantization/examples/configs/llama_gptq_ptq.yaml \
  --model unsloth/Llama-3.2-3B-Instruct \
  --device cuda \
  --set pipeline.spinquant.enabled=false \
  --set pipeline.gptq.mse=mse \
  --set pipeline.ptq.lm_head_weight=uint4 \
  --set pipeline.ptq.decode_calibration_steps=8 \
  --set evaluation.lm_eval_tasks=mmlu,hellaswag,piqa,truthfulqa \
  --set export.enabled=true \
  --set export.artifacts=[ptq_checkpoint]
```

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>