### PR TITLE
[quantization] Add CNN WrapQ support

### DIFF
--- a/test/quantization/test_prelu_channelwise_quantization.py
+++ b/test/quantization/test_prelu_channelwise_quantization.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for channel-wise PReLU slope quantization."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.utils.reduce_utils import channelwise_minmax
+from tico.quantization.wrapq.wrappers.nn.quant_prelu import QuantPReLU
+from torch import nn
+
+
+class ChannelwiseMinMaxTest(unittest.TestCase):
+    """Verify rank-one per-channel statistics used by PReLU slopes."""
+
+    def test_rank_one_tensor_keeps_one_value_per_channel(self) -> None:
+        """Avoid collapsing a rank-one channel tensor into one global range."""
+        values = torch.tensor([0.01, 0.10, 0.25, -0.05], dtype=torch.float32)
+
+        minimum, maximum = channelwise_minmax(values, channel_axis=0)
+
+        torch.testing.assert_close(minimum, values, rtol=0.0, atol=0.0)
+        torch.testing.assert_close(maximum, values, rtol=0.0, atol=0.0)
+
+    def test_multi_dimensional_tensor_reduces_non_channel_axes(self) -> None:
+        """Preserve the existing reduction behavior for regular weight tensors."""
+        values = torch.tensor(
+            [
+                [[1.0, -2.0], [3.0, 4.0]],
+                [[-5.0, 6.0], [7.0, 8.0]],
+            ]
+        )
+
+        minimum, maximum = channelwise_minmax(values, channel_axis=0)
+
+        torch.testing.assert_close(minimum, torch.tensor([-2.0, -5.0]))
+        torch.testing.assert_close(maximum, torch.tensor([4.0, 8.0]))
+
+
+class QuantPReLUChannelwiseTest(unittest.TestCase):
+    """Verify that one affine qparam is generated for every PReLU slope."""
+
+    @staticmethod
+    def _config(
+        dtype: DType,
+        activation_qscheme: QScheme,
+        weight_qscheme: QScheme,
+    ) -> PTQConfig:
+        """Create a compact affine configuration for one wrapper test."""
+        return PTQConfig(
+            activation=affine(dtype, qscheme=activation_qscheme),
+            weight=affine(dtype, qscheme=weight_qscheme),
+            strict_wrap=False,
+        )
+
+    def _run_case(
+        self,
+        *,
+        dtype: DType,
+        activation_qscheme: QScheme,
+        configured_weight_qscheme: QScheme,
+        expected_weight_qscheme: QScheme,
+    ) -> None:
+        """Calibrate one wrapper and validate its slope quantization metadata."""
+        module = nn.PReLU(num_parameters=4)
+        slopes = torch.tensor([0.01, 0.10, 0.25, -0.05], dtype=torch.float32)
+        module.weight.data.copy_(slopes)
+        wrapper = QuantPReLU(
+            module,
+            qcfg=self._config(
+                dtype,
+                activation_qscheme,
+                configured_weight_qscheme,
+            ),
+        )
+
+        self.assertEqual(wrapper.obs_weight.qscheme, expected_weight_qscheme)
+        self.assertEqual(wrapper.obs_weight.channel_axis, 0)
+
+        wrapper.enable_calibration()
+        wrapper(torch.randn(1, 4, 3, 3))
+        wrapper.freeze_qparams()
+
+        scale, zero_point = wrapper.obs_weight.compute_qparams()
+        self.assertEqual(tuple(scale.shape), (4,))
+        self.assertEqual(tuple(zero_point.shape), (4,))
+
+        quantized_slopes = wrapper.obs_weight.fake_quant(module.weight.detach())
+        torch.testing.assert_close(quantized_slopes, slopes, rtol=0.0, atol=0.0)
+
+    def test_uint8_slope_uses_per_channel_asymmetric_quantization(self) -> None:
+        """Convert an unsigned per-tensor role policy to per-channel slopes."""
+        self._run_case(
+            dtype=DType.uint(8),
+            activation_qscheme=QScheme.PER_TENSOR_ASYMM,
+            configured_weight_qscheme=QScheme.PER_TENSOR_ASYMM,
+            expected_weight_qscheme=QScheme.PER_CHANNEL_ASYMM,
+        )
+
+    def test_int16_slope_uses_per_channel_symmetric_quantization(self) -> None:
+        """Convert a signed per-tensor role policy to symmetric per-channel slopes."""
+        self._run_case(
+            dtype=DType.int(16),
+            activation_qscheme=QScheme.PER_TENSOR_SYMM,
+            configured_weight_qscheme=QScheme.PER_TENSOR_SYMM,
+            expected_weight_qscheme=QScheme.PER_CHANNEL_SYMM,
+        )
+
+    def test_shared_slope_still_uses_one_channel_qparam(self) -> None:
+        """Represent a shared one-element slope as one per-channel qparam."""
+        module = nn.PReLU(num_parameters=1)
+        wrapper = QuantPReLU(
+            module,
+            qcfg=self._config(
+                DType.uint(8),
+                QScheme.PER_TENSOR_ASYMM,
+                QScheme.PER_CHANNEL_ASYMM,
+            ),
+        )
+
+        wrapper.enable_calibration()
+        wrapper(torch.randn(1, 3, 2, 2))
+        wrapper.freeze_qparams()
+        scale, zero_point = wrapper.obs_weight.compute_qparams()
+
+        self.assertEqual(tuple(scale.shape), (1,))
+        self.assertEqual(tuple(zero_point.shape), (1,))
+        self.assertEqual(wrapper.obs_weight.channel_axis, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/test_prelu_channelwise_quantization.py
+++ b/test/quantization/test_prelu_channelwise_quantization.py
@@ -100,7 +100,9 @@ class QuantPReLUChannelwiseTest(unittest.TestCase):
         wrapper(torch.randn(1, 4, 3, 3))
         wrapper.freeze_qparams()
 
-        scale, zero_point = wrapper.obs_weight.compute_qparams()
+        qparams = wrapper.obs_weight.compute_qparams()
+        assert qparams is not None
+        scale, zero_point = qparams
         self.assertEqual(tuple(scale.shape), (4,))
         self.assertEqual(tuple(zero_point.shape), (4,))
 
@@ -140,7 +142,9 @@ class QuantPReLUChannelwiseTest(unittest.TestCase):
         wrapper.enable_calibration()
         wrapper(torch.randn(1, 3, 2, 2))
         wrapper.freeze_qparams()
-        scale, zero_point = wrapper.obs_weight.compute_qparams()
+        qparams = wrapper.obs_weight.compute_qparams()
+        assert qparams is not None
+        scale, zero_point = qparams
 
         self.assertEqual(tuple(scale.shape), (1,))
         self.assertEqual(tuple(zero_point.shape), (1,))

--- a/test/quantization/wrapq/test_cnn_quantized_export.py
+++ b/test/quantization/wrapq/test_cnn_quantized_export.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end UINT8 and INT16 Circle export tests for CNN WrapQ."""
+
+from __future__ import annotations
+
+import unittest
+
+import tico
+
+import torch
+import torch.nn.functional as F
+from circle_schema import circle
+from tico.circle.io import model_from_bytes
+from tico.ops import ResizeBilinear2d
+from tico.quantization import convert, prepare, QuantStub
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from torch import nn
+
+
+class ExportableCNN(nn.Module):
+    """Exercise regular Conv2d, PReLU, depthwise Conv2d, and ResizeBilinear."""
+
+    def __init__(self) -> None:
+        """Create a small static CNN with bias on both convolution types."""
+        super().__init__()
+        self.input_quantizer = QuantStub()
+        self.conv = nn.Conv2d(3, 4, kernel_size=3, padding=1, bias=True)
+        self.prelu = nn.PReLU(num_parameters=4)
+        self.depthwise = nn.Conv2d(
+            4,
+            4,
+            kernel_size=3,
+            padding=1,
+            groups=4,
+            bias=True,
+        )
+        self.resize = ResizeBilinear2d(
+            (12, 12),
+            align_corners=False,
+            half_pixel_centers=True,
+        )
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Run the static CNN."""
+        hidden = self.input_quantizer(input_)
+        hidden = self.prelu(self.conv(hidden))
+        hidden = self.depthwise(hidden)
+        return self.resize(hidden)
+
+
+class ResidualDownsampleCNN(nn.Module):
+    """Exercise quantized MaxPool2D and zero-padding on a residual shortcut."""
+
+    def __init__(self) -> None:
+        """Create one stride-two main path and a padded shortcut path."""
+        super().__init__()
+        self.input_quantizer = QuantStub()
+        self.main = nn.Conv2d(3, 4, kernel_size=1, stride=2, bias=True)
+        self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.output = nn.PReLU(num_parameters=4)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Add a pooled channel-padded shortcut to the main convolution."""
+        input_q = self.input_quantizer(input_)
+        main = self.main(input_q)
+        shortcut = F.pad(self.pool(input_q), (0, 0, 0, 0, 0, 1))
+        return self.output(main + shortcut)
+
+
+class ConcatenatedHeadCNN(nn.Module):
+    """Produce a quantized output by concatenating two Conv2d heads."""
+
+    def __init__(self) -> None:
+        """Create a shared trunk and two output heads."""
+        super().__init__()
+        self.input_quantizer = QuantStub()
+        self.trunk = nn.Conv2d(3, 4, kernel_size=3, padding=1, bias=True)
+        self.head0 = nn.Conv2d(4, 2, kernel_size=1, bias=True)
+        self.head1 = nn.Conv2d(4, 3, kernel_size=1, bias=True)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Concatenate the two head tensors along the channel dimension."""
+        hidden = self.trunk(self.input_quantizer(input_))
+        return torch.cat((self.head0(hidden), self.head1(hidden)), dim=1)
+
+
+def _single_quant_conv(module: nn.Module):
+    """Return the single QuantConv2d descendant of one wrapped module."""
+    from tico.quantization.wrapq.wrappers.nn.quant_conv2d import QuantConv2d
+
+    matches = [child for child in module.modules() if isinstance(child, QuantConv2d)]
+    if len(matches) != 1:
+        raise RuntimeError(f"Expected one QuantConv2d, but found {len(matches)}.")
+    return matches[0]
+
+
+@torch.inference_mode()
+def _synchronize_head_ranges(model: nn.Module) -> None:
+    """Assign one collected activation range to both concatenated heads."""
+    observers = [
+        _single_quant_conv(model.head0).obs_act_out,
+        _single_quant_conv(model.head1).obs_act_out,
+    ]
+    common_min = torch.stack(
+        [observer.min_val.reshape(()) for observer in observers]
+    ).min()
+    common_max = torch.stack(
+        [observer.max_val.reshape(()) for observer in observers]
+    ).max()
+    for observer in observers:
+        observer.min_val.copy_(common_min)
+        observer.max_val.copy_(common_max)
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy used by the test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+def _builtin_code(model, operator) -> int:
+    """Return the builtin code referenced by one Circle operator."""
+    return model.operatorCodes[operator.opcodeIndex].builtinCode
+
+
+class CNNQuantizedExportTest(unittest.TestCase):
+    """Verify quantized CNN Circle types, qparams, and resize options."""
+
+    def _export(self, bit_width: int):
+        """Calibrate, freeze, export, and deserialize one test model."""
+        torch.manual_seed(20260728)
+        model = ExportableCNN().eval()
+        sample = torch.randn(1, 3, 6, 6)
+        prepared = prepare(model, _quant_config(bit_width), inplace=True)
+        with torch.inference_mode():
+            prepared(sample)
+        quantized = convert(prepared, inplace=True).eval()
+        circle_model = tico.convert(quantized, (sample,))
+        return model_from_bytes(circle_model.circle_binary)
+
+    def _assert_export(self, bit_width: int) -> None:
+        """Validate one deserialized UINT8 or INT16 Circle graph."""
+        model = self._export(bit_width)
+        graph = model.subgraphs[0]
+        expected_type = (
+            circle.TensorType.TensorType.UINT8
+            if bit_width == 8
+            else circle.TensorType.TensorType.INT16
+        )
+        expected_bias_type = (
+            circle.TensorType.TensorType.INT32
+            if bit_width == 8
+            else circle.TensorType.TensorType.INT64
+        )
+
+        self.assertEqual(graph.tensors[graph.inputs[0]].type, expected_type)
+        self.assertEqual(graph.tensors[graph.outputs[0]].type, expected_type)
+
+        resize_count = 0
+        conv_count = 0
+        depthwise_count = 0
+        for operator in graph.operators:
+            builtin = _builtin_code(model, operator)
+            if builtin in {
+                circle.BuiltinOperator.BuiltinOperator.CONV_2D,
+                circle.BuiltinOperator.BuiltinOperator.DEPTHWISE_CONV_2D,
+            }:
+                input_tensor = graph.tensors[operator.inputs[0]]
+                weight_tensor = graph.tensors[operator.inputs[1]]
+                bias_tensor = graph.tensors[operator.inputs[2]]
+                output_tensor = graph.tensors[operator.outputs[0]]
+                self.assertEqual(input_tensor.type, expected_type)
+                self.assertEqual(weight_tensor.type, expected_type)
+                self.assertEqual(bias_tensor.type, expected_bias_type)
+                self.assertEqual(output_tensor.type, expected_type)
+                self.assertIsNotNone(input_tensor.quantization)
+                self.assertIsNotNone(weight_tensor.quantization)
+                self.assertIsNotNone(bias_tensor.quantization)
+                self.assertIsNotNone(output_tensor.quantization)
+
+                if builtin == circle.BuiltinOperator.BuiltinOperator.CONV_2D:
+                    conv_count += 1
+                    self.assertEqual(
+                        weight_tensor.quantization.quantizedDimension,
+                        0,
+                    )
+                else:
+                    depthwise_count += 1
+                    self.assertEqual(
+                        weight_tensor.quantization.quantizedDimension,
+                        3,
+                    )
+            elif builtin == circle.BuiltinOperator.BuiltinOperator.RESIZE_BILINEAR:
+                resize_count += 1
+                input_tensor = graph.tensors[operator.inputs[0]]
+                output_tensor = graph.tensors[operator.outputs[0]]
+                self.assertEqual(input_tensor.type, expected_type)
+                self.assertEqual(output_tensor.type, expected_type)
+                self.assertFalse(operator.builtinOptions.alignCorners)
+                self.assertTrue(operator.builtinOptions.halfPixelCenters)
+
+        self.assertEqual(conv_count, 1)
+        self.assertEqual(depthwise_count, 1)
+        self.assertEqual(resize_count, 1)
+
+    def test_identical_qparams_propagate_through_concat(self) -> None:
+        """Keep UINT8 and INT16 concatenation outputs quantized."""
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                torch.manual_seed(20260729)
+                model = ConcatenatedHeadCNN().eval()
+                sample = torch.randn(1, 3, 6, 6)
+                prepared = prepare(model, _quant_config(bit_width), inplace=True)
+                with torch.inference_mode():
+                    prepared(sample)
+                _synchronize_head_ranges(prepared)
+                quantized = convert(prepared, inplace=True).eval()
+                circle_model = tico.convert(quantized, (sample,))
+                exported = model_from_bytes(circle_model.circle_binary)
+                graph = exported.subgraphs[0]
+                expected_type = (
+                    circle.TensorType.TensorType.UINT8
+                    if bit_width == 8
+                    else circle.TensorType.TensorType.INT16
+                )
+                self.assertEqual(
+                    graph.tensors[graph.outputs[0]].type,
+                    expected_type,
+                )
+                concat_ops = [
+                    operator
+                    for operator in graph.operators
+                    if _builtin_code(exported, operator)
+                    == circle.BuiltinOperator.BuiltinOperator.CONCATENATION
+                ]
+                self.assertEqual(len(concat_ops), 1)
+                concat = concat_ops[0]
+                for tensor_index in [*concat.inputs, *concat.outputs]:
+                    tensor = graph.tensors[tensor_index]
+                    self.assertEqual(tensor.type, expected_type)
+                    self.assertIsNotNone(tensor.quantization)
+
+    def test_pool_and_pad_shortcut_remains_quantized(self) -> None:
+        """Propagate quantized qparams through MaxPool2D and zero padding."""
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                torch.manual_seed(20260730)
+                model = ResidualDownsampleCNN().eval()
+                sample = torch.randn(1, 3, 8, 8)
+                prepared = prepare(model, _quant_config(bit_width), inplace=True)
+                with torch.inference_mode():
+                    prepared(sample)
+                quantized = convert(prepared, inplace=True).eval()
+                circle_model = tico.convert(quantized, (sample,))
+                exported = model_from_bytes(circle_model.circle_binary)
+                graph = exported.subgraphs[0]
+                expected_type = (
+                    circle.TensorType.TensorType.UINT8
+                    if bit_width == 8
+                    else circle.TensorType.TensorType.INT16
+                )
+                checked = 0
+                for operator in graph.operators:
+                    builtin = _builtin_code(exported, operator)
+                    if builtin not in {
+                        circle.BuiltinOperator.BuiltinOperator.MAX_POOL_2D,
+                        circle.BuiltinOperator.BuiltinOperator.PAD,
+                    }:
+                        continue
+                    data_input = graph.tensors[operator.inputs[0]]
+                    data_output = graph.tensors[operator.outputs[0]]
+                    self.assertEqual(data_input.type, expected_type)
+                    self.assertEqual(data_output.type, expected_type)
+                    self.assertIsNotNone(data_input.quantization)
+                    self.assertIsNotNone(data_output.quantization)
+                    checked += 1
+                self.assertEqual(checked, 2)
+
+    def test_uint8_circle_export(self) -> None:
+        """Export the CNN as a fully quantized UINT8 Circle model."""
+        self._assert_export(8)
+
+    def test_int16_circle_export(self) -> None:
+        """Export the CNN as a fully quantized INT16 Circle model."""
+        self._assert_export(16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/test_same_padding_concat_export.py
+++ b/test/quantization/wrapq/test_same_padding_concat_export.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quantized Circle export tests for SAME Conv2d and Concat boundaries."""
+
+from __future__ import annotations
+
+import unittest
+
+import tico
+
+import torch
+from circle_schema import circle
+from tico.circle.io import model_from_bytes
+from tico.ops import Concat, SamePaddingConv2d
+from tico.quantization import convert, prepare, QuantStub
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from torch import nn
+
+
+class SamePaddingExportCNN(nn.Module):
+    """Exercise regular and depthwise Circle SAME-padding convolutions."""
+
+    def __init__(self) -> None:
+        """Create a compact CNN whose convolutions must not emit PAD operators."""
+        super().__init__()
+        self.input_quantizer = QuantStub()
+        self.conv = SamePaddingConv2d(
+            3,
+            4,
+            kernel_size=5,
+            stride=2,
+            bias=True,
+        )
+        self.prelu = nn.PReLU(num_parameters=4)
+        self.depthwise = SamePaddingConv2d(
+            4,
+            4,
+            kernel_size=5,
+            groups=4,
+            bias=True,
+        )
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Run the two SAME-padding convolution paths."""
+        hidden = self.input_quantizer(input_)
+        hidden = self.prelu(self.conv(hidden))
+        return self.depthwise(hidden)
+
+
+class ConcatHeadCNN(nn.Module):
+    """Concatenate two independently scaled output heads through TICO Concat."""
+
+    def __init__(self) -> None:
+        """Create a trunk and two heads with a quantizable concatenation boundary."""
+        super().__init__()
+        self.input_quantizer = QuantStub()
+        self.trunk = nn.Conv2d(3, 4, kernel_size=3, padding=1, bias=True)
+        self.head0 = nn.Conv2d(4, 2, kernel_size=1, bias=True)
+        self.head1 = nn.Conv2d(4, 3, kernel_size=1, bias=True)
+        self.concat = Concat(dim=1)
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Run both heads and concatenate their outputs along the channel axis."""
+        hidden = self.trunk(self.input_quantizer(input_))
+        return self.concat((self.head0(hidden), self.head1(hidden)))
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy used by the test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+def _builtin_code(model, operator) -> int:
+    """Return the builtin operator code referenced by one Circle operator."""
+    return model.operatorCodes[operator.opcodeIndex].builtinCode
+
+
+def _export(model: nn.Module, sample: torch.Tensor, bit_width: int):
+    """Calibrate, freeze, export, and deserialize one quantized model."""
+    prepared = prepare(model.eval(), _quant_config(bit_width), inplace=True)
+    with torch.inference_mode():
+        prepared(sample)
+    quantized = convert(prepared, inplace=True).eval()
+    circle_model = tico.convert(quantized, (sample,))
+    return model_from_bytes(circle_model.circle_binary)
+
+
+class CNNBoundaryQuantizedExportTest(unittest.TestCase):
+    """Verify quantized export semantics introduced for the hand detector."""
+
+    def test_same_padding_convolutions_do_not_emit_pad(self) -> None:
+        """Keep SAME padding in Conv options for UINT8 and INT16 models."""
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                torch.manual_seed(20260731)
+                exported = _export(
+                    SamePaddingExportCNN(),
+                    torch.randn(1, 3, 7, 9),
+                    bit_width,
+                )
+                graph = exported.subgraphs[0]
+                padding_values = []
+                pad_count = 0
+                for operator in graph.operators:
+                    builtin = _builtin_code(exported, operator)
+                    if builtin == circle.BuiltinOperator.BuiltinOperator.PAD:
+                        pad_count += 1
+                    if builtin in {
+                        circle.BuiltinOperator.BuiltinOperator.CONV_2D,
+                        circle.BuiltinOperator.BuiltinOperator.DEPTHWISE_CONV_2D,
+                    }:
+                        padding_values.append(operator.builtinOptions.padding)
+
+                self.assertEqual(pad_count, 0)
+                self.assertEqual(padding_values, [0, 0])
+
+    def test_concat_wrapper_exports_one_shared_quantization_domain(self) -> None:
+        """Use one observed qparam domain for all Concat inputs and its output."""
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                torch.manual_seed(20260801)
+                model = ConcatHeadCNN().eval()
+                with torch.no_grad():
+                    model.head0.weight.mul_(0.01)
+                    model.head1.weight.mul_(10.0)
+                exported = _export(
+                    model,
+                    torch.randn(1, 3, 6, 6),
+                    bit_width,
+                )
+                graph = exported.subgraphs[0]
+                concat_ops = [
+                    operator
+                    for operator in graph.operators
+                    if _builtin_code(exported, operator)
+                    == circle.BuiltinOperator.BuiltinOperator.CONCATENATION
+                ]
+                self.assertEqual(len(concat_ops), 1)
+
+                concat = concat_ops[0]
+                tensors = [
+                    graph.tensors[index] for index in [*concat.inputs, *concat.outputs]
+                ]
+                self.assertTrue(
+                    all(tensor.quantization is not None for tensor in tensors)
+                )
+                qparams = [
+                    (
+                        tuple(tensor.quantization.scale),
+                        tuple(tensor.quantization.zeroPoint),
+                    )
+                    for tensor in tensors
+                ]
+                self.assertTrue(all(qparam == qparams[0] for qparam in qparams[1:]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/nn/test_quant_conv2d.py
+++ b/test/quantization/wrapq/wrappers/nn/test_quant_conv2d.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for regular and depthwise Conv2d WrapQ support."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.nn.quant_conv2d import QuantConv2d
+from tico.quantization.wrapq.wrappers.registry import lookup
+from torch import nn
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy used by the test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantConv2dTest(unittest.TestCase):
+    """Verify Conv2d registration, calibration, and fake quantization."""
+
+    def test_registry_maps_torch_conv2d(self) -> None:
+        """Resolve the native wrapper for torch.nn.Conv2d."""
+        self.assertIs(lookup(nn.Conv2d), QuantConv2d)
+
+    def test_weight_observer_uses_output_channel_axis(self) -> None:
+        """Use PyTorch Conv2d output dimension zero for per-channel weights."""
+        wrapper = QuantConv2d(
+            nn.Conv2d(3, 5, kernel_size=3),
+            qcfg=_quant_config(8),
+        )
+        self.assertEqual(wrapper.obs_weight.channel_axis, 0)
+
+    def test_int16_uses_symmetric_activation_and_weight_qschemes(self) -> None:
+        """Use per-tensor activation and per-channel weight symmetry for INT16."""
+        wrapper = QuantConv2d(
+            nn.Conv2d(3, 5, kernel_size=3),
+            qcfg=_quant_config(16),
+        )
+        self.assertIs(wrapper.obs_act_in.qscheme, QScheme.PER_TENSOR_SYMM)
+        self.assertIs(wrapper.obs_act_out.qscheme, QScheme.PER_TENSOR_SYMM)
+        self.assertIs(wrapper.obs_weight.qscheme, QScheme.PER_CHANNEL_SYMM)
+
+    def test_regular_and_depthwise_uint8_int16(self) -> None:
+        """Calibrate and execute regular and depthwise convolutions."""
+        cases = (
+            nn.Conv2d(3, 4, kernel_size=3, padding=1),
+            nn.Conv2d(4, 4, kernel_size=3, padding=1, groups=4),
+        )
+        inputs = (
+            torch.randn(2, 3, 8, 8),
+            torch.randn(2, 4, 8, 8),
+        )
+        for bit_width in (8, 16):
+            for module, input_ in zip(cases, inputs):
+                with self.subTest(bit_width=bit_width, groups=module.groups):
+                    wrapper = QuantConv2d(module, qcfg=_quant_config(bit_width))
+                    wrapper.enable_calibration()
+                    wrapper(input_)
+                    wrapper.freeze_qparams()
+                    with torch.inference_mode():
+                        output = wrapper(input_)
+                    self.assertEqual(output.shape[0], input_.shape[0])
+                    self.assertEqual(output.shape[1], module.out_channels)
+                    self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/nn/test_quant_maxpool2d.py
+++ b/test/quantization/wrapq/wrappers/nn/test_quant_maxpool2d.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for MaxPool2d WrapQ support."""
+
+import unittest
+
+import torch
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.nn.quant_maxpool2d import QuantMaxPool2d
+from tico.quantization.wrapq.wrappers.registry import lookup
+from torch import nn
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy under test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantMaxPool2dTest(unittest.TestCase):
+    """Verify registration and shared MaxPool2d qparams."""
+
+    def test_registry_maps_maxpool2d(self) -> None:
+        """Resolve the native MaxPool2d wrapper."""
+        self.assertIs(lookup(nn.MaxPool2d), QuantMaxPool2d)
+
+    def test_input_and_output_share_one_observer(self) -> None:
+        """Expose the exact same observer for both sides of MaxPool2d."""
+        wrapper = QuantMaxPool2d(
+            nn.MaxPool2d(kernel_size=2, stride=2),
+            qcfg=_quant_config(8),
+        )
+        self.assertIs(wrapper.obs_act_in, wrapper.obs_act_out)
+        self.assertEqual(len(tuple(wrapper._all_observers())), 1)
+
+    def test_uint8_int16_execution(self) -> None:
+        """Calibrate and execute UINT8 and INT16 quantization."""
+        input_ = torch.randn(2, 4, 8, 8)
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                wrapper = QuantMaxPool2d(
+                    nn.MaxPool2d(kernel_size=2, stride=2),
+                    qcfg=_quant_config(bit_width),
+                )
+                wrapper.enable_calibration()
+                wrapper(input_)
+                wrapper.freeze_qparams()
+                output = wrapper(input_)
+                self.assertEqual(tuple(output.shape), (2, 4, 4, 4))
+                self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/nn/test_quant_prelu.py
+++ b/test/quantization/wrapq/wrappers/nn/test_quant_prelu.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for torch.nn.PReLU WrapQ support."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.nn.quant_prelu import QuantPReLU
+from tico.quantization.wrapq.wrappers.registry import lookup
+from torch import nn
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy used by the test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantPReLUTest(unittest.TestCase):
+    """Verify PReLU registration and fake-quantized execution."""
+
+    def test_registry_maps_torch_prelu(self) -> None:
+        """Resolve the native wrapper for torch.nn.PReLU."""
+        self.assertIs(lookup(nn.PReLU), QuantPReLU)
+
+    def test_slope_uses_per_channel_quantization(self) -> None:
+        """Quantize the PReLU slope per channel along axis 0."""
+        wrapper = QuantPReLU(
+            nn.PReLU(num_parameters=4),
+            qcfg=_quant_config(8),
+        )
+        self.assertEqual(wrapper.obs_weight.channel_axis, 0)
+        self.assertIs(wrapper.obs_weight.qscheme, QScheme.PER_CHANNEL_ASYMM)
+
+    def test_int16_slope_uses_per_channel_symmetric_quantization(self) -> None:
+        """Keep the INT16 PReLU slope symmetric with per-channel scales."""
+        wrapper = QuantPReLU(
+            nn.PReLU(num_parameters=4),
+            qcfg=_quant_config(16),
+        )
+        self.assertIs(wrapper.obs_weight.qscheme, QScheme.PER_CHANNEL_SYMM)
+
+    def test_uint8_and_int16(self) -> None:
+        """Calibrate and execute channel-wise PReLU at both bit widths."""
+        input_ = torch.randn(2, 4, 8, 8)
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                wrapper = QuantPReLU(
+                    nn.PReLU(num_parameters=4),
+                    qcfg=_quant_config(bit_width),
+                )
+                wrapper.enable_calibration()
+                wrapper(input_)
+                wrapper.freeze_qparams()
+                with torch.inference_mode():
+                    output = wrapper(input_)
+                self.assertEqual(tuple(output.shape), tuple(input_.shape))
+                self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/ops/test_quant_concat.py
+++ b/test/quantization/wrapq/wrappers/ops/test_quant_concat.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the quantized concatenation boundary."""
+
+import unittest
+
+import torch
+
+from tico.ops import Concat
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.ops.quant_concat import QuantConcat
+from tico.quantization.wrapq.wrappers.registry import lookup
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy under test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantConcatTest(unittest.TestCase):
+    """Verify registration and one shared concatenation observer."""
+
+    def test_registry_maps_concat(self) -> None:
+        """Resolve the TICO Concat wrapper."""
+        self.assertIs(lookup(Concat), QuantConcat)
+
+    def test_shared_observer_collects_all_inputs(self) -> None:
+        """Collect the union range of every concatenation input."""
+        wrapper = QuantConcat(Concat(dim=1), qcfg=_quant_config(8))
+        left = torch.full((1, 2, 3), -4.0)
+        right = torch.full((1, 3, 3), 7.0)
+        wrapper.enable_calibration()
+        wrapper((left, right))
+        self.assertEqual(wrapper.obs_act_out.min_val.item(), -4.0)
+        self.assertEqual(wrapper.obs_act_out.max_val.item(), 7.0)
+
+    def test_uint8_int16_execution(self) -> None:
+        """Calibrate and execute UINT8 and INT16 quantization."""
+        values = (torch.randn(2, 3, 4), torch.randn(2, 5, 4))
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                wrapper = QuantConcat(Concat(dim=1), qcfg=_quant_config(bit_width))
+                wrapper.enable_calibration()
+                wrapper(values)
+                wrapper.freeze_qparams()
+                output = wrapper(values)
+                self.assertEqual(tuple(output.shape), (2, 8, 4))
+                self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/ops/test_quant_resize_bilinear.py
+++ b/test/quantization/wrapq/wrappers/ops/test_quant_resize_bilinear.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Circle-semantic ResizeBilinear WrapQ wrapper."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from tico.ops import ResizeBilinear2d
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.ops.quant_resize_bilinear import (
+    QuantResizeBilinear2d,
+)
+from tico.quantization.wrapq.wrappers.registry import lookup
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy under test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantResizeBilinear2dTest(unittest.TestCase):
+    """Verify registration, configuration preservation, and execution."""
+
+    def test_registry_maps_tico_resize_bilinear(self) -> None:
+        """Resolve the operator wrapper from the public TICO facade type."""
+        self.assertIs(lookup(ResizeBilinear2d), QuantResizeBilinear2d)
+
+    def test_wrapper_preserves_coordinate_options(self) -> None:
+        """Retain the source-model half-pixel coordinate convention."""
+        module = ResizeBilinear2d(
+            (12, 12),
+            align_corners=False,
+            half_pixel_centers=True,
+        )
+        wrapper = QuantResizeBilinear2d(module, qcfg=_quant_config(8))
+        self.assertFalse(wrapper.module.align_corners)
+        self.assertTrue(wrapper.module.half_pixel_centers)
+
+    def test_input_and_output_observers_are_independent(self) -> None:
+        """Allow ResizeBilinear input and output qparams to differ."""
+        wrapper = QuantResizeBilinear2d(
+            ResizeBilinear2d(
+                (12, 12),
+                align_corners=False,
+                half_pixel_centers=True,
+            ),
+            qcfg=_quant_config(8),
+        )
+        self.assertIsNot(wrapper.obs_act_in, wrapper.obs_act_out)
+        self.assertEqual(len(tuple(wrapper._all_observers())), 2)
+
+    def test_uint8_and_int16(self) -> None:
+        """Calibrate and execute ResizeBilinear at both bit widths."""
+        input_ = torch.randn(1, 4, 6, 6)
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                wrapper = QuantResizeBilinear2d(
+                    ResizeBilinear2d(
+                        (12, 12),
+                        align_corners=False,
+                        half_pixel_centers=True,
+                    ),
+                    qcfg=_quant_config(bit_width),
+                )
+                wrapper.enable_calibration()
+                wrapper(input_)
+                wrapper.freeze_qparams()
+                with torch.inference_mode():
+                    output = wrapper(input_)
+                self.assertEqual(tuple(output.shape), (1, 4, 12, 12))
+                self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/ops/test_quant_same_padding_conv2d.py
+++ b/test/quantization/wrapq/wrappers/ops/test_quant_same_padding_conv2d.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SAME-padding Conv2d WrapQ support."""
+
+import unittest
+
+import torch
+
+from tico.ops import SamePaddingConv2d
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.nn.quant_conv2d import QuantConv2d
+from tico.quantization.wrapq.wrappers.ops.quant_same_padding_conv2d import (
+    QuantSamePaddingConv2d,
+)
+from tico.quantization.wrapq.wrappers.registry import lookup
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy under test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantSamePaddingConv2dTest(unittest.TestCase):
+    """Verify registration and inherited Conv2d quantization behavior."""
+
+    def test_registry_maps_same_padding_conv2d(self) -> None:
+        """Resolve the TICO SAME-padding convolution wrapper."""
+        self.assertIs(lookup(SamePaddingConv2d), QuantSamePaddingConv2d)
+        self.assertTrue(issubclass(QuantSamePaddingConv2d, QuantConv2d))
+
+    def test_uint8_int16_execution(self) -> None:
+        """Calibrate and execute strided SAME convolution."""
+        input_ = torch.randn(2, 3, 12, 14)
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                wrapper = QuantSamePaddingConv2d(
+                    SamePaddingConv2d(3, 4, kernel_size=5, stride=2),
+                    qcfg=_quant_config(bit_width),
+                )
+                wrapper.enable_calibration()
+                wrapper(input_)
+                wrapper.freeze_qparams()
+                output = wrapper(input_)
+                self.assertEqual(tuple(output.shape), (2, 4, 6, 7))
+                self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/test_quant_stub.py
+++ b/test/quantization/wrapq/wrappers/test_quant_stub.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the public TICO quantization boundary module."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from tico.quantization import QuantStub
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.config.specs import affine
+from tico.quantization.wrapq.dtypes import DType
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.quant_stub import QuantStubWrapper
+from tico.quantization.wrapq.wrappers.registry import lookup
+
+
+def _quant_config(bit_width: int) -> PTQConfig:
+    """Create the UINT8 or INT16 policy under test."""
+    if bit_width == 8:
+        dtype = DType.uint(8)
+        activation_qscheme = QScheme.PER_TENSOR_ASYMM
+        weight_qscheme = QScheme.PER_CHANNEL_ASYMM
+    elif bit_width == 16:
+        dtype = DType.int(16)
+        activation_qscheme = QScheme.PER_TENSOR_SYMM
+        weight_qscheme = QScheme.PER_CHANNEL_SYMM
+    else:
+        raise ValueError(f"Unsupported bit width: {bit_width}")
+
+    return PTQConfig(
+        activation=affine(dtype, qscheme=activation_qscheme),
+        weight=affine(dtype, qscheme=weight_qscheme),
+        strict_wrap=False,
+    )
+
+
+class QuantStubTest(unittest.TestCase):
+    """Verify identity behavior and explicit activation fake quantization."""
+
+    def test_float_module_is_stateless_identity(self) -> None:
+        """Keep the floating-point boundary transparent and state-free."""
+        module = QuantStub().eval()
+        input_ = torch.randn(1, 3, 6, 6)
+        self.assertIs(module(input_), input_)
+        self.assertEqual(module.state_dict(), {})
+
+    def test_registry_maps_quant_stub(self) -> None:
+        """Resolve the native wrapper for the public boundary module."""
+        self.assertIs(lookup(QuantStub), QuantStubWrapper)
+
+    def test_uint8_and_int16(self) -> None:
+        """Calibrate and execute the explicit input boundary at both widths."""
+        input_ = torch.randn(1, 3, 6, 6)
+        for bit_width in (8, 16):
+            with self.subTest(bit_width=bit_width):
+                wrapper = QuantStubWrapper(
+                    QuantStub(),
+                    qcfg=_quant_config(bit_width),
+                )
+                wrapper.enable_calibration()
+                wrapper(input_)
+                wrapper.freeze_qparams()
+                with torch.inference_mode():
+                    output = wrapper(input_)
+                self.assertEqual(tuple(output.shape), tuple(input_.shape))
+                self.assertTrue(torch.isfinite(output).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/passes/legalize_predefined_layout_operators.py
+++ b/tico/passes/legalize_predefined_layout_operators.py
@@ -262,6 +262,22 @@ class LegalizePreDefinedLayoutOperators(PassBase):
                 torch.ops.quantized_decomposed.dequantize_per_tensor.default,
             ]:
                 dq = args.weight
+                if (
+                    dq.target
+                    == torch.ops.quantized_decomposed.dequantize_per_channel.default
+                ):
+                    dq_args = DequantizePerChannelArgs(
+                        *dq.args, **dq.kwargs  # type: ignore[arg-type]
+                    )
+                    old_axis = dq_args.axis
+                    if old_axis < 0:
+                        old_axis += len(perm)
+                    if old_axis not in perm:
+                        raise NotYetSupportedError(
+                            f"Invalid per-channel axis {dq_args.axis} for "
+                            f"weight permutation {perm}."
+                        )
+                    dq.update_arg(3, perm.index(old_axis))
                 dq.update_arg(dq.args.index(weight), weight_permute)
                 # Need to update dq.meta["val"] in FillMetaVal pass.
                 del dq.meta["val"]
@@ -354,6 +370,22 @@ class LegalizePreDefinedLayoutOperators(PassBase):
                 torch.ops.quantized_decomposed.dequantize_per_tensor.default,
             ]:
                 dq = args.weight
+                if (
+                    dq.target
+                    == torch.ops.quantized_decomposed.dequantize_per_channel.default
+                ):
+                    dq_args = DequantizePerChannelArgs(
+                        *dq.args, **dq.kwargs  # type: ignore[arg-type]
+                    )
+                    old_axis = dq_args.axis
+                    if old_axis < 0:
+                        old_axis += len(perm)
+                    if old_axis not in perm:
+                        raise NotYetSupportedError(
+                            f"Invalid per-channel axis {dq_args.axis} for "
+                            f"weight permutation {perm}."
+                        )
+                    dq.update_arg(3, perm.index(old_axis))
                 dq.update_arg(dq.args.index(weight), weight_permute)
                 # Need to update dq.meta["val"] in FillMetaVal pass.
                 del dq.meta["val"]

--- a/tico/quantization/__init__.py
+++ b/tico/quantization/__init__.py
@@ -1,6 +1,10 @@
+"""Public interfaces for TICO quantization."""
+
 from tico.quantization.public_interface import convert, prepare
+from tico.quantization.quant_stub import QuantStub
 
 __all__ = [
+    "QuantStub",
     "convert",
     "prepare",
 ]

--- a/tico/quantization/passes/fold_quant_ops.py
+++ b/tico/quantization/passes/fold_quant_ops.py
@@ -107,9 +107,10 @@ class FoldQuantOps(PassBase):
        `q` and `dq` share identical (scale, zero-point, dtype).
     3. a) If the producer op has **no** QPARAM, attach one, then replace
           *this* DQ's usages with the producer op.
