### PR TITLE
[circle] Add bounded layout-region optimization pass

### DIFF
--- a/test/unit_test/circle/passes/optimization/remove/test_transpose_bounded_layout_region.py
+++ b/test/unit_test/circle/passes/optimization/remove/test_transpose_bounded_layout_region.py
@@ -1,0 +1,726 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import struct
+import unittest
+from dataclasses import dataclass
+
+from tico.circle.document import CircleDocument
+from tico.circle.passes import (
+    CirclePassContext,
+    CirclePassManager,
+    CirclePassStrategy,
+    EliminateTransposeBoundedLayoutRegionPass,
+    RemoveRedundantLayoutOpsPass,
+)
+from tico.circle.passes.cleanup import CompactIndicesPass, DeadCodeEliminationPass
+from tico.circle.passes.optimization.remove.layout_ops import _TRANSPOSE_BUILTIN_CODE
+from tico.circle.passes.optimization.remove.transpose_bounded_layout_region import (
+    _ADD_BUILTIN_CODE,
+    _PAD_BUILTIN_CODE,
+)
+
+from test.unit_test.circle.fixture import (
+    FakeBuffer,
+    FakeModel,
+    FakeOperator,
+    FakeOperatorCode,
+    FakeSignatureDef,
+    FakeSubGraph,
+    FakeTensor,
+    FakeTensorMap,
+)
+
+
+_RELU_BUILTIN_CODE = 19
+_FLOAT32_TENSOR_TYPE = 0
+_INT32_TENSOR_TYPE = 2
+_UINT8_TENSOR_TYPE = 3
+_SOURCE_TO_REGION = (0, 3, 1, 2)
+_REGION_TO_SOURCE = (0, 2, 3, 1)
+
+
+@dataclass
+class FakeQuantization:
+    """Provide affine quantization fields used by region-pass tests."""
+
+    scale: list[float]
+    zeroPoint: list[int]
+    quantizedDimension: int = 0
+
+
+def _encoding(
+    *,
+    quantized: bool,
+    scale: float = 0.125,
+    zero_point: int = 127,
+) -> tuple[int, FakeQuantization | None]:
+    """Return a test tensor type and optional per-tensor quantization object."""
+
+    if not quantized:
+        return _FLOAT32_TENSOR_TYPE, None
+    return _UINT8_TENSOR_TYPE, FakeQuantization([scale], [zero_point])
+
+
+def _tensor(
+    name: str,
+    shape: list[int],
+    *,
+    tensor_type: int,
+    quantization: FakeQuantization | None,
+    buffer: int = 0,
+) -> FakeTensor:
+    """Create one fake data tensor with copied quantization metadata."""
+
+    return FakeTensor(
+        name,
+        shape=shape,
+        shapeSignature=list(shape),
+        type=tensor_type,
+        quantization=quantization,
+        buffer=buffer,
+    )
+
+
+def _model(
+    tensors: list[FakeTensor],
+    operators: list[FakeOperator],
+    buffers: list[FakeBuffer],
+    *,
+    inputs: list[int],
+    outputs: list[int],
+    signature_outputs: list[FakeTensorMap],
+) -> CircleDocument:
+    """Create one single-subgraph Circle document for a region test."""
+
+    subgraph = FakeSubGraph(
+        name="main",
+        tensors=tensors,
+        inputs=inputs,
+        outputs=outputs,
+        operators=operators,
+    )
+    model = FakeModel(
+        subgraphs=[subgraph],
+        buffers=buffers,
+        operatorCodes=[
+            FakeOperatorCode(builtinCode=_TRANSPOSE_BUILTIN_CODE),
+            FakeOperatorCode(builtinCode=_ADD_BUILTIN_CODE),
+            FakeOperatorCode(builtinCode=_PAD_BUILTIN_CODE),
+            FakeOperatorCode(builtinCode=_RELU_BUILTIN_CODE),
+        ],
+        signatureDefs=[
+            FakeSignatureDef(
+                signatureKey="main",
+                subgraphIndex=0,
+                inputs=[
+                    FakeTensorMap(f"input_{position}", index)
+                    for position, index in enumerate(inputs)
+                ],
+                outputs=signature_outputs,
+            )
+        ],
+    )
+    return CircleDocument(model)
+
+
+def _permutation_buffer(values: tuple[int, ...]) -> FakeBuffer:
+    """Create one inline INT32 permutation buffer."""
+
+    return FakeBuffer(data=struct.pack(f"<{len(values)}i", *values))
+
+
+def _padding_buffer(rows: tuple[tuple[int, int], ...]) -> FakeBuffer:
+    """Create one inline INT32 rank-by-two padding buffer."""
+
+    values = [value for row in rows for value in row]
+    return FakeBuffer(data=struct.pack(f"<{len(values)}i", *values))
+
+
+def _decode_i32_buffer(buffer: FakeBuffer) -> tuple[int, ...]:
+    """Decode every INT32 value from one fake inline buffer."""
+
+    data = buffer.data or b""
+    return tuple(
+        struct.unpack_from("<i", data, offset)[0] for offset in range(0, len(data), 4)
+    )
+
+
+def _builtin_codes(document: CircleDocument) -> list[int]:
+    """Return live operator builtin codes in graph order."""
+
+    return [
+        document.model.operatorCodes[operator.opcodeIndex].builtinCode
+        for operator in document.subgraph().operators
+    ]
+
+
+def _make_simple_add_document(
+    *,
+    quantized: bool = False,
+    rhs_source_shape: list[int] | None = None,
+    shared_first_transpose: bool = False,
+) -> CircleDocument:
+    """Create one Transpose-bounded binary ADD component."""
+
+    tensor_type, qparam = _encoding(quantized=quantized)
+    source_shape = [1, 4, 5, 3]
+    rhs_shape = rhs_source_shape or source_shape
+    lhs_region_shape = [source_shape[index] for index in _SOURCE_TO_REGION]
+    rhs_region_shape = [rhs_shape[index] for index in _SOURCE_TO_REGION]
+
+    tensors = [
+        _tensor(
+            "lhs_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "rhs_nhwc",
+            rhs_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("to_nchw", buffer=1, shape=[4], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "lhs_nchw",
+            lhs_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "rhs_nchw",
+            rhs_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "add_nchw",
+            lhs_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("to_nhwc", buffer=2, shape=[4], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "output_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+    ]
+    operators = [
+        FakeOperator(opcodeIndex=0, inputs=[0, 2], outputs=[3]),
+        FakeOperator(opcodeIndex=0, inputs=[1, 2], outputs=[4]),
+        FakeOperator(opcodeIndex=1, inputs=[3, 4], outputs=[5]),
+        FakeOperator(opcodeIndex=0, inputs=[5, 6], outputs=[7]),
+    ]
+    outputs = [7]
+    signature_outputs = [FakeTensorMap("output", 7)]
+
+    if shared_first_transpose:
+        tensors.append(
+            _tensor(
+                "fanout_output",
+                lhs_region_shape,
+                tensor_type=tensor_type,
+                quantization=qparam,
+            )
+        )
+        operators.append(FakeOperator(opcodeIndex=3, inputs=[3], outputs=[8]))
+        outputs.append(8)
+        signature_outputs.append(FakeTensorMap("fanout", 8))
+
+    return _model(
+        tensors,
+        operators,
+        [
+            FakeBuffer(),
+            _permutation_buffer(_SOURCE_TO_REGION),
+            _permutation_buffer(_REGION_TO_SOURCE),
+        ],
+        inputs=[0, 1],
+        outputs=outputs,
+        signature_outputs=signature_outputs,
+    )
+
+
+def _make_downsample_document(*, quantized: bool = False) -> CircleDocument:
+    """Create one PAD-plus-ADD downsample layout region."""
+
+    tensor_type, qparam = _encoding(quantized=quantized)
+    main_source_shape = [1, 4, 5, 6]
+    shortcut_source_shape = [1, 4, 5, 3]
+    main_region_shape = [main_source_shape[index] for index in _SOURCE_TO_REGION]
+    shortcut_region_shape = [
+        shortcut_source_shape[index] for index in _SOURCE_TO_REGION
+    ]
+    padding_rows = ((0, 0), (0, 3), (0, 0), (0, 0))
+
+    tensors = [
+        _tensor(
+            "main_nhwc",
+            main_source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "shortcut_nhwc",
+            shortcut_source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("to_nchw", buffer=1, shape=[4], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "main_nchw",
+            main_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "shortcut_nchw",
+            shortcut_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("paddings", buffer=2, shape=[4, 2], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "padded_nchw",
+            main_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "add_nchw",
+            main_region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("to_nhwc", buffer=3, shape=[4], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "output_nhwc",
+            main_source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+    ]
+    operators = [
+        FakeOperator(opcodeIndex=0, inputs=[0, 2], outputs=[3]),
+        FakeOperator(opcodeIndex=0, inputs=[1, 2], outputs=[4]),
+        FakeOperator(opcodeIndex=2, inputs=[4, 5], outputs=[6]),
+        FakeOperator(opcodeIndex=1, inputs=[6, 3], outputs=[7]),
+        FakeOperator(opcodeIndex=0, inputs=[7, 8], outputs=[9]),
+    ]
+    return _model(
+        tensors,
+        operators,
+        [
+            FakeBuffer(),
+            _permutation_buffer(_SOURCE_TO_REGION),
+            _padding_buffer(padding_rows),
+            _permutation_buffer(_REGION_TO_SOURCE),
+        ],
+        inputs=[0, 1],
+        outputs=[9],
+        signature_outputs=[FakeTensorMap("output", 9)],
+    )
+
+
+def _make_decoder_document(*, quantized: bool = False) -> CircleDocument:
+    """Create two connected ADD nodes with an NHWC side path between them."""
+
+    tensor_type, qparam = _encoding(quantized=quantized)
+    source_shape = [1, 4, 5, 3]
+    region_shape = [source_shape[index] for index in _SOURCE_TO_REGION]
+
+    tensors = [
+        _tensor(
+            "skip_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "upsample_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("to_nchw", buffer=1, shape=[4], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "skip_nchw",
+            region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "upsample_nchw",
+            region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "merge_nchw",
+            region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        FakeTensor("to_nhwc", buffer=2, shape=[4], type=_INT32_TENSOR_TYPE),
+        _tensor(
+            "merge_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "path_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "path_nchw",
+            region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "residual_nchw",
+            region_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+        _tensor(
+            "output_nhwc",
+            source_shape,
+            tensor_type=tensor_type,
+            quantization=qparam,
+        ),
+    ]
+    operators = [
+        FakeOperator(opcodeIndex=0, inputs=[0, 2], outputs=[3]),
+        FakeOperator(opcodeIndex=0, inputs=[1, 2], outputs=[4]),
+        FakeOperator(opcodeIndex=1, inputs=[3, 4], outputs=[5]),
+        FakeOperator(opcodeIndex=0, inputs=[5, 6], outputs=[7]),
+        FakeOperator(opcodeIndex=3, inputs=[7], outputs=[8]),
+        FakeOperator(opcodeIndex=0, inputs=[8, 2], outputs=[9]),
+        FakeOperator(opcodeIndex=1, inputs=[5, 9], outputs=[10]),
+        FakeOperator(opcodeIndex=0, inputs=[10, 6], outputs=[11]),
+    ]
+    return _model(
+        tensors,
+        operators,
+        [
+            FakeBuffer(),
+            _permutation_buffer(_SOURCE_TO_REGION),
+            _permutation_buffer(_REGION_TO_SOURCE),
+        ],
+        inputs=[0, 1],
+        outputs=[11],
+        signature_outputs=[FakeTensorMap("output", 11)],
+    )
+
+
+class EliminateTransposeBoundedLayoutRegionPassTest(unittest.TestCase):
+    """Test Circle-side conversion of Transpose-bounded ADD/PAD regions."""
+
+    def test_rewrites_simple_float_add_region(self) -> None:
+        """Rewrite one floating-point ADD and bypass three Transpose nodes."""
+
+        document = _make_simple_add_document()
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertTrue(result.modified)
+        self.assertEqual(result.changes, 3)
+        add = document.subgraph().operators[2]
+        self.assertEqual(add.inputs, [0, 1])
+        self.assertEqual(document.subgraph().outputs, [5])
+        self.assertEqual(document.subgraph().tensors[5].shape, [1, 4, 5, 3])
+        self.assertEqual(document.subgraph().tensors[5].name, "output_nhwc")
+        self.assertTrue(
+            document.subgraph().tensors[7].name.startswith("output_nhwc::dead_layout_")
+        )
+        names = [tensor.name for tensor in document.subgraph().tensors if tensor.name]
+        self.assertEqual(len(names), len(set(names)))
+        self.assertTrue(document.verify(raise_on_error=False).ok)
+
+    def test_rewrites_per_tensor_quantized_add_region(self) -> None:
+        """Rewrite one UINT8 region while preserving one activation qparam."""
+
+        document = _make_simple_add_document(quantized=True)
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertTrue(result.modified)
+        output = document.subgraph().tensors[5]
+        self.assertEqual(output.type, _UINT8_TENSOR_TYPE)
+        self.assertEqual(output.quantization.scale, [0.125])
+        self.assertEqual(output.quantization.zeroPoint, [127])
+        self.assertEqual(output.quantization.quantizedDimension, 0)
+
+    def test_allows_distinct_per_tensor_qparams_between_add_operands(self) -> None:
+        """Preserve independent branch qparams across removed Transpose nodes."""
+
+        document = _make_simple_add_document(quantized=True)
+        tensors = document.subgraph().tensors
+        lhs = FakeQuantization([0.125], [127])
+        rhs = FakeQuantization([0.25], [120])
+        output = FakeQuantization([0.5], [111])
+        tensors[0].quantization = lhs
+        tensors[3].quantization = lhs
+        tensors[1].quantization = rhs
+        tensors[4].quantization = rhs
+        tensors[5].quantization = output
+        tensors[7].quantization = output
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertTrue(result.modified)
+        self.assertEqual(document.subgraph().operators[2].inputs, [0, 1])
+        self.assertEqual(document.subgraph().tensors[5].quantization, output)
+
+    def test_rewrites_downsample_pad_add_region(self) -> None:
+        """Move channel PAD and ADD to NHWC and remap the padding constant."""
+
+        document = _make_downsample_document()
+        old_padding_payload = document.model.buffers[2].data
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertTrue(result.modified)
+        self.assertEqual(result.changes, 3)
+        subgraph = document.subgraph()
+        pad = subgraph.operators[2]
+        add = subgraph.operators[3]
+        self.assertEqual(pad.inputs[0], 1)
+        self.assertNotEqual(pad.inputs[1], 5)
+        self.assertEqual(subgraph.tensors[pad.outputs[0]].shape, [1, 4, 5, 6])
+        self.assertEqual(add.inputs, [pad.outputs[0], 0])
+        self.assertEqual(subgraph.tensors[add.outputs[0]].shape, [1, 4, 5, 6])
+        new_padding = subgraph.tensors[pad.inputs[1]]
+        self.assertEqual(
+            _decode_i32_buffer(document.model.buffers[new_padding.buffer]),
+            (0, 0, 0, 0, 0, 0, 0, 3),
+        )
+        self.assertEqual(document.model.buffers[2].data, old_padding_payload)
+        self.assertTrue(document.verify(raise_on_error=False).ok)
+
+    def test_rewrites_decoder_region_with_fanout_and_side_path(self) -> None:
+        """Rewrite two connected ADD nodes and bypass five Transpose nodes."""
+
+        document = _make_decoder_document()
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertTrue(result.modified)
+        self.assertEqual(result.changes, 5)
+        subgraph = document.subgraph()
+        first_add = subgraph.operators[2]
+        path = subgraph.operators[4]
+        second_add = subgraph.operators[6]
+        self.assertEqual(first_add.inputs, [0, 1])
+        self.assertEqual(path.inputs, [5])
+        self.assertEqual(second_add.inputs, [5, 8])
+        self.assertEqual(subgraph.tensors[5].shape, [1, 4, 5, 3])
+        self.assertEqual(subgraph.tensors[10].shape, [1, 4, 5, 3])
+        self.assertEqual(subgraph.outputs, [10])
+        self.assertTrue(document.verify(raise_on_error=False).ok)
+
+    def test_restart_pipeline_removes_all_dead_transposes(self) -> None:
+        """Run the production pipeline until a decoder graph has no Transpose."""
+
+        document = _make_decoder_document(quantized=True)
+        pipeline = CirclePassManager(
+            [
+                EliminateTransposeBoundedLayoutRegionPass(),
+                RemoveRedundantLayoutOpsPass(),
+                DeadCodeEliminationPass(),
+                CompactIndicesPass(),
+            ],
+            strategy=CirclePassStrategy.RESTART,
+        )
+        result = pipeline.run(document, CirclePassContext())
+
+        self.assertTrue(result.modified)
+        self.assertEqual(
+            _builtin_codes(document),
+            [_ADD_BUILTIN_CODE, _RELU_BUILTIN_CODE, _ADD_BUILTIN_CODE],
+        )
+        self.assertEqual(document.subgraph().outputs, [4])
+        self.assertEqual(document.subgraph().tensors[4].shape, [1, 4, 5, 3])
+        self.assertTrue(document.verify(raise_on_error=False).ok)
+
+    def test_preserves_shared_input_transpose(self) -> None:
+        """Keep an input Transpose that still feeds another live operator."""
+
+        document = _make_simple_add_document(shared_first_transpose=True)
+        context = CirclePassContext()
+        EliminateTransposeBoundedLayoutRegionPass().run(document, context)
+        DeadCodeEliminationPass().run(document, context)
+
+        self.assertEqual(
+            _builtin_codes(document),
+            [_TRANSPOSE_BUILTIN_CODE, _ADD_BUILTIN_CODE, _RELU_BUILTIN_CODE],
+        )
+        self.assertTrue(document.verify(raise_on_error=False).ok)
+
+    def test_rejects_broadcasting_add(self) -> None:
+        """Do not rewrite an ADD whose input shapes require broadcasting."""
+
+        document = _make_simple_add_document(rhs_source_shape=[1, 1, 1, 3])
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(document.subgraph().operators[2].inputs, [3, 4])
+
+    def test_rejects_mismatched_transpose_qparams(self) -> None:
+        """Do not cross a Transpose whose input and output qparams differ."""
+
+        document = _make_simple_add_document(quantized=True)
+        document.subgraph().tensors[3].quantization = FakeQuantization([0.25], [127])
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(document.subgraph().outputs, [7])
+
+    def test_rejects_per_channel_activation_qparams(self) -> None:
+        """Reject activation metadata that contains more than one scale."""
+
+        document = _make_simple_add_document(quantized=True)
+        per_channel = FakeQuantization(
+            [0.125, 0.25, 0.5],
+            [127, 127, 127],
+            quantizedDimension=3,
+        )
+        document.subgraph().tensors[0].quantization = per_channel
+        document.subgraph().tensors[3].quantization = per_channel
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(document.subgraph().outputs, [7])
+
+    def test_rejects_mismatched_boundary_shape_signature(self) -> None:
+        """Reject a Transpose boundary with inconsistent shape signatures."""
+
+        document = _make_simple_add_document()
+        document.subgraph().tensors[3].shapeSignature = [1, 3, 5, 4]
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(document.subgraph().outputs, [7])
+
+    def test_rejects_negative_padding_even_when_total_padding_matches(self) -> None:
+        """Reject PAD constants that use unsupported negative padding values."""
+
+        document = _make_downsample_document()
+        document.model.buffers[2] = _padding_buffer(((0, 0), (-1, 4), (0, 0), (0, 0)))
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(document.subgraph().operators[2].inputs, [4, 5])
+
+    def test_rejects_dead_output_transpose_boundary(self) -> None:
+        """Do not count a dead Transpose output as a visible region boundary."""
+
+        document = _make_simple_add_document()
+        document.subgraph().outputs = []
+        document.model.signatureDefs[0].outputs = []
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(document.subgraph().operators[2].inputs, [3, 4])
+
+    def test_rejects_region_tensor_exposed_as_graph_output(self) -> None:
+        """Do not change the layout of an already exposed region tensor."""
+
+        document = _make_simple_add_document()
+        subgraph = document.subgraph()
+        subgraph.outputs.append(5)
+        document.model.signatureDefs[0].outputs.append(
+            FakeTensorMap("region_output", 5)
+        )
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(subgraph.operators[2].inputs, [3, 4])
+
+    def test_rejects_unsupported_direct_region_consumer(self) -> None:
+        """Reject a region output that directly feeds a non-Transpose operator."""
+
+        document = _make_simple_add_document()
+        subgraph = document.subgraph()
+        subgraph.tensors.append(
+            _tensor(
+                "direct_consumer_output",
+                [1, 3, 4, 5],
+                tensor_type=_FLOAT32_TENSOR_TYPE,
+                quantization=None,
+            )
+        )
+        subgraph.operators.append(FakeOperator(opcodeIndex=3, inputs=[5], outputs=[8]))
+        subgraph.outputs.append(8)
+        document.model.signatureDefs[0].outputs.append(FakeTensorMap("direct", 8))
+
+        result = EliminateTransposeBoundedLayoutRegionPass().run(
+            document,
+            CirclePassContext(),
+        )
+
+        self.assertFalse(result.modified)
+        self.assertEqual(subgraph.operators[2].inputs, [3, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit_test/circle/test_cli.py
+++ b/test/unit_test/circle/test_cli.py
@@ -15,14 +15,21 @@
 import unittest
 
 from tico.circle.cli.main import _build_parser, _parse_passes
+from tico.circle.passes import (
+    CirclePassStrategy,
+    EliminateTransposeBoundedLayoutRegionPass,
+    RemoveRedundantLayoutOpsPass,
+)
 from tico.circle.passes.cleanup import CompactIndicesPass, DeadCodeEliminationPass
-from tico.circle.passes.optimization import RemoveRedundantLayoutOpsPass
 
 
 class CircleCLITest(unittest.TestCase):
-    def test_extract_accepts_tensor_patterns_without_marker_flag(self):
-        parser = _build_parser()
+    """Test Circle CLI argument parsing and pass resolution."""
 
+    def test_extract_accepts_tensor_patterns_without_marker_flag(self) -> None:
+        """Parse extraction tensor patterns without a marker-only flag."""
+
+        parser = _build_parser()
         args = parser.parse_args(
             [
                 "extract",
@@ -39,9 +46,36 @@ class CircleCLITest(unittest.TestCase):
         self.assertEqual(args.from_tensor, ["input"])
         self.assertEqual(args.to_tensor, ["output"])
 
-    def test_optimization_and_cleanup_pass_names_are_resolved(self):
-        passes = _parse_passes("remove-redundant-layout-ops,dce,compact")
+    def test_optimization_and_cleanup_pass_names_are_resolved(self) -> None:
+        """Resolve the layout optimization and cleanup pass names in order."""
 
-        self.assertIsInstance(passes[0], RemoveRedundantLayoutOpsPass)
-        self.assertIsInstance(passes[1], DeadCodeEliminationPass)
-        self.assertIsInstance(passes[2], CompactIndicesPass)
+        passes = _parse_passes(
+            "eliminate-transpose-bounded-layout-region,"
+            "remove-redundant-layout-ops,dce,compact"
+        )
+
+        self.assertIsInstance(passes[0], EliminateTransposeBoundedLayoutRegionPass)
+        self.assertIsInstance(passes[1], RemoveRedundantLayoutOpsPass)
+        self.assertIsInstance(passes[2], DeadCodeEliminationPass)
+        self.assertIsInstance(passes[3], CompactIndicesPass)
+
+    def test_optimize_accepts_restart_strategy(self) -> None:
+        """Parse the restart scheduling strategy for a Circle pass pipeline."""
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "optimize",
+                "input.circle",
+                "-o",
+                "output.circle",
+                "--strategy",
+                CirclePassStrategy.RESTART.value,
+            ]
+        )
+
+        self.assertEqual(args.strategy, CirclePassStrategy.RESTART.value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tico/circle/cli/main.py
+++ b/tico/circle/cli/main.py
@@ -33,6 +33,8 @@ from tico.circle.passes import (
     CirclePass,
     CirclePassContext,
     CirclePassManager,
+    CirclePassStrategy,
+    EliminateTransposeBoundedLayoutRegionPass,
     RemoveRedundantLayoutOpsPass,
 )
 from tico.circle.passes.cleanup import CompactIndicesPass, DeadCodeEliminationPass
@@ -41,6 +43,9 @@ from tico.circle.selector import parse_operator_spec
 LOGGER = logging.getLogger("tico.circle.cli")
 
 _PASS_REGISTRY: dict[str, type[CirclePass]] = {
+    "eliminate-transpose-bounded-layout-region": (
+        EliminateTransposeBoundedLayoutRegionPass
+    ),
     "remove-redundant-layout-ops": RemoveRedundantLayoutOpsPass,
     "dce": DeadCodeEliminationPass,
     "compact": CompactIndicesPass,
@@ -48,6 +53,8 @@ _PASS_REGISTRY: dict[str, type[CirclePass]] = {
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Create the tico-circle command-line parser."""
+
     parser = argparse.ArgumentParser(
         prog="tico-circle",
         description="Inspect and transform exported Circle model artifacts.",
@@ -78,7 +85,10 @@ def _build_parser() -> argparse.ArgumentParser:
     inspect_parser.add_argument(
         "--verify",
         action="store_true",
-        help="Check internal references and graph bookkeeping; print findings to stderr.",
+        help=(
+            "Check internal references and graph bookkeeping; "
+            "print findings to stderr."
+        ),
     )
     inspect_parser.set_defaults(handler=_inspect_command)
 
@@ -162,6 +172,15 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     optimize_parser.add_argument(
+        "--strategy",
+        choices=[strategy.value for strategy in CirclePassStrategy],
+        default=CirclePassStrategy.ONCE.value,
+        help=(
+            "Pass scheduling strategy. Use 'restart' when an earlier pass can "
+            "become applicable after a later rewrite."
+        ),
+    )
+    optimize_parser.add_argument(
         "--no-verify",
         action="store_true",
         help="Skip internal-consistency checks after passes and at completion.",
@@ -171,6 +190,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _inspect_command(args: argparse.Namespace) -> int:
+    """Inspect one Circle document."""
+
     document = CircleDocument.load(args.input)
     if args.subgraph is not None:
         document.subgraph(args.subgraph)
@@ -196,6 +217,8 @@ def _inspect_command(args: argparse.Namespace) -> int:
 
 
 def _verify_command(args: argparse.Namespace) -> int:
+    """Verify one Circle document."""
+
     document = CircleDocument.load(args.input)
     report = document.verify(raise_on_error=False)
     failed_on_warnings = args.warnings_as_errors and bool(report.warnings)
@@ -207,6 +230,8 @@ def _verify_command(args: argparse.Namespace) -> int:
 
 
 def _extract_command(args: argparse.Namespace) -> int:
+    """Extract one operator region from a Circle document."""
+
     document = CircleDocument.load(args.input)
     policy = (
         SignaturePolicy.PRESERVE_COMPATIBLE
@@ -251,6 +276,8 @@ def _extract_command(args: argparse.Namespace) -> int:
 
 
 def _parse_passes(value: str) -> list[CirclePass]:
+    """Create Circle pass instances from a comma-separated CLI value."""
+
     passes: list[CirclePass] = []
     for raw_name in value.split(","):
         name = raw_name.strip().lower()
@@ -269,10 +296,15 @@ def _parse_passes(value: str) -> list[CirclePass]:
 
 
 def _optimize_command(args: argparse.Namespace) -> int:
+    """Run a configured Circle pass pipeline and save its output."""
+
     document = CircleDocument.load(args.input)
     passes = _parse_passes(args.passes)
     context = CirclePassContext(verify_after_each_pass=not args.no_verify)
-    result = CirclePassManager(passes).run(document, context)
+    result = CirclePassManager(
+        passes,
+        strategy=CirclePassStrategy(args.strategy),
+    ).run(document, context)
     if not args.no_verify:
         document.verify(raise_on_error=True)
     document.save(args.output)

--- a/tico/circle/passes/__init__.py
+++ b/tico/circle/passes/__init__.py
@@ -19,7 +19,10 @@ from tico.circle.passes.manager import (
     CirclePassManagerResult,
     CirclePassStrategy,
 )
-from tico.circle.passes.optimization import RemoveRedundantLayoutOpsPass
+from tico.circle.passes.optimization import (
+    EliminateTransposeBoundedLayoutRegionPass,
+    RemoveRedundantLayoutOpsPass,
+)
 
 __all__ = [
     "CirclePass",
@@ -29,5 +32,6 @@ __all__ = [
     "CirclePassManagerResult",
     "CirclePassResult",
     "CirclePassStrategy",
+    "EliminateTransposeBoundedLayoutRegionPass",
     "RemoveRedundantLayoutOpsPass",
 ]

--- a/tico/circle/passes/optimization/__init__.py
+++ b/tico/circle/passes/optimization/__init__.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tico.circle.passes.optimization.remove.layout_ops import (
+from tico.circle.passes.optimization.remove import (
+    EliminateTransposeBoundedLayoutRegionPass,
     RemoveRedundantLayoutOpsPass,
 )
 
 __all__ = [
+    "EliminateTransposeBoundedLayoutRegionPass",
     "RemoveRedundantLayoutOpsPass",
 ]

--- a/tico/circle/passes/optimization/remove/__init__.py
+++ b/tico/circle/passes/optimization/remove/__init__.py
@@ -15,7 +15,11 @@
 from tico.circle.passes.optimization.remove.layout_ops import (
     RemoveRedundantLayoutOpsPass,
 )
+from tico.circle.passes.optimization.remove.transpose_bounded_layout_region import (
+    EliminateTransposeBoundedLayoutRegionPass,
+)
 
 __all__ = [
+    "EliminateTransposeBoundedLayoutRegionPass",
     "RemoveRedundantLayoutOpsPass",
 ]

--- a/tico/circle/passes/optimization/remove/transpose_bounded_layout_region.py
+++ b/tico/circle/passes/optimization/remove/transpose_bounded_layout_region.py
@@ -1,0 +1,984 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import struct
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from tico.circle.document import CircleDocument
+from tico.circle.graph import as_indices, as_list
+from tico.circle.passes.base import CirclePass, CirclePassContext, CirclePassResult
+from tico.circle.passes.optimization.remove.layout_ops import (
+    _builtin_operator_value,
+    _check_perm,
+    _get_const_data,
+    _is_transpose_op,
+)
+from tico.circle.rewrite import replace_tensor_uses
+
+
+_ADD_BUILTIN_CODE = _builtin_operator_value("ADD")
+_PAD_BUILTIN_CODE = _builtin_operator_value("PAD")
+
+
+@dataclass(frozen=True)
+class _PerTensorEncoding:
+    """Describe a tensor type and its optional per-tensor affine qparam."""
+
+    tensor_type: int
+    scale: float | None
+    zero_point: int | None
+
+
+@dataclass(frozen=True)
+class _InputBoundary:
+    """Describe one source-layout tensor entering a region through Transpose."""
+
+    region_operator_index: int
+    region_input_position: int
+    transpose_index: int
+    transpose_output_index: int
+    source_tensor_index: int
+    permutation: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _OutputBoundary:
+    """Describe one region-layout tensor leaving through inverse Transpose."""
+
+    region_tensor_index: int
+    transpose_index: int
+    transpose_output_index: int
+    permutation: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _PadRewrite:
+    """Describe one PAD constant that must be reordered for source layout."""
+
+    operator_index: int
+    constant_input_position: int
+    padding_tensor_index: int
+    remapped_values: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _RegionPlan:
+    """Describe one validated Transpose-bounded layout region rewrite."""
+
+    operator_indices: tuple[int, ...]
+    source_to_region_permutation: tuple[int, ...]
+    region_to_source_permutation: tuple[int, ...]
+    input_boundaries: tuple[_InputBoundary, ...]
+    output_boundaries: tuple[_OutputBoundary, ...]
+    pad_rewrites: tuple[_PadRewrite, ...]
+
+    @property
+    def bypassed_transpose_indices(self) -> tuple[int, ...]:
+        """Return unique boundary Transpose indices in graph order."""
+
+        indices = {boundary.transpose_index for boundary in self.input_boundaries}
+        indices.update(boundary.transpose_index for boundary in self.output_boundaries)
+        return tuple(sorted(indices))
+
+
+@dataclass(frozen=True)
+class _TransposeInfo:
+    """Describe one well-formed single-output Transpose operator."""
+
+    operator_index: int
+    source_tensor_index: int
+    permutation_tensor_index: int
+    output_tensor_index: int
+    permutation: tuple[int, ...]
+
+
+def _vector(value: Any) -> tuple[Any, ...]:
+    """Convert one generated vector field to an immutable Python tuple."""
+
+    if value is None:
+        return ()
+    return tuple(value)
+
+
+def _operator_builtin_code(
+    operator: Any,
+    operator_codes: list[Any],
+) -> int | None:
+    """Return one operator's Circle builtin code when its index is valid."""
+
+    try:
+        opcode_index = int(getattr(operator, "opcodeIndex", -1))
+        if opcode_index < 0 or opcode_index >= len(operator_codes):
+            return None
+        return int(getattr(operator_codes[opcode_index], "builtinCode", -1))
+    except (TypeError, ValueError, AttributeError):
+        return None
+
+
+def _is_add_op(operator: Any, operator_codes: list[Any]) -> bool:
+    """Return whether an operator references the Circle ADD builtin."""
+
+    return _operator_builtin_code(operator, operator_codes) == _ADD_BUILTIN_CODE
+
+
+def _is_pad_op(operator: Any, operator_codes: list[Any]) -> bool:
+    """Return whether an operator references the Circle PAD builtin."""
+
+    return _operator_builtin_code(operator, operator_codes) == _PAD_BUILTIN_CODE
+
+
+def _is_supported_region_op(
+    operator: Any,
+    operator_codes: list[Any],
+) -> bool:
+    """Return whether an operator can execute unchanged in either layout."""
+
+    return _is_add_op(operator, operator_codes) or _is_pad_op(
+        operator,
+        operator_codes,
+    )
+
+
+def _data_input_positions(
+    operator: Any,
+    operator_codes: list[Any],
+) -> tuple[int, ...]:
+    """Return input positions whose tensor layout follows the operator data."""
+
+    if _is_add_op(operator, operator_codes):
+        return (0, 1)
+    if _is_pad_op(operator, operator_codes):
+        return (0,)
+    return ()
+
+
+def _data_output_positions(
+    operator: Any,
+    operator_codes: list[Any],
+) -> tuple[int, ...]:
+    """Return output positions whose tensor layout follows the operator data."""
+
+    if _is_supported_region_op(operator, operator_codes):
+        return (0,)
+    return ()
+
+
+def _operator_consumes_data_tensor(
+    operator: Any,
+    operator_codes: list[Any],
+    tensor_index: int,
+) -> bool:
+    """Return whether an operator consumes a tensor through a data input."""
+
+    inputs = as_indices(getattr(operator, "inputs", None))
+    return any(
+        position < len(inputs) and inputs[position] == tensor_index
+        for position in _data_input_positions(operator, operator_codes)
+    )
+
+
+def _shape(tensor: Any) -> tuple[int, ...]:
+    """Return one tensor shape as a tuple of integers."""
+
+    return tuple(int(value) for value in _vector(getattr(tensor, "shape", None)))
+
+
+def _shape_signature(tensor: Any) -> tuple[int, ...]:
+    """Return one optional tensor shape signature as an integer tuple."""
+
+    return tuple(
+        int(value) for value in _vector(getattr(tensor, "shapeSignature", None))
+    )
+
+
+def _is_valid_permutation(permutation: Iterable[int]) -> bool:
+    """Return whether values form a complete rank-preserving permutation."""
+
+    values = tuple(int(value) for value in permutation)
+    return bool(values) and sorted(values) == list(range(len(values)))
+
+
+def _inverse_permutation(permutation: Iterable[int]) -> tuple[int, ...] | None:
+    """Return the inverse permutation, or None when the input is invalid."""
+
+    values = tuple(int(value) for value in permutation)
+    if not _is_valid_permutation(values):
+        return None
+    inverse = [0] * len(values)
+    for output_axis, input_axis in enumerate(values):
+        inverse[input_axis] = output_axis
+    return tuple(inverse)
+
+
+def _permuted_shape(
+    shape: tuple[int, ...],
+    permutation: Iterable[int],
+) -> tuple[int, ...] | None:
+    """Return a permuted shape, or None for an invalid rank or permutation."""
+
+    values = tuple(int(value) for value in permutation)
+    if len(shape) != len(values) or not _is_valid_permutation(values):
+        return None
+    return tuple(shape[index] for index in values)
+
+
+def _per_tensor_encoding(tensor: Any) -> _PerTensorEncoding | None:
+    """Return one tensor encoding, or None for per-channel activation qparams."""
+
+    tensor_type = int(getattr(tensor, "type", 0))
+    quantization = getattr(tensor, "quantization", None)
+    if quantization is None:
+        return _PerTensorEncoding(tensor_type, None, None)
+
+    scales = tuple(
+        float(value) for value in _vector(getattr(quantization, "scale", None))
+    )
+    zero_points = tuple(
+        int(value) for value in _vector(getattr(quantization, "zeroPoint", None))
+    )
+    if not scales and not zero_points:
+        return _PerTensorEncoding(tensor_type, None, None)
+    if len(scales) != 1 or len(zero_points) != 1:
+        return None
+    quantized_dimension = int(getattr(quantization, "quantizedDimension", 0) or 0)
+    if quantized_dimension != 0:
+        return None
+    return _PerTensorEncoding(tensor_type, scales[0], zero_points[0])
+
+
+def _same_tensor_encoding(first: Any, second: Any) -> bool:
+    """Return whether two tensors use the same type and per-tensor qparam."""
+
+    first_encoding = _per_tensor_encoding(first)
+    second_encoding = _per_tensor_encoding(second)
+    return (
+        first_encoding is not None
+        and second_encoding is not None
+        and first_encoding == second_encoding
+    )
+
+
+def _same_runtime_buffer(first: Any, second: Any) -> bool:
+    """Return whether two runtime tensors reference the same Circle buffer."""
+
+    return int(getattr(first, "buffer", 0) or 0) == int(
+        getattr(second, "buffer", 0) or 0
+    )
+
+
+def _copy_tensor_contract(target: Any, source: Any) -> None:
+    """Copy externally visible tensor metadata without changing its buffer."""
+
+    fields = (
+        "name",
+        "shape",
+        "shapeSignature",
+        "type",
+        "quantization",
+        "isVariable",
+        "sparsity",
+        "hasRank",
+        "variantTensors",
+    )
+    for field_name in fields:
+        if hasattr(source, field_name):
+            setattr(target, field_name, copy.deepcopy(getattr(source, field_name)))
+
+
+def _append_name_suffix(value: Any, suffix: str) -> Any:
+    """Append a stable suffix while preserving bytes or string storage."""
+
+    if isinstance(value, bytes):
+        return value + suffix.encode("utf-8")
+    return f"{value or ''}{suffix}"
+
+
+def _rename_dead_tensor(tensor: Any, suffix: str) -> None:
+    """Rename one bypassed tensor before dead-code compaction."""
+
+    if hasattr(tensor, "name"):
+        tensor.name = _append_name_suffix(getattr(tensor, "name", ""), suffix)
+
+
+def _shape_signature_matches_permutation(
+    source: Any,
+    transposed: Any,
+    permutation: tuple[int, ...],
+) -> bool:
+    """Return whether optional shape signatures follow one permutation."""
+
+    source_signature = _shape_signature(source)
+    transposed_signature = _shape_signature(transposed)
+    if not source_signature and not transposed_signature:
+        return True
+    if not source_signature or not transposed_signature:
+        return False
+    return _permuted_shape(source_signature, permutation) == transposed_signature
+
+
+def _tensor_has_visible_use(
+    document: CircleDocument,
+    graph: Any,
+    tensor_index: int,
+) -> bool:
+    """Return whether a tensor has a consumer or an exported graph use."""
+
+    return bool(
+        graph.consumers(tensor_index)
+        or tensor_index in graph.outputs
+        or _is_signature_output(
+            document,
+            graph.subgraph_index,
+            tensor_index,
+        )
+    )
+
+
+def _set_tensor_layout(
+    tensor: Any,
+    permutation: tuple[int, ...],
+) -> bool:
+    """Permute one tensor's shape and optional shape signature in place."""
+
+    new_shape = _permuted_shape(_shape(tensor), permutation)
+    if new_shape is None:
+        return False
+    signature = _shape_signature(tensor)
+    new_signature = _permuted_shape(signature, permutation) if signature else ()
+    if signature and new_signature is None:
+        return False
+
+    tensor.shape = list(new_shape)
+    if signature:
+        tensor.shapeSignature = list(new_signature)
+    return True
+
+
+def _is_signature_output(
+    document: CircleDocument,
+    subgraph_index: int,
+    tensor_index: int,
+) -> bool:
+    """Return whether a tensor is exposed by a signature output mapping."""
+
+    return any(
+        int(getattr(tensor_map, "tensorIndex", -1)) == tensor_index
+        for signature in as_list(getattr(document.model, "signatureDefs", None))
+        if int(getattr(signature, "subgraphIndex", -1)) == subgraph_index
+        for tensor_map in as_list(getattr(signature, "outputs", None))
+    )
+
+
+def _transpose_info(
+    graph: Any,
+    operator_index: int,
+    operator_codes: list[Any],
+) -> _TransposeInfo | None:
+    """Return decoded information for one well-formed Transpose operator."""
+
+    operators = as_list(graph.subgraph.operators)
+    if operator_index < 0 or operator_index >= len(operators):
+        return None
+    operator = operators[operator_index]
+    if not _is_transpose_op(operator, operator_codes):
+        return None
+
+    inputs = as_indices(getattr(operator, "inputs", None))
+    outputs = as_indices(getattr(operator, "outputs", None))
+    if len(inputs) < 2 or len(outputs) != 1:
+        return None
+    permutation = _get_const_data(graph, inputs[1])
+    if permutation is None or not _is_valid_permutation(permutation):
+        return None
+    return _TransposeInfo(
+        operator_index=operator_index,
+        source_tensor_index=inputs[0],
+        permutation_tensor_index=inputs[1],
+        output_tensor_index=outputs[0],
+        permutation=tuple(int(value) for value in permutation),
+    )
+
+
+def _supported_components(
+    graph: Any,
+    operator_codes: list[Any],
+) -> tuple[tuple[int, ...], ...]:
+    """Return dataflow-connected components of supported region operators."""
+
+    operators = as_list(graph.subgraph.operators)
+    supported = {
+        index
+        for index, operator in enumerate(operators)
+        if _is_supported_region_op(operator, operator_codes)
+    }
+    pending = set(supported)
+    components: list[tuple[int, ...]] = []
+
+    while pending:
+        seed = min(pending)
+        queue: deque[int] = deque([seed])
+        component: set[int] = set()
+        while queue:
+            operator_index = queue.popleft()
+            if operator_index in component:
+                continue
+            component.add(operator_index)
+            operator = operators[operator_index]
+
+            inputs = as_indices(getattr(operator, "inputs", None))
+            for position in _data_input_positions(operator, operator_codes):
+                if position >= len(inputs):
+                    continue
+                producer = graph.producer(inputs[position])
+                if producer in supported and producer not in component:
+                    queue.append(producer)
+
+            outputs = as_indices(getattr(operator, "outputs", None))
+            for position in _data_output_positions(operator, operator_codes):
+                if position >= len(outputs):
+                    continue
+                tensor_index = outputs[position]
+                for consumer in graph.consumers(tensor_index):
+                    if consumer not in supported or consumer in component:
+                        continue
+                    if _operator_consumes_data_tensor(
+                        operators[consumer],
+                        operator_codes,
+                        tensor_index,
+                    ):
+                        queue.append(consumer)
+
+        pending.difference_update(component)
+        components.append(tuple(sorted(component)))
+
+    return tuple(sorted(components, key=lambda values: values[0]))
+
+
+def _flatten_padding_rows(rows: Iterable[Iterable[int]]) -> tuple[int, ...]:
+    """Flatten rank-by-two padding rows into one integer tuple."""
+
+    return tuple(int(value) for row in rows for value in row)
+
+
+def _remap_padding_values(
+    values: tuple[int, ...],
+    rank: int,
+    source_to_region: tuple[int, ...],
+) -> tuple[int, ...] | None:
+    """Reorder region-layout padding rows into source-layout axis order."""
+
+    if len(values) != rank * 2 or len(source_to_region) != rank:
+        return None
+    old_rows = [values[axis * 2 : axis * 2 + 2] for axis in range(rank)]
+    new_rows: list[tuple[int, int] | None] = [None] * rank
+    for region_axis, source_axis in enumerate(source_to_region):
+        before, after = old_rows[region_axis]
+        new_rows[source_axis] = (before, after)
+    if any(row is None for row in new_rows):
+        return None
+    return _flatten_padding_rows(row for row in new_rows if row is not None)
+
+
+def _padding_matches_shape(
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    values: tuple[int, ...],
+) -> bool:
+    """Return whether constant padding transforms one shape into the other."""
+
+    if len(input_shape) != len(output_shape) or len(values) != len(input_shape) * 2:
+        return False
+    for axis, input_size in enumerate(input_shape):
+        before = values[axis * 2]
+        after = values[axis * 2 + 1]
+        if before < 0 or after < 0:
+            return False
+        if input_size + before + after != output_shape[axis]:
+            return False
+    return True
+
+
+def _encode_i32_payload_like(original: Any, values: tuple[int, ...]) -> Any:
+    """Encode INT32 values while preserving a buffer's common container type."""
+
+    payload = struct.pack(f"<{len(values)}i", *values)
+    if isinstance(original, bytes) or original is None:
+        return payload
+    if isinstance(original, bytearray):
+        return bytearray(payload)
+    if isinstance(original, list):
+        return list(payload)
+    if isinstance(original, tuple):
+        return tuple(payload)
+
+    try:
+        import numpy as np
+
+        if isinstance(original, np.ndarray):
+            return np.frombuffer(payload, dtype=np.uint8).copy()
+    except ImportError:
+        pass
+    return payload
+
+
+def _clone_padding_constant(
+    graph: Any,
+    tensor_index: int,
+    values: tuple[int, ...],
+) -> int:
+    """Clone one inline INT32 padding constant with replacement values."""
+
+    tensors = as_list(graph.subgraph.tensors)
+    if tensor_index < 0 or tensor_index >= len(tensors):
+        raise IndexError(f"Padding tensor index {tensor_index} is out of range.")
+    source_tensor = tensors[tensor_index]
+    buffer_index = int(getattr(source_tensor, "buffer", 0) or 0)
+    buffers = as_list(graph.model.buffers)
+    if buffer_index <= 0 or buffer_index >= len(buffers):
+        raise ValueError(f"Padding tensor {tensor_index} has no inline buffer.")
+
+    source_buffer = buffers[buffer_index]
+    source_data = getattr(source_buffer, "data", None)
+    if source_data is None or len(source_data) == 0:
+        raise ValueError(f"Padding tensor {tensor_index} has no inline data.")
+
+    new_buffer = copy.deepcopy(source_buffer)
+    new_buffer.data = _encode_i32_payload_like(source_data, values)
+    if hasattr(new_buffer, "offset"):
+        new_buffer.offset = 0
+    if hasattr(new_buffer, "size"):
+        new_buffer.size = 0
+    new_buffer_index = len(buffers)
+    graph.model.buffers = [*buffers, new_buffer]
+
+    new_tensor = copy.deepcopy(source_tensor)
+    new_tensor.buffer = new_buffer_index
+    new_tensor_index = len(tensors)
+    suffix = f"::layout_remapped_{new_tensor_index}"
+    name = getattr(source_tensor, "name", "")
+    if isinstance(name, bytes):
+        new_tensor.name = name + suffix.encode("utf-8")
+    else:
+        new_tensor.name = f"{name}{suffix}"
+    graph.subgraph.tensors = [*tensors, new_tensor]
+    return new_tensor_index
+
+
+def _region_data_tensor_indices(
+    graph: Any,
+    component: tuple[int, ...],
+    operator_codes: list[Any],
+) -> tuple[int, ...]:
+    """Return unique data tensor indices referenced by one region component."""
+
+    operators = as_list(graph.subgraph.operators)
+    result: list[int] = []
+    seen: set[int] = set()
+    for operator_index in component:
+        operator = operators[operator_index]
+        inputs = as_indices(getattr(operator, "inputs", None))
+        for position in _data_input_positions(operator, operator_codes):
+            if position < len(inputs) and inputs[position] not in seen:
+                seen.add(inputs[position])
+                result.append(inputs[position])
+        outputs = as_indices(getattr(operator, "outputs", None))
+        for position in _data_output_positions(operator, operator_codes):
+            if position < len(outputs) and outputs[position] not in seen:
+                seen.add(outputs[position])
+                result.append(outputs[position])
+    return tuple(result)
+
+
+def _build_region_plan(
+    document: CircleDocument,
+    graph: Any,
+    component: tuple[int, ...],
+    operator_codes: list[Any],
+) -> _RegionPlan | None:
+    """Validate one supported component and return its complete rewrite plan."""
+
+    operators = as_list(graph.subgraph.operators)
+    tensors = as_list(graph.subgraph.tensors)
+    component_set = set(component)
+    input_boundaries: list[_InputBoundary] = []
+    output_boundaries: list[_OutputBoundary] = []
+
+    for operator_index in component:
+        operator = operators[operator_index]
+        inputs = as_indices(getattr(operator, "inputs", None))
+        outputs = as_indices(getattr(operator, "outputs", None))
+        data_inputs = _data_input_positions(operator, operator_codes)
+        data_outputs = _data_output_positions(operator, operator_codes)
+        if not data_inputs or not data_outputs:
+            return None
+        if any(position >= len(inputs) for position in data_inputs):
+            return None
+        if any(position >= len(outputs) for position in data_outputs):
+            return None
+
+        for position in data_inputs:
+            tensor_index = inputs[position]
+            producer = graph.producer(tensor_index)
+            if producer in component_set:
+                continue
+            if producer is None:
+                return None
+            transpose = _transpose_info(graph, producer, operator_codes)
+            if transpose is None or transpose.output_tensor_index != tensor_index:
+                return None
+            input_boundaries.append(
+                _InputBoundary(
+                    region_operator_index=operator_index,
+                    region_input_position=position,
+                    transpose_index=producer,
+                    transpose_output_index=tensor_index,
+                    source_tensor_index=transpose.source_tensor_index,
+                    permutation=transpose.permutation,
+                )
+            )
+
+        for position in data_outputs:
+            tensor_index = outputs[position]
+            if tensor_index in graph.outputs or _is_signature_output(
+                document,
+                graph.subgraph_index,
+                tensor_index,
+            ):
+                return None
+            for consumer in graph.consumers(tensor_index):
+                if consumer in component_set:
+                    if not _operator_consumes_data_tensor(
+                        operators[consumer],
+                        operator_codes,
+                        tensor_index,
+                    ):
+                        return None
+                    continue
+                transpose = _transpose_info(graph, consumer, operator_codes)
+                if transpose is None or transpose.source_tensor_index != tensor_index:
+                    return None
+                output_boundaries.append(
+                    _OutputBoundary(
+                        region_tensor_index=tensor_index,
+                        transpose_index=consumer,
+                        transpose_output_index=transpose.output_tensor_index,
+                        permutation=transpose.permutation,
+                    )
+                )
+
+    if not input_boundaries or not output_boundaries:
+        return None
+
+    source_to_region = input_boundaries[0].permutation
+    if any(boundary.permutation != source_to_region for boundary in input_boundaries):
+        return None
+    region_to_source = output_boundaries[0].permutation
+    if any(boundary.permutation != region_to_source for boundary in output_boundaries):
+        return None
+    if not _check_perm(list(source_to_region), list(region_to_source)):
+        return None
+    if _inverse_permutation(source_to_region) != region_to_source:
+        return None
+
+    rank = len(source_to_region)
+    boundary_tensor_indices = {
+        boundary.source_tensor_index for boundary in input_boundaries
+    }
+    boundary_tensor_indices.update(
+        boundary.transpose_output_index for boundary in input_boundaries
+    )
+    boundary_tensor_indices.update(
+        boundary.region_tensor_index for boundary in output_boundaries
+    )
+    boundary_tensor_indices.update(
+        boundary.transpose_output_index for boundary in output_boundaries
+    )
+    if any(index < 0 or index >= len(tensors) for index in boundary_tensor_indices):
+        return None
+
+    for boundary in input_boundaries:
+        source = tensors[boundary.source_tensor_index]
+        transposed = tensors[boundary.transpose_output_index]
+        if _permuted_shape(_shape(source), source_to_region) != _shape(transposed):
+            return None
+        if not _shape_signature_matches_permutation(
+            source,
+            transposed,
+            source_to_region,
+        ):
+            return None
+        if not _same_tensor_encoding(source, transposed):
+            return None
+        if not _same_runtime_buffer(source, transposed):
+            return None
+
+    output_contracts: dict[int, tuple[Any, ...]] = {}
+    for boundary in output_boundaries:
+        region_tensor = tensors[boundary.region_tensor_index]
+        final_tensor = tensors[boundary.transpose_output_index]
+        if _permuted_shape(_shape(region_tensor), region_to_source) != _shape(
+            final_tensor
+        ):
+            return None
+        if not _shape_signature_matches_permutation(
+            region_tensor,
+            final_tensor,
+            region_to_source,
+        ):
+            return None
+        if not _same_tensor_encoding(region_tensor, final_tensor):
+            return None
+        if not _same_runtime_buffer(region_tensor, final_tensor):
+            return None
+        if not _tensor_has_visible_use(
+            document,
+            graph,
+            boundary.transpose_output_index,
+        ):
+            return None
+        contract = (
+            getattr(final_tensor, "name", ""),
+            _shape(final_tensor),
+            _shape_signature(final_tensor),
+            _per_tensor_encoding(final_tensor),
+            int(getattr(final_tensor, "buffer", 0) or 0),
+        )
+        previous = output_contracts.setdefault(
+            boundary.region_tensor_index,
+            contract,
+        )
+        if previous != contract:
+            return None
+
+    data_tensor_indices = _region_data_tensor_indices(
+        graph,
+        component,
+        operator_codes,
+    )
+    for tensor_index in data_tensor_indices:
+        if tensor_index < 0 or tensor_index >= len(tensors):
+            return None
+        tensor = tensors[tensor_index]
+        if len(_shape(tensor)) != rank:
+            return None
+        signature = _shape_signature(tensor)
+        if signature and len(signature) != rank:
+            return None
+        if _per_tensor_encoding(tensor) is None:
+            return None
+
+    pad_rewrites: list[_PadRewrite] = []
+    for operator_index in component:
+        operator = operators[operator_index]
+        inputs = as_indices(getattr(operator, "inputs", None))
+        outputs = as_indices(getattr(operator, "outputs", None))
+        if _is_add_op(operator, operator_codes):
+            if len(inputs) != 2 or len(outputs) != 1:
+                return None
+            input_shapes = [_shape(tensors[index]) for index in inputs]
+            output_shape = _shape(tensors[outputs[0]])
+            if input_shapes[0] != input_shapes[1] or input_shapes[0] != output_shape:
+                return None
+            continue
+
+        if not _is_pad_op(operator, operator_codes):
+            return None
+        if len(inputs) != 2 or len(outputs) != 1:
+            return None
+        padding_tensor_index = inputs[1]
+        if padding_tensor_index < 0 or padding_tensor_index >= len(tensors):
+            return None
+        padding_shape = _shape(tensors[padding_tensor_index])
+        if padding_shape != (rank, 2):
+            return None
+        raw_values = _get_const_data(graph, padding_tensor_index)
+        if raw_values is None:
+            return None
+        values = tuple(int(value) for value in raw_values)
+        input_shape = _shape(tensors[inputs[0]])
+        output_shape = _shape(tensors[outputs[0]])
+        if not _padding_matches_shape(input_shape, output_shape, values):
+            return None
+        remapped_values = _remap_padding_values(
+            values,
+            rank,
+            source_to_region,
+        )
+        if remapped_values is None:
+            return None
+        source_input_shape = _permuted_shape(input_shape, region_to_source)
+        source_output_shape = _permuted_shape(output_shape, region_to_source)
+        if source_input_shape is None or source_output_shape is None:
+            return None
+        if not _padding_matches_shape(
+            source_input_shape,
+            source_output_shape,
+            remapped_values,
+        ):
+            return None
+        pad_rewrites.append(
+            _PadRewrite(
+                operator_index=operator_index,
+                constant_input_position=1,
+                padding_tensor_index=padding_tensor_index,
+                remapped_values=remapped_values,
+            )
+        )
+
+    return _RegionPlan(
+        operator_indices=component,
+        source_to_region_permutation=source_to_region,
+        region_to_source_permutation=region_to_source,
+        input_boundaries=tuple(input_boundaries),
+        output_boundaries=tuple(output_boundaries),
+        pad_rewrites=tuple(pad_rewrites),
+    )
+
+
+def _apply_region_plan(
+    document: CircleDocument,
+    graph: Any,
+    plan: _RegionPlan,
+) -> None:
+    """Apply one validated region rewrite without deleting dead operators."""
+
+    operators = as_list(graph.subgraph.operators)
+
+    for rewrite in plan.pad_rewrites:
+        new_tensor_index = _clone_padding_constant(
+            graph,
+            rewrite.padding_tensor_index,
+            rewrite.remapped_values,
+        )
+        operator = operators[rewrite.operator_index]
+        inputs = as_indices(getattr(operator, "inputs", None))
+        inputs[rewrite.constant_input_position] = new_tensor_index
+        operator.inputs = inputs
+
+    for boundary in plan.input_boundaries:
+        operator = operators[boundary.region_operator_index]
+        inputs = as_indices(getattr(operator, "inputs", None))
+        inputs[boundary.region_input_position] = boundary.source_tensor_index
+        operator.inputs = inputs
+
+    tensors = as_list(graph.subgraph.tensors)
+    output_boundaries: dict[int, list[_OutputBoundary]] = {}
+    for boundary in plan.output_boundaries:
+        output_boundaries.setdefault(boundary.region_tensor_index, []).append(boundary)
+
+    for operator_index in plan.operator_indices:
+        operator = operators[operator_index]
+        outputs = as_indices(getattr(operator, "outputs", None))
+        for output_position in _data_output_positions(
+            operator,
+            as_list(document.model.operatorCodes),
+        ):
+            tensor_index = outputs[output_position]
+            boundaries = output_boundaries.get(tensor_index, [])
+            if boundaries:
+                source = tensors[boundaries[0].transpose_output_index]
+                _copy_tensor_contract(tensors[tensor_index], source)
+            elif not _set_tensor_layout(
+                tensors[tensor_index],
+                plan.region_to_source_permutation,
+            ):
+                raise RuntimeError(
+                    f"Failed to update tensor {tensor_index} to source layout."
+                )
+
+    for boundary in plan.output_boundaries:
+        final_tensor = tensors[boundary.transpose_output_index]
+        _rename_dead_tensor(
+            final_tensor,
+            f"::dead_layout_{boundary.transpose_index}",
+        )
+        replacement = replace_tensor_uses(
+            document.model,
+            subgraph_index=graph.subgraph_index,
+            old_tensor_index=boundary.transpose_output_index,
+            new_tensor_index=boundary.region_tensor_index,
+        )
+        if not replacement.modified:
+            raise RuntimeError(
+                "Layout-region elimination expected a visible Transpose output use."
+            )
+
+
+class EliminateTransposeBoundedLayoutRegionPass(CirclePass):
+    """Rewrite Transpose-bounded ADD/PAD regions into their source layout.
+
+    The pass finds dataflow-connected components composed only of binary ADD and
+    constant PAD operators. Every external data input must enter through the same
+    Transpose permutation, and every external data output must leave through its
+    inverse. The complete component is then executed directly in the source
+    layout, PAD axis constants are remapped, and the boundary Transpose outputs
+    are bypassed. Dead-code elimination removes the now-unused Transpose nodes.
+
+    Float tensors and per-tensor quantized activation tensors are supported.
+    Per-channel activation qparams are rejected because the target backend only
+    supports per-tensor activation quantization and this pass does not remap a
+    quantized axis.
+    """
+
+    def run(
+        self,
+        document: CircleDocument,
+        context: CirclePassContext,
+    ) -> CirclePassResult:
+        """Rewrite every supported bounded layout region in every subgraph."""
+
+        changes = 0
+        diagnostics: list[str] = []
+        for subgraph_index in range(document.subgraph_count):
+            while True:
+                graph = document.graph(subgraph_index)
+                operator_codes = as_list(document.model.operatorCodes)
+                rewritten = False
+                for component in _supported_components(graph, operator_codes):
+                    plan = _build_region_plan(
+                        document,
+                        graph,
+                        component,
+                        operator_codes,
+                    )
+                    if plan is None:
+                        continue
+                    _apply_region_plan(document, graph, plan)
+                    bypassed = plan.bypassed_transpose_indices
+                    changes += len(bypassed)
+                    diagnostics.append(
+                        f"Subgraph {subgraph_index}: rewrote layout region "
+                        f"{list(plan.operator_indices)} and bypassed Transpose "
+                        f"operators {list(bypassed)}."
+                    )
+                    rewritten = True
+                    break
+                if not rewritten:
+                    break
+
+        context.logger.debug(
+            "EliminateTransposeBoundedLayoutRegionPass bypassed %d Transpose "
+            "operators.",
+            changes,
+        )
+        return CirclePassResult(
+            modified=changes > 0,
+            changes=changes,
+            diagnostics=tuple(diagnostics),
+        )

--- a/tico/circle/passes/optimization/remove/transpose_bounded_layout_region.py
+++ b/tico/circle/passes/optimization/remove/transpose_bounded_layout_region.py
@@ -360,12 +360,12 @@ def _set_tensor_layout(
     if new_shape is None:
         return False
     signature = _shape_signature(tensor)
-    new_signature = _permuted_shape(signature, permutation) if signature else ()
+    new_signature = _permuted_shape(signature, permutation) if signature else None
     if signature and new_signature is None:
         return False
 
     tensor.shape = list(new_shape)
-    if signature:
+    if new_signature is not None:
         tensor.shapeSignature = list(new_signature)
     return True
 
@@ -729,9 +729,9 @@ def _build_region_plan(
             return None
 
     output_contracts: dict[int, tuple[Any, ...]] = {}
-    for boundary in output_boundaries:
-        region_tensor = tensors[boundary.region_tensor_index]
-        final_tensor = tensors[boundary.transpose_output_index]
+    for output_boundary in output_boundaries:
+        region_tensor = tensors[output_boundary.region_tensor_index]
+        final_tensor = tensors[output_boundary.transpose_output_index]
         if _permuted_shape(_shape(region_tensor), region_to_source) != _shape(
             final_tensor
         ):
@@ -749,7 +749,7 @@ def _build_region_plan(
         if not _tensor_has_visible_use(
             document,
             graph,
-            boundary.transpose_output_index,
+            output_boundary.transpose_output_index,
         ):
             return None
         contract = (
@@ -760,7 +760,7 @@ def _build_region_plan(
             int(getattr(final_tensor, "buffer", 0) or 0),
         )
         previous = output_contracts.setdefault(
-            boundary.region_tensor_index,
+            output_boundary.region_tensor_index,
             contract,
         )
         if previous != contract:
@@ -879,8 +879,10 @@ def _apply_region_plan(
 
     tensors = as_list(graph.subgraph.tensors)
     output_boundaries: dict[int, list[_OutputBoundary]] = {}
-    for boundary in plan.output_boundaries:
-        output_boundaries.setdefault(boundary.region_tensor_index, []).append(boundary)
+    for output_boundary in plan.output_boundaries:
+        output_boundaries.setdefault(output_boundary.region_tensor_index, []).append(
+            output_boundary
+        )
 
     for operator_index in plan.operator_indices:
         operator = operators[operator_index]
@@ -902,17 +904,17 @@ def _apply_region_plan(
                     f"Failed to update tensor {tensor_index} to source layout."
                 )
 
-    for boundary in plan.output_boundaries:
-        final_tensor = tensors[boundary.transpose_output_index]
+    for output_boundary in plan.output_boundaries:
+        final_tensor = tensors[output_boundary.transpose_output_index]
         _rename_dead_tensor(
             final_tensor,
-            f"::dead_layout_{boundary.transpose_index}",
+            f"::dead_layout_{output_boundary.transpose_index}",
         )
         replacement = replace_tensor_uses(
             document.model,
             subgraph_index=graph.subgraph_index,
-            old_tensor_index=boundary.transpose_output_index,
-            new_tensor_index=boundary.region_tensor_index,
+            old_tensor_index=output_boundary.transpose_output_index,
+            new_tensor_index=output_boundary.region_tensor_index,
         )
         if not replacement.modified:
             raise RuntimeError(


### PR DESCRIPTION
This commit adds EliminateTransposeBoundedLayoutRegionPass.

It executes connected layout-convertible Circle regions directly in the source layout when every external boundary crosses one Transpose permutation and its inverse, and integrates the pass into the Circle pass registry and tico-circle CLI with a selectable restart scheduling strategy, along with pass and CLI tests.

Related: https://github.com/Samsung/TICO/issues/841
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>