### PR TITLE
[quantization] Split Gemma4 dynamic and static fusion paths

### DIFF
--- a/test/quantization/recipes/adapters/test_gemma4.py
+++ b/test/quantization/recipes/adapters/test_gemma4.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from quantization.recipes.optional_dependency_stubs import (
+        install_optional_dependency_stubs,
+    )
+except ModuleNotFoundError:
+    from optional_dependency_stubs import install_optional_dependency_stubs
+
+install_optional_dependency_stubs()
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import tico.quantization.recipes.adapters.gemma4 as gemma4_mod
+from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+from tico.quantization.recipes.context import RecipeContext
+
+
+class _TestGemma4Adapter(Gemma4Adapter):
+    """Concrete test double of Gemma4Adapter for testing."""
+
+    def export(self, ctx: RecipeContext) -> None:
+        pass
+
+
+class TestGemma4AdapterStaticCalibration(unittest.TestCase):
+    """Tests for Gemma4 static image sizing during calibration input build."""
+
+    def test_build_calibration_inputs_forces_static_image_processor_size(self):
+        """Static Gemma4 image dimensions should be applied during preprocessing."""
+        adapter = _TestGemma4Adapter()
+        image_processor = SimpleNamespace(
+            do_resize=False,
+            size={"height": 224, "width": 224},
+            crop_size={"height": 224, "width": 224},
+        )
+        processor = SimpleNamespace(image_processor=image_processor)
+        ctx = RecipeContext(
+            cfg={
+                "calibration": {
+                    "dataset": "vqav2",
+                    "split": "testdev",
+                    "n_samples": 2,
+                    "seq_len": 2048,
+                },
+                "runtime": {"seed": 123},
+                "model_args": {
+                    "vision": {
+                        "image_height": 896,
+                        "image_width": 896,
+                        "num_visual_tokens": 256,
+                    }
+                },
+            },
+            adapter=adapter,
+            processor=processor,
+        )
+        calls = []
+
+        def fake_build_vlm_calibration_inputs(**kwargs):
+            calls.append(kwargs)
+            self.assertTrue(image_processor.do_resize)
+            self.assertEqual(image_processor.size, {"height": 896, "width": 896})
+            self.assertEqual(image_processor.crop_size, {"height": 896, "width": 896})
+            return [{"input_ids": "sample"}]
+
+        with patch.object(
+            gemma4_mod,
+            "build_vlm_calibration_inputs",
+            fake_build_vlm_calibration_inputs,
+        ):
+            result = adapter.build_calibration_inputs(ctx)
+
+        self.assertEqual(result, [{"input_ids": "sample"}])
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["processor"], processor)
+        self.assertEqual(calls[0]["dataset"], "vqav2")
+        self.assertEqual(calls[0]["split"], "testdev")
+        self.assertEqual(calls[0]["n_samples"], 2)
+        self.assertEqual(calls[0]["max_seq_len"], 2048)
+        self.assertEqual(calls[0]["seed"], 123)
+        self.assertFalse(image_processor.do_resize)
+        self.assertEqual(image_processor.size, {"height": 224, "width": 224})
+        self.assertEqual(image_processor.crop_size, {"height": 224, "width": 224})
+
+    def test_build_calibration_inputs_without_static_size_keeps_processor(self):
+        """Omitting static image dimensions should preserve processor settings."""
+        adapter = _TestGemma4Adapter()
+        image_processor = SimpleNamespace(
+            do_resize=False,
+            size={"height": 224, "width": 224},
+        )
+        processor = SimpleNamespace(image_processor=image_processor)
+        ctx = RecipeContext(
+            cfg={
+                "calibration": {"dataset": "vqav2"},
+                "runtime": {},
+                "model_args": {"vision": {"num_visual_tokens": 256}},
+            },
+            adapter=adapter,
+            processor=processor,
+        )
+
+        with patch.object(
+            gemma4_mod,
+            "build_vlm_calibration_inputs",
+            lambda **kwargs: [],
+        ):
+            result = adapter.build_calibration_inputs(ctx)
+
+        self.assertEqual(result, [])
+        self.assertFalse(image_processor.do_resize)
+        self.assertEqual(image_processor.size, {"height": 224, "width": 224})
+
+    def test_static_calibration_image_size_requires_height_and_width(self):
+        """Partial static image size configuration should fail clearly."""
+        adapter = _TestGemma4Adapter()
+        ctx = RecipeContext(
+            cfg={
+                "model_args": {
+                    "vision": {
+                        "image_height": 896,
+                        "num_visual_tokens": 256,
+                    }
+                }
+            },
+            adapter=adapter,
+            processor=SimpleNamespace(image_processor=SimpleNamespace()),
+        )
+
+        with self.assertRaisesRegex(ValueError, "image_height"):
+            adapter.build_calibration_inputs(ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/gemma4/test_static_export_adapters.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_static_export_adapters.py
@@ -16,6 +16,7 @@ import unittest
 
 import torch
 
+from tico.quantization.wrapq.wrappers.gemma4.quant_model import QuantGemma4Model
 from tico.quantization.wrapq.wrappers.gemma4.utils import (
     dynamic_placeholder_fuse,
     fixed_slot_fuse,
@@ -124,6 +125,46 @@ class Gemma4StaticExportAdapterUtilityTest(unittest.TestCase):
                 num_visual_tokens=2,
                 seq_len=6,
             )
+
+    def test_force_export_flag_enables_static_branch_for_unit_tests(self) -> None:
+        """force_export should allow tests to exercise the static fusion branch."""
+        model = object.__new__(QuantGemma4Model)
+
+        model.force_export = False
+        self.assertFalse(model._uses_static_fusion())
+
+        model.force_export = True
+        self.assertTrue(model._uses_static_fusion())
+
+    def test_static_layout_validation_is_opt_in_for_eager_path(self) -> None:
+        """Dynamic eager validation should not enforce static spans by default."""
+        model = object.__new__(QuantGemma4Model)
+        model.validate_static_layout = False
+        model.visual_start_idx = 2
+        model.num_visual_tokens = 2
+        image_mask = torch.tensor([[False, True, False, True, False, False]])
+
+        model._validate_static_image_layout(image_mask, seq_len=6)
+
+    def test_static_layout_validation_rejects_wrong_span_when_enabled(self) -> None:
+        """Opt-in static validation should reject non-static eager inputs."""
+        model = object.__new__(QuantGemma4Model)
+        model.validate_static_layout = True
+        model.visual_start_idx = 2
+        model.num_visual_tokens = 2
+        image_mask = torch.tensor([[False, True, False, True, False, False]])
+
+        with self.assertRaisesRegex(ValueError, "static visual-token span"):
+            model._validate_static_image_layout(image_mask, seq_len=6)
+
+    def test_static_visual_token_count_validation_has_clear_error(self) -> None:
+        """Static token-count validation should report image-size config hints."""
+        model = object.__new__(QuantGemma4Model)
+        model.num_visual_tokens = 3
+        image_embeds = torch.zeros(1, 2, 4)
+
+        with self.assertRaisesRegex(ValueError, "image_height"):
+            model._validate_static_visual_token_count(image_embeds)
 
 
 if __name__ == "__main__":

--- a/test/quantization/wrapq/wrappers/gemma4/test_static_export_adapters.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_static_export_adapters.py
@@ -16,7 +16,11 @@ import unittest
 
 import torch
 
-from tico.quantization.wrapq.wrappers.gemma4.utils import fixed_slot_fuse
+from tico.quantization.wrapq.wrappers.gemma4.utils import (
+    dynamic_placeholder_fuse,
+    fixed_slot_fuse,
+    validate_static_visual_layout,
+)
 
 
 class Gemma4StaticExportAdapterUtilityTest(unittest.TestCase):
@@ -39,30 +43,18 @@ class Gemma4StaticExportAdapterUtilityTest(unittest.TestCase):
         self.assertTrue(torch.equal(fused[:, 2:4], torch.ones(1, 2, 2)))
         self.assertTrue(torch.equal(fused[:, 4:], torch.zeros(1, 2, 2)))
 
-    def test_fixed_slot_fuse_warns_on_wrong_visual_length(self) -> None:
-        """Fixed-slot fusion should warn on mismatched visual token counts but still work."""
+    def test_fixed_slot_fuse_rejects_wrong_visual_length(self) -> None:
+        """Fixed-slot fusion should reject mismatched visual token counts."""
         text = torch.zeros(1, 6, 2)
         visual = torch.ones(1, 2, 2)
 
-        # Should warn but not raise - uses actual visual token count
-        import warnings
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            fused = fixed_slot_fuse(
+        with self.assertRaisesRegex(ValueError, "expected 3, got 2"):
+            fixed_slot_fuse(
                 text,
                 visual,
                 visual_start_idx=2,
-                num_visual_tokens=3,  # Mismatch: visual has 2 tokens, config expects 3
+                num_visual_tokens=3,
             )
-            # Verify warning was issued
-            self.assertEqual(len(w), 1)
-            self.assertIn("Visual token count mismatch", str(w[0].message))
-
-        # Fusion should succeed using actual token count (2)
-        self.assertEqual(tuple(fused.shape), (1, 6, 2))
-        # Visual tokens inserted at positions [2:4] (actual count = 2)
-        self.assertTrue(torch.equal(fused[:, 2:4], torch.ones(1, 2, 2)))
 
     def test_fixed_slot_fuse_rejects_out_of_range_slot(self) -> None:
         """Fixed-slot fusion should reject visual slots that exceed max sequence length."""
@@ -75,6 +67,62 @@ class Gemma4StaticExportAdapterUtilityTest(unittest.TestCase):
                 visual,
                 visual_start_idx=5,
                 num_visual_tokens=2,
+            )
+
+    def test_dynamic_placeholder_fuse_replaces_mask_positions(self) -> None:
+        """Dynamic fusion should replace the actual image placeholder positions."""
+        text = torch.zeros(1, 6, 2)
+        visual = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+        image_mask = torch.tensor([[False, True, False, True, False, False]])
+
+        fused = dynamic_placeholder_fuse(text, visual, image_mask)
+
+        expected = text.clone()
+        expected[:, 1, :] = visual[:, 0, :]
+        expected[:, 3, :] = visual[:, 1, :]
+        self.assertTrue(torch.equal(fused, expected))
+
+    def test_dynamic_placeholder_fuse_rejects_token_mismatch(self) -> None:
+        """Dynamic fusion should reject placeholder and feature count mismatches."""
+        text = torch.zeros(1, 6, 2)
+        visual = torch.ones(1, 2, 2)
+        image_mask = torch.tensor([[False, True, False, False, False, False]])
+
+        with self.assertRaisesRegex(ValueError, "placeholder count"):
+            dynamic_placeholder_fuse(text, visual, image_mask)
+
+    def test_dynamic_and_fixed_fusion_match_for_valid_static_layout(self) -> None:
+        """Dynamic and fixed fusion should agree for a valid static visual span."""
+        text = torch.arange(12, dtype=torch.float32).view(1, 6, 2)
+        visual = torch.full((1, 2, 2), 99.0)
+        image_mask = torch.tensor([[False, False, True, True, False, False]])
+
+        validate_static_visual_layout(
+            image_mask,
+            visual_start_idx=2,
+            num_visual_tokens=2,
+            seq_len=6,
+        )
+        dynamic = dynamic_placeholder_fuse(text, visual, image_mask)
+        static = fixed_slot_fuse(
+            text,
+            visual,
+            visual_start_idx=2,
+            num_visual_tokens=2,
+        )
+
+        torch.testing.assert_close(dynamic, static)
+
+    def test_validate_static_visual_layout_rejects_wrong_span(self) -> None:
+        """Static validation should reject non-contiguous or wrong-start masks."""
+        image_mask = torch.tensor([[False, True, False, True, False, False]])
+
+        with self.assertRaisesRegex(ValueError, "static visual-token span"):
+            validate_static_visual_layout(
+                image_mask,
+                visual_start_idx=2,
+                num_visual_tokens=2,
+                seq_len=6,
             )
 
 

--- a/tico/quantization/examples/configs/gemma4_e2b_llava_bench_judge.yaml
+++ b/tico/quantization/examples/configs/gemma4_e2b_llava_bench_judge.yaml
@@ -24,6 +24,7 @@ model_args:
     num_visual_tokens: 256
     image_height: 896
     image_width: 896
+    validate_static_layout: false
 
 pipeline: []
 

--- a/tico/quantization/examples/configs/gemma4_e2b_ptq_only.yaml
+++ b/tico/quantization/examples/configs/gemma4_e2b_ptq_only.yaml
@@ -24,6 +24,7 @@ model_args:
     num_visual_tokens: 256
     image_height: 896
     image_width: 896
+    validate_static_layout: false
 
 pipeline:
   - name: ptq

--- a/tico/quantization/recipes/adapters/gemma4.py
+++ b/tico/quantization/recipes/adapters/gemma4.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Mapping, Sequence
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Sequence
 
 import torch
 import tqdm
@@ -111,19 +112,95 @@ class Gemma4Adapter(ModelAdapter):
         if text_config is not None and hasattr(text_config, "use_cache"):
             text_config.use_cache = False
 
+    @staticmethod
+    def _static_calibration_image_size(
+        cfg: Mapping[str, Any],
+    ) -> tuple[int, int] | None:
+        """Return the configured static image size for calibration samples."""
+        model_args = cfg.get("model_args", {})
+        if not isinstance(model_args, Mapping):
+            return None
+
+        vision_cfg = model_args.get("vision", {})
+        if not isinstance(vision_cfg, Mapping):
+            return None
+
+        height = vision_cfg.get("image_height")
+        width = vision_cfg.get("image_width")
+        if height is None and width is None:
+            return None
+        if height is None or width is None:
+            raise ValueError(
+                "Both model_args.vision.image_height and "
+                "model_args.vision.image_width must be set for static Gemma4 "
+                "calibration resizing."
+            )
+
+        parsed_height = int(height)
+        parsed_width = int(width)
+        if parsed_height <= 0 or parsed_width <= 0:
+            raise ValueError(
+                "Gemma4 static calibration image dimensions must be positive: "
+                f"image_height={parsed_height}, image_width={parsed_width}."
+            )
+        return parsed_height, parsed_width
+
+    @staticmethod
+    @contextmanager
+    def _fixed_image_processor_size(
+        processor: Any,
+        image_size: tuple[int, int] | None,
+    ) -> Iterator[None]:
+        """Temporarily force processor image resizing for static calibration."""
+        if image_size is None:
+            yield
+            return
+
+        image_processor = getattr(processor, "image_processor", None)
+        if image_processor is None:
+            yield
+            return
+
+        height, width = image_size
+        updates: dict[str, Any] = {
+            "do_resize": True,
+            "size": {"height": height, "width": width},
+        }
+        if hasattr(image_processor, "crop_size"):
+            updates["crop_size"] = {"height": height, "width": width}
+
+        originals: dict[str, tuple[bool, Any]] = {}
+        for attr, value in updates.items():
+            originals[attr] = (
+                hasattr(image_processor, attr),
+                getattr(image_processor, attr, None),
+            )
+            setattr(image_processor, attr, value)
+
+        try:
+            yield
+        finally:
+            for attr, (had_attr, original) in originals.items():
+                if had_attr:
+                    setattr(image_processor, attr, original)
+                elif hasattr(image_processor, attr):
+                    delattr(image_processor, attr)
+
     def build_calibration_inputs(self, ctx: RecipeContext) -> list[dict]:
         """Build VLM calibration inputs for fixed image-text PTQ."""
         calib = ctx.cfg.get("calibration", {})
         runtime = ctx.cfg.get("runtime", {})
-        return build_vlm_calibration_inputs(
-            processor=ctx.processor,
-            dataset=calib.get("dataset", "vqav2"),
-            datasets=calib.get("datasets"),
-            n_samples=int(calib.get("n_samples", 128)),
-            split=calib.get("split", "testdev"),
-            max_seq_len=calib.get("seq_len"),
-            seed=int(runtime.get("seed", 42)),
-        )
+        image_size = self._static_calibration_image_size(ctx.cfg)
+        with self._fixed_image_processor_size(ctx.processor, image_size):
+            return build_vlm_calibration_inputs(
+                processor=ctx.processor,
+                dataset=calib.get("dataset", "vqav2"),
+                datasets=calib.get("datasets"),
+                n_samples=int(calib.get("n_samples", 128)),
+                split=calib.get("split", "testdev"),
+                max_seq_len=calib.get("seq_len"),
+                seed=int(runtime.get("seed", 42)),
+            )
 
     def forward_calibration(
         self,

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
@@ -22,7 +22,9 @@ from tico.quantization.wrapq.mode import Mode
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.gemma4.utils import (
     assert_gemma4_e2b_no_moe,
+    dynamic_placeholder_fuse,
     fixed_slot_fuse,
+    validate_static_visual_layout,
 )
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
@@ -64,6 +66,10 @@ def _get_placeholder_mask(
 class QuantGemma4Model(QuantModuleBase):
     """PTQ wrapper skeleton for image-text Gemma4 E2B."""
 
+    # This boolean flag is used by unit tests to exercise the static fusion path
+    # without running torch.export.
+    force_export: bool = False
+
     def __init__(
         self,
         fp_model: nn.Module,
@@ -100,11 +106,11 @@ class QuantGemma4Model(QuantModuleBase):
             else None
         )
 
-        self.visual_start_idx = int(
-            self.qcfg.model_args.get("vision", {}).get("visual_start_idx", 0)
-        )
-        self.num_visual_tokens = int(
-            self.qcfg.model_args.get("vision", {}).get("num_visual_tokens", 0)
+        vision_args = self.qcfg.model_args.get("vision", {})
+        self.visual_start_idx = int(vision_args.get("visual_start_idx", 0))
+        self.num_visual_tokens = int(vision_args.get("num_visual_tokens", 0))
+        self.validate_static_layout = bool(
+            vision_args.get("validate_static_layout", self.num_visual_tokens > 0)
         )
         self.obs_mm_fusion = self._make_obs("mm_fusion")
         self.obs_per_layer_inputs = self._make_obs("per_layer_inputs")
@@ -123,6 +129,44 @@ class QuantGemma4Model(QuantModuleBase):
         )
         return self.embed_vision(vision_outputs.last_hidden_state)
 
+    def _uses_static_fusion(self) -> bool:
+        """Return whether the current call should use static fixed-slot fusion."""
+        return bool(torch.compiler.is_compiling() or self.force_export)
+
+    def _validate_runtime_multimodal_masks(
+        self,
+        *,
+        image_mask: torch.Tensor,
+        video_mask: torch.Tensor,
+        audio_mask: torch.Tensor,
+        pixel_values: Optional[torch.Tensor],
+    ) -> None:
+        """Reject unsupported or incomplete multimodal eager inputs."""
+        if video_mask.any() or audio_mask.any():
+            raise NotImplementedError(
+                "Gemma4 PTQ wrapper supports image-text inputs only. "
+                "Video and audio placeholder tokens are not supported."
+            )
+        if pixel_values is None and image_mask.any():
+            raise ValueError(
+                "pixel_values must be provided when input_ids contain image placeholders."
+            )
+
+    def _validate_static_image_layout(
+        self,
+        image_mask: torch.Tensor,
+        seq_len: int,
+    ) -> None:
+        """Validate image placeholders against the configured static layout."""
+        if not self.validate_static_layout:
+            return
+        validate_static_visual_layout(
+            image_mask,
+            visual_start_idx=self.visual_start_idx,
+            num_visual_tokens=self.num_visual_tokens,
+            seq_len=seq_len,
+        )
+
     def forward(
         self,
         input_ids: Optional[torch.Tensor] = None,
@@ -134,22 +178,22 @@ class QuantGemma4Model(QuantModuleBase):
         per_layer_inputs: Optional[torch.Tensor] = None,
         **kwargs,
     ):
-        """Run Gemma4 image-text forward with fixed-slot fusion.
+        """Run Gemma4 image-text forward with separated eager and static fusion.
 
         Mirrors ``Gemma4Model.forward`` with the following adaptations for
-        quantized calibration:
+        quantized calibration and static export:
 
-        * Multimodal placeholder token IDs (image / video / audio) are replaced
-          with ``pad_token_id`` before the token-embedding lookup so that the
-          embedding at those positions is a neutral pad embedding (the real
-          features will be fused in later).
-        * The dynamic ``masked_scatter`` used by the original model is replaced
-          by ``fixed_slot_fuse`` which writes image features into a static,
-          pre-determined position range.
+        * Multimodal placeholder token IDs are replaced with ``pad_token_id``
+          before token-embedding lookup so placeholder positions start from a
+          neutral pad embedding.
+        * The eager/PTQ path uses dynamic placeholder-mask fusion, preserving HF
+          multimodal semantics during calibration.
+        * The static/export path uses strict fixed-slot fusion, preserving the
+          static runtime contract and avoiding data-dependent scatter operations.
+        * Optional static-layout validation checks that eager calibration inputs
+          are equivalent to the fixed visual-token span required by export.
         * Per-Layer Embeddings (PLE) are computed when the text config has
-          ``hidden_size_per_layer_input > 0`` (E2B / E4B models).  The PLE
-          token-identity and context-projection paths are both exercised so
-          their observers collect statistics during calibration.
+          ``hidden_size_per_layer_input > 0`` (E2B / E4B models).
         * Video and audio paths are not supported in the v0 scope.
 
         TODO: Implement full HF-compatible output objects after the static layer
@@ -169,16 +213,24 @@ class QuantGemma4Model(QuantModuleBase):
         # QuantGemma4TextModel is the concrete type behind the PTQWrapper.
         text_model = self.language_model.wrapped  # QuantGemma4TextModel
         llm_input_ids: Optional[torch.Tensor] = None
+        image_mask: Optional[torch.BoolTensor] = None
 
         if inputs_embeds is None:
             assert input_ids is not None  # guaranteed by validation above
             # Replace multimodal placeholder token IDs with pad_token_id so
             # the embedding lookup returns a neutral pad embedding at those
-            # positions.  The real features will be fused in by fixed_slot_fuse.
+            # positions.  Image features are fused later.
             llm_input_ids = input_ids.clone()
             image_mask, video_mask, audio_mask = _get_placeholder_mask(
                 input_ids, self.config
             )
+            if not torch.compiler.is_compiling():
+                self._validate_runtime_multimodal_masks(
+                    image_mask=image_mask,
+                    video_mask=video_mask,
+                    audio_mask=audio_mask,
+                    pixel_values=pixel_values,
+                )
             multimodal_mask = image_mask | video_mask | audio_mask
             if multimodal_mask.any():
                 pad_token_id = self.config.text_config.pad_token_id
@@ -241,12 +293,38 @@ class QuantGemma4Model(QuantModuleBase):
             image_embeds = image_embeds.to(
                 device=inputs_embeds.device, dtype=inputs_embeds.dtype
             )
-            inputs_embeds = fixed_slot_fuse(
-                inputs_embeds,
-                image_embeds,
-                visual_start_idx=self.visual_start_idx,
-                num_visual_tokens=self.num_visual_tokens,
-            )
+
+            if self._uses_static_fusion():
+                if (
+                    image_mask is not None
+                    and self.validate_static_layout
+                    and not torch.compiler.is_compiling()
+                ):
+                    self._validate_static_image_layout(
+                        image_mask,
+                        seq_len=int(inputs_embeds.shape[1]),
+                    )
+                inputs_embeds = fixed_slot_fuse(
+                    inputs_embeds,
+                    image_embeds,
+                    visual_start_idx=self.visual_start_idx,
+                    num_visual_tokens=self.num_visual_tokens,
+                )
+            else:
+                if image_mask is None:
+                    raise ValueError(
+                        "input_ids must be provided with pixel_values when running "
+                        "Gemma4 eager/PTQ dynamic placeholder fusion."
+                    )
+                self._validate_static_image_layout(
+                    image_mask,
+                    seq_len=int(inputs_embeds.shape[1]),
+                )
+                inputs_embeds = dynamic_placeholder_fuse(
+                    inputs_embeds,
+                    image_embeds,
+                    image_mask,
+                )
             inputs_embeds = self._fq(inputs_embeds, self.obs_mm_fusion)
 
         # --- Language model -----------------------------------------------

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
@@ -64,10 +64,19 @@ def _get_placeholder_mask(
 
 @try_register("transformers.models.gemma4.modeling_gemma4.Gemma4Model")
 class QuantGemma4Model(QuantModuleBase):
-    """PTQ wrapper skeleton for image-text Gemma4 E2B."""
+    """PTQ wrapper skeleton for image-text Gemma4 E2B.
 
-    # This boolean flag is used by unit tests to exercise the static fusion path
-    # without running torch.export.
+    The default eager/PTQ path uses dynamic placeholder-mask fusion so natural
+    PyTorch benchmarks and general calibration follow HF-style placeholder
+    positions. The static export/runtime path uses strict fixed-slot fusion.
+
+    ``validate_static_layout`` is opt-in because benchmark prompts may differ
+    from deployment/NPU prompts. Enable it only for deployment-style calibration
+    or NPU-proxy benchmarks whose inputs follow the static runtime layout.
+    """
+
+    # Test-only override that exercises the static fusion branch without running
+    # torch.export. Unit tests should reset it after use.
     force_export: bool = False
 
     def __init__(
@@ -110,7 +119,7 @@ class QuantGemma4Model(QuantModuleBase):
         self.visual_start_idx = int(vision_args.get("visual_start_idx", 0))
         self.num_visual_tokens = int(vision_args.get("num_visual_tokens", 0))
         self.validate_static_layout = bool(
-            vision_args.get("validate_static_layout", self.num_visual_tokens > 0)
+            vision_args.get("validate_static_layout", False)
         )
         self.obs_mm_fusion = self._make_obs("mm_fusion")
         self.obs_per_layer_inputs = self._make_obs("per_layer_inputs")
@@ -157,7 +166,11 @@ class QuantGemma4Model(QuantModuleBase):
         image_mask: torch.Tensor,
         seq_len: int,
     ) -> None:
-        """Validate image placeholders against the configured static layout."""
+        """Validate image placeholders against the static layout when enabled.
+
+        This is opt-in for eager/PTQ because benchmark prompts may not match
+        deployment/NPU prompt layouts.
+        """
         if not self.validate_static_layout:
             return
         validate_static_visual_layout(
@@ -166,6 +179,24 @@ class QuantGemma4Model(QuantModuleBase):
             num_visual_tokens=self.num_visual_tokens,
             seq_len=seq_len,
         )
+
+    def _validate_static_visual_token_count(self, image_embeds: torch.Tensor) -> None:
+        """Validate vision output length for static export/runtime layouts."""
+        expected = int(self.num_visual_tokens)
+        actual = int(image_embeds.shape[1])
+        if expected <= 0:
+            raise ValueError(
+                "Static Gemma4 visual-token validation requires "
+                "model_args.vision.num_visual_tokens to be positive."
+            )
+        if actual != expected:
+            raise ValueError(
+                "Vision tower produced "
+                f"{actual} visual tokens, but static Gemma4 config expects "
+                f"{expected}. Check model_args.vision.image_height, "
+                "model_args.vision.image_width, and "
+                "model_args.vision.num_visual_tokens."
+            )
 
     def forward(
         self,
@@ -178,26 +209,17 @@ class QuantGemma4Model(QuantModuleBase):
         per_layer_inputs: Optional[torch.Tensor] = None,
         **kwargs,
     ):
-        """Run Gemma4 image-text forward with separated eager and static fusion.
+        """Run Gemma4 image-text forward with eager and static fusion paths.
 
-        Mirrors ``Gemma4Model.forward`` with the following adaptations for
-        quantized calibration and static export:
+        Eager/PTQ uses dynamic placeholder-mask fusion by default, matching
+        HF-style image placeholder positions. Static export/runtime uses strict
+        fixed-slot fusion. Static layout validation is opt-in in eager mode and
+        should be enabled only for deployment-style calibration or NPU-proxy
+        benchmarks whose prompts follow the final static runtime layout.
 
-        * Multimodal placeholder token IDs are replaced with ``pad_token_id``
-          before token-embedding lookup so placeholder positions start from a
-          neutral pad embedding.
-        * The eager/PTQ path uses dynamic placeholder-mask fusion, preserving HF
-          multimodal semantics during calibration.
-        * The static/export path uses strict fixed-slot fusion, preserving the
-          static runtime contract and avoiding data-dependent scatter operations.
-        * Optional static-layout validation checks that eager calibration inputs
-          are equivalent to the fixed visual-token span required by export.
-        * Per-Layer Embeddings (PLE) are computed when the text config has
-          ``hidden_size_per_layer_input > 0`` (E2B / E4B models).
-        * Video and audio paths are not supported in the v0 scope.
-
-        TODO: Implement full HF-compatible output objects after the static layer
-        wrappers are complete.
+        Image-size alignment and static-layout validation solve different
+        problems: resizing stabilizes visual-token count, while layout
+        validation checks visual-token positions in the sequence.
         """
         # --- Input validation (matches original Gemma4Model.forward) ------
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -295,13 +317,12 @@ class QuantGemma4Model(QuantModuleBase):
             )
 
             if self._uses_static_fusion():
-                if (
-                    image_mask is not None
-                    and self.validate_static_layout
-                    and not torch.compiler.is_compiling()
-                ):
-                    self._validate_static_image_layout(
+                self._validate_static_visual_token_count(image_embeds)
+                if image_mask is not None and not torch.compiler.is_compiling():
+                    validate_static_visual_layout(
                         image_mask,
+                        visual_start_idx=self.visual_start_idx,
+                        num_visual_tokens=self.num_visual_tokens,
                         seq_len=int(inputs_embeds.shape[1]),
                     )
                 inputs_embeds = fixed_slot_fuse(
@@ -316,10 +337,12 @@ class QuantGemma4Model(QuantModuleBase):
                         "input_ids must be provided with pixel_values when running "
                         "Gemma4 eager/PTQ dynamic placeholder fusion."
                     )
-                self._validate_static_image_layout(
-                    image_mask,
-                    seq_len=int(inputs_embeds.shape[1]),
-                )
+                if self.validate_static_layout:
+                    self._validate_static_visual_token_count(image_embeds)
+                    self._validate_static_image_layout(
+                        image_mask,
+                        seq_len=int(inputs_embeds.shape[1]),
+                    )
                 inputs_embeds = dynamic_placeholder_fuse(
                     inputs_embeds,
                     image_embeds,

--- a/tico/quantization/wrapq/wrappers/gemma4/utils.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/utils.py
@@ -87,6 +87,172 @@ def assert_gemma4_e2b_no_moe(model_or_config: Any) -> None:
                 )
 
 
+def _ensure_batched_visual_embeds(visual_embeds: torch.Tensor) -> torch.Tensor:
+    """Return visual embeddings with an explicit batch dimension."""
+    if visual_embeds.dim() == 2:
+        return visual_embeds.unsqueeze(0)
+    return visual_embeds
+
+
+def _normalize_image_mask(
+    image_mask: torch.Tensor,
+    *,
+    batch: int,
+    seq_len: int,
+    device: torch.device,
+) -> torch.BoolTensor:
+    """Return an image placeholder mask with shape ``(B, S)``."""
+    if image_mask.dim() == 3:
+        image_mask = image_mask[..., 0]
+    if image_mask.dim() != 2:
+        raise ValueError(
+            "image_mask must have shape `(B, S)` or `(B, S, D)`, "
+            f"got shape={tuple(image_mask.shape)}."
+        )
+    if tuple(image_mask.shape) != (batch, seq_len):
+        raise ValueError(
+            "image_mask shape is incompatible with text_embeds: "
+            f"mask={tuple(image_mask.shape)}, expected={(batch, seq_len)}."
+        )
+    return image_mask.to(device=device, dtype=torch.bool)
+
+
+def dynamic_placeholder_fuse(
+    text_embeds: torch.Tensor,
+    visual_embeds: torch.Tensor,
+    image_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Fuse visual embeddings into the actual image placeholder positions.
+
+    This eager/PTQ helper follows the original HF-style multimodal semantics:
+    visual embeddings are written to the token positions selected by
+    ``image_mask`` instead of assuming a static contiguous visual-token slot.
+    The helper intentionally uses boolean indexing and is not meant for static
+    export graphs.
+
+    Args:
+        text_embeds: Text embedding tensor with shape ``(B, S, D)``.
+        visual_embeds: Visual embedding tensor with shape ``(B, V, D)`` or
+            ``(V, D)``. A missing batch dimension is inserted.
+        image_mask: Boolean image placeholder mask with shape ``(B, S)`` or
+            ``(B, S, D)``.
+
+    Returns:
+        Fused embedding tensor with the same shape as ``text_embeds``.
+
+    Raises:
+        ValueError: If tensor ranks, batch dimensions, hidden dimensions, or
+            placeholder counts are incompatible.
+    """
+    visual_embeds = _ensure_batched_visual_embeds(visual_embeds)
+
+    if text_embeds.dim() != 3:
+        raise ValueError(
+            f"text_embeds must be rank 3, got shape={tuple(text_embeds.shape)}."
+        )
+    if visual_embeds.dim() != 3:
+        raise ValueError(
+            f"visual_embeds must be rank 3, got shape={tuple(visual_embeds.shape)}."
+        )
+
+    batch, seq_len, hidden = text_embeds.shape
+    if visual_embeds.shape[0] != batch or visual_embeds.shape[2] != hidden:
+        raise ValueError(
+            "visual_embeds shape is incompatible with text_embeds: "
+            f"text={tuple(text_embeds.shape)}, visual={tuple(visual_embeds.shape)}."
+        )
+
+    image_mask = _normalize_image_mask(
+        image_mask,
+        batch=batch,
+        seq_len=seq_len,
+        device=text_embeds.device,
+    )
+    visual_len = int(visual_embeds.shape[1])
+    token_counts = image_mask.sum(dim=1)
+    if not torch.all(token_counts == visual_len):
+        raise ValueError(
+            "Image placeholder count must match visual embedding length for each "
+            "batch row: "
+            f"expected={visual_len}, actual={token_counts.detach().cpu().tolist()}."
+        )
+
+    fused = text_embeds.clone()
+    visual_embeds = visual_embeds.to(device=fused.device, dtype=fused.dtype)
+    for batch_idx in range(batch):
+        fused[batch_idx, image_mask[batch_idx], :] = visual_embeds[batch_idx]
+    return fused
+
+
+def validate_static_visual_layout(
+    image_mask: torch.Tensor,
+    *,
+    visual_start_idx: int,
+    num_visual_tokens: int,
+    seq_len: int | None = None,
+) -> None:
+    """Validate that image placeholders match the static visual-token span.
+
+    This validator is intended for static-runtime calibration and pre-export
+    checks. It verifies that each batch row has image placeholders exactly in
+    the range ``[visual_start_idx, visual_start_idx + num_visual_tokens)`` and
+    nowhere else.
+
+    Args:
+        image_mask: Boolean image placeholder mask with shape ``(B, S)`` or
+            ``(B, S, D)``.
+        visual_start_idx: Start index of the static visual-token span.
+        num_visual_tokens: Expected length of the static visual-token span.
+        seq_len: Optional expected sequence length. When provided, it must match
+            the mask sequence dimension.
+
+    Raises:
+        ValueError: If the static span is invalid or the placeholders do not
+            exactly match the configured span.
+    """
+    if image_mask.dim() == 3:
+        image_mask = image_mask[..., 0]
+    if image_mask.dim() != 2:
+        raise ValueError(
+            "image_mask must have shape `(B, S)` or `(B, S, D)`, "
+            f"got shape={tuple(image_mask.shape)}."
+        )
+
+    mask = image_mask.to(dtype=torch.bool)
+    _, actual_seq_len = mask.shape
+    if seq_len is not None and int(seq_len) != int(actual_seq_len):
+        raise ValueError(
+            "image_mask sequence length does not match the expected sequence "
+            f"length: mask_seq_len={actual_seq_len}, expected={int(seq_len)}."
+        )
+
+    start = int(visual_start_idx)
+    count = int(num_visual_tokens)
+    if start < 0:
+        raise ValueError(f"visual_start_idx must be non-negative, got {start}.")
+    if count < 0:
+        raise ValueError(f"num_visual_tokens must be non-negative, got {count}.")
+    end = start + count
+    if end > actual_seq_len:
+        raise ValueError(
+            "Static visual-token span exceeds the sequence length: "
+            f"visual_start_idx={start}, num_visual_tokens={count}, "
+            f"seq_len={actual_seq_len}."
+        )
+
+    expected = torch.zeros_like(mask, dtype=torch.bool)
+    if count:
+        expected[:, start:end] = True
+    if not torch.equal(mask, expected):
+        actual_counts = mask.sum(dim=1).detach().cpu().tolist()
+        raise ValueError(
+            "Image placeholder layout does not match the configured static "
+            "visual-token span: "
+            f"visual_start_idx={start}, num_visual_tokens={count}, "
+            f"seq_len={actual_seq_len}, actual_counts={actual_counts}."
+        )
+
+
 def fixed_slot_fuse(
     text_embeds: torch.Tensor,
     visual_embeds: torch.Tensor,
@@ -112,8 +278,7 @@ def fixed_slot_fuse(
         Fused embedding tensor with the same shape as ``text_embeds``.
     """
 
-    if visual_embeds.dim() == 2:
-        visual_embeds = visual_embeds.unsqueeze(0)
+    visual_embeds = _ensure_batched_visual_embeds(visual_embeds)
 
     if text_embeds.dim() != 3:
         raise ValueError(
@@ -136,14 +301,10 @@ def fixed_slot_fuse(
     # static export, but calibration images may produce different token counts.
     expected_len = visual_len if num_visual_tokens is None else int(num_visual_tokens)
     if visual_len != expected_len:
-        # Warn instead of raising error - use actual token count for flexibility
-        import warnings
-
-        warnings.warn(
-            f"Visual token count mismatch: expected {expected_len}, got {visual_len}. "
-            "Using actual count. If this is unexpected, check image resolution settings."
+        raise ValueError(
+            "Visual token count mismatch for fixed-slot fusion: "
+            f"expected {expected_len}, got {visual_len}."
         )
-        expected_len = visual_len
 
     end = int(visual_start_idx) + expected_len
     if visual_start_idx < 0 or end > seq_len:


### PR DESCRIPTION
Refactor the Gemma4 wrapper to keep the eager/PTQ calibration path close to the original HF semantics while preserving strict fixed-slot fusion for static export/runtime.

- Add dynamic placeholder-mask fusion for eager/PTQ execution
- Keep fixed_slot_fuse strict for static/export paths
- Add static calibration image-size alignment in Gemma4Adapter

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>