### PR TITLE
[quantization] Support multi-turn workflows

### DIFF
--- a/test/quantization/recipes/integration/test_static_llama_runtime_helpers.py
+++ b/test/quantization/recipes/integration/test_static_llama_runtime_helpers.py
@@ -14,10 +14,36 @@
 
 import importlib.util
 import unittest
+from types import SimpleNamespace
+from typing import Optional
 
 import torch
 
 HAS_TRANSFORMERS = importlib.util.find_spec("transformers") is not None
+
+
+class _FixedDeltaAppendLayer(torch.nn.Module):
+    def __init__(self, new_k: torch.Tensor, new_v: torch.Tensor):
+        super().__init__()
+        self.register_buffer("new_k", new_k)
+        self.register_buffer("new_v", new_v)
+        self.past_key_value: Optional[tuple[torch.Tensor, ...]] = None
+        self.attention_mask: Optional[torch.Tensor] = None
+        self.position_embeddings: Optional[tuple[torch.Tensor, ...]] = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        past_key_value: tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ):
+        self.past_key_value = tuple(tensor.clone() for tensor in past_key_value)
+        self.attention_mask = attention_mask.clone()
+        self.position_embeddings = tuple(
+            tensor.clone() for tensor in position_embeddings
+        )
+        return hidden_states, self.new_k, self.new_v
 
 
 @unittest.skipUnless(
@@ -65,3 +91,122 @@ class TestStaticLlamaRuntimeHelpers(unittest.TestCase):
 
         self.assertTrue(torch.equal(gathered[0], logits[0, 1]))
         self.assertTrue(torch.equal(gathered[1], logits[1, 3]))
+
+    def test_append_prefill_attention_mask_layout(self):
+        """Append mask should expose valid past and causal tail slots only."""
+        from tico.quantization.recipes.debug.static_llama_runtime import (
+            _build_append_prefill_attention_mask,
+        )
+
+        mask_value = -120.0
+        mask = _build_append_prefill_attention_mask(
+            batch_size=1,
+            past_len=2,
+            actual_len=2,
+            bucket_size=3,
+            max_seq=8,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            mask_value=mask_value,
+        )
+
+        expected = torch.full((1, 3, 8), mask_value, dtype=torch.float32)
+        expected[0, 0, [0, 1, 5]] = 0.0
+        expected[0, 1, [0, 1, 5, 6]] = 0.0
+
+        torch.testing.assert_close(mask, expected)
+
+    def test_append_prefill_writes_only_valid_delta_kv(self):
+        """Only the valid prefix of a bucket's delta KV should enter the cache."""
+        from tico.quantization.recipes.debug.static_llama_runtime import (
+            LayerCache,
+            StaticLlamaLayerRuntime,
+        )
+
+        runtime = StaticLlamaLayerRuntime.__new__(StaticLlamaLayerRuntime)
+        runtime.device = torch.device("cpu")
+        runtime.padding_side = "right"
+        runtime.tokenizer = SimpleNamespace(pad_token_id=0)
+        runtime.max_seq = 8
+        runtime.num_hidden_layers = 1
+        runtime.past_len = 2
+        runtime.embed_tokens = torch.nn.Embedding(32, 2)
+        runtime.final_norm = torch.nn.Identity()
+        runtime.lm_head = torch.nn.Identity()
+        runtime.rope_cos = torch.zeros(1, runtime.max_seq, 1)
+        runtime.rope_sin = torch.zeros_like(runtime.rope_cos)
+
+        past_k = torch.full((1, 1, runtime.max_seq - 1, 1), -1.0)
+        past_v = torch.full_like(past_k, -2.0)
+        past_k[0, 0, :2, 0] = torch.tensor([10.0, 11.0])
+        past_v[0, 0, :2, 0] = torch.tensor([20.0, 21.0])
+        before_k = past_k.clone()
+        before_v = past_v.clone()
+        cache = LayerCache(past_k=past_k, past_v=past_v)
+        runtime.layer_caches = [cache]
+
+        new_k = torch.tensor([[[[30.0], [31.0], [99.0]]]])
+        new_v = torch.tensor([[[[40.0], [41.0], [98.0]]]])
+        append_layer = _FixedDeltaAppendLayer(new_k, new_v)
+        runtime.append_prefill_layers = torch.nn.ModuleList([append_layer])
+
+        logits = runtime.append_prefill(
+            torch.tensor([[5, 6]]),
+            torch.ones(1, 2, dtype=torch.long),
+            bucket_size=3,
+        )
+
+        self.assertEqual(runtime.past_len, 4)
+        self.assertEqual(tuple(logits.shape), (1, 2))
+        torch.testing.assert_close(cache.past_k[:, :, :2, :], before_k[:, :, :2, :])
+        torch.testing.assert_close(cache.past_v[:, :, :2, :], before_v[:, :, :2, :])
+        torch.testing.assert_close(cache.past_k[:, :, 2:4, :], new_k[:, :, :2, :])
+        torch.testing.assert_close(cache.past_v[:, :, 2:4, :], new_v[:, :, :2, :])
+        torch.testing.assert_close(cache.past_k[:, :, 4:, :], before_k[:, :, 4:, :])
+        torch.testing.assert_close(cache.past_v[:, :, 4:, :], before_v[:, :, 4:, :])
+
+        assert append_layer.past_key_value is not None
+        self.assertEqual(tuple(append_layer.past_key_value[0].shape), (1, 1, 5, 1))
+        assert append_layer.attention_mask is not None
+        self.assertEqual(tuple(append_layer.attention_mask.shape), (1, 3, 8))
+        assert append_layer.position_embeddings is not None
+        self.assertEqual(tuple(append_layer.position_embeddings[0].shape), (1, 3, 1))
+        self.assertEqual(tuple(append_layer.position_embeddings[1].shape), (1, 3, 1))
+
+    def test_append_prefill_chunked_keeps_bucket_for_short_final_chunk(self):
+        """The final short chunk should still invoke the fixed-size bucket graph."""
+        from tico.quantization.recipes.debug.static_llama_runtime import (
+            StaticLlamaLayerRuntime,
+        )
+
+        runtime = StaticLlamaLayerRuntime.__new__(StaticLlamaLayerRuntime)
+        runtime.device = torch.device("cpu")
+        runtime.padding_side = "right"
+        runtime.tokenizer = SimpleNamespace(pad_token_id=0)
+
+        calls = []
+
+        def fake_append_prefill(
+            input_ids: torch.LongTensor,
+            attention_mask: torch.Tensor,
+            *,
+            bucket_size: int,
+        ) -> torch.Tensor:
+            calls.append((input_ids.clone(), attention_mask.clone(), int(bucket_size)))
+            return torch.tensor([[float(len(calls))]])
+
+        runtime.append_prefill = fake_append_prefill
+        logits = runtime.append_prefill_chunked(
+            torch.tensor([[1, 2, 3, 4, 5]]),
+            torch.ones(1, 5, dtype=torch.long),
+            bucket_size=3,
+        )
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0].tolist(), [[1, 2, 3]])
+        self.assertEqual(calls[1][0].tolist(), [[4, 5]])
+        self.assertEqual(calls[0][1].tolist(), [[1, 1, 1]])
+        self.assertEqual(calls[1][1].tolist(), [[1, 1]])
+        self.assertEqual(calls[0][2], 3)
+        self.assertEqual(calls[1][2], 3)
+        torch.testing.assert_close(logits, torch.tensor([[2.0]]))

