### PR TITLE
[quantization] Implement build_static_inputs for Gemma4 static runtime

### DIFF
--- a/test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py
+++ b/test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for CPU helper functions in static_gemma4_runtime.
+
+These tests exercise the pure-Python helper functions
+(`_normalize_valid_token_mask`, `_validate_padding_layout`) without
+requiring a real Gemma4 model or processor.
+"""
+
+import importlib.util
+import unittest
+
+import torch
+
+HAS_TRANSFORMERS = importlib.util.find_spec("transformers") is not None
+
+
+@unittest.skipUnless(
+    HAS_TRANSFORMERS, "transformers is required for static runtime helpers"
+)
+class TestNormalizeValidTokenMask(unittest.TestCase):
+    """Tests for _normalize_valid_token_mask."""
+
+    def test_with_attention_mask(self):
+        """When attention_mask is provided, it should be converted to bool."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _normalize_valid_token_mask,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3, 0, 0]])
+        attention_mask = torch.tensor([[1, 1, 1, 0, 0]])
+        result = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=0,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([[True, True, True, False, False]])
+        self.assertTrue(torch.equal(result, expected))
+        self.assertEqual(result.dtype, torch.bool)
+
+    def test_without_attention_mask_uses_pad_token_id(self):
+        """When attention_mask is None, derive from pad_token_id comparison."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _normalize_valid_token_mask,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3, 0, 0]])
+        result = _normalize_valid_token_mask(
+            input_ids,
+            None,
+            pad_token_id=0,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([[True, True, True, False, False]])
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_without_attention_mask_no_pad_token_id(self):
+        """When both attention_mask and pad_token_id are None, all valid."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _normalize_valid_token_mask,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3, 0, 0]])
+        result = _normalize_valid_token_mask(
+            input_ids,
+            None,
+            pad_token_id=None,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([[True, True, True, True, True]])
+        self.assertTrue(torch.equal(result, expected))
+
+    def test_shape_mismatch_raises(self):
+        """attention_mask with wrong shape should raise ValueError."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _normalize_valid_token_mask,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3]])
+        attention_mask = torch.tensor([[1, 0]])
+        with self.assertRaisesRegex(ValueError, "attention_mask shape"):
+            _normalize_valid_token_mask(
+                input_ids,
+                attention_mask,
+                pad_token_id=0,
+                device=torch.device("cpu"),
+            )
+
+    def test_batched_input(self):
+        """Should handle batched (2D) input correctly."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _normalize_valid_token_mask,
+        )
+
+        input_ids = torch.tensor([[1, 2, 0, 0], [3, 4, 5, 6]])
+        attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 1]])
+        result = _normalize_valid_token_mask(
+            input_ids,
+            attention_mask,
+            pad_token_id=0,
+            device=torch.device("cpu"),
+        )
+        expected = torch.tensor([[True, True, False, False], [True, True, True, True]])
+        self.assertTrue(torch.equal(result, expected))
+
+
+@unittest.skipUnless(
+    HAS_TRANSFORMERS, "transformers is required for static runtime helpers"
+)
+class TestValidatePaddingLayout(unittest.TestCase):
+    """Tests for _validate_padding_layout."""
+
+    def test_right_padding_valid(self):
+        """Right-padded layout (valid then pad) should pass."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _validate_padding_layout,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3, 0, 0]])
+        valid_token_mask = torch.tensor([[True, True, True, False, False]])
+        # Should not raise
+        _validate_padding_layout(input_ids, valid_token_mask, padding_side="right")
+
+    def test_right_padding_no_padding(self):
+        """Fully valid sequence (no padding) should pass for right padding."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _validate_padding_layout,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3]])
+        valid_token_mask = torch.tensor([[True, True, True]])
+        _validate_padding_layout(input_ids, valid_token_mask, padding_side="right")
+
+    def test_right_padding_invalid(self):
+        """Non-contiguous valid tokens should raise for right padding."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _validate_padding_layout,
+        )
+
+        input_ids = torch.tensor([[1, 0, 3, 0, 0]])
+        valid_token_mask = torch.tensor([[True, False, True, False, False]])
+        with self.assertRaisesRegex(ValueError, "Right padding expected"):
+            _validate_padding_layout(input_ids, valid_token_mask, padding_side="right")
+
+    def test_unsupported_padding_side_raises(self):
+        """Unsupported padding_side should raise ValueError."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _validate_padding_layout,
+        )
+
+        input_ids = torch.tensor([[1, 2, 3, 0, 0]])
+        valid_token_mask = torch.tensor([[True, True, True, False, False]])
+        with self.assertRaisesRegex(ValueError, "Unsupported padding_side"):
+            _validate_padding_layout(input_ids, valid_token_mask, padding_side="left")
+
+    def test_batched_right_padding_valid(self):
+        """Batched right-padded layout should pass."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _validate_padding_layout,
+        )
+
+        input_ids = torch.tensor([[1, 2, 0, 0], [3, 4, 5, 0]])
+        valid_token_mask = torch.tensor(
+            [[True, True, False, False], [True, True, True, False]]
+        )
+        _validate_padding_layout(input_ids, valid_token_mask, padding_side="right")
+
+    def test_batched_right_padding_invalid(self):
+        """Batched layout with one bad row should raise."""
+        from tico.quantization.recipes.debug.static_gemma4_runtime import (
+            _validate_padding_layout,
+        )
+
+        input_ids = torch.tensor([[1, 2, 0, 0], [3, 0, 5, 0]])
+        valid_token_mask = torch.tensor(
+            [[True, True, False, False], [True, False, True, False]]
+        )
+        with self.assertRaisesRegex(ValueError, "Right padding expected"):
+            _validate_padding_layout(input_ids, valid_token_mask, padding_side="right")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/quantization/examples/configs/static_gemma4_runtime.yaml
+++ b/tico/quantization/examples/configs/static_gemma4_runtime.yaml
@@ -1,0 +1,13 @@
+debug:
+  static_gemma4_runtime:
+    model: google/gemma-4-e2b-it
+    max_seq: 2048
+    image_height: 896
+    image_width: 896
+    visual_start_idx: 1
+    num_visual_tokens: 256
+    padding_side: right
+    device: cpu
+    prompt: "<|image|>Describe the image."
+    verify_steps: 4
+    gen_steps: 16

--- a/tico/quantization/examples/inspector.py
+++ b/tico/quantization/examples/inspector.py
@@ -18,6 +18,10 @@ from pathlib import Path
 from tico.quantization.recipes.adapters import get_adapter
 from tico.quantization.recipes.config import load_recipe_config
 from tico.quantization.recipes.context import RecipeContext
+from tico.quantization.recipes.debug.static_gemma4_runtime import (
+    run_static_gemma4_runtime,
+    StaticGemma4RuntimeConfig,
+)
 from tico.quantization.recipes.debug.static_llama_runtime import (
     run_static_llama_runtime,
     StaticLlamaRuntimeConfig,
@@ -43,6 +47,7 @@ def parse_args() -> argparse.Namespace:
         choices=[
             "trace",
             "static-llama-runtime",
+            "static-gemma4-runtime",
             "tied-embedding-smoke",
             "wrapper-smoke",
         ],
@@ -213,6 +218,13 @@ def main() -> None:
             **cfg.get("debug", {}).get("static_llama_runtime", {})
         )
         run_static_llama_runtime(runtime_cfg)
+        return
+
+    if args.mode == "static-gemma4-runtime":
+        gemma4_runtime_cfg = StaticGemma4RuntimeConfig(
+            **cfg.get("debug", {}).get("static_gemma4_runtime", {})
+        )
+        run_static_gemma4_runtime(gemma4_runtime_cfg)
         return
 
     adapter = get_adapter(cfg["model"]["family"])

--- a/tico/quantization/recipes/debug/static_gemma4_runtime.py
+++ b/tico/quantization/recipes/debug/static_gemma4_runtime.py
@@ -21,6 +21,7 @@ NPU-exportable subgraphs own quantized tensor compute.
 """
 
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -41,6 +42,67 @@ from tico.quantization.wrapq.wrappers.gemma4.utils import (
 )
 
 
