### PR TITLE
[quantization] fix QuantGemma4ClippableLinear module

### DIFF
--- a/test/quantization/config/test_builders.py
+++ b/test/quantization/config/test_builders.py
@@ -297,7 +297,7 @@ class TestBuildGemma4E2BPtqConfig(unittest.TestCase):
             DType.uint(4),
         )
         self.assertEqual(
-            cfg.overrides["model"]["vision_tower"]["encoder"]["layers"]["0"]["mlp"]["down_proj"]["weight"]["dtype"],  # type: ignore[index]
+            cfg.overrides["model"]["vision_tower"]["encoder"]["layers"]["0"]["mlp"]["down_proj"]["linear"]["weight"]["dtype"],  # type: ignore[index]
             DType.uint(4),
         )
         self.assertEqual(

--- a/tico/quantization/config/gemma4_builders.py
+++ b/tico/quantization/config/gemma4_builders.py
@@ -60,6 +60,25 @@ def _linear_tree_override(
     return root
 
 
+def _clippable_linear_tree_override(
+    linear_weight: Optional[QuantSpec], names: tuple[str, ...]
+) -> Dict[str, Any]:
+    """Build a tree of clippable linear weight overrides nested under 'linear'.
+
+    Gemma4ClippableLinear wraps an inner ``nn.Linear`` as ``.linear``.
+    ``QuantGemma4ClippableLinear`` scopes the child config via
+    ``qcfg.child("linear")``, so weight overrides must be placed at
+    ``<name>.linear.weight`` instead of ``<name>.weight``.
+    """
+    root: Dict[str, Any] = {}
+    override = _weight_override(linear_weight)
+    if not override:
+        return root
+    for name in names:
+        _set_nested(root, (name, "linear"), override)
+    return root
+
+
 def _deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> Dict[str, Any]:
     """Return ``base`` recursively merged with ``overlay``."""
     out: Dict[str, Any] = copy.deepcopy(dict(base))
@@ -191,8 +210,13 @@ def _gemma4_vision_attention_override(
     linear_weight: Optional[QuantSpec],
     norm_weight: Optional[QuantSpec],
 ) -> Dict[str, Any]:
-    """Build overrides for Gemma4VisionAttention."""
-    result = _linear_tree_override(
+    """Build overrides for Gemma4VisionAttention.
+
+    Vision attention uses ``Gemma4ClippableLinear`` (not plain ``nn.Linear``)
+    for q/k/v/o projections, so weight overrides must be nested under
+    ``.linear`` to match ``QuantGemma4ClippableLinear``'s ``qcfg.child("linear")``.
+    """
+    result = _clippable_linear_tree_override(
         linear_weight,
         ("q_proj", "k_proj", "v_proj", "o_proj"),
     )
@@ -241,7 +265,7 @@ def _gemma4_vision_model_override(
     for idx in range(num_vision_layers):
         layer = {
             "self_attn": _gemma4_vision_attention_override(linear_weight, norm_weight),
-            "mlp": _linear_tree_override(
+            "mlp": _clippable_linear_tree_override(
                 linear_weight,
                 ("gate_proj", "up_proj", "down_proj"),
             ),

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_clippable_linear.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_clippable_linear.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.utils.utils import join_name
 from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
 from tico.quantization.wrapq.wrappers.registry import try_register
@@ -43,19 +44,21 @@ class QuantGemma4ClippableLinear(QuantModuleBase):
         self.module = fp
         self.use_clipped_linears = bool(getattr(fp, "use_clipped_linears", False))
         self.linear = PTQWrapper(
-            fp.linear, qcfg=qcfg.child("linear") if qcfg else None, fp_name=fp_name
+            fp.linear,  # type: ignore[arg-type]
+            qcfg=qcfg.child("linear") if qcfg else None,
+            fp_name=join_name(fp_name, "linear"),
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Run the clippable linear layer with quantized inner linear weights."""
         if self.use_clipped_linears:
             hidden_states = torch.clamp(
-                hidden_states, self.module.input_min, self.module.input_max
+                hidden_states, self.module.input_min, self.module.input_max  # type: ignore[arg-type]
             )
         hidden_states = self.linear(hidden_states)
         if self.use_clipped_linears:
             hidden_states = torch.clamp(
-                hidden_states, self.module.output_min, self.module.output_max
+                hidden_states, self.module.output_min, self.module.output_max  # type: ignore[arg-type]
             )
         return hidden_states
 


### PR DESCRIPTION
This PR corrects `fp_name` for QuantGemma4ClippableLinear module and introduces `_clippable_linear_tree_override` in `gemma4_builders.py`.


### Why
- The `fp_name` passed to the inner `PTQWrapper` was wrong — it passed the parent's name (e.g., `"layers.0.self_attn.q_proj"`) instead of the child's qualified name (e.g., `"layers.0.self_attn.q_proj.linear"`).
- New `_clippable_linear_tree_override` resolves the problem when vision modules use `Gemma4ClippableLinear` (which wraps an inner `nn.Linear` as `.linear`), and `QuantGemma4ClippableLinear` scopes the child config via `qcfg.child("linear")`. As Example, the builder was placing weight overrides at `gate_proj.weight` instead of `gate_proj.linear.weight`, so `qcfg.child("linear")` found nothing. `test_builders.py` has been corrected accordingly.





TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>