--- a/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
+++ b/test/quantization/wrapq/wrappers/llama/test_quant_decoder_layer.py
@@ -427,6 +427,30 @@ class TestQuantLlamaDecoderLayer(unittest.TestCase):
         self.assertEqual(new_k.shape, (batch_size, self.n_kv, 1, self.head_dim))
         self.assertEqual(new_v.shape, (batch_size, self.n_kv, 1, self.head_dim))
 
+    def test_export_decode_adapter_supports_multi_token_block(self):
+        qlayer = QuantLlamaDecoderLayer(self.fp_layer)
+        adapter = qlayer.as_export_module(mode="decode", return_kv=True)
+        self.assertIsInstance(adapter, LlamaDecoderLayerDecodeExportAdapter)
+
+        batch_size = 1
+        query_len = 4
+        hidden = torch.randn(batch_size, query_len, self.hidden_size)
+        pos = self._rand_rope(batch_size, query_len)
+        mask = torch.zeros(batch_size, query_len, self.max_seq)
+        past = self._rand_past(batch_size, self.max_seq - query_len)
+
+        with torch.no_grad():
+            hidden_out, new_k, new_v = adapter(
+                hidden_states=hidden,
+                attention_mask=mask,
+                position_embeddings=pos,
+                past_key_value=past,
+            )
+
+        self.assertEqual(hidden_out.shape, (batch_size, query_len, self.hidden_size))
+        self.assertEqual(new_k.shape, (batch_size, self.n_kv, query_len, self.head_dim))
+        self.assertEqual(new_v.shape, (batch_size, self.n_kv, query_len, self.head_dim))
+
     def test_export_adapter_without_kv_returns_hidden_only(self):
         qlayer = QuantLlamaDecoderLayer(self.fp_layer)
         adapter = qlayer.as_export_module(mode="decode", return_kv=False)

--- a/tico/quantization/config/ptq.py
+++ b/tico/quantization/config/ptq.py
@@ -32,7 +32,7 @@ from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.qscheme import QScheme
 
 
-ExportMode = Literal["prefill", "decode"]
+ExportMode = Literal["prefill", "decode", "append_prefill"]
 OverridePath = Union[str, Iterable[str]]
 OverrideValue = Union[QuantSpec, Mapping[str, Any]]
 _PARAMETER_OBSERVER_NAMES = {"weight", "bias"}

--- a/tico/quantization/recipes/adapters/llama.py
+++ b/tico/quantization/recipes/adapters/llama.py
@@ -390,6 +390,7 @@ class LlamaAdapter(ModelAdapter):
                 max_seq_len=max_seq_len,
                 output_dir=output_dir,
                 prefill_decode=bool(export_cfg.get("prefill_decode", False)),
+                append_prefill_buckets=export_cfg.get("append_prefill_buckets"),
             )
 
 

--- a/tico/quantization/recipes/debug/static_llama_runtime.py
+++ b/tico/quantization/recipes/debug/static_llama_runtime.py
@@ -621,6 +621,9 @@ class StaticLlamaLayerRuntime:
         _validate_padding_layout(valid, self.padding_side)
         compact_input_ids = _compact_valid_tokens(input_ids, valid)
 
+        # TODO Select the smallest exported bucket satisfying
+        # chunk_len <= Q and self.past_len + Q <= self.max_seq. Define the
+        # context-length policy to use when no exported bucket fits.
         logits = None
         for start in range(0, compact_input_ids.size(1), bucket_size):
             chunk = compact_input_ids[:, start : start + bucket_size].to(self.device)

--- a/tico/quantization/recipes/debug/static_llama_runtime.py
+++ b/tico/quantization/recipes/debug/static_llama_runtime.py
@@ -43,6 +43,14 @@ class StaticLlamaRuntimeConfig:
     prompt: str = "The capital of France is"
     verify_steps: int = 6
     gen_steps: int = 16
+    run_baseline: bool = True
+    run_multiturn: bool = False
+    multiturn_first_prompt: str = "User: What is the capital of France?\nAssistant:"
+    multiturn_second_turn: str = "\nUser: What country is that city in?\nAssistant:"
+    multiturn_decode_steps_before_append: int = 4
+    multiturn_decode_steps_after_append: int = 4
+    append_bucket: int = 16
+    compare_append_prefill_with_decode_loop: bool = True
 
 
 def _clone_quant_layer(layer: nn.Module) -> nn.Module:
@@ -188,6 +196,43 @@ def _slice_rope(
     return cos, sin
 
 
+def _slice_rope_range(
+    rope_cos: torch.Tensor,
+    rope_sin: torch.Tensor,
+    start: int,
+    seq_len: int,
+    batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return RoPE tensors for an absolute position range."""
+    end = start + seq_len
+    if start < 0 or end > rope_cos.size(1):
+        raise ValueError(
+            f"RoPE range [{start}, {end}) exceeds available table length "
+            f"{rope_cos.size(1)}."
+        )
+    cos = rope_cos[:, start:end, :].to(device=device, dtype=dtype)
+    sin = rope_sin[:, start:end, :].to(device=device, dtype=dtype)
+    if batch_size != 1:
+        cos = cos.expand(batch_size, -1, -1).contiguous()
+        sin = sin.expand(batch_size, -1, -1).contiguous()
+    return cos, sin
+
+
+def _compact_valid_tokens(
+    input_ids: torch.LongTensor,
+    valid_token_mask: torch.Tensor,
+) -> torch.LongTensor:
+    """Compact equally sized valid token rows into a dense token tensor."""
+    valid_lengths = valid_token_mask.sum(dim=1)
+    if torch.unique(valid_lengths).numel() != 1:
+        raise ValueError("All batch rows must have the same valid token length.")
+    return input_ids.to(valid_token_mask.device)[valid_token_mask].reshape(
+        input_ids.size(0), int(valid_lengths[0].item())
+    )
+
+
 def _build_prefill_attention_mask(
     valid_token_mask: torch.Tensor,
     device: torch.device,
@@ -216,6 +261,51 @@ def _build_decode_attention_mask(
     if past_len > 0:
         mask[:, :, :past_len] = 0.0
     mask[:, :, max_seq - 1] = 0.0
+    return mask
+
+
+def _build_append_prefill_attention_mask(
+    batch_size: int,
+    past_len: int,
+    actual_len: int,
+    bucket_size: int,
+    max_seq: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    mask_value: float = -120.0,
+) -> torch.Tensor:
+    """Build a static additive mask for one append-prefill bucket."""
+    if actual_len < 1:
+        raise ValueError(f"actual_len must be positive, got {actual_len}.")
+    if actual_len > bucket_size:
+        raise ValueError(
+            f"actual_len must not exceed bucket_size. Got actual_len={actual_len}, "
+            f"bucket_size={bucket_size}."
+        )
+    if past_len > max_seq - bucket_size:
+        raise ValueError(
+            f"past_len={past_len} does not fit an append bucket of size "
+            f"{bucket_size} with max_seq={max_seq}."
+        )
+
+    mask = torch.full(
+        (batch_size, bucket_size, max_seq),
+        mask_value,
+        device=device,
+        dtype=dtype,
+    )
+    if past_len > 0:
+        mask[:, :actual_len, :past_len] = 0.0
+
+    tail_start = max_seq - bucket_size
+    causal = torch.tril(
+        torch.ones(bucket_size, bucket_size, device=device, dtype=torch.bool)
+    )
+    tail_mask = torch.zeros(bucket_size, bucket_size, device=device, dtype=dtype)
+    tail_mask = tail_mask.masked_fill(~causal, mask_value)
+    mask[:, :actual_len, tail_start:max_seq] = (
+        tail_mask[:actual_len, :].unsqueeze(0).expand(batch_size, -1, -1)
+    )
     return mask
 
 
@@ -262,6 +352,12 @@ class StaticLlamaLayerRuntime:
         self.decode_layers = nn.ModuleList(
             [
                 layer.wrapped.as_export_module("decode", return_kv=True)
+                for layer in self.layers
+            ]
+        ).to(self.device)
+        self.append_prefill_layers = nn.ModuleList(
+            [
+                layer.wrapped.as_export_module("append_prefill", return_kv=True)
                 for layer in self.layers
             ]
         ).to(self.device)
@@ -376,10 +472,204 @@ class StaticLlamaLayerRuntime:
         return _gather_last_token_logits(logits, valid)
 
     @torch.no_grad()
+    def append_prefill(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        *,
+        bucket_size: Optional[int] = None,
+    ) -> torch.Tensor:
+        """
+        Append a multi-token user-turn block to the existing external KV cache.
+
+        The method mirrors the proposed static append-prefill NPU contract. The
+        runtime owns the dynamic metadata (`past_len`, actual token count,
+        position selection, mask construction, and compact cache write-back),
+        while every decoder-layer call receives static tensor shapes based on the
+        selected `bucket_size`.
+        """
+        assert (
+            input_ids.dim() == 2
+        ), f"Expected input_ids as (B, T), got {tuple(input_ids.shape)}"
+        assert len(self.layer_caches) == self.num_hidden_layers, "Call prefill() first."
+
+        batch_size = input_ids.size(0)
+        if batch_size != self.layer_caches[0].past_k.size(0):
+            raise ValueError(
+                "append_prefill batch size must match the existing cache batch size. "
+                f"Got input batch={batch_size}, cache batch="
+                f"{self.layer_caches[0].past_k.size(0)}."
+            )
+
+        valid = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        _validate_padding_layout(valid, self.padding_side)
+        compact_input_ids = _compact_valid_tokens(input_ids, valid)
+        actual_len = compact_input_ids.size(1)
+
+        if bucket_size is None:
+            bucket_size = actual_len
+        bucket_size = int(bucket_size)
+        if bucket_size < actual_len:
+            raise ValueError(
+                f"bucket_size must cover all valid tokens. Got bucket_size="
+                f"{bucket_size}, actual_len={actual_len}."
+            )
+        if bucket_size < 1:
+            raise ValueError(f"bucket_size must be positive, got {bucket_size}.")
+
+        start_pos = self.past_len
+        if start_pos + actual_len > self.max_seq - 1:
+            raise ValueError(
+                "Not enough compact KV-cache capacity for append_prefill. "
+                f"past_len={start_pos}, actual_len={actual_len}, "
+                f"cache_capacity={self.max_seq - 1}."
+            )
+        if start_pos + bucket_size > self.max_seq:
+            raise ValueError(
+                "The selected append_prefill bucket does not fit the static "
+                f"attention window. past_len={start_pos}, bucket_size={bucket_size}, "
+                f"max_seq={self.max_seq}."
+            )
+
+        pad_token_id = self.tokenizer.pad_token_id
+        if pad_token_id is None:
+            pad_token_id = 0
+        padded_input_ids = torch.full(
+            (batch_size, bucket_size),
+            int(pad_token_id),
+            device=self.device,
+            dtype=torch.long,
+        )
+        padded_input_ids[:, :actual_len] = compact_input_ids.to(self.device)
+
+        hidden_states = self.embed_tokens(padded_input_ids)
+        runtime_dtype = hidden_states.dtype
+
+        attention_mask_for_append = _build_append_prefill_attention_mask(
+            batch_size=batch_size,
+            past_len=start_pos,
+            actual_len=actual_len,
+            bucket_size=bucket_size,
+            max_seq=self.max_seq,
+            device=self.device,
+            dtype=runtime_dtype,
+        )
+        position_embeddings = _slice_rope_range(
+            self.rope_cos,
+            self.rope_sin,
+            start=start_pos,
+            seq_len=bucket_size,
+            batch_size=batch_size,
+            device=self.device,
+            dtype=runtime_dtype,
+        )
+
+        past_storage_len_for_attn = self.max_seq - bucket_size
+        for layer_idx, layer in enumerate(self.append_prefill_layers):
+            cache = self.layer_caches[layer_idx]
+            past_key_value = (
+                cache.past_k[:, :, :past_storage_len_for_attn, :],
+                cache.past_v[:, :, :past_storage_len_for_attn, :],
+            )
+            out = layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask_for_append,
+                past_key_value=past_key_value,
+                position_embeddings=position_embeddings,
+            )
+            if not isinstance(out, tuple) or len(out) != 3:
+                raise RuntimeError(
+                    "Expected append-prefill adapter output as "
+                    "(hidden_states, new_k, new_v)."
+                )
+            hidden_states, new_k, new_v = out
+            cache.past_k[:, :, start_pos : start_pos + actual_len, :] = new_k[
+                :, :, :actual_len, :
+            ]
+            cache.past_v[:, :, start_pos : start_pos + actual_len, :] = new_v[
+                :, :, :actual_len, :
+            ]
+
+        self.past_len = start_pos + actual_len
+        hidden_states = self.final_norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+        return logits[:, actual_len - 1, :]
+
+    @torch.no_grad()
+    def append_prefill_chunked(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        *,
+        bucket_size: int,
+    ) -> torch.Tensor:
+        """Append a token block using one or more static append-prefill buckets."""
+        if bucket_size < 1:
+            raise ValueError(f"bucket_size must be positive, got {bucket_size}.")
+
+        valid = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        _validate_padding_layout(valid, self.padding_side)
+        compact_input_ids = _compact_valid_tokens(input_ids, valid)
+
+        logits = None
+        for start in range(0, compact_input_ids.size(1), bucket_size):
+            chunk = compact_input_ids[:, start : start + bucket_size].to(self.device)
+            chunk_mask = torch.ones_like(chunk, dtype=torch.long, device=self.device)
+            logits = self.append_prefill(
+                chunk,
+                chunk_mask,
+                bucket_size=bucket_size,
+            )
+
+        if logits is None:
+            raise RuntimeError("append_prefill_chunked received no valid token.")
+        return logits
+
+    @torch.no_grad()
+    def append_turn_by_decode_loop(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Append a user turn by repeatedly invoking the single-token decode path.
+
+        This is a correctness fallback for comparing the append-prefill path
+        against the existing decode contract. It is not the preferred serving
+        path because it runs one graph invocation per user token.
+        """
+        valid = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=self.tokenizer.pad_token_id,
+            device=self.device,
+        )
+        _validate_padding_layout(valid, self.padding_side)
+        compact_input_ids = _compact_valid_tokens(input_ids, valid)
+        if self.past_len + compact_input_ids.size(1) > self.max_seq - 1:
+            raise ValueError("Not enough KV-cache capacity for decode-loop append.")
+
+        logits = None
+        for i in range(compact_input_ids.size(1)):
+            logits = self.decode_one(compact_input_ids[:, i : i + 1].to(self.device))
+        assert logits is not None
+        return logits
+
+    @torch.no_grad()
     def decode_one(self, input_ids: torch.LongTensor) -> torch.Tensor:
         assert input_ids.dim() == 2 and input_ids.size(1) == 1
         assert len(self.layer_caches) == self.num_hidden_layers, "Call prefill() first."
-        assert self.past_len < self.max_seq
+        assert self.past_len < self.max_seq - 1
 
         batch_size = input_ids.size(0)
         hidden_states = self.embed_tokens(input_ids.to(self.device))
@@ -510,9 +800,9 @@ class StaticLlamaLayerRuntime:
 
             next_token = torch.argmax(logits_rt, dim=-1, keepdim=True)
             generated = torch.cat([generated, next_token], dim=1)
-            if generated.size(1) >= self.max_seq:
+            if generated.size(1) >= self.max_seq - 1:
                 if verbose:
-                    print("Stopped because the static decode window is full.")
+                    print("Stopped because the static decode cache window is full.")
                 break
 
     @staticmethod
@@ -527,6 +817,186 @@ class StaticLlamaLayerRuntime:
         print(f"mean|diff| = {diff.mean().item():.8f}")
         print(f" max|diff| = {diff.max().item():.8f}")
         print(f"PEIR       = {compute_peir(actual, expected) * 100:.6f} %")
+
+
+def _clone_layer_caches(caches: Sequence[LayerCache]) -> list[LayerCache]:
+    """Return detached copies of per-layer KV cache tensors."""
+    return [
+        LayerCache(past_k=cache.past_k.clone(), past_v=cache.past_v.clone())
+        for cache in caches
+    ]
+
+
+def _tokenize_to_device(
+    tokenizer: AutoTokenizer,
+    text: str,
+    *,
+    device: torch.device,
+    add_special_tokens: bool,
+    padding: bool | str = False,
+    truncation: bool = False,
+    max_length: Optional[int] = None,
+) -> tuple[torch.LongTensor, Optional[torch.Tensor]]:
+    """Tokenize text and move token tensors to the requested device."""
+    batch = tokenizer(
+        text,
+        return_tensors="pt",
+        add_special_tokens=add_special_tokens,
+        padding=padding,
+        truncation=truncation,
+        max_length=max_length,
+    )
+    input_ids = batch["input_ids"].to(device)
+    attention_mask = batch.get("attention_mask")
+    if attention_mask is not None:
+        attention_mask = attention_mask.to(device)
+    return input_ids, attention_mask
+
+
+def _run_decode_steps_against_reference(
+    runtime: StaticLlamaLayerRuntime,
+    generated: torch.LongTensor,
+    logits: torch.Tensor,
+    *,
+    steps: int,
+    title_prefix: str,
+    verbose: bool,
+) -> tuple[torch.LongTensor, torch.Tensor]:
+    """Run greedy decode steps and compare each step with the reference model."""
+    for step in range(1, steps + 1):
+        if generated.size(1) >= runtime.max_seq - 1:
+            if verbose:
+                print("Stopped because the static decode cache window is full.")
+            break
+
+        next_token = torch.argmax(logits, dim=-1, keepdim=True)
+        generated = torch.cat([generated, next_token], dim=1)
+        logits = runtime.decode_one(next_token)
+        ref_out = runtime.model(input_ids=generated)
+        logits_ref = ref_out.logits[:, -1, :]
+        runtime._print_diff(
+            f"{title_prefix} step {step}",
+            logits,
+            logits_ref,
+            verbose,
+        )
+
+    return generated, logits
+
+
+def _run_multiturn_append_prefill_check(
+    runtime: StaticLlamaLayerRuntime,
+    cfg: StaticLlamaRuntimeConfig,
+    *,
+    verbose: bool = True,
+) -> torch.LongTensor:
+    """Validate append-prefill in a two-turn static runtime scenario.
+
+    Returns:
+        Compact token IDs containing the full generated multi-turn sequence.
+    """
+    if cfg.append_bucket < 1:
+        raise ValueError(f"append_bucket must be positive, got {cfg.append_bucket}.")
+
+    first_input_ids, first_attention_mask = _tokenize_to_device(
+        runtime.tokenizer,
+        cfg.multiturn_first_prompt,
+        device=runtime.device,
+        add_special_tokens=True,
+        padding="max_length",
+        truncation=True,
+        max_length=runtime.max_seq,
+    )
+
+    runtime.reset_cache()
+    logits = runtime.prefill(first_input_ids, first_attention_mask)
+    first_valid = _normalize_valid_token_mask(
+        first_input_ids,
+        first_attention_mask,
+        pad_token_id=runtime.tokenizer.pad_token_id,
+        device=runtime.device,
+    )
+    generated = _compact_valid_tokens(first_input_ids, first_valid)
+    ref_out = runtime.model(input_ids=generated)
+    runtime._print_diff(
+        "Multi-turn step 0: first prefill last-token logits",
+        logits,
+        ref_out.logits[:, -1, :],
+        verbose,
+    )
+
+    generated, logits = _run_decode_steps_against_reference(
+        runtime,
+        generated,
+        logits,
+        steps=cfg.multiturn_decode_steps_before_append,
+        title_prefix="Multi-turn pre-append decode logits",
+        verbose=verbose,
+    )
+
+    second_input_ids, second_attention_mask = _tokenize_to_device(
+        runtime.tokenizer,
+        cfg.multiturn_second_turn,
+        device=runtime.device,
+        add_special_tokens=False,
+    )
+    second_valid = _normalize_valid_token_mask(
+        second_input_ids,
+        second_attention_mask,
+        pad_token_id=runtime.tokenizer.pad_token_id,
+        device=runtime.device,
+    )
+    compact_second_input_ids = _compact_valid_tokens(second_input_ids, second_valid)
+
+    before_append_caches = _clone_layer_caches(runtime.layer_caches)
+    before_append_past_len = runtime.past_len
+
+    logits = runtime.append_prefill_chunked(
+        second_input_ids,
+        second_attention_mask,
+        bucket_size=cfg.append_bucket,
+    )
+    generated = torch.cat(
+        [generated, compact_second_input_ids.to(runtime.device)], dim=1
+    )
+    ref_out = runtime.model(input_ids=generated)
+    runtime._print_diff(
+        f"Multi-turn append-prefill logits (bucket={cfg.append_bucket})",
+        logits,
+        ref_out.logits[:, -1, :],
+        verbose,
+    )
+
+    if cfg.compare_append_prefill_with_decode_loop:
+        append_prefill_caches = _clone_layer_caches(runtime.layer_caches)
+        append_prefill_past_len = runtime.past_len
+
+        runtime.layer_caches = _clone_layer_caches(before_append_caches)
+        runtime.past_len = before_append_past_len
+        logits_loop = runtime.append_turn_by_decode_loop(
+            second_input_ids,
+            second_attention_mask,
+        )
+        runtime._print_diff(
+            "Multi-turn append-prefill vs decode-loop append logits",
+            logits,
+            logits_loop,
+            verbose,
+        )
+
+        runtime.layer_caches = append_prefill_caches
+        runtime.past_len = append_prefill_past_len
+
+    generated, logits = _run_decode_steps_against_reference(
+        runtime,
+        generated,
+        logits,
+        steps=cfg.multiturn_decode_steps_after_append,
+        title_prefix="Multi-turn post-append decode logits",
+        verbose=verbose,
+    )
+
+    return generated
 
 
 def run_static_llama_runtime(cfg: StaticLlamaRuntimeConfig) -> None:
@@ -551,31 +1021,47 @@ def run_static_llama_runtime(cfg: StaticLlamaRuntimeConfig) -> None:
         padding_side=cfg.padding_side,
     )
 