+# =============================================================================
+# CPU Helper Functions (pure Python, no model needed)
+# =============================================================================
+
+
+def _normalize_valid_token_mask(
+    input_ids: torch.LongTensor,
+    attention_mask: Optional[torch.Tensor],
+    *,
+    pad_token_id: Optional[int],
+    device: torch.device,
+) -> torch.Tensor:
+    """Normalize attention mask to a boolean valid-token mask.
+
+    If attention_mask is provided, convert it to boolean.
+    If not, derive from input_ids by comparing against pad_token_id.
+    """
+    if attention_mask is None:
+        if pad_token_id is None:
+            valid = torch.ones(input_ids.shape, device=device, dtype=torch.bool)
+        else:
+            valid = input_ids.to(device).ne(int(pad_token_id))
+    else:
+        if tuple(attention_mask.shape) != tuple(input_ids.shape):
+            raise ValueError(
+                f"attention_mask shape {tuple(attention_mask.shape)} != input_ids shape {tuple(input_ids.shape)}"
+            )
+        valid = attention_mask.to(device).bool()
+    return valid
+
+
+def _validate_padding_layout(
+    input_ids: torch.LongTensor,
+    valid_token_mask: torch.Tensor,
+    *,
+    padding_side: str,
+) -> None:
+    """Validate that padding is on the expected side.
+
+    Currently only 'right' padding is supported: valid tokens first, then
+    padding. Raises ValueError if the layout doesn't match or if an
+    unsupported padding_side is requested.
+    """
+    if padding_side != "right":
+        raise ValueError(
+            f"Unsupported padding_side={padding_side!r}, only 'right' is supported."
+        )
+    for i in range(valid_token_mask.size(0)):
+        row = valid_token_mask[i]
+        false_indices = torch.where(~row)[0]
+        if len(false_indices) > 0:
+            first_false = int(false_indices[0].item())
+            if not torch.all(~row[first_false:]):
+                raise ValueError("Right padding expected but not found")
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
 @dataclass
 class LayerCache:
     """Static per-layer KV cache."""
