### PR TITLE
[serialize] Remove redundant empty buffer

### DIFF
--- a/test/unit_test/serialize/operator/fixture.py
+++ b/test/unit_test/serialize/operator/fixture.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch.fx
-from circle_schema import circle
+import torch
 
 from tico.serialize.circle_graph import CircleModel, CircleSubgraph
 from tico.serialize.operators.node_visitor import get_node_visitor
@@ -27,7 +26,6 @@ class SingleOpGraphFixture:
         self.torch_target = torch_target
 
         self._circle_model = CircleModel()
-        self._circle_model.add_buffer(circle.Buffer.BufferT())
         self.circle_graph = CircleSubgraph(self._circle_model)
 
         self.forward_args, self.forward_kwargs = torch_module.get_example_inputs()  # type: ignore[operator]

--- a/test/unit_test/serialize/test_circle_graph.py
+++ b/test/unit_test/serialize/test_circle_graph.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import numpy as np
 import torch
 from tico.serialize.circle_graph import CircleModel, CircleSubgraph, is_const
 
@@ -29,6 +30,48 @@ class CircleGraphTest(unittest.TestCase):
         self.assertTrue(is_const([torch.tensor(1), 1]))
         self.assertTrue(is_const([torch.tensor([1, 1])]))
 
+    def test_model_initializes_reserved_empty_buffer(self):
+        model = CircleModel()
+
+        self.assertEqual(len(model.buffers), 1)
+        self.assertIsNone(model.buffers[0].data)
+
+    def test_tensor_without_data_uses_reserved_empty_buffer(self):
+        model = CircleModel()
+        graph = CircleSubgraph(model)
+        exported_program = torch.export.export(
+            torch.nn.Identity().eval(),
+            (torch.ones(1),),
+        )
+        input_node = next(
+            node for node in exported_program.graph.nodes if node.op == "placeholder"
+        )
+
+        graph.add_tensor_from_node(input_node)
+
+        tensor = graph.tensors[graph.name_to_tid[input_node.name]]
+        self.assertEqual(tensor.buffer, 0)
+        self.assertEqual(len(model.buffers), 1)
+
+    def test_tensor_with_data_uses_dedicated_buffer(self):
+        model = CircleModel()
+        graph = CircleSubgraph(model)
+        exported_program = torch.export.export(
+            torch.nn.Identity().eval(),
+            (torch.ones(1),),
+        )
+        input_node = next(
+            node for node in exported_program.graph.nodes if node.op == "placeholder"
+        )
+        data = np.ones((1,), dtype=np.float32)
+
+        graph.add_tensor_from_node(input_node, data)
+
+        tensor = graph.tensors[graph.name_to_tid[input_node.name]]
+        self.assertEqual(tensor.buffer, 1)
+        self.assertEqual(len(model.buffers), 2)
+        self.assertEqual(bytes(model.buffers[1].data), data.tobytes())
+
     def test_duplicate_names(self):
         mod = CircleModel()
         g = CircleSubgraph(mod)
@@ -43,3 +86,5 @@ class CircleGraphTest(unittest.TestCase):
         # This result depends on the naming rule of _gen_unique_name_with_prefix
         # Change this if the rule changes
         self.assertTrue(g.has_tensor("name_0"))
+        self.assertEqual(len(mod.buffers), 1)
+        self.assertEqual([tensor.buffer for tensor in g.tensors], [0, 0])

--- a/test/unit_test/serialize/test_circle_serializer.py
+++ b/test/unit_test/serialize/test_circle_serializer.py
@@ -18,7 +18,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from tico.serialize.circle_serializer import _export_tensors, _initialize_model
+from tico.serialize.circle_serializer import (
+    _export_tensors,
+    _handle_get_attr_node,
+    _initialize_model,
+)
+from tico.utils.errors import NotYetSupportedError
 
 
 _TIED_WEIGHT_NAMES = {"embed.weight", "lm_head.weight"}
@@ -48,6 +53,81 @@ class UntiedEmbeddingModel(nn.Module):
     def forward(self, tokens):
         hidden = self.embed(tokens)
         return F.linear(hidden, self.lm_head.weight)
