### PR TITLE
[quantization] Remove redundant transpose in attention

### DIFF
--- a/tico/quantization/wrapq/wrappers/llama/quant_attention.py
+++ b/tico/quantization/wrapq/wrappers/llama/quant_attention.py
@@ -859,11 +859,11 @@ class QuantLlamaAttention(QuantModuleBase):
             self.obs_attn_weights,
         )
         attn_out_h = self._fq(
-            torch.stack(attn_out_parts, dim=1),
+            torch.stack(attn_out_parts, dim=2),
             self.obs_attn_out_h,
         )
 
-        attn_out = attn_out_h.transpose(1, 2).reshape(B, S, -1)
+        attn_out = attn_out_h.reshape(B, S, -1)
         out = self.o_proj(attn_out)
 
         outputs = (out, attn_weights)


### PR DESCRIPTION
This commit removes redundant transpose in llama attention.

### Before

<img width="287" height="547" alt="image" src="https://github.com/user-attachments/assets/ec0dc653-8239-4d7b-83a7-d4c5e827ce9e" />

### After

<img width="268" height="377" alt="image" src="https://github.com/user-attachments/assets/749f40e1-7c4a-4157-b29b-22356158d4bf" />


TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>