### PR TITLE
[quantization] Add generation step to StaticGemma4Runtime

### DIFF
--- a/tico/quantization/recipes/debug/static_gemma4_runtime.py
+++ b/tico/quantization/recipes/debug/static_gemma4_runtime.py
@@ -584,6 +584,9 @@ class StaticGemma4Runtime:
         # K/V into shared_kv_states; consumer layers read from it.
         shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
+        # Extract valid length once before the loop to avoid GPU→CPU sync per layer.
+        valid_len = int(batch["valid_length"].item())
+
         for layer_idx, layer in enumerate(self.prefill_layers):
             layer_type = self.text_config.layer_types[layer_idx]
             per_layer_input = (
@@ -607,14 +610,21 @@ class StaticGemma4Runtime:
 
             if isinstance(out, tuple) and len(out) == 3:
                 hidden_states, new_k, new_v = out
-                # Write full-sequence K/V into the pre-allocated fixed cache.
-                # For prefill, new_k/new_v cover the entire max_seq, so no
-                # positional slicing is needed — copy_ preserves the buffer.
-                self.layer_caches[layer_idx].past_k.copy_(new_k)
-                self.layer_caches[layer_idx].past_v.copy_(new_v)
-                # Store full-length K/V for shared-KV consumer layers
+                # Write only valid K/V (excluding padding) into the cache.
+                # new_k/new_v from prefill have shape (B, kv_heads, max_seq, head_dim)
+                # but positions >= valid_length contain garbage from padding tokens.
+                self.layer_caches[layer_idx].past_k[:, :, :valid_len, :].copy_(
+                    new_k[:, :, :valid_len, :]
+                )
+                self.layer_caches[layer_idx].past_v[:, :, :valid_len, :].copy_(
+                    new_v[:, :, :valid_len, :]
+                )
+                # Store valid-length K/V for shared-KV consumer layers
                 if bool(getattr(attn, "store_full_length_kv", False)):
-                    shared_kv_states[layer_type] = (new_k, new_v)
+                    shared_kv_states[layer_type] = (
+                        new_k[:, :, :valid_len, :],
+                        new_v[:, :, :valid_len, :],
+                    )
             else:
                 hidden_states = out
 
@@ -713,6 +723,21 @@ class StaticGemma4Runtime:
         # keyed by layer_type, updated after each store layer writes its delta.
         shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
+        # Pre-populate shared_kv_states from layer_caches for shared consumer layers.
+        # This ensures consumer layers have access to KV cache from previous tokens
+        # before store layers update it in this decode step.
+        for layer_idx, layer_type in enumerate(self.text_config.layer_types):
+            if layer_type not in shared_kv_states:
+                attn = self.decode_layers[layer_idx].wrapped.self_attn.wrapped
+                is_shared = bool(getattr(attn, "is_kv_shared_layer", False))
+
+                if is_shared:
+                    cache = self.layer_caches[layer_idx]
+                    shared_kv_states[layer_type] = (
+                        cache.past_k[:, :, : self.past_len, :],
+                        cache.past_v[:, :, : self.past_len, :],
+                    )
+
         for layer_idx, layer in enumerate(self.decode_layers):
             layer_type = self.text_config.layer_types[layer_idx]
             per_layer_input = (
@@ -746,9 +771,11 @@ class StaticGemma4Runtime:
 
             if isinstance(out, tuple) and len(out) == 3:
                 hidden_states, new_k, new_v = out
+
                 # Write single-token K/V delta into the fixed cache
                 cache.past_k[:, :, self.past_len : self.past_len + 1, :].copy_(new_k)
                 cache.past_v[:, :, self.past_len : self.past_len + 1, :].copy_(new_v)
+
                 # Update shared_kv_states for consumer layers.
                 # The valid K/V (prefill + all decode deltas so far) occupies
                 # positions 0..past_len inclusive in the cache.  Slice to that
@@ -764,6 +791,55 @@ class StaticGemma4Runtime:
         self.past_len += 1
         logits = self.lm_head(hidden_states)[:, -1, :]
         return self._apply_final_logit_softcapping(logits)
+
+    @torch.no_grad()
+    def generate_greedy(
+        self,
+        batch: dict[str, torch.Tensor],
+        max_new_tokens: int,
+        eos_token_id: Optional[int] = None,
+    ) -> torch.LongTensor:
+        """Generate tokens greedily from a preprocessed static batch.
+
+        Args:
+            batch: The batch dict returned by ``build_static_inputs``.
+            max_new_tokens: Maximum number of new tokens to generate.
+            eos_token_id: Optional EOS token ID to stop generation early.
+                If not provided, uses ``text_config.eos_token_id``.
+
+        Returns:
+            Generated token IDs of shape ``(1, prompt_len + num_generated)``.
+        """
+        # Run prefill
+        logits = self.prefill(batch)
+
+        # Get prompt length
+        prompt_len = int(batch["valid_length"].item())
+
+        # Extract valid input_ids from _raw_inputs (preserves image tokens)
+        raw_inputs = batch.get("_raw_inputs", None)
+        if raw_inputs is not None:
+            input_ids = raw_inputs["input_ids"][0].clone()  # Original with image tokens
+        else:
+            input_ids = batch["llm_input_ids"][0, :prompt_len].clone()  # Fallback
+
+        if eos_token_id is None:
+            eos_token_id = int(getattr(self.text_config, "eos_token_id", -1))
+
+        # Generate loop
+        for _ in range(max_new_tokens):
+            next_token = torch.argmax(logits, dim=-1)  # (1,)
+            print(f"[generate_greedy] Next token: {next_token}")
+            input_ids = torch.cat([input_ids, next_token], dim=0)
+
+            # Check EOS
+            if eos_token_id >= 0 and next_token.item() == eos_token_id:
+                break
+
+            # Decode step: next_token is (1,), need (1, 1) for decode_one
+            logits = self.decode_one(next_token.unsqueeze(0))
+
+        return input_ids.unsqueeze(0)  # (1, generated_len)
 
     def _apply_final_logit_softcapping(self, logits: torch.Tensor) -> torch.Tensor:
         """Apply Gemma4 final logit softcapping.
@@ -1581,6 +1657,101 @@ def verify_step_decode(
     return rt_decode_logits_list[-1]
 
 
+@torch.no_grad()
+def verify_step_generation(
+    runtime: StaticGemma4Runtime,
+    batch: dict[str, torch.Tensor],
+    prompt: str,
+    image,
+    max_new_tokens: int = 16,
+) -> torch.LongTensor:
+    """Side-by-side validation of ``generate_greedy`` against HF reference.
+
+    Runs greedy generation from the runtime and HF reference, comparing
+    generated token sequences.  The runtime uses quantized weights while
+    HF uses FP, so exact match is not expected — we report token-level
+    accuracy and first mismatch position.
+
+    Args:
+        runtime: The ``StaticGemma4Runtime`` instance.
+        batch: The batch dict returned by ``build_static_inputs``.
+        prompt: Original prompt string.
+        image: Original image.
+        max_new_tokens: Maximum number of new tokens to generate.
+
+    Returns:
+        Runtime-generated token IDs of shape ``(1, prompt_len + num_generated)``.
+    """
+    # Runtime generation
+    runtime.reset_cache()
+    rt_generated = runtime.generate_greedy(batch, max_new_tokens, eos_token_id=None)
+
+    # HF reference generation
+    raw_inputs = batch.get("_raw_inputs", None)
+    if raw_inputs is None:
+        raw_inputs = runtime.processor(
+            text=prompt, images=image, return_tensors="pt", padding=False
+        )
+    raw_input_ids = raw_inputs["input_ids"].to(runtime.device)
+    pixel_values = raw_inputs["pixel_values"].to(runtime.device).to(runtime.model.dtype)
+    image_position_ids = raw_inputs.get("image_position_ids", None)
+    if image_position_ids is not None:
+        image_position_ids = image_position_ids.to(runtime.device)
+
+    # HF generate with explicit max_new_tokens
+    hf_generated = runtime.model.generate(
+        input_ids=raw_input_ids,
+        pixel_values=pixel_values,
+        image_position_ids=image_position_ids,
+        max_new_tokens=max_new_tokens,
+        do_sample=False,
+        pad_token_id=runtime.processor.tokenizer.pad_token_id,
+        eos_token_id=getattr(runtime.text_config, "eos_token_id", None),
+    )
+
+    # Compare sequences
+    rt_len = rt_generated.shape[1]
+    hf_len = hf_generated.shape[1]
+    min_len = min(rt_len, hf_len)
+
+    # Count matching tokens
+    matches = (rt_generated[:, :min_len] == hf_generated[:, :min_len]).sum().item()
+    accuracy = matches / min_len if min_len > 0 else 0.0
+
+    # Find first mismatch
+    first_mismatch = None
+    for i in range(min_len):
+        if rt_generated[0, i] != hf_generated[0, i]:
+            first_mismatch = i
+            break
+
+    print(f"[verify_step_generation] Runtime generated {rt_len} tokens")
+    print(f"[verify_step_generation] HF generated {hf_len} tokens")
+    print(
+        f"[verify_step_generation] Token accuracy: {accuracy * 100:.2f}% ({matches}/{min_len})"
+    )
+    if first_mismatch is not None:
+        print(f"[verify_step_generation] First mismatch at position {first_mismatch}")
+    else:
+        print("[verify_step_generation] All tokens match!")
+
+    # Print runtime generated text
+    rt_text = runtime.processor.decode(
+        rt_generated[0].tolist(), skip_special_tokens=False
+    )
+    hf_text = runtime.processor.decode(
+        hf_generated[0].tolist(), skip_special_tokens=False
+    )
+    print(f"[verify_step_generation] Runtime text: {rt_text}")
+    print(f"[verify_step_generation] HF text: {hf_text}")
+
+    if first_mismatch is None:
+        print("[verify_step_generation] All checks passed.")
+    else:
+        print("[verify_step_generation] Mismatches detected.")
+    return rt_generated
+
+
 def run_static_gemma4_runtime(cfg: StaticGemma4RuntimeConfig) -> None:
     """Run the Gemma4 E2B static runtime smoke flow.
 
@@ -1658,6 +1829,19 @@ def run_static_gemma4_runtime(cfg: StaticGemma4RuntimeConfig) -> None:
         num_decode_steps=cfg.verify_steps,
     )
 
-    # --- Step 8+: generation (not yet implemented) ---
-    print("[run_static_gemma4_runtime] SKIP: generation (not implemented in this PR)")
+    # --- Step 8: generation validation ---
+    print("[run_static_gemma4_runtime] Step 8: verify generation")
+    rt_generated = verify_step_generation(
+        runtime,
+        batch,
+        cfg.prompt,
+        image,
+        max_new_tokens=cfg.gen_steps,
+    )
+    # Detokenize and print generated text
+    rt_generated_text = processor.decode(
+        rt_generated[0].tolist(), skip_special_tokens=False
+    )
+    print(f"[run_static_gemma4_runtime] Generated text: {rt_generated_text}")
+
     print("[run_static_gemma4_runtime] Done.")


### PR DESCRIPTION
Related issue: https://github.com/Samsung/TICO/issues/768
Related PR: https://github.com/Samsung/TICO/pull/822

## What

This PR implements the **generation step (Step 8)** for the `StaticGemma4Runtime` in the TICO project, completing the full 8-step static runtime verification flow for Gemma4 E2B. It adds a greedy generation method with side-by-side validation against HuggingFace's reference implementation.

Additionally, this PR fixes the KV cache write logic in `prefill` to only store valid tokens (excluding padding), and adds proper shared-KV cache pre-population in `decode_one` for consumer layers.

## Why

The static runtime needed a complete generation loop to verify end-to-end functionality beyond single-step decode verification. This enables:
- Full sequence generation validation (not just single-token decode)
- Token-level accuracy tracking against HF reference
- Early detection of error accumulation across multiple decode steps
- Visual inspection of generated text for qualitative assessment

## Key Design Decisions

1. **Greedy generation loop**: The `generate_greedy` method reuses `prefill()` and `decode_one()` internally, ensuring consistency with the verified single-step implementations.

2. **Image token preservation**: The method extracts input IDs from `_raw_inputs["input_ids"]` (which preserves original image tokens) rather than `llm_input_ids` (which has image tokens replaced with `pad_token_id` for NPU compute).

3. **Token accuracy metric**: Instead of exact sequence match (which is unrealistic for quantized vs. FP models), we report token-level accuracy percentage and first mismatch position.

4. **Detokenized output**: Both runtime and HF generated sequences are detokenized and printed for visual inspection, enabling qualitative assessment beyond numerical metrics.

5. **KV cache fix**: In `prefill`, only valid K/V positions (up to `valid_length`) are written to the cache, excluding padding positions that contain garbage from padding tokens.

6. **Shared-KV pre-population**: In `decode_one`, shared-KV consumer layers are pre-populated from `layer_caches` before store layers update the cache, ensuring correct KV access across decode steps.

## Changes

**`tico/quantization/recipes/debug/static_gemma4_runtime.py`** (+190/-9 lines):

1. **`StaticGemma4Runtime.prefill`**: Fixed KV cache write to only store valid-length K/V (excluding padding garbage).

2. **`StaticGemma4Runtime.decode_one`**: Added shared-KV cache pre-population for consumer layers before the layer loop.

3. **`StaticGemma4Runtime.generate_greedy`** (new, ~49 lines): Greedy generation method that:
   - Runs `prefill` to process prompt + image
   - Extracts input IDs from `_raw_inputs` to preserve image tokens
   - Iteratively calls `decode_one` and collects generated tokens
   - Supports early stopping on EOS token

4. **`verify_step_generation`** (new, ~92 lines): Validation function that:
   - Runs runtime greedy generation
   - Runs HF reference generation
   - Reports token accuracy (%) and first mismatch position
   - Prints detokenized text from both paths

5. **`run_static_gemma4_runtime`**: Wired Step 8 to call `verify_step_generation` and print generated text.

## Tests

```
$ python -m pytest test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py -v
================================================================================ test session starts ================================================================================
platform linux -- Python 3.10.12, pytest-8.4.0, pluggy-1.6.0 -- /home/d.savchenkov/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/d.savchenkov/TICO
configfile: pyproject.toml
plugins: anyio-4.12.0, mock-3.15.1, xdist-3.7.0, cov-6.2.1
collected 21 items                                                                                                                                                                  

test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_batched_input PASSED                                           [  4%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_shape_mismatch_raises PASSED                                   [  9%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_with_attention_mask PASSED                                     [ 14%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_without_attention_mask_no_pad_token_id PASSED                  [ 19%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestNormalizeValidTokenMask::test_without_attention_mask_uses_pad_token_id PASSED                [ 23%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_batched_right_padding_invalid PASSED                             [ 28%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_batched_right_padding_valid PASSED                               [ 33%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_right_padding_invalid PASSED                                     [ 38%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_right_padding_no_padding PASSED                                  [ 42%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_right_padding_valid PASSED                                       [ 47%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestValidatePaddingLayout::test_unsupported_padding_side_raises PASSED                           [ 52%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestAllocateEmptyCache::test_all_full_attention_layers PASSED                                    [ 57%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestAllocateEmptyCache::test_all_sliding_layers PASSED                                           [ 61%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestAllocateEmptyCache::test_no_global_head_dim_falls_back PASSED                                [ 66%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestAllocateEmptyCache::test_per_layer_type_head_dim PASSED                                      [ 71%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestBuildDecodeMasksAndRope::test_full_attention_mask_shape PASSED                               [ 76%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestBuildDecodeMasksAndRope::test_full_attention_mask_values PASSED                              [ 80%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestBuildDecodeMasksAndRope::test_rope_computed_at_past_len PASSED                               [ 85%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestBuildDecodeMasksAndRope::test_sliding_window_mask_boundary_early_decode PASSED               [ 90%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestBuildDecodeMasksAndRope::test_sliding_window_mask_boundary_late_decode PASSED                [ 95%]
test/quantization/recipes/integration/test_static_gemma4_runtime_helpers.py::TestBuildDecodeMasksAndRope::test_sliding_window_mask_first_step PASSED                          [100%]

========================================================================== 21 passed, 2 warnings in 4.86s ===========================================================================
```

## Example Script

```
$ python -m pdb ./tico/quantization/examples/inspector.py \
    --mode static-gemma4-runtime \
    --config ./tico/quantization/examples/configs/static_gemma4_runtime.yaml

[run_static_gemma4_runtime] Loading model: google/gemma-4-e2b-it
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
Loading weights: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1951/1951 [00:00<00:00, 4661.76it/s]
[run_static_gemma4_runtime] Creating StaticGemma4Runtime ...
[run_static_gemma4_runtime] Step 1: verify build_static_inputs
[verify_step_build_static_inputs] All checks passed.
[run_static_gemma4_runtime] Step 8: verify generation
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[generate_greedy] Next token: tensor([106])
[verify_step_generation] Runtime generated 278 tokens
[verify_step_generation] HF generated 278 tokens
[verify_step_generation] Token accuracy: 100.00% (278/278)
[verify_step_generation] All tokens match!
[verify_step_generation] Runtime text: <|image><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><image|>Describe the image.<turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|>
[verify_step_generation] HF text: <|image><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><|image|><image|>Describe the image.<turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|><turn|>
[verify_step_generation] All checks passed.
[run_static_gemma4_runtime] Done.
```
