### PR TITLE
[quantization] Print effective PTQ overrides and converted model

### DIFF
--- a/test/quantization/recipes/test_runner.py
+++ b/test/quantization/recipes/test_runner.py
@@ -119,6 +119,119 @@ class TestQuantizationRunner(unittest.TestCase):
             ],
         )
 
+    def test_config_summary_prints_ptq_override_policies(self):
+        """Config summary should print PTQ override policy declarations."""
+        cfg = {
+            "model": {
+                "family": "qwen3_vl",
+                "name_or_path": "Qwen/Qwen3-VL-4B-Instruct",
+            },
+            "pipeline": [
+                {
+                    "name": "ptq",
+                    "enabled": True,
+                    "specs": {
+                        "mx_int8_activation": {
+                            "kind": "mx",
+                            "elem_format": "int8",
+                            "axis": -1,
+                            "shared_exp_method": "max",
+                            "round": "nearest",
+                        }
+                    },
+                    "override_policies": [
+                        {
+                            "name": "all_linear_activations_mx",
+                            "target": {
+                                "component": "all",
+                                "layers": "all",
+                                "op_type": "linear",
+                                "observer_role": "activation",
+                            },
+                            "spec": "mx_int8_activation",
+                        },
+                        {
+                            "name": "optional_vision_softmax",
+                            "enabled": False,
+                            "allow_empty": True,
+                            "target": {
+                                "component": "vision",
+                                "layers": "all",
+                                "module": "attn",
+                                "observers": ["softmax"],
+                            },
+                            "spec": "int16",
+                        },
+                    ],
+                }
+            ],
+            "calibration": {"n_samples": 2, "seq_len": 128},
+        }
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            runner_mod._print_config_summary(cfg)
+
+        output = stdout.getvalue()
+        header = "=== PTQ override policies ==="
+
+        self.assertIn(header, output)
+        self.assertIn(
+            "all_linear_activations_mx -> "
+            "spec=mx_int8_activation "
+            "[mx(elem_format=int8, axis=-1, "
+            "shared_exp_method=max, round=nearest)]",
+            output,
+        )
+        self.assertIn("component=all, layers=all", output)
+        self.assertIn("op_type=linear, observer_role=activation", output)
+        self.assertIn("optional_vision_softmax (disabled)", output)
+        self.assertIn("module=attn, observers=['softmax']", output)
+        self.assertIn("allow_empty=True", output)
+        self.assertLess(output.index("Calibration samples"), output.index("Profile"))
+        self.assertLess(output.index("Profile"), output.index(header))
+        self.assertIn("Profile               : not set\n\n" + header, output)
+
+    def test_config_summary_omits_override_policy_section_without_policies(self):
+        """Config summary should omit the policy section when no policies exist."""
+        cfg = {
+            "model": {"family": "dummy", "name_or_path": "model"},
+            "pipeline": [{"name": "ptq", "enabled": True}],
+        }
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            runner_mod._print_config_summary(cfg)
+
+        self.assertNotIn("=== PTQ override policies ===", stdout.getvalue())
+
+    def test_config_summary_respects_print_config_for_override_policies(self):
+        """Disabling the config summary should also hide policy declarations."""
+        cfg = {
+            "runtime": {"print_config": False},
+            "pipeline": [
+                {
+                    "name": "ptq",
+                    "override_policies": [
+                        {
+                            "name": "all_linear_activations",
+                            "target": {
+                                "op_type": "linear",
+                                "observer_role": "activation",
+                            },
+                            "spec": "int16",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            runner_mod._print_config_summary(cfg)
+
+        self.assertEqual(stdout.getvalue(), "")
+
     def test_runner_requires_model_family_and_name(self):
         """QuantizationRunner should reject configs without required model keys."""
         for cfg in [

--- a/test/quantization/recipes/test_stages.py
+++ b/test/quantization/recipes/test_stages.py
@@ -26,9 +26,12 @@ import tico.quantization.recipes.stages.ptq as ptq_mod
 
 import torch
 
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
 from tico.quantization.recipes.context import RecipeContext
 from tico.quantization.recipes.stages.gptq import GPTQStage
 from tico.quantization.recipes.stages.ptq import PTQStage
+from tico.quantization.wrapq.dtypes import DType
 
 
 class DummyAdapter:
@@ -61,6 +64,7 @@ class TestRecipeStages(unittest.TestCase):
         ctx = RecipeContext(cfg={}, adapter=adapter, model=source_model)
         prepared_model = SimpleNamespace(name="prepared")
         calls: dict[str, Any] = {}
+        stdout = io.StringIO()
 
         def fake_prepare(model, config):
             calls["prepare"] = (model, config)
@@ -85,7 +89,7 @@ class TestRecipeStages(unittest.TestCase):
             "clear_gptq_quantizers",
             lambda model: calls.setdefault("clear", model),
         ):
-            with contextlib.redirect_stdout(io.StringIO()):
+            with contextlib.redirect_stdout(stdout):
                 result = PTQStage().run(ctx, {"name": "ptq", "verbose": True})
 
         self.assertEqual(result.model, "converted")
@@ -99,6 +103,102 @@ class TestRecipeStages(unittest.TestCase):
         assert calibrated is not None
         self.assertIs(calibrated[1], prepared_model)
         self.assertIs(calls["convert"], prepared_model)
+        self.assertNotIn("=== Effective PTQ overrides ===", stdout.getvalue())
+        self.assertNotIn("=== Model after PTQ ===", stdout.getvalue())
+
+    def test_ptq_stage_prints_final_overrides_and_converted_model(self):
+        """PTQStage should print final overrides and the converted model on request."""
+
+        class EffectiveOverrideAdapter(DummyAdapter):
+            """Adapter fake that returns a real PTQ config."""
+
+            def build_ptq_config(self, ctx, stage_cfg):
+                """Return a PTQ config containing an unrelated adapter override."""
+                config = PTQConfig()
+                config.set_override(
+                    (
+                        "model",
+                        "layers",
+                        "0",
+                        "self_attn",
+                        "q_proj",
+                        "weight",
+                    ),
+                    affine(DType.uint(4)),
+                )
+                return config
+
+        adapter = EffectiveOverrideAdapter()
+        source_model = SimpleNamespace(model=SimpleNamespace(layers=[object()]))
+        ctx = RecipeContext(cfg={}, adapter=adapter, model=source_model)
+        prepared_model = SimpleNamespace(name="prepared")
+        calls: dict[str, Any] = {}
+
+        def fake_prepare(model, config):
+            calls["prepare"] = (model, config)
+            return prepared_model
+
+        def fake_convert(model):
+            calls["convert"] = model
+            return "converted-model"
+
+        stage_cfg = {
+            "name": "ptq",
+            "print_overrides": True,
+            "print_model": True,
+            "specs": {
+                "mx_int8": {
+                    "kind": "mx",
+                    "elem_format": "int8",
+                    "axis": -1,
+                }
+            },
+            "override_policies": [
+                {
+                    "name": "all_down_proj_outputs_mx",
+                    "target": {
+                        "component": "text",
+                        "layers": "all",
+                        "module": "mlp.down_proj",
+                        "observers": ["act_out"],
+                    },
+                    "spec": "mx_int8",
+                }
+            ],
+            "raw_overrides": {
+                "model.layers.0.mlp.down_proj.act_out": "int16",
+            },
+        }
+
+        stdout = io.StringIO()
+        with patch.object(ptq_mod, "prepare", fake_prepare), patch.object(
+            ptq_mod, "convert", fake_convert
+        ), patch.object(ptq_mod, "find_gptq_quantizers", lambda model: (None, None)):
+            with contextlib.redirect_stdout(stdout):
+                result = PTQStage().run(ctx, stage_cfg)
+
+        output = stdout.getvalue()
+        override_path = "model.layers.0.mlp.down_proj.act_out"
+        matching_lines = [line for line in output.splitlines() if override_path in line]
+
+        self.assertEqual(result.model, "converted-model")
+        self.assertIs(calls["convert"], prepared_model)
+        self.assertIsInstance(calls["prepare"][1], PTQConfig)
+        self.assertEqual(len(matching_lines), 1)
+        self.assertIn("observer=MinMaxObserver", matching_lines[0])
+        self.assertIn("dtype=int16", matching_lines[0])
+        self.assertNotIn("MXObserver", matching_lines[0])
+        self.assertNotIn("elem_format=int8", matching_lines[0])
+        self.assertNotIn("__quant_spec_replace_role__", output)
+        self.assertNotIn(
+            "model.layers.0.self_attn.q_proj.weight",
+            output,
+        )
+        self.assertIn("=== Model after PTQ ===\nconverted-model", output)
+        self.assertLess(
+            output.index("=== Effective PTQ overrides ==="),
+            output.index("=== Model after PTQ ==="),
+        )
 
     def test_ptq_stage_allows_missing_gptq_quantizers(self):
         """PTQStage should continue when no GPTQ quantizers are attached."""

--- a/tico/quantization/config/specs.py
+++ b/tico/quantization/config/specs.py
@@ -75,8 +75,14 @@ class QuantSpec:
             infer_qscheme: If True, missing affine qscheme values are inferred
                 immediately. If False, only explicitly configured qschemes are
                 emitted so wrapper defaults may still participate in precedence.
-            mark_replace: If True, mark the returned mapping as a full policy
-                override so role-level defaults are not inherited later.
+            mark_replace: If True, add the internal
+                ``__quant_spec_replace_role__`` marker to the returned mapping.
+                ``QuantModuleBase`` consumes and removes the marker before
+                constructing the observer. A marked QuantSpec is treated as a
+                complete observer-level policy, so fields omitted from the
+                role-level activation or weight QuantSpec are not inherited.
+                Wrapper-provided defaults may still supply fields omitted from
+                the explicit observer override.
         """
         out: dict[str, Any] = {"observer": self.observer}
         if mark_replace:

--- a/tico/quantization/examples/configs/PTQ_OVERRIDE_POLICIES.md
+++ b/tico/quantization/examples/configs/PTQ_OVERRIDE_POLICIES.md
@@ -100,3 +100,25 @@ a `component: vision` policy with `allow_empty: true`.
 
 Do not use `allow_empty: true` for required overrides, because it can hide
 configuration mistakes.
+
+## Diagnostics
+
+Set `print_overrides: true` on the PTQ stage to print the normalized final
+values only for observer paths targeted by enabled `override_policies` or
+`raw_overrides`. Values are read after all precedence rules have been applied,
+so each targeted path is printed once with the final value passed to
+`prepare()`. Model-family defaults and unrelated adapter override paths are not
+printed. The internal `__quant_spec_replace_role__` merge marker is omitted.
+
+Set `print_model: true` to print the converted model immediately after the PTQ
+`convert()` call.
+
+```yaml
+pipeline:
+  - name: ptq
+    enabled: true
+    print_overrides: true
+    print_model: true
+```
+
+Both options default to `false`.

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite_mx_override_polices.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite_mx_override_polices.yaml
@@ -79,6 +79,7 @@ pipeline:
 
   - name: ptq
     enabled: true
+    print_overrides: true
     print_model: true
 
     # Global default for activation observers that are not matched by a policy.

--- a/tico/quantization/recipes/runner.py
+++ b/tico/quantization/recipes/runner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -100,6 +101,84 @@ def _stage_quant_spec(
 ) -> Any:
     """Read and format a quantization spec from a stage config."""
     return _format_quant_spec(_stage_value(stage_cfg, key, None), default)
+
+
+def _format_override_policy_spec(
+    policy: Mapping[str, Any],
+    specs: Mapping[str, Any],
+) -> str:
+    """Format a policy spec and expand a referenced named spec."""
+    spec = policy.get("spec", "not set")
+    if isinstance(spec, str) and spec in specs:
+        return f"{spec} [{_format_quant_spec(specs[spec])}]"
+    return str(_format_quant_spec(spec))
+
+
+def _format_override_policy(
+    policy: Mapping[str, Any],
+    specs: Mapping[str, Any],
+) -> str:
+    """Format one PTQ override policy for the config summary."""
+    name = str(policy.get("name", "<unnamed>"))
+    status = "" if bool(policy.get("enabled", True)) else " (disabled)"
+
+    target = policy.get("target", {})
+    if not isinstance(target, Mapping):
+        target = {}
+
+    fields = [
+        f"spec={_format_override_policy_spec(policy, specs)}",
+        f"component={target.get('component', 'all')}",
+        f"layers={target.get('layers', 'all')}",
+    ]
+
+    for key in ("module", "modules", "op_type"):
+        value = target.get(key)
+        if value is not None:
+            fields.append(f"{key}={value}")
+
+    for key in ("observers", "observer_role"):
+        value = target.get(key)
+        if value is not None:
+            fields.append(f"{key}={value}")
+
+    if bool(policy.get("allow_empty", False)):
+        fields.append("allow_empty=True")
+
+    return f"{name}{status} -> {', '.join(fields)}"
+
+
+def _print_override_policy_summary(
+    ptq_stage: Mapping[str, Any] | None,
+) -> None:
+    """Print PTQ override policies as part of the config summary."""
+    if ptq_stage is None:
+        return
+
+    policies = ptq_stage.get("override_policies")
+    if (
+        not isinstance(policies, Sequence)
+        or isinstance(policies, (str, bytes))
+        or not policies
+    ):
+        return
+
+    specs = ptq_stage.get("specs", {})
+    if not isinstance(specs, Mapping):
+        specs = {}
+
+    formatted = [
+        _format_override_policy(policy, specs)
+        for policy in policies
+        if isinstance(policy, Mapping)
+    ]
+    if not formatted:
+        return
+
+    print()
+    print("=== PTQ override policies ===")
+    for policy in formatted:
+        print(f"  {policy}")
 
 
 def _gptq_weight_bits(gptq_stage: Mapping[str, Any] | None) -> Any:
@@ -239,6 +318,7 @@ def _print_config_summary(cfg: Mapping[str, Any]) -> None:
     )
     _print_config_row("Max seq length", _max_seq_len(cfg))
     _print_config_row("Profile", profile)
+    _print_override_policy_summary(ptq_stage)
     print()
 
 

--- a/tico/quantization/recipes/stages/ptq.py
+++ b/tico/quantization/recipes/stages/ptq.py
@@ -15,14 +15,33 @@
 from typing import Any, Mapping
 
 from tico.quantization import convert, prepare
+from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.recipes.context import RecipeContext
-from tico.quantization.recipes.override_policies import apply_ptq_override_policies
+from tico.quantization.recipes.override_policies import (
+    apply_ptq_override_policies,
+    build_quant_target_resolver_context,
+    compile_override_policies,
+    compile_raw_overrides,
+    parse_named_specs,
+)
 from tico.quantization.recipes.qparams import (
     clear_gptq_quantizers,
     find_gptq_quantizers,
     inject_gptq_qparams,
 )
 from tico.quantization.recipes.stages.base import Stage
+
+
+_INTERNAL_OVERRIDE_FIELDS = frozenset({"__quant_spec_replace_role__"})
+_OVERRIDE_FIELD_ORDER = (
+    "observer",
+    "dtype",
+    "qscheme",
+    "elem_format",
+    "axis",
+    "shared_exp_method",
+    "round",
+)
 
 
 def _find_enabled_stage(
@@ -57,6 +76,100 @@ def _qparam_injection_verbose(
     return bool(gptq_stage and gptq_stage.get("verbose", False))
 
 
+def _resolve_configured_override_paths(
+    stage_cfg: Mapping[str, Any],
+    *,
+    family: str,
+    model: Any,
+) -> tuple[tuple[str, ...], ...]:
+    """Resolve exact observer paths targeted by selector and raw overrides."""
+    policies = stage_cfg.get("override_policies")
+    raw_overrides = stage_cfg.get("raw_overrides")
+    if not policies and not raw_overrides:
+        return ()
+
+    specs = parse_named_specs(stage_cfg.get("specs", {}))
+    paths: set[tuple[str, ...]] = set()
+
+    if policies:
+        context = build_quant_target_resolver_context(family=family, model=model)
+        paths.update(
+            override.path
+            for override in compile_override_policies(
+                policies,
+                specs=specs,
+                context=context,
+            )
+        )
+
+    paths.update(
+        path
+        for path, _ in compile_raw_overrides(
+            raw_overrides,
+            specs=specs,
+        )
+    )
+    return tuple(sorted(paths))
+
+
+def _get_effective_override_fields(
+    overrides: Mapping[str, Any],
+    path: tuple[str, ...],
+) -> dict[str, Any]:
+    """Read normalized override fields at one exact observer path."""
+    current: Any = overrides
+    for key in path:
+        if not isinstance(current, Mapping) or key not in current:
+            dotted_path = ".".join(path)
+            raise KeyError(f"Effective PTQ override path is missing: {dotted_path}")
+        current = current[key]
+
+    if not isinstance(current, Mapping):
+        dotted_path = ".".join(path)
+        raise TypeError(
+            "Effective PTQ override must resolve to a mapping at "
+            f"{dotted_path}, got {type(current).__name__}."
+        )
+
+    return {
+        str(key): value
+        for key, value in current.items()
+        if str(key) not in _INTERNAL_OVERRIDE_FIELDS
+    }
+
+
+def _format_override_value(value: Any) -> str:
+    """Return a compact display value for a normalized override field."""
+    name = getattr(value, "__name__", None)
+    if isinstance(name, str):
+        return name
+    return str(value)
+
+
+def _format_effective_override(fields: Mapping[str, Any]) -> str:
+    """Format one normalized effective override."""
+    ordered_keys = [key for key in _OVERRIDE_FIELD_ORDER if key in fields]
+    ordered_keys.extend(sorted(key for key in fields if key not in ordered_keys))
+    return ", ".join(
+        f"{key}={_format_override_value(fields[key])}" for key in ordered_keys
+    )
+
+
+def _print_effective_overrides(
+    ptq_config: PTQConfig,
+    override_paths: tuple[tuple[str, ...], ...],
+) -> None:
+    """Print final values only for observer paths targeted by recipe overrides."""
+    print("=== Effective PTQ overrides ===")
+    if not override_paths:
+        print("  <none>")
+    else:
+        for path in override_paths:
+            fields = _get_effective_override_fields(ptq_config.overrides, path)
+            print(f"  {'.'.join(path)}: {_format_effective_override(fields)}")
+    print()
+
+
 class PTQStage(Stage):
     name = "ptq"
 
@@ -69,6 +182,15 @@ class PTQStage(Stage):
             family=ctx.adapter.family,
             model=ctx.require_model(),
         )
+
+        if bool(stage_cfg.get("print_overrides", False)):
+            override_paths = _resolve_configured_override_paths(
+                stage_cfg,
+                family=ctx.adapter.family,
+                model=ctx.require_model(),
+            )
+            _print_effective_overrides(ptq_config, override_paths)
+
         q_model = prepare(ctx.require_model(), ptq_config)
 
         owner, quantizers = find_gptq_quantizers(q_model)
@@ -88,4 +210,8 @@ class PTQStage(Stage):
         ctx.adapter.calibrate_prepared_model(ctx, q_model, stage_cfg)
 
         ctx.model = convert(q_model)
+        if bool(stage_cfg.get("print_model", False)):
+            print("=== Model after PTQ ===")
+            print(ctx.require_model())
+
         return ctx

--- a/tico/quantization/wrapq/wrappers/quant_module_base.py
+++ b/tico/quantization/wrapq/wrappers/quant_module_base.py
@@ -172,6 +172,18 @@ class QuantModuleBase(nn.Module, ABC):
             1. explicit observer override in PTQConfig.overrides
             2. wrapper defaults passed by the wrapper implementation
             3. role-level QuantSpec from PTQConfig.activation or PTQConfig.weight
+
+        ``QuantSpec.to_kwargs(mark_replace=True)`` adds the internal
+        ``__quant_spec_replace_role__`` marker to an explicit observer override.
+        This method removes the marker before observer construction. When the
+        marker is set, the role-level activation or weight QuantSpec is discarded
+        entirely, while wrapper defaults may still fill fields omitted from the
+        explicit observer override.
+
+        For example, an MX activation override must not inherit the ``dtype`` or
+        ``qscheme`` from an affine role-level activation policy. Clearing
+        ``role_cfg`` prevents incompatible affine settings from being passed to
+        the MX observer.
         """
         _UNSPEC: Any = object()
 


### PR DESCRIPTION
This commit prints effective overrdies and converted model for debugging purpose.

### Output

```bash
=== Config ===
Model                 : Maykeye/TinyLLama-v0
Device                : cuda
DType                 : float32
Seed                  : 42
GPTQ enabled          : True
GPTQ lm_head enabled  : True
PTQ enabled           : True
SpinQuant enabled     : True
CLE enabled           : False
Activation            : int16
Linear weight         : uint4
Embedding weight      : uint4
LM head weight        : uint4
Norm weight           : int16
Spin rotation weight  : int16
Calibration samples   : 1
Calibration seq length: 256
Max seq length        : 256
Profile               : npu_export

=== Loading model ===
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 16150.16it/s]
=== Building calibration inputs ===
Using the latest cached version of the dataset since wikitext couldn't be found on the Hugging Face Hub
Found the latest cached dataset configuration 'wikitext-2-raw-v1' at /home/seongwoo/.cache/huggingface/datasets/wikitext/wikitext-2-raw-v1/0.0.0/b08601e04326c79dfdd32d625aee71d232d685c3 (last modified on Thu Jul 31 15:33:46 2025).
[transformers] Token indices sequence length is longer than the specified maximum sequence length for this model (2683980 > 2048). Running this sequence through the model will result in indexing errors
=== Running quantization pipeline ===
Applying SpinQuant preprocessing …
Applying SpinQuant rotations: 100%|█████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 671.98it/s]
Skipping cle …
Applying gptq …
GPTQ calibration: 100%|██████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 18.76it/s]
Quantizing layers: 100%|██████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:01<00:00,  6.54layer/s]
Wrapping model with PTQ wrappers …                                                                                                             
=== Effective PTQ overrides ===
  model.layers.0.mlp.down_proj.act_in: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.mlp.down_proj.act_out: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.mlp.gate_proj.act_in: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.mlp.gate_proj.act_out: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.mlp.up_proj.act_in: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.mlp.up_proj.act_out: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.self_attn.k_proj.act_in: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.self_attn.k_proj.act_out: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.self_attn.o_proj.act_in: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.self_attn.o_proj.act_out: observer=MXObserver, elem_format=fp8_e4m3, axis=-1, shared_exp_method=max, round=nearest
  model.layers.0.self_attn.q_proj.act_in: observer=MinMaxObserver, dtype=int16, qscheme=per_tensor_symm

...
```

Related: #823
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>