+
+
+class TensorAttributeModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.value = torch.ones(4)
+
+    def forward(self, x):
+        return x + self.value
+
+
+class CircleSerializerInvariantTest(unittest.TestCase):
+    @staticmethod
+    def _make_get_attr_node(name, value):
+        """Create a get_attr node owned by a GraphModule."""
+        root = nn.Module()
+        if isinstance(value, nn.Module):
+            root.add_module(name, value)
+        elif isinstance(value, torch.Tensor):
+            root.register_buffer(name, value)
+        else:
+            setattr(root, name, value)
+
+        graph = torch.fx.Graph()
+        attr_node = graph.get_attr(name)
+        graph.output(attr_node)
+        graph_module = torch.fx.GraphModule(root, graph)
+
+        return next(node for node in graph_module.graph.nodes if node.op == "get_attr")
+
+    def test_initialize_model_has_single_reserved_empty_buffer(self):
+        model, _ = _initialize_model()
+
+        self.assertEqual(len(model.buffers), 1)
+        self.assertIsNone(model.buffers[0].data)
+
+    def test_tensor_attribute_is_lifted_as_constant_placeholder(self):
+        exported_program = torch.export.export(
+            TensorAttributeModel().eval(),
+            (torch.zeros(4),),
+        )
+
+        self.assertFalse(
+            any(node.op == "get_attr" for node in exported_program.graph.nodes)
+        )
+
+        constant_inputs = (
+            exported_program.graph_signature.inputs_to_lifted_tensor_constants
+        )
+        self.assertEqual(len(constant_inputs), 1)
+
+        model, graph = _initialize_model()
+        _export_tensors(graph, exported_program)
+
+        placeholder_name = next(iter(constant_inputs))
+        tensor = graph.tensors[graph.name_to_tid[placeholder_name]]
+
+        self.assertGreater(tensor.buffer, 0)
+        self.assertEqual(len(model.buffers), 2)
+
+    def test_tensor_get_attr_is_rejected_as_invariant_violation(self):
+        node = self._make_get_attr_node("value", torch.ones(1))
+
+        with self.assertRaisesRegex(RuntimeError, "must be lifted"):
+            _handle_get_attr_node(node)
+
+    def test_nested_graph_module_get_attr_is_rejected(self):
+        branch = torch.fx.symbolic_trace(nn.Identity())
+        node = self._make_get_attr_node("branch", branch)
+
+        with self.assertRaisesRegex(
+            NotYetSupportedError,
+            "nested GraphModule",
+        ):
+            _handle_get_attr_node(node)
 
 
 class CircleSerializerSharedTensorTest(unittest.TestCase):

--- a/tico/serialize/circle_graph.py
+++ b/tico/serialize/circle_graph.py
@@ -70,7 +70,9 @@ class CircleModel(circle.Model.ModelT):
     def __init__(self):
         super().__init__()
         self.subgraphs: List[circle.SubGraph.SubGraphT] = []
-        self.buffers: List[circle.Buffer.BufferT] = []
+        # Circle reserves buffer 0 for tensors without embedded data, such as
+        # graph inputs, intermediate activations, and operator outputs.
+        self.buffers: List[circle.Buffer.BufferT] = [circle.Buffer.BufferT()]
 
     def add_subgraph(self, graph: circle.SubGraph.SubGraphT) -> None:
         self.subgraphs.append(graph)
@@ -159,20 +161,21 @@ class CircleSubgraph(circle.SubGraph.SubGraphT):
             tensor.quantization = to_circle_qparam(node.meta[QPARAM_KEY])
             tensor.type = str_to_circle_dtype(node.meta[QPARAM_KEY].dtype)
 
-        buffer = circle.Buffer.BufferT()
-        if data is not None and isinstance(data, np.ndarray):
+        if data is None:
+            tensor.buffer = 0
+        else:
+            assert isinstance(data, np.ndarray)
             data = to_flat_contiguous_numpy(data)
 
             if QPARAM_KEY in node.meta:
                 if node.meta[QPARAM_KEY].dtype == "uint4":
                     data = pack_buffer(data, "uint4")
 
+            buffer = circle.Buffer.BufferT()
             # Packing np.ndarray is faster than packing bytes
             buffer.data = data.view(np.uint8)  # type: ignore[assignment]
