### PR TITLE
[quantization] Add identity quant spec for weights-only PTQ

### DIFF
--- a/test/quantization/config/test_quant_specs.py
+++ b/test/quantization/config/test_quant_specs.py
@@ -16,9 +16,10 @@ import unittest
 
 from tico.quantization.config.builders import build_llm_ptq_config
 from tico.quantization.config.ptq import PTQConfig
-from tico.quantization.config.specs import affine, mx
+from tico.quantization.config.specs import affine, identity, mx
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.observers.base import ObserverBase
+from tico.quantization.wrapq.observers.identity import IdentityObserver
 from tico.quantization.wrapq.observers.minmax import MinMaxObserver
 from tico.quantization.wrapq.observers.mx import MXObserver
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
@@ -113,6 +114,58 @@ class TestQuantSpecBuilders(unittest.TestCase):
 
         self.assertIsInstance(wrapper.obs_act_in, CustomObserver)
         self.assertIsInstance(wrapper.obs_act_out, MXObserver)
+
+
+class TestIdentitySpec(unittest.TestCase):
+    """Tests for the identity() spec — enables weights-only quantization."""
+
+    def test_identity_returns_identity_observer(self):
+        """identity() must produce a QuantSpec with IdentityObserver."""
+        spec = identity()
+        self.assertEqual(spec.observer, IdentityObserver)
+        self.assertIsNone(spec.dtype)
+        self.assertIsNone(spec.qscheme)
+
+    def test_identity_to_kwargs_has_no_dtype_or_qscheme(self):
+        """Identity spec must not emit dtype/qscheme (no quantization)."""
+        spec = identity()
+        kwargs = spec.to_kwargs(obs_name="act_in", context="test")
+        self.assertEqual(kwargs["observer"], IdentityObserver)
+        self.assertNotIn("dtype", kwargs)
+        self.assertNotIn("qscheme", kwargs)
+
+    def test_identity_to_kwargs_mark_replace(self):
+        """mark_replace should add the internal replace marker."""
+        spec = identity()
+        kwargs = spec.to_kwargs(obs_name="act_in", mark_replace=True)
+        self.assertTrue(kwargs.get("__quant_spec_replace_role__"))
+
+    def test_identity_activation_weight_quantized(self):
+        """Weight-only quantization: identity activations + affine weights."""
+        cfg = PTQConfig(
+            activation=identity(),
+            weight=affine(DType.uint(4)),
+        )
+        wrapper = DummyWrapper(cfg)
+
+        # Activations must be IdentityObserver (float32 passthrough)
+        self.assertIsInstance(wrapper.obs_act_in, IdentityObserver)
+        self.assertIsInstance(wrapper.obs_act_out, IdentityObserver)
+
+        # Weights must still be quantized
+        self.assertIsInstance(wrapper.obs_weight, MinMaxObserver)
+        self.assertEqual(wrapper.obs_weight.dtype, DType.uint(4))
+
+    def test_identity_observer_fake_quant_is_passthrough(self):
+        """IdentityObserver.fake_quant() must return input unchanged."""
+        import torch
+
+        cfg = PTQConfig(activation=identity())
+        wrapper = DummyWrapper(cfg)
+
+        x = torch.randn(2, 3)
+        out = wrapper.obs_act_in.fake_quant(x)
+        self.assertTrue(torch.equal(x, out))
 
 
 if __name__ == "__main__":

--- a/tico/quantization/config/specs.py
+++ b/tico/quantization/config/specs.py
@@ -18,6 +18,7 @@ from typing import Any, Mapping, Optional, Type
 from tico.quantization.config.utils import auto_qscheme_for, dtype_is_unsigned
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.observers.base import ObserverBase
+from tico.quantization.wrapq.observers.identity import IdentityObserver
 from tico.quantization.wrapq.observers.minmax import MinMaxObserver
 from tico.quantization.wrapq.observers.mx import MXObserver
 from tico.quantization.wrapq.qscheme import QScheme
@@ -167,3 +168,18 @@ def mx(
             "round": round,
         },
     )
+
+
+def identity() -> QuantSpec:
+    """
+    Create a no-op (identity) quantization spec.
+
+    The ``IdentityObserver`` passes tensors through unchanged — it collects
+    no statistics and applies no fake-quantization.  Use this spec to disable
+    quantization for a role (e.g. ``activation``) while keeping other roles
+    (e.g. ``weight``) quantized, enabling weight-only quantization estimation.
+
+    Returns:
+        A QuantSpec that expands to IdentityObserver kwargs.
+    """
+    return QuantSpec(observer=IdentityObserver)

--- a/tico/quantization/recipes/utils.py
+++ b/tico/quantization/recipes/utils.py
@@ -19,7 +19,7 @@ from typing import Any, Mapping
 
 import torch
 
-from tico.quantization.config.specs import affine, mx, QuantSpec
+from tico.quantization.config.specs import affine, identity, mx, QuantSpec
 from tico.quantization.wrapq.dtypes import DType
 from tico.quantization.wrapq.qscheme import QScheme
 
@@ -102,11 +102,14 @@ def quant_spec_from_config(
       - mapping with ``kind: affine``: affine spec with ``dtype`` and optional
         ``qscheme``.
       - mapping with ``kind: mx``: MX spec with ``elem_format`` and MX kwargs.
+      - mapping with ``kind: identity`` or ``kind: none``: no-op spec that
+        disables quantization for the role (passthrough observer).
 
     Examples:
         ``activation: int16``
         ``linear_weight: uint4``
         ``activation: {kind: mx, elem_format: fp8_e4m3, axis: -1}``
+        ``activation: {kind: identity}``
     """
     if value is None:
         return default
@@ -115,6 +118,9 @@ def quant_spec_from_config(
 
     if isinstance(value, Mapping):
         kind = str(value.get("kind", value.get("type", "affine"))).strip().lower()
+
+        if kind in ("identity", "none"):
+            return identity()
 
         if kind == "mx":
             return mx(


### PR DESCRIPTION
This PR adds identity quant spec for weights-only PTQ.

The weights-only quantization simplifies the debugging process.

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>