-       b) If the producer is already quantized with a different dtype,
-          this is a *re-quantization*: attach QPARAM to `q` and keep it,
-          but still remove the DQ.
+       b) If the producer is already quantized with different affine qparams,
+          including a different scale or zero point with the same dtype, this
+          is a *re-quantization*: attach QPARAM to `q` and keep it, but still
+          remove the DQ.
     4. After all replacements, run `graph.eliminate_dead_code()`.
        Any Quantize that became orphaned because *all* its DQs were folded
        is deleted automatically.
@@ -168,9 +169,14 @@ class FoldQuantOps(PassBase):
             else:
                 op_qparam: QuantParam = op.meta[QPARAM_KEY]
                 qdq_dtype = get_quant_dtype(q_args.quant_min, q_args.quant_max)
+                same_qparams = (
+                    op_qparam.dtype == qdq_dtype
+                    and op_qparam.scale == [q_args.scale]
+                    and op_qparam.zero_point == [q_args.zero_p]
+                    and op_qparam.quantized_dimension is None
+                )
 
-                if op_qparam.dtype != qdq_dtype:
-                    # Attach QPARAM to Q once
+                if not same_qparams:
                     if QPARAM_KEY not in q.meta:
                         qparam = QuantParam()
                         qparam.scale = [q_args.scale]