-    runtime.verify_against_reference(
-        prompt=cfg.prompt,
-        steps=cfg.verify_steps,
-        verbose=True,
-    )
-
-    out_ids = runtime.generate_greedy(
-        prompt=cfg.prompt,
-        max_new_tokens=cfg.gen_steps,
-        eos_token_id=tokenizer.eos_token_id,
-    )
-
-    print("=" * 100)
-    print("Generated text:")
-    print(
-        tokenizer.decode(
-            out_ids[0], skip_special_tokens=True, clean_up_tokenization_spaces=False
+    if cfg.run_baseline:
+        runtime.verify_against_reference(
+            prompt=cfg.prompt,
+            steps=cfg.verify_steps,
+            verbose=True,
         )
-    )
+
+        out_ids = runtime.generate_greedy(
+            prompt=cfg.prompt,
+            max_new_tokens=cfg.gen_steps,
+            eos_token_id=tokenizer.eos_token_id,
+        )
+
+        print("=" * 100)
+        print("Generated text:")
+        print(
+            tokenizer.decode(
+                out_ids[0],
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=False,
+            )
+        )
+
+    if cfg.run_multiturn:
+        out_ids = _run_multiturn_append_prefill_check(runtime, cfg, verbose=True)
+        print("=" * 100)
+        print("Multi-turn generated text:")
+        print(
+            tokenizer.decode(
+                out_ids[0], skip_special_tokens=True, clean_up_tokenization_spaces=False
+            )
+        )
 
 
 def _parse_args() -> StaticLlamaRuntimeConfig:
     """Parse command-line arguments for the static runtime smoke test."""
     parser = argparse.ArgumentParser(
-        description="Run the static LLaMA prefill/decode runtime."
+        description=(
+            "Run the static LLaMA prefill/decode runtime, including the optional "
+            "multi-turn append-prefill check."
+        )
     )
     parser.add_argument(
         "--model",
@@ -587,7 +1073,7 @@ def _parse_args() -> StaticLlamaRuntimeConfig:
         "--max-seq",
         type=int,
         default=StaticLlamaRuntimeConfig.max_seq,
-        help="Static sequence length used by prefill and decode.",
+        help="Static sequence length used by prefill, append-prefill, and decode.",
     )
     parser.add_argument(
         "--padding-side",
@@ -606,19 +1092,67 @@ def _parse_args() -> StaticLlamaRuntimeConfig:
         "--prompt",
         type=str,
         default=StaticLlamaRuntimeConfig.prompt,
-        help="Prompt used for verification and greedy generation.",
+        help="Prompt used for baseline verification and greedy generation.",
     )
     parser.add_argument(
         "--verify-steps",
         type=int,
         default=StaticLlamaRuntimeConfig.verify_steps,
-        help="Number of decode steps for reference verification.",
+        help="Number of decode steps for baseline reference verification.",
     )
     parser.add_argument(
         "--gen-steps",
         type=int,
         default=StaticLlamaRuntimeConfig.gen_steps,
-        help="Maximum number of generated tokens.",
+        help="Maximum number of generated tokens in the baseline workflow.",
+    )
+    parser.add_argument(
+        "--run-baseline",
+        action=argparse.BooleanOptionalAction,
+        default=StaticLlamaRuntimeConfig.run_baseline,
+        help="Run baseline reference verification and greedy generation.",
+    )
+    parser.add_argument(
+        "--run-multiturn",
+        action=argparse.BooleanOptionalAction,
+        default=StaticLlamaRuntimeConfig.run_multiturn,
+        help="Run the multi-turn append-prefill validation workflow.",
+    )
+    parser.add_argument(
+        "--multiturn-first-prompt",
+        type=str,
+        default=StaticLlamaRuntimeConfig.multiturn_first_prompt,
+        help="Initial prompt used to populate the multi-turn KV cache.",
+    )
+    parser.add_argument(
+        "--multiturn-second-turn",
+        type=str,
+        default=StaticLlamaRuntimeConfig.multiturn_second_turn,
+        help="Second-turn text appended without special tokens.",
+    )
+    parser.add_argument(
+        "--multiturn-decode-steps-before-append",
+        type=int,
+        default=StaticLlamaRuntimeConfig.multiturn_decode_steps_before_append,
+        help="Greedy decode steps to run before appending the second turn.",
+    )
+    parser.add_argument(
+        "--multiturn-decode-steps-after-append",
+        type=int,
+        default=StaticLlamaRuntimeConfig.multiturn_decode_steps_after_append,
+        help="Greedy decode steps to run after appending the second turn.",
+    )
+    parser.add_argument(
+        "--append-bucket",
+        type=int,
+        default=StaticLlamaRuntimeConfig.append_bucket,
+        help="Static append-prefill bucket size.",
+    )
+    parser.add_argument(
+        "--compare-append-prefill-with-decode-loop",
+        action=argparse.BooleanOptionalAction,
+        default=StaticLlamaRuntimeConfig.compare_append_prefill_with_decode_loop,
+        help="Compare append-prefill logits with the single-token decode-loop path.",
     )
     args = parser.parse_args()
 
@@ -630,6 +1164,18 @@ def _parse_args() -> StaticLlamaRuntimeConfig:
         prompt=args.prompt,
         verify_steps=args.verify_steps,
         gen_steps=args.gen_steps,
+        run_baseline=args.run_baseline,
+        run_multiturn=args.run_multiturn,
+        multiturn_first_prompt=args.multiturn_first_prompt,
+        multiturn_second_turn=args.multiturn_second_turn,
+        multiturn_decode_steps_before_append=(
+            args.multiturn_decode_steps_before_append
+        ),
+        multiturn_decode_steps_after_append=(args.multiturn_decode_steps_after_append),
+        append_bucket=args.append_bucket,
+        compare_append_prefill_with_decode_loop=(
+            args.compare_append_prefill_with_decode_loop
+        ),
     )
 
 