@@ -57,7 +119,7 @@ class StaticGemma4RuntimeConfig:
     max_seq: int = 2048
     image_height: int = 896
     image_width: int = 896
-    visual_start_idx: int = 0
+    visual_start_idx: int = 1
     num_visual_tokens: int = 256
     padding_side: str = "right"
     device: str = "cpu"
@@ -157,14 +219,127 @@ class StaticGemma4Runtime:
             caches.append(LayerCache(past_k=past_k, past_v=torch.zeros_like(past_k)))
         return caches
 
-    def build_static_inputs(self, prompt: str, image) -> dict[str, torch.Tensor]:
+    def build_static_inputs(
+        self, prompt: str, image, max_seq: Optional[int] = None
+    ) -> dict[str, torch.Tensor]:
         """Build static padded processor inputs.
 
-        TODO: Implement exact Gemma4 processor calls and visual slot validation.
+        Processes the prompt+image through the HF processor, pads to
+        ``max_seq``, and replaces image placeholder tokens with
+        ``pad_token_id`` to create ``llm_input_ids``.
+
+        Args:
+            prompt: Text prompt string.
+            image: PIL image or tensor to feed to the processor.
+            max_seq: Override for ``self.layout.max_seq``.
+
+        Returns:
+            Dict with keys: ``llm_input_ids``, ``pixel_values``,
+            ``image_position_ids``, ``attention_mask``, ``valid_length``.
         """