-        else:
-            assert data is None
-        bid = self.model.add_buffer(buffer)
-        tensor.buffer = bid
+            tensor.buffer = self.model.add_buffer(buffer)
+
         self._add_tensor(tensor)
 
     def add_const_tensor(
@@ -257,9 +260,7 @@ class CircleSubgraph(circle.SubGraph.SubGraphT):
         else:
             tensor.type = dtype
 
-        buffer = circle.Buffer.BufferT()
-        bid = self.model.add_buffer(buffer)
-        tensor.buffer = bid
+        tensor.buffer = 0
         self._add_tensor(tensor)
 
         return tensor

--- a/tico/serialize/circle_serializer.py
+++ b/tico/serialize/circle_serializer.py
@@ -17,17 +17,16 @@ from typing import Dict, Optional
 
 import flatbuffers
 import torch
-from circle_schema import circle
 from torch.export.exported_program import ConstantArgument, ExportedProgram, InputKind
 
 from tico.config import CompileConfigBase, get_default_config
-from tico.serialize.circle_mapping import to_circle_dtype, to_circle_shape
 from tico.serialize.operators import *
 from tico.serialize.circle_graph import CircleModel, CircleSubgraph
 from tico.serialize.operators.hashable_opcode import OpCode
 from tico.serialize.operators.node_visitor import get_node_visitors
 from tico.serialize.quant_param import QPARAM_KEY
 from tico.utils import logging
+from tico.utils.errors import NotYetSupportedError
 from tico.utils.serialize import finalise_tensor_names, validate_tensor_shapes
 
 
@@ -65,7 +64,6 @@ def _initialize_model() -> tuple[CircleModel, CircleSubgraph]:
         Tuple containing the model and subgraph
     """
     model = CircleModel()
-    model.add_buffer(circle.Buffer.BufferT())  # Add empty buffer at the front
     graph = CircleSubgraph(model)
     return model, graph
 
@@ -296,7 +294,7 @@ def _export_tensors(graph: CircleSubgraph, ep: ExportedProgram) -> None:
             _handle_placeholder_node(graph, node, ep, buf_name_to_data, shared_tensors)
 
         elif node.op == "get_attr":
-            _handle_get_attr_node(graph, node)
+            _handle_get_attr_node(node)
 
         elif node.op == "output":
             for output in node.args[0]:
@@ -476,31 +474,46 @@ def _handle_user_input_node(
     logger.debug(f"Exported user input tensor: {node.name}")
 
 
-def _handle_get_attr_node(
-    graph: CircleSubgraph,
-    node: torch.fx.Node,
-) -> None:
-    """Handle a get_attr node by exporting its tensor data.
+def _handle_get_attr_node(node: torch.fx.Node) -> None:
+    """
+    Reject unsupported attributes in the top-level ExportedProgram graph.
+
+    Parameters, buffers, and tensor constants in a valid top-level
+    ExportedProgram graph must be lifted to placeholder nodes. A get_attr node
+    therefore represents either an unsupported auxiliary object, such as a
+    nested GraphModule used by a higher-order operator, or an ExportedProgram
+    invariant violation.
 
     Args:
-        graph: CircleSubgraph to add tensor to
-        node: The get_attr node to process
+        node: The get_attr node to inspect.
+
+    Raises:
+        RuntimeError: If the get_attr node is malformed or references a tensor
+            that should have been lifted.
+        NotYetSupportedError: If the node references an unsupported non-tensor
+            attribute such as a nested GraphModule.
     """
-    assert isinstance(node.target, str)
-    attr_tensor = getattr(node.graph.owning_module, node.target)
+    if not isinstance(node.target, str):
+        raise RuntimeError(
+            "Expected get_attr target to be a string, "
+            f"but got {type(node.target).__name__}."
+        )
 
-    if not isinstance(attr_tensor, torch.Tensor):
-        raise ValueError(f"Attribute {node.target} is not a tensor")
+    attr = getattr(node.graph.owning_module, node.target)
 
-    attr_shape, attr_shape_signature = to_circle_shape(attr_tensor.shape)
+    if isinstance(attr, torch.Tensor):
+        raise RuntimeError(
+            f"Unexpected tensor get_attr '{node.target}'. Parameters, buffers, "
+            "and tensor constants must be lifted as ExportedProgram inputs."
+        )
 
-    graph.add_tensor_from_scratch(
-        prefix=node.name,
-        shape=attr_shape,
-        shape_signature=attr_shape_signature,
-        dtype=to_circle_dtype(attr_tensor.dtype),
-        source_node=node,
+    if isinstance(attr, torch.fx.GraphModule):
+        raise NotYetSupportedError(
+            f"ExportedProgram contains nested GraphModule '{node.target}'. "
+            "Higher-order operators and control-flow subgraphs are not supported."
+        )
+
+    raise NotYetSupportedError(
+        f"Unsupported top-level get_attr '{node.target}' with type "
+        f"{type(attr).__name__}."
     )
-
-    logger = logging.getLogger(__name__)
-    logger.debug(f"Exported attribute tensor: {node.name}")


### PR DESCRIPTION
This commit removes redundant empty buffer.

Circle always use index-0 buffer for empty buffers. Currently, the tensor creation api always creates a empty buffer, which makes redundant buffers.
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>