### PR TITLE
[quantization] Add BOS token

### DIFF
--- a/tico/quantization/recipes/data/llm.py
+++ b/tico/quantization/recipes/data/llm.py
@@ -45,7 +45,13 @@ def build_wikitext_calibration_inputs(
 
     random.seed(seed)
     samples: list[torch.Tensor] = []
+    bos = getattr(tokenizer, "bos_token_id", None)
     for _ in range(n_samples):
         i = random.randint(0, token_ids.shape[1] - seq_len - 1)
-        samples.append(token_ids[:, i : i + seq_len].cpu())
+        w = token_ids[:, i : i + seq_len]
+        if bos is not None:
+            w = torch.cat(
+                [torch.tensor([[bos]], device=w.device), w[:, : seq_len - 1]], dim=1
+            )
+        samples.append(w.cpu())
     return samples

--- a/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
+++ b/tico/quantization/wrapq/examples/quantize_full_qmodel_with_gptq.py
@@ -1295,10 +1295,16 @@ def build_calibration_inputs(
 
     random.seed(args.seed)
     calib_inputs = []
+    bos = getattr(tokenizer, "bos_token_id", None)
     for _ in range(nsamples):
         i = random.randint(0, train_ids.shape[1] - seqlen - 1)
-        j = i + seqlen
-        calib_inputs.append(train_ids[:, i:j].cpu())
+        w = train_ids[:, i : i + seqlen].cpu()
+        if bos is not None:
+            w = torch.cat(
+                [torch.tensor([[bos]], device=w.device), w[:, : seqlen - 1]], dim=1
+            )
+
+        calib_inputs.append(w)
 
     return calib_inputs
 


### PR DESCRIPTION
This commit adds BOS token to calibration dataset for llama model.

Here are the results of `GPTQ+mse` quantizing `HuggingFaceTB/SmolLM2-135M-Instruct` using 128 samples without PTQ and without/with BOS token included.

| | no_BOS | BOS |
|---|---|---|
| quantize_full_qmodel  | 19.83|19.78|
| quantize | 19.83|19.78|


TICO-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>