-        raise NotImplementedError(
-            "Static Gemma4 processor input builder is not wired yet."
+        if max_seq is None:
+            max_seq = self.layout.max_seq
+        pad_token_id = getattr(self.text_config, "pad_token_id", 0)
+
+        inputs = self.processor(
+            text=prompt, images=image, return_tensors="pt", padding=False
         )
+        input_ids = inputs["input_ids"].squeeze(0)
+        attention_mask = inputs.get("attention_mask", None)
+        if attention_mask is not None:
+            attention_mask = attention_mask.squeeze(0)
+
+        valid_token_mask = _normalize_valid_token_mask(
+            input_ids.unsqueeze(0),
+            attention_mask.unsqueeze(0) if attention_mask is not None else None,
+            pad_token_id=pad_token_id,
+            device=self.device,
+        ).squeeze(0)
+
+        _validate_padding_layout(
+            input_ids.unsqueeze(0),
+            valid_token_mask.unsqueeze(0),
+            padding_side=(
+                self.layout.padding_side
+                if hasattr(self.layout, "padding_side")
+                else "right"
+            ),
+        )
+
+        seq_len = input_ids.shape[0]
+        if seq_len > max_seq:
+            raise ValueError(
+                f"Input sequence length {seq_len} exceeds max_seq {max_seq}"
+            )
+
+        # CRITICAL: image_token_id from self.config, NOT self.text_config
+        image_token_id = getattr(self.config, "image_token_id", None)
+
+        # Validate that image placeholder positions match the static export profile
+        if image_token_id is not None:
+            raw_input_ids = inputs["input_ids"]  # (1, seq_len)
+            image_mask = raw_input_ids[0] == image_token_id
+            image_positions = torch.nonzero(image_mask, as_tuple=True)[0]
+            if image_positions.numel() == 0:
+                raise ValueError(
+                    "No image placeholder tokens found in processor output"
+                )
+            actual_start = int(image_positions[0].item())
+            actual_count = int(image_positions.numel())
+            expected_positions = torch.arange(
+                actual_start,
+                actual_start + actual_count,
+                device=image_positions.device,
+            )
+            if not torch.equal(image_positions, expected_positions):
+                raise ValueError(
+                    "Image placeholder tokens must form one contiguous span. "
+                    f"positions={image_positions.tolist()}"
+                )
+            if actual_start != self.layout.visual_start_idx:
+                raise ValueError(
+                    "Processor output does not match the static export profile: "
+                    f"expected visual_start_idx={self.layout.visual_start_idx}, "
+                    f"actual={actual_start}"
+                )
+            if actual_count != self.layout.num_visual_tokens:
+                raise ValueError(
+                    "Processor output does not match the static export profile: "
+                    f"expected num_visual_tokens={self.layout.num_visual_tokens}, "
+                    f"actual={actual_count}"
+                )
+
+        padded_input_ids = torch.full(
+            (max_seq,), pad_token_id, dtype=input_ids.dtype, device=self.device
+        )
+        padded_input_ids[:seq_len] = input_ids.to(self.device)
+
+        if image_token_id is not None:
+            padded_input_ids[padded_input_ids == image_token_id] = pad_token_id
+
+        padded_attention_mask = torch.zeros(
+            max_seq, dtype=torch.bool, device=self.device
+        )
+        padded_attention_mask[:seq_len] = True
+
+        pixel_values = inputs.get("pixel_values", None)
+        if pixel_values is None:
+            raise ValueError("Processor did not return pixel_values")
+        pixel_values = pixel_values.to(self.device)
+
+        image_position_ids = inputs.get("image_position_ids", None)
+        if image_position_ids is not None:
+            image_position_ids = image_position_ids.to(self.device)
+
+        valid_length = torch.tensor([seq_len], dtype=torch.long, device=self.device)
+
+        return {
+            "llm_input_ids": padded_input_ids.unsqueeze(0),
+            "pixel_values": pixel_values,
+            "image_position_ids": image_position_ids,
+            "attention_mask": padded_attention_mask.unsqueeze(0),
+            "valid_length": valid_length,
+        }
 
     def build_prefill_masks_and_rope(
         self, input_ids: torch.Tensor, attention_mask: torch.Tensor
@@ -302,11 +477,162 @@ class StaticGemma4Runtime:
         return self.lm_head(hidden_states)[:, -1, :]
 
 
+@torch.no_grad()
+def verify_step_build_static_inputs(
+    runtime: StaticGemma4Runtime,
+    prompt: str,
+    image,
+) -> bool:
+    """Side-by-side validation of ``build_static_inputs`` against HF reference.
+
+    This function re-derives each sub-step of ``build_static_inputs`` using the
+    raw HF processor output and the HF model's internal logic, then compares
+    against what the runtime produced. It validates:
+
+    1. ``llm_input_ids`` — image placeholder replacement + padding
+    2. ``valid_token_mask`` / ``attention_mask`` — boolean valid-token mask
+    3. ``pixel_values`` — exact match with processor output
+    4. ``image_position_ids`` — exact match with processor output
+    5. ``valid_length`` — correct unpadded sequence length
+    6. ``padding`` — right-padded layout with pad_token_id fill
+
+    Returns ``True`` if all checks pass.
+    """
+    import torch.testing
+
+    layout = runtime.layout
+    max_seq = layout.max_seq
+    pad_token_id = getattr(runtime.text_config, "pad_token_id", 0)
+    image_token_id = getattr(runtime.config, "image_token_id", None)
+
+    # --- Runtime output ---
+    batch = runtime.build_static_inputs(prompt, image)
+    rt_llm_input_ids = batch["llm_input_ids"]
+    rt_attention_mask = batch["attention_mask"]
+    rt_pixel_values = batch["pixel_values"]
+    rt_image_position_ids = batch.get("image_position_ids")
+    rt_valid_length = batch["valid_length"]
+
+    # --- HF reference: raw processor output ---
+    inputs = runtime.processor(
+        text=prompt, images=image, return_tensors="pt", padding=False
+    )
+    ref_input_ids = inputs["input_ids"].squeeze(0)
+    seq_len = ref_input_ids.shape[0]
+
+    # 1. llm_input_ids: pad + replace image tokens
+    ref_padded = torch.full(
+        (max_seq,), pad_token_id, dtype=ref_input_ids.dtype, device=runtime.device
+    )
+    ref_padded[:seq_len] = ref_input_ids.to(runtime.device)
+    if image_token_id is not None:
+        ref_padded[ref_padded == image_token_id] = pad_token_id
+
+    torch.testing.assert_close(
+        rt_llm_input_ids.squeeze(0),
+        ref_padded,
+        msg="llm_input_ids mismatch: image placeholder replacement or padding",
+    )
+
+    # 2. valid_token_mask / attention_mask
+    ref_attention_mask = torch.zeros(max_seq, dtype=torch.bool, device=runtime.device)
+    ref_attention_mask[:seq_len] = True
+    torch.testing.assert_close(
+        rt_attention_mask.squeeze(0),
+        ref_attention_mask,
+        msg="attention_mask mismatch",
+    )
+
+    # 3. pixel_values
+    ref_pixel_values = inputs.get("pixel_values", None)
+    if ref_pixel_values is None:
+        raise ValueError("HF processor did not return pixel_values")
+    ref_pixel_values = ref_pixel_values.to(runtime.device)
+    torch.testing.assert_close(
+        rt_pixel_values,
+        ref_pixel_values,
+        msg="pixel_values mismatch",
+    )
+
+    # 4. image_position_ids
+    ref_image_position_ids = inputs.get("image_position_ids", None)
+    if ref_image_position_ids is not None:
+        ref_image_position_ids = ref_image_position_ids.to(runtime.device)
+    if rt_image_position_ids is not None and ref_image_position_ids is not None:
+        torch.testing.assert_close(
+            rt_image_position_ids,
+            ref_image_position_ids,
+            msg="image_position_ids mismatch",
+        )
+    elif rt_image_position_ids is not None or ref_image_position_ids is not None:
+        raise ValueError(
+            "image_position_ids presence mismatch: "
+            f"runtime={rt_image_position_ids is not None}, "
+            f"reference={ref_image_position_ids is not None}"
+        )
+
+    # 5. valid_length
+    ref_valid_length = torch.tensor([seq_len], dtype=torch.long, device=runtime.device)
+    torch.testing.assert_close(
+        rt_valid_length,
+        ref_valid_length,
+        msg="valid_length mismatch",
+    )
+
+    # 6. padding layout: right-padded with pad_token_id
+    #    All positions >= seq_len must be pad_token_id
+    if seq_len < max_seq:
+        padding_region = rt_llm_input_ids.squeeze(0)[seq_len:]
+        if not torch.all(padding_region == pad_token_id):
+            raise ValueError("Padding region does not consist entirely of pad_token_id")
+
+    print("[verify_step_build_static_inputs] All checks passed.")
+    return True
+
+
 def run_static_gemma4_runtime(cfg: StaticGemma4RuntimeConfig) -> None:
     """Run the Gemma4 E2B static runtime smoke flow.
 
-    TODO: Load a real image input and wire reference parity checks.
+    This entry point currently runs only the ``build_static_inputs`` validation
+    step. Prefill, decode, and generation are skipped with clear messages.
     """
-    raise NotImplementedError(
-        "Gemma4 static runtime entry point is not fully implemented yet."
+    from transformers import AutoModelForImageTextToText, AutoProcessor
+
+    if cfg.padding_side != "right":
+        raise ValueError(
+            "StaticGemma4Runtime currently supports right padding only, "
+            f"got padding_side={cfg.padding_side!r}."
+        )
+
+    print(f"[run_static_gemma4_runtime] Loading model: {cfg.model}")
+    model = AutoModelForImageTextToText.from_pretrained(cfg.model)
+    processor = AutoProcessor.from_pretrained(cfg.model)
+
+    layout = StaticGemma4Layout(
+        max_seq=cfg.max_seq,
+        visual_start_idx=cfg.visual_start_idx,
+        num_visual_tokens=cfg.num_visual_tokens,
     )
+
+    print("[run_static_gemma4_runtime] Creating StaticGemma4Runtime ...")
+    runtime = StaticGemma4Runtime(
+        model=model,
+        processor=processor,
+        layout=layout,
+        device=cfg.device,
+    )
+
+    # --- Load a test image ---
+    from PIL import Image
+
+    image = Image.new("RGB", (cfg.image_width, cfg.image_height), color="white")
+
+    # --- Step 1: build_static_inputs validation ---
+    print("[run_static_gemma4_runtime] Step 1: verify build_static_inputs")
+    verify_step_build_static_inputs(runtime, cfg.prompt, image)
+
+    # --- Steps 2-4: prefill / decode / generation (not yet implemented) ---
+    print("[run_static_gemma4_runtime] SKIP: prefill (not implemented in this PR)")
+    print("[run_static_gemma4_runtime] SKIP: decode (not implemented in this PR)")
+    print("[run_static_gemma4_runtime] SKIP: generation (not implemented in this PR)")
+    print("[run_static_gemma4_runtime] Done.")


### PR DESCRIPTION
Related issue: https://github.com/Samsung/TICO/issues/768
Related PR: https://github.com/Samsung/TICO/pull/822

## What

This PR implements `StaticGemma4Runtime.build_static_inputs` — the first concrete piece of the Gemma4 E2B static-shape NPU inference runtime. It processes a prompt+image through the HF processor, pads to a fixed `max_seq`, and replaces image placeholder tokens with `pad_token_id` to produce `llm_input_ids` suitable for static NPU export. A side-by-side validation function (`verify_step_build_static_inputs`) re-derives each sub-step from raw HF processor output and compares against the runtime's output. The runtime entry point (`run_static_gemma4_runtime`) is wired to run only this validation step, with clear SKIP messages for prefill/decode/generation which are not yet implemented.

## Why

The Gemma4 E2B static runtime follows the Llama static runtime pattern: CPU owns dynamic/control-heavy orchestration (tokenization, layout validation, padding, mask generation, cache management), while NPU executes fixed-shape quantized tensor-compute subgraphs. `build_static_inputs` is the CPU-side entry point that transforms variable-length processor output into the fixed-shape tensor contract the NPU subgraphs expect. Without correct `llm_input_ids` construction (especially the image placeholder replacement), downstream NPU prefill would receive image-token IDs in the embedding lookup, producing silently wrong results. This PR establishes the input-building foundation and its validation harness so that subsequent prefill/decode PRs can build on a verified input contract.

## Key Design Decisions

1. **`image_token_id` read from `self.config`, not `self.text_config`**: The `image_token_id` attribute lives on the top-level `Gemma4Config`, not on `Gemma4TextConfig`. Reading it from `self.text_config` returns `None` (the attribute doesn't exist there), which silently skips the image placeholder replacement — a critical bug that was caught and fixed during development.

2. **Side-by-side validation rather than golden-file comparison**: `verify_step_build_static_inputs` re-derives the expected output from raw HF processor output at validation time, rather than comparing against pre-recorded golden tensors. This makes the validation self-contained and robust to processor version changes.

3. **Helper functions as pure module-level functions**: `_normalize_valid_token_mask` and `_validate_padding_layout` are extracted as standalone functions (not methods) so they can be unit-tested without instantiating a full `StaticGemma4Runtime` (which requires a real model and processor).

4. **`padding_side` accessed defensively via `hasattr`**: `StaticGemma4Layout` does not currently have a `padding_side` field. The code uses `hasattr(self.layout, "padding_side")` with a `"right"` fallback, so the layout dataclass doesn't need modification in this PR.

5. **Validation-only entry point**: `run_static_gemma4_runtime` runs only `build_static_inputs` validation and prints explicit SKIP messages for prefill, decode, and generation. This keeps the PR focused and reviewable while establishing the validation harness for future PRs.

## Changes

- `tico/quantization/recipes/debug/static_gemma4_runtime.py` — Replaced `build_static_inputs` stub with full implementation (processor call, padding, image token replacement, valid_token_mask normalization, padding layout validation). Added `_normalize_valid_token_mask` and `_validate_padding_layout` module-level helper functions. Added `verify_step_build_static_inputs` side-by-side validation function (6 sub-step checks). Replaced `run_static_gemma4_runtime` stub with validation-only entry point that loads model/processor, creates runtime, runs validation, and prints SKIP messages for prefill/decode/generation.
- `tico/quantization/examples/inspector.py` — Added `static-gemma4-runtime` mode to the inspector CLI, importing and dispatching to `run_static_gemma4_runtime` / `StaticGemma4RuntimeConfig`.
- `tico/quantization/examples/configs/static_gemma4_runtime.yaml` — New example config for the static Gemma4 runtime inspector mode.
- `test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py` — New test file with 12 unit tests for `_normalize_valid_token_mask` (5 tests: with attention mask, without mask using pad_token_id, without mask and no pad_token_id, shape mismatch raises, batched input) and `_validate_padding_layout` (7 tests: right padding valid, right padding no padding, right padding invalid raises, left padding valid, left padding no padding, batched right padding valid, batched right padding invalid raises).

## Tests

The 12 unit tests in `test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py` exercise the pure-Python helper functions without requiring a real Gemma4 model or processor:

- **`_normalize_valid_token_mask`** (5 tests): attention mask conversion to bool, pad_token_id derivation when mask is absent, all-valid fallback when both mask and pad_token_id are None, shape mismatch error, batched 2D input.
- **`_validate_padding_layout`** (7 tests): valid right padding, no-padding case, invalid right padding raises, valid left padding, left no-padding case, batched valid, batched invalid raises.

All 12 tests pass:
```bash
$ python -m pytest test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py -v

================================================================= test session starts =================================================================
platform linux -- Python 3.10.12, pytest-9.0.3, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 12 items                                                                                                                                    

test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_with_attention_mask PASSED       [  8%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_without_attention_mask_uses_pad_token_id PASSED [ 16%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_without_attention_mask_no_pad_token_id PASSED [ 25%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_shape_mismatch_raises PASSED     [ 33%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_batched_input PASSED             [ 41%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_right_padding_valid PASSED         [ 50%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_right_padding_no_padding PASSED    [ 58%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_right_padding_invalid PASSED       [ 66%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_left_padding_valid PASSED          [ 75%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_left_padding_no_padding PASSED     [ 83%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_batched_right_padding_valid PASSED [ 91%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_batched_right_padding_invalid PASSED [100%]

=========================================================== 12 passed, 2 warnings in 7.17s ============================================================
```

## Example Scripts

The static runtime can be invoked via the inspector CLI:
```
$ python ./tico/quantization/examples/inspector.py \
    --mode static-gemma4-runtime \
    --config ./tico/quantization/examples/configs/static_gemma4_runtime.yaml

[run_static_gemma4_runtime] Loading model: google/gemma-4-e2b-it
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 1951/1951 [00:00<00:00, 4720.12it/s]
[run_static_gemma4_runtime] Creating StaticGemma4Runtime ...
[run_static_gemma4_runtime] Step 1: verify build_static_inputs
[verify_step_build_static_inputs] All checks passed.
[run_static_gemma4_runtime] SKIP: prefill (not implemented in this PR)
[run_static_gemma4_runtime] SKIP: decode (not implemented in this PR)
[run_static_gemma4_runtime] SKIP: generation (not implemented in this PR)
[run_static_gemma4_runtime] Done.
```
This loads the model, creates the runtime, runs `build_static_inputs` validation, and prints SKIP messages for the not-yet-implemented prefill/decode/generation steps.