@@ -180,14 +186,10 @@ class FoldQuantOps(PassBase):
                         assert len(q.users) == 1, "Fix me unless"
 
                     dq.replace_all_uses_with(q, propagate_meta=False)
-                    logger.debug(f"{dq.name} is folded ({q.name} is left).")
-                else:
-                    # Same dtype → the Quantize–Dequantize pair is redundant.
-                    assert op_qparam.scale and op_qparam.scale[0] == q_args.scale
-                    assert (
-                        op_qparam.zero_point
-                        and op_qparam.zero_point[0] == q_args.zero_p
+                    logger.debug(
+                        f"{dq.name} is folded as requantization " f"({q.name} is left)."
                     )
+                else:
                     dq.replace_all_uses_with(op, propagate_meta=False)
                     logger.debug(f"Removed redundant {dq.name}")
 

--- a/tico/quantization/passes/propagate_qparam_forward.py
+++ b/tico/quantization/passes/propagate_qparam_forward.py
@@ -76,6 +76,13 @@ class PropagateQParamForward(PassBase):
             if node.target == torch.ops.aten.permute.default:
                 permute_args = PermuteArgs(*node.args, **node.kwargs)
                 _propagate_qparam_if_possible(permute_args.input, node)
+            elif node.target in {
+                torch.ops.aten.constant_pad_nd.default,
+                torch.ops.circle_custom.maxpool2d.default,
+            }:
+                input_ = node.args[0]
+                if isinstance(input_, torch.fx.Node):
+                    _propagate_qparam_if_possible(input_, node)
             elif node.target == torch.ops.aten.reshape.default:
                 reshape_args = ReshapeArgs(*node.args, **node.kwargs)
                 _propagate_qparam_if_possible(reshape_args.input, node)
@@ -97,39 +104,51 @@ class PropagateQParamForward(PassBase):
                 concat_args = CatArgs(*node.args, **node.kwargs)
                 concat_inputs = concat_args.tensors
 
+                if not concat_inputs:
+                    continue
+                if any(
+                    QPARAM_KEY not in concat_input.meta
+                    for concat_input in concat_inputs
+                ):
+                    continue
+
+                first_qparam = concat_inputs[0].meta[QPARAM_KEY]
+                if (
+                    first_qparam.scale is None
+                    or first_qparam.zero_point is None
+                    or first_qparam.quantized_dimension is not None
+                ):
+                    continue
+                identical_qparams = all(
+                    concat_input.meta[QPARAM_KEY].dtype == first_qparam.dtype
+                    and concat_input.meta[QPARAM_KEY].scale == first_qparam.scale
+                    and concat_input.meta[QPARAM_KEY].zero_point
+                    == first_qparam.zero_point
+                    and concat_input.meta[QPARAM_KEY].quantized_dimension
+                    == first_qparam.quantized_dimension
+                    for concat_input in concat_inputs[1:]
+                )
+                if identical_qparams:
+                    _propagate_qparam_if_possible(concat_inputs[0], node)
+                    continue
+
+                # Preserve the existing symmetric INT16 fallback.
                 cond = True
                 for concat_input in concat_inputs:
-                    # Check all inputs have qparam
-                    if QPARAM_KEY not in concat_input.meta:
+                    qparam = concat_input.meta[QPARAM_KEY]
+                    if qparam.dtype != "int16":
                         cond = False
                         break
-
-                    # Only support int16 for now
-                    if concat_input.meta[QPARAM_KEY].dtype != "int16":
+                    if qparam.scale is None or len(qparam.scale) != 1:
                         cond = False
                         break
-
-                    if concat_input.meta[QPARAM_KEY].scale is None:
-                        cond = False
-                        break
-
-                    if len(concat_input.meta[QPARAM_KEY].scale) != 1:
-                        cond = False
-                        break
-
                 if not cond:
                     continue
 
-                # Find max scale node
-                max_scale = 0.0
-                max_scale_node = None
-                for concat_input in concat_inputs:
-                    scale = concat_input.meta[QPARAM_KEY].scale[0]
-                    if max_scale < scale:
-                        max_scale = scale
-                        max_scale_node = concat_input
-
-                assert max_scale_node is not None
+                max_scale_node = max(
+                    concat_inputs,
+                    key=lambda concat_input: concat_input.meta[QPARAM_KEY].scale[0],
+                )
                 _propagate_qparam_if_possible(max_scale_node, node)
             elif node.target == torch.ops.aten.expand.default:
                 expand_args = ExpandArgs(*node.args, **node.kwargs)

--- a/tico/quantization/passes/quantize_bias.py
+++ b/tico/quantization/passes/quantize_bias.py
@@ -47,6 +47,8 @@ def _get_input_weight_bias_for_bias_quantization(
     if node.target in [
         torch.ops.circle_custom.conv2d,
         torch.ops.circle_custom.conv2d.padding,
+        torch.ops.circle_custom.depthwise_conv2d,
+        torch.ops.circle_custom.depthwise_conv2d.padding,
     ]:
         conv_args = Conv2DArgs(*node.args, **node.kwargs)
         if conv_args.bias is None:

--- a/tico/quantization/quant_stub.py
+++ b/tico/quantization/quant_stub.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Explicit activation boundary for TICO quantization workflows."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class QuantStub(nn.Module):
+    """Act as identity in FP32 and as a WrapQ boundary after preparation."""
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Return the input tensor unchanged in the floating-point model."""
+        return input_

--- a/tico/quantization/wrapq/utils/reduce_utils.py
+++ b/tico/quantization/wrapq/utils/reduce_utils.py
@@ -15,11 +15,18 @@
 import torch
 
 
-def channelwise_minmax(x: torch.Tensor, channel_axis: int):
-    """
-    Compute per-channel (min, max) by reducing all axes except `channel_axis`.
-    """
-    channel_axis = channel_axis % x.ndim  # handle negative indices safely
-    dims = tuple(d for d in range(x.ndim) if d != channel_axis)
+def channelwise_minmax(
+    x: torch.Tensor,
+    channel_axis: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-channel minimum and maximum values.
 
+    Every dimension except ``channel_axis`` is reduced. A rank-one tensor whose
+    channel axis is its only dimension already contains one scalar per channel,
+    so no reduction is performed in that case.
+    """
+    channel_axis = channel_axis % x.ndim
+    dims = tuple(dimension for dimension in range(x.ndim) if dimension != channel_axis)
+    if not dims:
+        return x, x
     return x.amin(dim=dims), x.amax(dim=dims)

--- a/tico/quantization/wrapq/wrap_helper.py
+++ b/tico/quantization/wrapq/wrap_helper.py
@@ -52,9 +52,7 @@ class PTQWrapHelper:
         try:
             return PTQWrapper(root, qcfg=qcfg, fp_name=fp_name)
         except NotImplementedError:
-            print(
-                f"No specialized wrapper found for {type(root).__name__}; applying recursive wrapping."
-            )
+            pass
 
         # Case A: HuggingFace-style transformers: model.model.layers
         lm = getattr(root, "model", None)

--- a/tico/quantization/wrapq/wrappers/nn/quant_conv2d.py
+++ b/tico/quantization/wrapq/wrappers/nn/quant_conv2d.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for regular and depthwise ``torch.nn.Conv2d`` modules."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+def _per_channel_weight_qscheme(qcfg: PTQConfig) -> QScheme:
+    """Return a per-channel weight qscheme with the configured symmetry."""
+    role = qcfg.get_role_kwargs("weight")
+    qscheme = role.get("qscheme")
+    if qscheme is not None:
+        return (
+            QScheme.PER_CHANNEL_SYMM
+            if qscheme.is_symmetric()
+            else QScheme.PER_CHANNEL_ASYMM
+        )
+
+    dtype = role.get("dtype")
+    if dtype is not None and dtype.signed:
+        return QScheme.PER_CHANNEL_SYMM
+    return QScheme.PER_CHANNEL_ASYMM
+
+
+@register(nn.Conv2d)
+class QuantConv2d(QuantModuleBase):
+    """Fake-quantize Conv2d input, per-output-channel weight, and output."""
+
+    def __init__(
+        self,
+        fp: nn.Conv2d,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ) -> None:
+        """Create observers around one floating-point Conv2d module."""
+        super().__init__(qcfg, fp_name=fp_name)
+        self.module = fp
+        self.obs_weight = self._make_obs(
+            "weight",
+            qscheme=_per_channel_weight_qscheme(self.qcfg),
+            channel_axis=0,
+        )
+        self.obs_act_in = self._make_obs("act_in")
+        self.obs_act_out = self._make_obs("act_out")
+
+    def enable_calibration(self) -> None:
+        """Enable activation calibration and collect the fixed weight range."""
+        super().enable_calibration()
+        self.obs_weight.collect(self.module.weight.detach())
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Execute Conv2d under the current WrapQ mode."""
+        input_q = self._fq(input_, self.obs_act_in)
+        weight = self.module.weight
+        if self._mode is Mode.QUANT:
+            weight = self.obs_weight.fake_quant(weight)
+
+        output = self.module._conv_forward(
+            input_q,
+            weight,
+            self.module.bias,
+        )
+        return self._fq(output, self.obs_act_out)
+
+    def _all_observers(self):
+        """Return observers owned directly by this wrapper."""
+        return self.obs_weight, self.obs_act_in, self.obs_act_out

--- a/tico/quantization/wrapq/wrappers/nn/quant_maxpool2d.py
+++ b/tico/quantization/wrapq/wrappers/nn/quant_maxpool2d.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for ``torch.nn.MaxPool2d`` modules."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+@register(nn.MaxPool2d)
+class QuantMaxPool2d(QuantModuleBase):
+    """Use one shared activation observer on both sides of MaxPool2d."""
+
+    def __init__(
+        self,
+        fp: nn.MaxPool2d,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ) -> None:
+        """Create one shared activation quantization domain for MaxPool2d."""
+        super().__init__(qcfg, fp_name=fp_name)
+        if fp.return_indices:
+            raise ValueError("QuantMaxPool2d does not support return_indices=True.")
+        self.module = fp
+        self.obs_act_in = self._make_obs("act_in")
+
+    @property
+    def obs_act_out(self):
+        """Return the shared output observer alias."""
+        return self.obs_act_in
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Execute MaxPool2d with identical input and output qparams."""
+        input_q = self._fq(input_, self.obs_act_in)
+        output = self.module(input_q)
+        return self._fq(output, self.obs_act_in)
+
+    def _all_observers(self):
+        """Return the single shared activation observer."""
+        return (self.obs_act_in,)

--- a/tico/quantization/wrapq/wrappers/nn/quant_prelu.py
+++ b/tico/quantization/wrapq/wrappers/nn/quant_prelu.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for ``torch.nn.PReLU`` modules."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.mode import Mode
+from tico.quantization.wrapq.qscheme import QScheme
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+def _per_channel_weight_qscheme(qcfg: PTQConfig) -> QScheme:
+    """Return a per-channel weight qscheme with the configured symmetry."""
+    role = qcfg.get_role_kwargs("weight")
+    qscheme = role.get("qscheme")
+    if qscheme is not None:
+        return (
+            QScheme.PER_CHANNEL_SYMM
+            if qscheme.is_symmetric()
+            else QScheme.PER_CHANNEL_ASYMM
+        )
+
+    dtype = role.get("dtype")
+    if dtype is not None and dtype.signed:
+        return QScheme.PER_CHANNEL_SYMM
+    return QScheme.PER_CHANNEL_ASYMM
+
+
+@register(nn.PReLU)
+class QuantPReLU(QuantModuleBase):
+    """Fake-quantize PReLU input, per-channel slope, and output tensors."""
+
+    def __init__(
+        self,
+        fp: nn.PReLU,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ) -> None:
+        """Create observers around one floating-point PReLU module."""
+        super().__init__(qcfg, fp_name=fp_name)
+        self.module = fp
+        self.obs_weight = self._make_obs(
+            "weight",
+            qscheme=_per_channel_weight_qscheme(self.qcfg),
+            channel_axis=0,
+        )
+        self.obs_act_in = self._make_obs("act_in")
+        self.obs_act_out = self._make_obs("act_out")
+
+    def enable_calibration(self) -> None:
+        """Enable activation calibration and collect every fixed slope value."""
+        super().enable_calibration()
+        self.obs_weight.collect(self.module.weight.detach())
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Execute PReLU under the current WrapQ mode."""
+        input_q = self._fq(input_, self.obs_act_in)
+        weight = self.module.weight
+        if self._mode is Mode.QUANT:
+            weight = self.obs_weight.fake_quant(weight)
+        output = F.prelu(input_q, weight)
+        return self._fq(output, self.obs_act_out)
+
+    def _all_observers(self):
+        """Return observers owned directly by this wrapper."""
+        return self.obs_weight, self.obs_act_in, self.obs_act_out

--- a/tico/quantization/wrapq/wrappers/ops/quant_concat.py
+++ b/tico/quantization/wrapq/wrappers/ops/quant_concat.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for ``tico.ops.Concat`` modules."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Optional
+
+import torch
+
+from tico.ops import Concat
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+@register(Concat)
+class QuantConcat(QuantModuleBase):
+    """Force all concatenation inputs and the output into one quantization domain."""
+
+    def __init__(
+        self,
+        fp: Concat,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ) -> None:
+        """Create one shared observer for every connected concatenation tensor."""
+        super().__init__(qcfg, fp_name=fp_name)
+        self.module = fp
+        self.obs_act_out = self._make_obs("act_out")
+
+    def forward(self, tensors: Sequence[torch.Tensor]) -> torch.Tensor:
+        """Concatenate inputs after applying one shared fake-quantization domain."""
+        values = tuple(tensors)
+        if not values:
+            raise ValueError("QuantConcat requires at least one input tensor.")
+        inputs_q = tuple(self._fq(value, self.obs_act_out) for value in values)
+        output = self.module(inputs_q)
+        return self._fq(output, self.obs_act_out)
+
+    def _all_observers(self):
+        """Return the single shared concatenation observer."""
+        return (self.obs_act_out,)

--- a/tico/quantization/wrapq/wrappers/ops/quant_resize_bilinear.py
+++ b/tico/quantization/wrapq/wrappers/ops/quant_resize_bilinear.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for ``tico.ops.ResizeBilinear2d`` modules."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from tico.ops import ResizeBilinear2d
+from tico.quantization.config.ptq import PTQConfig
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+@register(ResizeBilinear2d)
+class QuantResizeBilinear2d(QuantModuleBase):
+    """Fake-quantize both sides of one ResizeBilinear boundary."""
+
+    def __init__(
+        self,
+        fp: ResizeBilinear2d,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ) -> None:
+        """Create activation observers around one ResizeBilinear module."""
+        super().__init__(qcfg, fp_name=fp_name)
+        self.module = fp
+        self.obs_act_in = self._make_obs("act_in")
+        self.obs_act_out = self._make_obs("act_out")
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Execute ResizeBilinear under the current WrapQ mode."""
+        input_q = self._fq(input_, self.obs_act_in)
+        output = self.module(input_q)
+        return self._fq(output, self.obs_act_out)
+
+    def _all_observers(self):
+        """Return observers owned directly by this wrapper."""
+        return self.obs_act_in, self.obs_act_out

--- a/tico/quantization/wrapq/wrappers/ops/quant_same_padding_conv2d.py
+++ b/tico/quantization/wrapq/wrappers/ops/quant_same_padding_conv2d.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for ``tico.ops.SamePaddingConv2d`` modules."""
+
+from tico.ops import SamePaddingConv2d
+from tico.quantization.wrapq.wrappers.nn.quant_conv2d import QuantConv2d
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+@register(SamePaddingConv2d)
+class QuantSamePaddingConv2d(QuantConv2d):
+    """Reuse Conv2d quantization while preserving Circle SAME padding."""

--- a/tico/quantization/wrapq/wrappers/quant_stub.py
+++ b/tico/quantization/wrapq/wrappers/quant_stub.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WrapQ support for the public ``tico.quantization.QuantStub`` boundary."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from tico.quantization.config.ptq import PTQConfig
+
+from tico.quantization.quant_stub import QuantStub
+from tico.quantization.wrapq.wrappers.quant_module_base import QuantModuleBase
+from tico.quantization.wrapq.wrappers.registry import register
+
+
+@register(QuantStub)
+class QuantStubWrapper(QuantModuleBase):
+    """Fake-quantize one activation tensor at an explicit model boundary."""
+
+    def __init__(
+        self,
+        fp: QuantStub,
+        *,
+        qcfg: Optional[PTQConfig] = None,
+        fp_name: Optional[str] = None,
+    ) -> None:
+        """Create one output observer for an identity boundary."""
+        super().__init__(qcfg, fp_name=fp_name)
+        self.module = fp
+        self.obs_act_out = self._make_obs("act_out")
+
+    def forward(self, input_: torch.Tensor) -> torch.Tensor:
+        """Return the input through the current WrapQ activation mode."""
+        return self._fq(self.module(input_), self.obs_act_out)
+
+    def _all_observers(self):
+        """Return the activation observer owned by this wrapper."""
+        return (self.obs_act_out,)

--- a/tico/quantization/wrapq/wrappers/registry.py
+++ b/tico/quantization/wrapq/wrappers/registry.py
@@ -27,15 +27,22 @@ _WRAPPERS: Dict[
 _IMPORT_ONCE = False
 _CORE_MODULES = (
     "tico.quantization.wrapq.wrappers.quant_elementwise",
+    "tico.quantization.wrapq.wrappers.quant_stub",
     ## nn ##
     "tico.quantization.wrapq.wrappers.nn.quant_embedding",
     "tico.quantization.wrapq.wrappers.nn.quant_layernorm",
     "tico.quantization.wrapq.wrappers.nn.quant_linear",
+    "tico.quantization.wrapq.wrappers.nn.quant_maxpool2d",
+    "tico.quantization.wrapq.wrappers.nn.quant_conv2d",
+    "tico.quantization.wrapq.wrappers.nn.quant_prelu",
     "tico.quantization.wrapq.wrappers.nn.quant_conv3d_decomposed",
     # This includes not only `nn.SiLU` but also `SiLUActivation` from transformers
     # as they are same operation.
     "tico.quantization.wrapq.wrappers.nn.quant_silu",
     ## ops ##
+    "tico.quantization.wrapq.wrappers.ops.quant_concat",
+    "tico.quantization.wrapq.wrappers.ops.quant_resize_bilinear",
+    "tico.quantization.wrapq.wrappers.ops.quant_same_padding_conv2d",
     "tico.quantization.wrapq.wrappers.ops.quant_rmsnorm",
     ## llama ##
     "tico.quantization.wrapq.wrappers.llama.quant_attention",
@@ -142,6 +149,7 @@ def register(
     """
 
     def _decorator(quant_cls: Type[QuantModuleBase]):
+        """Register and return one quantization wrapper class."""
         existing = _WRAPPERS.get(fp_cls)
         if existing is not None and existing is not quant_cls:
             raise ValueError(
@@ -176,6 +184,7 @@ def try_register(
     """
 
     def _decorator(quant_cls: Type[QuantModuleBase]):
+        """Conditionally register and return one wrapper class."""
         for path in paths:
             module_name, _, cls_name = path.rpartition(".")
             try:


### PR DESCRIPTION
This commit adds WrapQ wrappers for Conv2d, MaxPool2d, PReLU, Concat, ResizeBilinear, SamePaddingConv2d, and QuantStub.

Related: https://github.com/Samsung/TICO/issues/841
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>