--- a/tico/quantization/recipes/export/llama.py
+++ b/tico/quantization/recipes/export/llama.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import torch
 
@@ -51,21 +51,65 @@ def _convert_and_save(
     cm.save(save_path)
 
 
-def _make_random_position_embeddings(batch: int, head_dim: int, device: str):
-    cos = torch.randn(batch, 1, head_dim, device=device)
-    sin = torch.randn(batch, 1, head_dim, device=device)
+def _make_random_position_embeddings(
+    batch: int, seq_len: int, head_dim: int, device: str
+):
+    """Create example RoPE position embeddings with static export shapes."""
+    cos = torch.randn(batch, seq_len, head_dim, device=device)
+    sin = torch.randn(batch, seq_len, head_dim, device=device)
     return cos, sin
 
 
 def _make_random_decode_attn_mask(batch: int, max_seq: int, device: str):
+    """Create an example static additive attention mask for decode export."""
     effective_len = torch.randint(low=1, high=max_seq + 1, size=(1,)).item()
     mask = torch.zeros(batch, 1, max_seq, device=device, dtype=torch.float32)
     if effective_len < max_seq:
-        mask[:, :, effective_len:] = float("-120")
+        mask[:, :, effective_len:] = -120.0
+    return mask
+
+
+def _make_random_append_prefill_attn_mask(
+    batch: int,
+    max_seq: int,
+    append_seq: int,
+    device: str,
+):
+    """Create an example static additive attention mask for append-prefill export."""
+    if append_seq < 1:
+        raise ValueError(f"append_seq must be positive, got {append_seq}.")
+    if append_seq > max_seq:
+        raise ValueError(
+            f"append_seq must be less than or equal to max_seq. "
+            f"Got append_seq={append_seq}, max_seq={max_seq}."
+        )
+
+    max_past_len = max_seq - append_seq
+    if max_past_len > 0:
+        effective_past_len = torch.randint(
+            low=0, high=max_past_len + 1, size=(1,)
+        ).item()
+    else:
+        effective_past_len = 0
+
+    mask = torch.full(
+        (batch, append_seq, max_seq), -120.0, device=device, dtype=torch.float32
+    )
+    if effective_past_len > 0:
+        mask[:, :, :effective_past_len] = 0.0
+
+    tail_start = max_seq - append_seq
+    causal = torch.tril(
+        torch.ones(append_seq, append_seq, device=device, dtype=torch.bool)
+    )
+    tail_mask = torch.zeros(append_seq, append_seq, device=device, dtype=torch.float32)
+    tail_mask = tail_mask.masked_fill(~causal, -120.0)
+    mask[:, :, tail_start:max_seq] = tail_mask.unsqueeze(0).expand(batch, -1, -1)
     return mask
 
 
 def _make_random_decode_batch(model, batch: int, device: str, max_seq: int):
+    """Create example inputs for a static single-token decode graph."""
     hidden_size = model.config.hidden_size
     head_dim = getattr(
         model.config, "head_dim", hidden_size // model.config.num_attention_heads
@@ -73,11 +117,62 @@ def _make_random_decode_batch(model, batch: int, device: str, max_seq: int):
     n_kv = model.config.num_key_value_heads
 
     hidden = torch.randn(batch, 1, hidden_size, device=device)
-    pos = _make_random_position_embeddings(batch, head_dim, device)
+    pos = _make_random_position_embeddings(batch, 1, head_dim, device)
     mask = _make_random_decode_attn_mask(batch, max_seq, device)
     past_k = torch.randn(batch, n_kv, max_seq - 1, head_dim, device=device)
     past_v = torch.randn(batch, n_kv, max_seq - 1, head_dim, device=device)
     return hidden, pos, mask, (past_k, past_v)
+
+
+def _make_random_append_prefill_batch(
+    model,
+    batch: int,
+    device: str,
+    max_seq: int,
+    append_seq: int,
+):
+    """Create example inputs for a static append-prefill graph."""
+    hidden_size = model.config.hidden_size
+    head_dim = getattr(
+        model.config, "head_dim", hidden_size // model.config.num_attention_heads
+    )
+    n_kv = model.config.num_key_value_heads
+
+    if append_seq < 1:
+        raise ValueError(f"append_seq must be positive, got {append_seq}.")
+    if append_seq > max_seq:
+        raise ValueError(
+            f"append_seq must be less than or equal to max_seq. "
+            f"Got append_seq={append_seq}, max_seq={max_seq}."
+        )
+
+    hidden = torch.randn(batch, append_seq, hidden_size, device=device)
+    pos = _make_random_position_embeddings(batch, append_seq, head_dim, device)
+    mask = _make_random_append_prefill_attn_mask(batch, max_seq, append_seq, device)
+    past_len = max_seq - append_seq
+    past_k = torch.randn(batch, n_kv, past_len, head_dim, device=device)
+    past_v = torch.randn(batch, n_kv, past_len, head_dim, device=device)
+    return hidden, pos, mask, (past_k, past_v)
+
+
+def _normalize_append_prefill_buckets(
+    append_prefill_buckets: Sequence[int] | None,
+    max_seq_len: int,
+) -> tuple[int, ...]:
+    """Validate and normalize append-prefill bucket sizes."""
+    if append_prefill_buckets is None:
+        return ()
+
+    buckets = tuple(sorted({int(bucket) for bucket in append_prefill_buckets}))
+    for bucket in buckets:
+        if bucket < 1:
+            raise ValueError(f"append-prefill bucket size must be positive: {bucket}")
+        if bucket > max_seq_len:
+            raise ValueError(
+                f"append-prefill bucket size {bucket} exceeds max_seq_len "
+                f"{max_seq_len}."
+            )
+    return buckets
 
 
 def _is_wrapped_export_model(model: torch.nn.Module) -> bool:
@@ -181,8 +276,20 @@ def export_llama_per_layer(
     max_seq_len: int,
     output_dir: str | Path,
     prefill_decode: bool = False,
+    append_prefill_buckets: Sequence[int] | None = None,
 ) -> None:
-    """Export a floating-point or PTQ-wrapped LLaMA model by stage and layer."""
+    """Export a floating-point or PTQ-wrapped LLaMA model by stage and layer.
+
+    Args:
+        q_model: Floating-point or PTQ-wrapped LLaMA model.
+        max_seq_len: Static attention key length used for exported decoder graphs.
+        output_dir: Directory where Circle artifacts are saved.
+        prefill_decode: If True, export both prefill and single-token decode graphs.
+        append_prefill_buckets: Optional fixed block sizes `Q` for multi-turn
+            append-prefill graphs. Each graph consumes `(B, Q, D)` hidden states,
+            `(B, Q, max_seq_len)` additive masks, `(B, Q, head_dim)` RoPE tensors,
+            and `(B, num_kv_heads, max_seq_len - Q, head_dim)` past KV tensors.
+    """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -194,6 +301,9 @@ def export_llama_per_layer(
     qmodel = export_model.wrapped
     layers = qmodel.model.wrapped.layers
     config = qmodel.config
+    append_buckets = _normalize_append_prefill_buckets(
+        append_prefill_buckets, max_seq_len
+    )
 
     export_token_embedding(
         qmodel,
@@ -237,6 +347,22 @@ def export_llama_per_layer(
             )
             _convert_and_save(
                 qlayer.wrapped.as_export_module("decode"),
+                (hidden,),
+                output_dir / _circle_name(layer_name, artifact_tag),
+                kwargs={
+                    "attention_mask": mask,
+                    "past_key_value": past,
+                    "position_embeddings": pos,
+                },
+            )
+
+        for append_seq in append_buckets:
+            layer_name = f"decoder_layer_append_prefill_q{append_seq}_{i}"
+            hidden, pos, mask, past = _make_random_append_prefill_batch(
+                qmodel, 1, "cpu", max_seq_len, append_seq
+            )
+            _convert_and_save(
+                qlayer.wrapped.as_export_module("append_prefill"),
                 (hidden,),
                 output_dir / _circle_name(layer_name, artifact_tag),
                 kwargs={

--- a/tico/quantization/wrapq/wrappers/llama/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/llama/export_adapters.py
@@ -323,6 +323,65 @@ class LlamaAttentionDecodeExportAdapter(nn.Module):
         return hidden, new_k, new_v
 
 
+class LlamaAttentionAppendPrefillExportAdapter(nn.Module):
+    """
+    Export adapter for append-prefill attention.
+
+    Append-prefill consumes a fixed-size block of new tokens and attends to a
+    runtime-managed static past buffer. The runtime must prepare the additive
+    attention mask and RoPE position embeddings outside the exported graph.
+
+    Input contract
+    --------------
+    - hidden_states:        (B, Q, D)
+    - position_embeddings:  (B, Q, head_dim)
+    - attention_mask:       (B, Q, K)
+    - past_key_value:       (B, num_kv_heads, K - Q, head_dim)
+
+    Return contract
+    ---------------
+    - return_kv=True:
+        (hidden_states, (new_key, new_value))
+      where new_key/new_value are the KV delta for the appended block with
+      shape `(B, num_kv_heads, Q, head_dim)`.
+
+    - return_kv=False:
+        hidden_states
+    """
+
+    def __init__(self, wrapped, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
+        self.return_kv = return_kv
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs,
+    ):
+        """Run append-prefill attention and return delta-only K/V tensors."""
+        outputs = self.wrapped(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            past_key_value=past_key_value,
+            use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
+        )
+
+        hidden = outputs[0]
+
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[2]
+        return hidden, new_k, new_v
+
+
 class LlamaDecoderLayerPrefillExportAdapter(nn.Module):
     """
     Export adapter for prefill.
@@ -406,6 +465,69 @@ class LlamaDecoderLayerDecodeExportAdapter(nn.Module):
         """
         Run the decoder layer decode path and return delta-only K/V tensors
         when caching is enabled.
+        """
+        outputs = self.wrapped(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+            use_cache=self.return_kv,
+            cache_output_mode="delta",
+            **kwargs,
+        )
+
+        hidden = outputs[0]
+
+        if not self.return_kv:
+            return hidden
+
+        new_k, new_v = outputs[1]
+        return hidden, new_k, new_v
+
+
+class LlamaDecoderLayerAppendPrefillExportAdapter(nn.Module):
+    """
+    Export adapter for append-prefill.
+
+    Append-prefill is the multi-token cache-append path used for multi-turn
+    serving. It keeps the exported graph static by requiring the runtime to
+    prepare position embeddings, additive attention masks, and static past-cache
+    slices before calling the graph.
+
+    Input contract
+    --------------
+    - hidden_states:     (B, Q, D)
+    - attention_mask:    additive mask, typically (B, Q, K)
+    - past_key / past_value:
+                        (B, num_kv_heads, K-Q, head_dim)
+    - cos / sin:         (B, Q, head_dim)
+
+    Return contract
+    ---------------
+    - return_kv=True:
+        (hidden_states, new_key, new_value)
+      where new_key/new_value are the delta KV tensors for the current block.
+
+    - return_kv=False:
+        hidden_states
+    """
+
+    def __init__(self, wrapped, *, return_kv: bool = True):
+        super().__init__()
+        self.wrapped = wrapped
+        self.wrapped.return_type = "tuple"
+        self.return_kv = return_kv
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        past_key_value: Tuple[torch.Tensor, torch.Tensor],
+        **kwargs,
+    ):
+        """
+        Run the decoder layer append-prefill path and return delta-only K/V tensors.
         """
         outputs = self.wrapped(
             hidden_states,

--- a/tico/quantization/wrapq/wrappers/llama/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/llama/export_adapters.py
@@ -334,6 +334,7 @@ class LlamaDecoderLayerPrefillExportAdapter(nn.Module):
     def __init__(self, wrapped, *, return_kv: bool = True):
         super().__init__()
         self.wrapped = wrapped
+        # TODO: Replace this shared-state mutation with a per-call return-type override.
         self.wrapped.return_type = "tuple"
         self.return_kv = return_kv
 

--- a/tico/quantization/wrapq/wrappers/llama/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/llama/export_adapters.py
@@ -277,7 +277,7 @@ class LlamaAttentionDecodeExportAdapter(nn.Module):
     Return contract
     ---------------
     - return_kv=True:
-        (hidden_states, (new_key, new_value))
+        (hidden_states, new_key, new_value)
       where new_key/new_value are the KV delta for the current token.
 
     - return_kv=False:
@@ -304,65 +304,6 @@ class LlamaAttentionDecodeExportAdapter(nn.Module):
         attention computation, but only the newly produced K/V tensors are
         returned to the caller.
         """
-        outputs = self.wrapped(
-            hidden_states=hidden_states,
-            position_embeddings=position_embeddings,
-            attention_mask=attention_mask,
-            past_key_value=past_key_value,
-            use_cache=self.return_kv,
-            cache_output_mode="delta",
-            **kwargs,
-        )
-
-        hidden = outputs[0]
-
-        if not self.return_kv:
-            return hidden
-
-        new_k, new_v = outputs[2]
-        return hidden, new_k, new_v
-
-
-class LlamaAttentionAppendPrefillExportAdapter(nn.Module):
-    """
-    Export adapter for append-prefill attention.
-
-    Append-prefill consumes a fixed-size block of new tokens and attends to a
-    runtime-managed static past buffer. The runtime must prepare the additive
-    attention mask and RoPE position embeddings outside the exported graph.
-
-    Input contract
-    --------------
-    - hidden_states:        (B, Q, D)
-    - position_embeddings:  (B, Q, head_dim)
-    - attention_mask:       (B, Q, K)
-    - past_key_value:       (B, num_kv_heads, K - Q, head_dim)
-
-    Return contract
-    ---------------
-    - return_kv=True:
-        (hidden_states, (new_key, new_value))
-      where new_key/new_value are the KV delta for the appended block with
-      shape `(B, num_kv_heads, Q, head_dim)`.
-
-    - return_kv=False:
-        hidden_states
-    """
-
-    def __init__(self, wrapped, *, return_kv: bool = True):
-        super().__init__()
-        self.wrapped = wrapped
-        self.return_kv = return_kv
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
-        attention_mask: Optional[torch.Tensor] = None,
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        **kwargs,
-    ):
-        """Run append-prefill attention and return delta-only K/V tensors."""
         outputs = self.wrapped(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
@@ -428,71 +369,12 @@ class LlamaDecoderLayerPrefillExportAdapter(nn.Module):
 
 class LlamaDecoderLayerDecodeExportAdapter(nn.Module):
     """
-    Export adapter for decode.
+    Export adapter for cache-aware decoder-layer execution.
 
-    Input contract
-    --------------
-    - hidden_states:     (B, 1, D)
-    - attention_mask:    additive mask, typically (B, 1, K)
-    - past_key / past_value:
-                        (B, num_kv_heads, K-1, head_dim)
-    - cos / sin:         (B, 1, head_dim)
-
-    Return contract
-    ---------------
-    - return_kv=True:
-        (hidden_states, new_key, new_value)
-      where new_key/new_value are the delta KV for the current token.
-
-    - return_kv=False:
-        hidden_states
-    """
-
-    def __init__(self, wrapped, *, return_kv: bool = True):
-        super().__init__()
-        self.wrapped = wrapped
-        self.wrapped.return_type = "tuple"
-        self.return_kv = return_kv
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor],
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
-        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
-        **kwargs,
-    ):
-        """
-        Run the decoder layer decode path and return delta-only K/V tensors
-        when caching is enabled.
-        """
-        outputs = self.wrapped(
-            hidden_states,
-            attention_mask=attention_mask,
-            position_embeddings=position_embeddings,
-            past_key_value=past_key_value,
-            use_cache=self.return_kv,
-            cache_output_mode="delta",
-            **kwargs,
-        )
-
-        hidden = outputs[0]
-
-        if not self.return_kv:
-            return hidden
-
-        new_k, new_v = outputs[1]
-        return hidden, new_k, new_v
-
-
-class LlamaDecoderLayerAppendPrefillExportAdapter(nn.Module):
-    """
-    Export adapter for append-prefill.
-
-    Append-prefill is the multi-token cache-append path used for multi-turn
-    serving. It keeps the exported graph static by requiring the runtime to
-    prepare position embeddings, additive attention masks, and static past-cache
-    slices before calling the graph.
+    The adapter is query-length agnostic. Single-token decode uses `Q = 1`,
+    while append-prefill uses a fixed multi-token block `Q > 1`. In both cases,
+    the runtime supplies static attention masks, RoPE position embeddings, and
+    past-cache tensors.
 
     Input contract
     --------------
@@ -523,11 +405,12 @@ class LlamaDecoderLayerAppendPrefillExportAdapter(nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor],
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
-        past_key_value: Tuple[torch.Tensor, torch.Tensor],
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]],
         **kwargs,
     ):
         """
-        Run the decoder layer append-prefill path and return delta-only K/V tensors.
+        Run a cache-aware decoder-layer block and return delta-only K/V tensors
+        when caching is enabled.
         """
         outputs = self.wrapped(
             hidden_states,

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -23,6 +23,7 @@ from tico.quantization.config.llama_attention import get_llama_attention_options
 from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
+    LlamaDecoderLayerAppendPrefillExportAdapter,
     LlamaDecoderLayerDecodeExportAdapter,
     LlamaDecoderLayerPrefillExportAdapter,
 )
@@ -391,4 +392,8 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
             return LlamaDecoderLayerPrefillExportAdapter(self, return_kv=return_kv)
         if mode == "decode":
             return LlamaDecoderLayerDecodeExportAdapter(self, return_kv=return_kv)
+        if mode == "append_prefill":
+            return LlamaDecoderLayerAppendPrefillExportAdapter(
+                self, return_kv=return_kv
+            )
         raise ValueError(f"Unsupported export mode: {mode!r}")

--- a/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_decoder_layer.py
@@ -23,7 +23,6 @@ from tico.quantization.config.llama_attention import get_llama_attention_options
 from tico.quantization.config.ptq import ExportMode, PTQConfig
 from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.llama.export_adapters import (
-    LlamaDecoderLayerAppendPrefillExportAdapter,
     LlamaDecoderLayerDecodeExportAdapter,
     LlamaDecoderLayerPrefillExportAdapter,
 )
@@ -390,10 +389,6 @@ class QuantLlamaDecoderLayer(QuantModuleBase):
         """
         if mode == "prefill":
             return LlamaDecoderLayerPrefillExportAdapter(self, return_kv=return_kv)
-        if mode == "decode":
+        if mode in ("decode", "append_prefill"):
             return LlamaDecoderLayerDecodeExportAdapter(self, return_kv=return_kv)
-        if mode == "append_prefill":
-            return LlamaDecoderLayerAppendPrefillExportAdapter(
-                self, return_kv=return_kv
-            )
         raise ValueError(f"Unsupported export mode: {mode!r}")


### PR DESCRIPTION
This commit supports multi-turn workflows.

```bash
python -m tico.quantization.recipes.debug.static_llama_runtime \
  --model /mnt/sdb/model/Llama-3.2-1B-Instruct \
  --max-seq 256 \
  --device cpu \
  --no-run-baseline \
  --run-multiturn \
  --append-bucket 16


python -m tico.quantization.recipes.debug.static_llama_runtime \
  --model /mnt/sdb/model/Llama-3.2-1B-Instruct \
  --max-seq 256 \
  --padding-side right \
  --device cpu \
  --no-run-baseline \
  --run-multiturn \
  --multiturn-first-prompt $'User: What is the capital of France?\nAssistant:' \
  --multiturn-second-turn $'\nUser: What country is that city in?\nAssistant:' \
  --multiturn-decode-steps-before-append 4 \
  --multiturn-decode-steps-after-append 4 \
  --append-bucket 16 \
  --compare-append-prefill-with-decode-loop

```

```bash
...
====================================================================================================
Multi-turn post-append decode logits step 1
mean|diff| = 0.02939297
 max|diff| = 0.10098839
PEIR       = 0.340664 %
====================================================================================================
Multi-turn post-append decode logits step 2
mean|diff| = 0.03495336
 max|diff| = 0.17215163
PEIR       = 0.569002 %
====================================================================================================
Multi-turn post-append decode logits step 3
mean|diff| = 0.02905156
 max|diff| = 0.19826031
PEIR       = 0.583857 %
====================================================================================================
Multi-turn post-append decode logits step 4
mean|diff| = 0.01603191
 max|diff| = 0.09334183
PEIR       = 0.341133 %
====================================================================================================
Multi-turn generated text:
User: What is the capital of France?
Assistant: The capital of France
User: What country is that city in?
Assistant: France
User:

```

Related: #812
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>