### PR TITLE
[evaluation] Generation mode and videomme benchmark support for Gemma4

### DIFF
--- a/test/quantization/evaluation/test_video_mme_gemma4.py
+++ b/test/quantization/evaluation/test_video_mme_gemma4.py
@@ -1,0 +1,436 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Video-MME evaluation support for Gemma4.
+
+These tests exercise:
+- ``_load_video_frames`` in ``lmms_gemma4.py``
+- ``patch_huggingface_wrapper_for_gemma4`` context manager
+- ``evaluate_and_print_video_mme`` delegation
+- The Gemma4 adapter's videomme config parsing
+"""
+
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+
+
+def _has_decord() -> bool:
+    try:
+        import decord  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _has_lmms_eval() -> bool:
+    try:
+        import lmms_eval  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+class TestLoadVideoFrames(unittest.TestCase):
+    """Test ``_load_video_frames`` from ``lmms_gemma4.py``."""
+
+    def test_load_video_frames_fewer_than_max(self):
+        """When total frames <= max_num_frames, all frames are returned."""
+        from tico.quantization.evaluation.lmms_gemma4 import _load_video_frames
+
+        fake_frames = np.random.rand(5, 8, 8, 3).astype(np.uint8)
+
+        mock_vr = MagicMock()
+        mock_vr.__len__ = Mock(return_value=5)
+        mock_vr.get_batch = Mock(
+            return_value=MagicMock(asnumpy=Mock(return_value=fake_frames))
+        )
+
+        mock_decord = MagicMock()
+        mock_decord.VideoReader = Mock(return_value=mock_vr)
+
+        with patch.dict("sys.modules", {"decord": mock_decord}):
+            result = _load_video_frames("/fake/path.mp4", max_num_frames=32)
+
+        self.assertEqual(result.shape, (5, 8, 8, 3))
+        np.testing.assert_array_equal(result, fake_frames)
+
+    def test_load_video_frames_subsample(self):
+        """When total frames > max_num_frames, frames are subsampled."""
+        from tico.quantization.evaluation.lmms_gemma4 import _load_video_frames
+
+        total = 100
+        max_frames = 10
+        fake_frames = np.random.rand(max_frames, 8, 8, 3).astype(np.uint8)
+
+        mock_vr = MagicMock()
+        mock_vr.__len__ = Mock(return_value=total)
+        mock_vr.get_batch = Mock(
+            return_value=MagicMock(asnumpy=Mock(return_value=fake_frames))
+        )
+
+        mock_decord = MagicMock()
+        mock_decord.VideoReader = Mock(return_value=mock_vr)
+
+        with patch.dict("sys.modules", {"decord": mock_decord}):
+            result = _load_video_frames("/fake/path.mp4", max_num_frames=max_frames)
+
+        self.assertEqual(result.shape[0], max_frames)
+        # Verify get_batch was called with a list of indices
+        call_args = mock_vr.get_batch.call_args[0][0]
+        self.assertIsInstance(call_args, list)
+        self.assertEqual(len(call_args), max_frames)
+        # Indices should be within range
+        self.assertTrue(all(0 <= i < total for i in call_args))
+
+    def test_load_video_frames_zero_frames_raises(self):
+        """A video with 0 frames should raise ValueError."""
+        from tico.quantization.evaluation.lmms_gemma4 import _load_video_frames
+
+        mock_vr = MagicMock()
+        mock_vr.__len__ = Mock(return_value=0)
+
+        mock_decord = MagicMock()
+        mock_decord.VideoReader = Mock(return_value=mock_vr)
+
+        with patch.dict("sys.modules", {"decord": mock_decord}):
+            with self.assertRaises(ValueError) as ctx:
+                _load_video_frames("/fake/path.mp4", max_num_frames=32)
+            self.assertIn("0 frames", str(ctx.exception))
+
+
+class TestPatchHuggingfaceWrapperForGemma4(unittest.TestCase):
+    """Test ``patch_huggingface_wrapper_for_gemma4`` context manager."""
+
+    @staticmethod
+    def _make_mock_modules(mock_hf_class):
+        """Build a dict of mock lmms_eval modules for patch.dict('sys.modules')."""
+        # The function does ``from lmms_eval.models.chat.huggingface import Huggingface``
+        # so Huggingface must be an attribute on the mock module object.
+        hf_module = MagicMock()
+        hf_module.Huggingface = mock_hf_class
+
+        instance_module = MagicMock()
+        instance_module.GenerationResult = Mock
+        instance_module.TokenCounts = Mock
+
+        protocol_module = MagicMock()
+        protocol_module.ChatMessages = Mock
+
+        utils_module = MagicMock()
+        utils_module.Collator = Mock
+
+        gen_metrics_module = MagicMock()
+        gen_metrics_module.log_metrics = Mock()
+
+        return {
+            "lmms_eval": MagicMock(),
+            "lmms_eval.api": MagicMock(),
+            "lmms_eval.api.instance": instance_module,
+            "lmms_eval.models": MagicMock(),
+            "lmms_eval.models.chat": MagicMock(),
+            "lmms_eval.models.chat.huggingface": hf_module,
+            "lmms_eval.protocol": protocol_module,
+            "lmms_eval.utils": utils_module,
+            "lmms_eval.models.model_utils": MagicMock(),
+            "lmms_eval.models.model_utils.gen_metrics": gen_metrics_module,
+            "loguru": MagicMock(),
+            "tqdm": MagicMock(),
+        }
+
+    def test_patch_restores_on_exit(self):
+        """The context manager should restore the original generate_until on exit."""
+        from tico.quantization.evaluation.lmms_gemma4 import (
+            patch_huggingface_wrapper_for_gemma4,
+        )
+
+        mock_hf_class = Mock()
+        original_generate_until = Mock()
+        mock_hf_class.generate_until = original_generate_until
+
+        mock_modules = self._make_mock_modules(mock_hf_class)
+
+        with patch.dict("sys.modules", mock_modules):
+            with patch_huggingface_wrapper_for_gemma4(max_num_frames=5):
+                # Inside the context, generate_until should be patched
+                self.assertIsNot(mock_hf_class.generate_until, original_generate_until)
+
+            # After exiting, the original should be restored
+            self.assertIs(mock_hf_class.generate_until, original_generate_until)
+
+    def test_patch_default_max_num_frames(self):
+        """The default max_num_frames should be 32."""
+        from tico.quantization.evaluation.lmms_gemma4 import (
+            patch_huggingface_wrapper_for_gemma4,
+        )
+
+        mock_hf_class = Mock()
+        original_generate_until = Mock()
+        mock_hf_class.generate_until = original_generate_until
+
+        mock_modules = self._make_mock_modules(mock_hf_class)
+
+        with patch.dict("sys.modules", mock_modules):
+            with patch_huggingface_wrapper_for_gemma4():
+                # The patched function should exist
+                self.assertTrue(callable(mock_hf_class.generate_until))
+
+
+class TestEvaluateAndPrintVideoMME(unittest.TestCase):
+    """Test ``evaluate_and_print_video_mme`` delegation."""
+
+    @patch("tico.quantization.recipes.evaluation.video_mme.evaluate_vlm_on_tasks")
+    @patch("tico.quantization.recipes.evaluation.video_mme.print_lmms_eval_results")
+    @patch("builtins.print")
+    def test_delegates_to_evaluate_vlm_on_tasks(
+        self, mock_print, mock_print_results, mock_eval
+    ):
+        """evaluate_and_print_video_mme should call evaluate_vlm_on_tasks with tasks=['videomme']."""
+        from tico.quantization.recipes.evaluation.video_mme import (
+            evaluate_and_print_video_mme,
+        )
+
+        mock_results = {"results": {"videomme": {"accuracy": 0.5}}}
+        mock_eval.return_value = mock_results
+
+        result = evaluate_and_print_video_mme(
+            model=Mock(),
+            processor=Mock(),
+            device="cpu",
+            batch_size=2,
+            max_num_frames=21,
+            max_new_tokens=30,
+            n_samples=10,
+            verbose=False,
+        )
+
+        mock_eval.assert_called_once()
+        call_kwargs = mock_eval.call_args.kwargs
+        self.assertEqual(call_kwargs["tasks"], ["videomme"])
+        self.assertEqual(call_kwargs["device"], "cpu")
+        self.assertEqual(call_kwargs["batch_size"], 2)
+        self.assertEqual(call_kwargs["max_num_frames"], 21)
+        self.assertEqual(call_kwargs["max_new_tokens"], 30)
+        self.assertEqual(call_kwargs["limit"], 10)
+        self.assertEqual(call_kwargs["verbose"], False)
+
+        mock_print_results.assert_called_once_with(mock_results)
+        self.assertEqual(result, mock_results)
+
+    @patch("tico.quantization.recipes.evaluation.video_mme.evaluate_vlm_on_tasks")
+    @patch("tico.quantization.recipes.evaluation.video_mme.print_lmms_eval_results")
+    @patch("builtins.print")
+    def test_n_samples_none_passes_none_limit(
+        self, mock_print, mock_print_results, mock_eval
+    ):
+        """When n_samples is None, limit should be None."""
+        from tico.quantization.recipes.evaluation.video_mme import (
+            evaluate_and_print_video_mme,
+        )
+
+        mock_eval.return_value = {}
+
+        evaluate_and_print_video_mme(
+            model=Mock(),
+            processor=Mock(),
+            device="cpu",
+            n_samples=None,
+        )
+
+        call_kwargs = mock_eval.call_args.kwargs
+        self.assertIsNone(call_kwargs["limit"])
+
+    @patch("tico.quantization.recipes.evaluation.video_mme.evaluate_vlm_on_tasks")
+    @patch("tico.quantization.recipes.evaluation.video_mme.print_lmms_eval_results")
+    @patch("builtins.print")
+    def test_default_max_num_frames(self, mock_print, mock_print_results, mock_eval):
+        """Default max_num_frames should be 32."""
+        from tico.quantization.recipes.evaluation.video_mme import (
+            evaluate_and_print_video_mme,
+        )
+
+        mock_eval.return_value = {}
+
+        evaluate_and_print_video_mme(
+            model=Mock(),
+            processor=Mock(),
+            device="cpu",
+        )
+
+        call_kwargs = mock_eval.call_args.kwargs
+        self.assertEqual(call_kwargs["max_num_frames"], 32)
+
+
+class TestGemma4AdapterVideoMMEConfig(unittest.TestCase):
+    """Test the Gemma4 adapter's videomme config parsing."""
+
+    def test_videomme_disabled_by_default(self):
+        """When videomme is not in eval_cfg, evaluate_and_print_video_mme should not be called."""
+        from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+
+        adapter = Gemma4Adapter()
+        ctx = Mock()
+        ctx.cfg = {
+            "evaluation": {"enabled": True},
+        }
+        ctx.model = Mock()
+        ctx.processor = Mock()
+        ctx.device = "cpu"
+
+        with patch(
+            "tico.quantization.recipes.adapters.gemma4.evaluate_and_print_video_mme"
+        ) as mock_eval:
+            adapter.evaluate(ctx)
+            mock_eval.assert_not_called()
+
+    def test_videomme_enabled_calls_evaluate(self):
+        """When videomme.enabled is True, evaluate_and_print_video_mme should be called."""
+        from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+
+        adapter = Gemma4Adapter()
+        ctx = Mock()
+        ctx.cfg = {
+            "evaluation": {
+                "enabled": True,
+                "videomme": {
+                    "enabled": True,
+                    "n_samples": 5,
+                    "max_num_frames": 21,
+                    "batch_size": 1,
+                    "max_new_tokens": 30,
+                },
+            },
+        }
+        ctx.model = Mock()
+        ctx.processor = Mock()
+        ctx.device = "cpu"
+
+        with patch(
+            "tico.quantization.recipes.adapters.gemma4.evaluate_and_print_video_mme"
+        ) as mock_eval:
+            adapter.evaluate(ctx)
+            mock_eval.assert_called_once()
+            call_kwargs = mock_eval.call_args.kwargs
+            self.assertEqual(call_kwargs["n_samples"], 5)
+            self.assertEqual(call_kwargs["max_num_frames"], 21)
+            self.assertEqual(call_kwargs["batch_size"], 1)
+            self.assertEqual(call_kwargs["max_new_tokens"], 30)
+
+    def test_videomme_default_max_num_frames_is_21(self):
+        """Gemma4 adapter should default max_num_frames to 21 (not 32)."""
+        from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+
+        adapter = Gemma4Adapter()
+        ctx = Mock()
+        ctx.cfg = {
+            "evaluation": {
+                "enabled": True,
+                "videomme": {
+                    "enabled": True,
+                },
+            },
+        }
+        ctx.model = Mock()
+        ctx.processor = Mock()
+        ctx.device = "cpu"
+
+        with patch(
+            "tico.quantization.recipes.adapters.gemma4.evaluate_and_print_video_mme"
+        ) as mock_eval:
+            adapter.evaluate(ctx)
+            call_kwargs = mock_eval.call_args.kwargs
+            # Gemma4 defaults to 21 frames (not 32) due to soft_tokens_per_frame
+            self.assertEqual(call_kwargs["max_num_frames"], 21)
+
+    def test_videomme_invalid_max_num_frames_raises(self):
+        """max_num_frames <= 0 should raise ValueError."""
+        from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+
+        adapter = Gemma4Adapter()
+        ctx = Mock()
+        ctx.cfg = {
+            "evaluation": {
+                "enabled": True,
+                "videomme": {
+                    "enabled": True,
+                    "max_num_frames": 0,
+                },
+            },
+        }
+        ctx.model = Mock()
+        ctx.processor = Mock()
+        ctx.device = "cpu"
+
+        with patch(
+            "tico.quantization.recipes.adapters.gemma4.evaluate_and_print_video_mme"
+        ):
+            with self.assertRaises(ValueError) as exc_ctx:
+                adapter.evaluate(ctx)
+            self.assertIn("max_num_frames", str(exc_ctx.exception))
+
+    def test_videomme_negative_max_num_frames_raises(self):
+        """Negative max_num_frames should raise ValueError."""
+        from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+
+        adapter = Gemma4Adapter()
+        ctx = Mock()
+        ctx.cfg = {
+            "evaluation": {
+                "enabled": True,
+                "videomme": {
+                    "enabled": True,
+                    "max_num_frames": -1,
+                },
+            },
+        }
+        ctx.model = Mock()
+        ctx.processor = Mock()
+        ctx.device = "cpu"
+
+        with patch(
+            "tico.quantization.recipes.adapters.gemma4.evaluate_and_print_video_mme"
+        ):
+            with self.assertRaises(ValueError):
+                adapter.evaluate(ctx)
+
+    def test_videomme_n_samples_negative_becomes_none(self):
+        """When n_samples is negative, it should be passed as None."""
+        from tico.quantization.recipes.adapters.gemma4 import Gemma4Adapter
+
+        adapter = Gemma4Adapter()
+        ctx = Mock()
+        ctx.cfg = {
+            "evaluation": {
+                "enabled": True,
+                "videomme": {
+                    "enabled": True,
+                    "n_samples": -1,
+                },
+            },
+        }
+        ctx.model = Mock()
+        ctx.processor = Mock()
+        ctx.device = "cpu"
+
+        with patch(
+            "tico.quantization.recipes.adapters.gemma4.evaluate_and_print_video_mme"
+        ) as mock_eval:
+            adapter.evaluate(ctx)
+            call_kwargs = mock_eval.call_args.kwargs
+            self.assertIsNone(call_kwargs["n_samples"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_for_causal_lm.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_for_causal_lm.py
@@ -232,5 +232,79 @@ class TestQuantGemma4ForCausalLMSmoke(unittest.TestCase):
             )
 
 
+# ---------------------------------------------------------------------------
+# Tests for Generation support in QuantGemma4ForCausalLM
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestQuantGemma4ForCausalLMGeneration(unittest.TestCase):
+    """Exercise GenerationMixin support added to QuantGemma4ForCausalLM."""
+
+    def setUp(self):
+        """Create deterministic tiny Gemma4ForCausalLM modules."""
+        torch.manual_seed(2026)
+        self.fp_model = _make_gemma4_for_causal_lm()
+        self.fp_ref = copy.deepcopy(self.fp_model).eval()
+        self.config = self.fp_model.config
+        self.seq_len = 4
+        self.batch_size = 1
+        self.qcfg = PTQConfig()
+
+    def _text_only_sample(self):
+        """Create a text-only sample."""
+        return {
+            "input_ids": torch.randint(
+                0, self.config.vocab_size, (self.batch_size, self.seq_len)
+            ),
+        }
+
+    def _make_quantized(self):
+        """prepare → calibrate → convert and return the quantized wrapper."""
+        qmodel = prepare(self.fp_model, self.qcfg).eval()
+        sample = self._text_only_sample()
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+        return convert(qmodel)
+
+    # --- End-to-end generation ---------------------------------------------
+
+    def test_generate_returns_tensor(self):
+        """generate() should return a tensor of token ids."""
+        quantized = self._make_quantized()
+        sample = self._text_only_sample()
+
+        with torch.no_grad():
+            out = quantized.generate(
+                **sample,
+                max_new_tokens=1,
+                do_sample=False,
+            )
+
+        self.assertIsInstance(out, torch.Tensor)
+        # Output should be at least as long as the input.
+        self.assertGreaterEqual(out.shape[1], sample["input_ids"].shape[1])
+
+    def test_generate_extends_sequence(self):
+        """generate(max_new_tokens=N) should add exactly N new tokens."""
+        quantized = self._make_quantized()
+        sample = self._text_only_sample()
+        max_new = 1
+
+        with torch.no_grad():
+            out = quantized.generate(
+                **sample,
+                max_new_tokens=max_new,
+                do_sample=False,
+            )
+
+        self.assertEqual(out.shape[1], self.seq_len + max_new)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_for_conditional_generation.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_for_conditional_generation.py
@@ -284,5 +284,98 @@ class TestQuantGemma4ForConditionalGenerationSmoke(unittest.TestCase):
             )
 
 
+# ---------------------------------------------------------------------------
+# Tests for Generation support in QuantGemma4ForConditionalGeneration
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipIf(
+    not IS_INTERNAL_TEST,
+    "Internal smoke test — set RUN_INTERNAL_TESTS=1 to enable it.",
+)
+@unittest.skipUnless(_has_gemma4(), _SKIP_MSG)
+class TestQuantGemma4ForConditionalGenerationGeneration(unittest.TestCase):
+    """Exercise GenerationMixin support added to QuantGemma4ForConditionalGeneration."""
+
+    def setUp(self):
+        """Create deterministic tiny Gemma4ForConditionalGeneration modules."""
+        torch.manual_seed(2026)
+        self.fp_model = _make_gemma4_for_conditional_generation()
+        self.fp_ref = copy.deepcopy(self.fp_model).eval()
+        self.config = self.fp_model.config
+        self.text_config = self.config.get_text_config()
+        self.seq_len = 4
+        self.batch_size = 1
+        self.qcfg = PTQConfig(
+            model_args={
+                "vision": {
+                    "visual_start_idx": 0,
+                    "num_visual_tokens": 4,
+                }
+            }
+        )
+
+    def _text_only_sample(self):
+        """Create a text-only sample (no image/video/audio tokens).
+
+        Token IDs 10, 11, 12 are reserved for image, video, and audio
+        placeholders.  We exclude them so the multimodal validation in
+        ``QuantGemma4Model`` does not reject the input.
+        """
+        special_ids = {
+            self.config.image_token_id,
+            self.config.video_token_id,
+            self.config.audio_token_id,
+        }
+        valid_ids = [
+            i for i in range(self.text_config.vocab_size) if i not in special_ids
+        ]
+        idx = torch.randint(0, len(valid_ids), (self.batch_size, self.seq_len))
+        input_ids = torch.tensor(valid_ids)[idx]
+        return {"input_ids": input_ids}
+
+    def _make_quantized(self):
+        """prepare → calibrate → convert and return the quantized wrapper."""
+        qmodel = prepare(self.fp_model, self.qcfg).eval()
+        sample = self._text_only_sample()
+        with torch.no_grad():
+            for _ in range(3):
+                qmodel(**sample)
+        return convert(qmodel)
+
+    # --- End-to-end generation ---------------------------------------------
+
+    def test_generate_returns_tensor(self):
+        """generate() should return a tensor of token ids."""
+        quantized = self._make_quantized()
+        sample = self._text_only_sample()
+
+        with torch.no_grad():
+            out = quantized.generate(
+                **sample,
+                max_new_tokens=1,
+                do_sample=False,
+            )
+
+        self.assertIsInstance(out, torch.Tensor)
+        # Output should be at least as long as the input.
+        self.assertGreaterEqual(out.shape[1], sample["input_ids"].shape[1])
+
+    def test_generate_extends_sequence(self):
+        """generate(max_new_tokens=N) should add exactly N new tokens."""
+        quantized = self._make_quantized()
+        sample = self._text_only_sample()
+        max_new = 1
+
+        with torch.no_grad():
+            out = quantized.generate(
+                **sample,
+                max_new_tokens=max_new,
+                do_sample=False,
+            )
+
+        self.assertEqual(out.shape[1], self.seq_len + max_new)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tico/quantization/evaluation/lmms_eval_utils.py
+++ b/tico/quantization/evaluation/lmms_eval_utils.py
@@ -34,6 +34,9 @@ import os
 from typing import Any
 
 
+_GEMMA4_DEFAULT_VIDEO_SOFT_TOKENS = 70
+
+
 def _check_lmms_eval_available() -> None:
     """Raise a clear error if ``lmms-eval`` is not installed."""
     try:
@@ -389,6 +392,12 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
         _model_classes.append(_Q2)
     except ImportError:
         pass
+    try:
+        from transformers import Gemma4ForConditionalGeneration as _G4
+
+        _model_classes.append(_G4)
+    except ImportError:
+        pass
 
     _original_model_fps = {cls: cls.from_pretrained for cls in _model_classes}
 
@@ -406,6 +415,30 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
             return _patched_from_pretrained
 
         cls.from_pretrained = classmethod(_make_patched_fp(_orig_fn))
+
+    # Also patch AutoModel, AutoModelForCausalLM, and AutoModelForImageTextToText
+    # because the Huggingface wrapper's __init__ uses AutoConfig to pick the
+    # model class, and for models not in the mapping (e.g. Gemma4), it falls
+    # back to AutoModel which returns a base model without generate().
+    from transformers import (
+        AutoModel,
+        AutoModelForCausalLM,
+        AutoModelForImageTextToText,
+    )
+
+    _auto_classes = [AutoModel, AutoModelForCausalLM, AutoModelForImageTextToText]
+    _original_auto_fps = {cls: cls.from_pretrained for cls in _auto_classes}
+
+    for cls in _auto_classes:
+        _orig_fn = cls.from_pretrained
+
+        def _make_patched_auto_fp(orig_fn):
+            def _patched_from_pretrained(cls_arg, *args, **kwargs):
+                return model
+
+            return _patched_from_pretrained
+
+        cls.from_pretrained = classmethod(_make_patched_auto_fp(_orig_fn))
 
     # --- Patch AutoProcessor.from_pretrained ---
     _original_processor_fp = AutoProcessor.from_pretrained
@@ -431,6 +464,8 @@ def _patch_from_pretrained_to_reuse_model(model, processor):
         finally:
             # Restore original from_pretrained methods
             for cls, orig_fp in _original_model_fps.items():
+                cls.from_pretrained = orig_fp
+            for cls, orig_fp in _original_auto_fps.items():
                 cls.from_pretrained = orig_fp
             AutoProcessor.from_pretrained = _original_processor_fp
             AutoTokenizer.from_pretrained = _original_tokenizer_fp
@@ -624,6 +659,8 @@ def evaluate_vlm_on_tasks(
 
     from lmms_eval.evaluator import simple_evaluate
 
+    _effective_max_new_tokens = max_new_tokens if max_new_tokens is not None else 30
+
     if isinstance(model, str):
         model_name = model
         model_args_dict = {}
@@ -641,7 +678,6 @@ def evaluate_vlm_on_tasks(
         # (text + visual tokens from all frames) must fit within this
         # budget, so we compute max_pixels/min_pixels per frame.
         _max_pos_emb = _get_max_position_embeddings(inner_model)
-        _effective_max_new_tokens = max_new_tokens if max_new_tokens is not None else 30
 
         # Determine the lmms-eval model name and build model_args.
         # When max_position_embeddings is available, the budget-aware
@@ -660,12 +696,17 @@ def evaluate_vlm_on_tasks(
         # loading them a second time.
         _model_ctx = _patch_from_pretrained_to_reuse_model(model, processor)
 
+    _effective_max_num_frames = model_args_dict.get("max_num_frames", max_num_frames)
+
     # Propagate verbose flag to custom task utils via environment variable.
     # The videomme_mini utils.py checks LMMS_VERBOSE to decide whether to
     # print prompts, video paths, etc.
     os.environ["LMMS_VERBOSE"] = "1" if verbose else "0"
 
-    print(f"evaluate_vlm_on_tasks: model={model_name}, max_num_frames={max_num_frames}")
+    print(
+        f"evaluate_vlm_on_tasks: model={model_name}, "
+        f"max_num_frames={_effective_max_num_frames}"
+    )
     print(f"model_args: {model_args_dict}")
 
     # Normalise tasks to a list
@@ -723,6 +764,20 @@ def evaluate_vlm_on_tasks(
     # Forward any additional kwargs (may override task_manager)
     eval_kwargs.update(kwargs)
 
+    # For models without a dedicated lmms-eval wrapper (e.g. Gemma4), patch
+    # the generic Huggingface wrapper's generate_until to handle Gemma4's
+    # processor quirks (no "audios" kwarg, no empty image lists, video
+    # frames must be loaded as tensors).
+    _gemma4_ctx = contextlib.nullcontext()
+    if model_name == "huggingface":
+        from tico.quantization.evaluation.lmms_gemma4 import (
+            patch_huggingface_wrapper_for_gemma4,
+        )
+
+        _gemma4_ctx = patch_huggingface_wrapper_for_gemma4(
+            max_num_frames=int(_effective_max_num_frames),
+        )
+
     # Patch _subsample_video_inputs to add debug logging
     _subsample_ctx = _patch_subsample_video_inputs_for_debug()
 
@@ -769,7 +824,7 @@ def evaluate_vlm_on_tasks(
     if _is_videomme and limit is not None and isinstance(limit, int) and limit > 0:
         _download_ctx = _patch_snapshot_download_for_limit(limit)
 
-    with _model_ctx, _subsample_ctx, _budget_ctx:
+    with _model_ctx, _gemma4_ctx, _subsample_ctx, _budget_ctx:
         if _download_ctx is not None:
             with _download_ctx:
                 results = simple_evaluate(**eval_kwargs)
@@ -821,6 +876,56 @@ def _processor_vision_factor(processor: Any) -> int:
     patch_size = _coerce_int_attr(getattr(image_processor, "patch_size", None), 16)
     merge_size = _coerce_int_attr(getattr(image_processor, "merge_size", None), 2)
     return max(1, patch_size * merge_size)
+
+
+def _processor_gemma4_video_soft_tokens(processor: Any) -> int:
+    """Return Gemma4's per-frame video soft-token budget."""
+    video_processor = getattr(processor, "video_processor", None)
+    value = getattr(video_processor, "max_soft_tokens", None)
+    return max(1, _coerce_int_attr(value, _GEMMA4_DEFAULT_VIDEO_SOFT_TOKENS))
+
+
+def _compute_gemma4_max_num_frames_for_budget(
+    *,
+    max_position_embeddings: int,
+    max_num_frames: int,
+    max_new_tokens: int,
+    processor: Any,
+    text_token_margin: int = 512,
+) -> int:
+    """Compute a Gemma4 frame cap that fits a static text context budget.
+
+    Gemma4 controls video cost through ``max_soft_tokens`` per frame, not
+    Qwen-style ``max_pixels`` / ``min_pixels`` arguments.  The generic
+    lmms-eval HuggingFace wrapper cannot receive Gemma4-specific processor
+    kwargs, so TICO caps the sampled frame count before the patched Gemma4
+    generation path calls the processor.
+
+    The *text_token_margin* reserves tokens for the text portion of the
+    prompt (system prompt, question, answer choices, special tokens).
+    Video-MME prompts can be lengthy, so the default is 512 to avoid
+    exceeding the static context budget.
+    """
+    if max_num_frames <= 0:
+        raise ValueError(f"max_num_frames must be positive, got {max_num_frames}.")
+
+    # Reserve a small safety margin (4 tokens) to account for special tokens
+    # that may push the total sequence length to exactly static_max_seq + 1.
+    _safety_margin = 4
+    input_budget = int(max_position_embeddings) - int(max_new_tokens) - _safety_margin
+    visual_budget = input_budget - int(text_token_margin)
+    soft_tokens_per_frame = _processor_gemma4_video_soft_tokens(processor)
+    if visual_budget < soft_tokens_per_frame:
+        raise ValueError(
+            "Not enough context budget for one Gemma4 video frame: "
+            f"max_position_embeddings={max_position_embeddings}, "
+            f"max_new_tokens={max_new_tokens}, "
+            f"text_token_margin={text_token_margin}, "
+            f"safety_margin={_safety_margin}, "
+            f"soft_tokens_per_frame={soft_tokens_per_frame}."
+        )
+
+    return max(1, min(int(max_num_frames), visual_budget // soft_tokens_per_frame))
 
 
 def _compute_video_max_pixels_for_budget(
@@ -895,12 +1000,53 @@ def _compute_video_max_pixels_for_budget(
     return max_pixels, min_pixels, adjusted_max_num_frames
 
 
-def _get_max_position_embeddings(model: Any) -> int | None:
-    """Extract ``max_position_embeddings`` from a model config.
+def _find_static_max_seq(model: Any, _depth: int = 0) -> int | None:
+    """Walk the model tree to find a ``static_max_seq`` attribute.
 
-    Handles both plain transformers models and PTQ-wrapped models.
-    Returns ``None`` if the attribute cannot be found.
+    Quantized Gemma4 models store ``static_max_seq`` on the inner
+    ``QuantGemma4TextModel``.  This attribute represents the actual
+    runtime constraint enforced by the precomputed static mask and RoPE
+    templates, which may be smaller than ``config.max_position_embeddings``.
+
+    Returns ``None`` if no ``static_max_seq`` is found.
     """
+    if _depth > 10:
+        return None
+
+    value = getattr(model, "static_max_seq", None)
+    if value is not None:
+        return int(value)
+
+    for attr in ("wrapped", "model", "language_model"):
+        child = getattr(model, attr, None)
+        if child is not None and child is not model:
+            result = _find_static_max_seq(child, _depth + 1)
+            if result is not None:
+                return result
+
+    return None
+
+
+def _get_max_position_embeddings(model: Any) -> int | None:
+    """Extract the effective context length from a model.
+
+    For PTQ-wrapped Gemma4 models the actual runtime constraint is
+    ``static_max_seq`` (the size of the precomputed static mask and RoPE
+    templates), which may be smaller than ``config.max_position_embeddings``.
+    This function returns ``static_max_seq`` when present so that budget
+    computations respect the real limit.
+
+    For plain (non-quantized) models it falls back to
+    ``config.max_position_embeddings`` (or ``config.text_config.max_position_embeddings``
+    for VLMs like Qwen3-VL).
+
+    Returns ``None`` if no context length can be determined.
+    """
+    # Check for static_max_seq first (PTQ-wrapped Gemma4 models)
+    static_max_seq = _find_static_max_seq(model)
+    if static_max_seq is not None:
+        return static_max_seq
+
     config = getattr(model, "config", None)
     if config is None:
         return None
@@ -952,6 +1098,9 @@ def _build_model_args(
         A ``(model_name, model_args_dict)`` tuple.
     """
     model_cls_name = type(model).__name__.lower()
+    config = getattr(model, "config", None)
+    config_model_type = str(getattr(config, "model_type", "")).lower()
+    is_gemma4 = "gemma4" in model_cls_name or config_model_type == "gemma4"
 
     # Map model class names to lmms-eval registry names
     if "qwen3" in model_cls_name and (
@@ -976,18 +1125,28 @@ def _build_model_args(
 
     # Get the Hugging Face model id from the model config if available
     pretrained = None
-    if hasattr(model, "config") and hasattr(model.config, "_name_or_path"):
-        pretrained = model.config._name_or_path
+    if config is not None and hasattr(config, "_name_or_path"):
+        pretrained = config._name_or_path
 
     model_args_dict: dict[str, Any] = {}
 
     if pretrained is not None:
         model_args_dict["pretrained"] = pretrained
 
+    # max_pixels and min_pixels are only accepted by dedicated lmms-eval VLM
+    # wrappers (e.g. qwen3_vl, qwen2_5_vl).  The generic "huggingface"
+    # fallback wrapper does NOT accept them and will raise an AssertionError.
+    # However, max_num_frames IS accepted by the generic wrapper.
+    _has_dedicated_wrapper = lmms_model_name != "huggingface"
+
     # When a static context budget is provided, compute max_pixels and
     # min_pixels per video frame so that the total token count stays within
     # the budget.
-    if max_position_embeddings is not None and processor is not None:
+    if (
+        max_position_embeddings is not None
+        and processor is not None
+        and _has_dedicated_wrapper
+    ):
         (
             budget_max_pixels,
             budget_min_pixels,
@@ -1009,13 +1168,35 @@ def _build_model_args(
             f"max_pixels={budget_max_pixels}, "
             f"min_pixels={budget_min_pixels}"
         )
+    elif max_position_embeddings is not None and processor is not None and is_gemma4:
+        adjusted_max_num_frames = _compute_gemma4_max_num_frames_for_budget(
+            max_position_embeddings=max_position_embeddings,
+            max_num_frames=max_num_frames,
+            max_new_tokens=max_new_tokens,
+            processor=processor,
+        )
+        model_args_dict["max_num_frames"] = adjusted_max_num_frames
+
+        print(
+            f"[INFO] Gemma4 video frame budget computed for static context: "
+            f"max_position_embeddings={max_position_embeddings}, "
+            f"max_num_frames={max_num_frames} -> {adjusted_max_num_frames}, "
+            f"soft_tokens_per_frame={_processor_gemma4_video_soft_tokens(processor)}"
+        )
     else:
-        # Pass max_num_frames to the lmms-eval model wrapper.
-        # The Qwen3_VL wrapper accepts this in __init__ and uses it in
-        # _subsample_video_inputs to control how many frames are sampled
-        # from each video.
+        # max_num_frames is accepted by both dedicated wrappers and the
+        # generic "huggingface" wrapper.
         if max_num_frames is not None:
             model_args_dict["max_num_frames"] = max_num_frames
+
+        if not _has_dedicated_wrapper:
+            # For models without a dedicated lmms-eval wrapper (e.g. Gemma),
+            # the generic "huggingface" wrapper does not accept max_pixels
+            # or min_pixels.  We skip them here.
+            print(
+                f"[INFO] Model {lmms_model_name!r} has no dedicated lmms-eval "
+                f"wrapper; skipping max_pixels/min_pixels in model_args."
+            )
 
     return lmms_model_name, model_args_dict
 

--- a/tico/quantization/evaluation/lmms_gemma4.py
+++ b/tico/quantization/evaluation/lmms_gemma4.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom lmms-eval model wrapper for Gemma4.
+
+The generic ``huggingface`` wrapper in lmms-eval passes ``audios`` (plural)
+and always includes empty ``images``/``videos``/``audios`` lists to the
+processor.  The Gemma4 processor expects ``audio`` (singular) and non empty image list.
+
+This module provides a :func:`patch_huggingface_wrapper_for_gemma4` function
+that monkey-patches the ``generate_until`` method of the generic
+``Huggingface`` wrapper to:
+  - Skip empty ``images`` / ``videos`` / ``audios`` kwargs.
+  - Rename ``audios`` → ``audio`` for the Gemma4 processor.
+  - Load video frames from file paths using ``decord`` and pass them as
+    tensors (the Gemma4 processor does not accept video file paths).
+"""
+
+import numpy as np
+
+
+def _load_video_frames(
+    video_path: str,
+    max_num_frames: int = 32,
+) -> np.ndarray:
+    """Load up to *max_num_frames* uniformly-sampled frames from a video.
+
+    Uses ``decord`` to read the video and uniformly subsample frames.
+
+    Args:
+        video_path: Path to the video file.
+        max_num_frames: Maximum number of frames to return.
+
+    Returns:
+        A numpy array of shape ``(n_frames, H, W, 3)`` in RGB order.
+    """
+    import decord
+
+    vr = decord.VideoReader(video_path, num_threads=1)
+    total_frames = len(vr)
+    if total_frames == 0:
+        raise ValueError(f"Video {video_path} has 0 frames.")
+
+    if total_frames <= max_num_frames:
+        indices = list(range(total_frames))
+    else:
+        indices = np.linspace(0, total_frames - 1, max_num_frames, dtype=int).tolist()
+        # Ensure unique indices
+        indices = sorted(set(indices))
+
+    frames = vr.get_batch(indices).asnumpy()  # (n, H, W, 3)
+    return frames
+
+
+def patch_huggingface_wrapper_for_gemma4(
+    max_num_frames: int = 32,
+):
+    """Patch the generic ``Huggingface`` wrapper to work with Gemma4.
+
+    Returns a context manager that restores the original ``generate_until``
+    on exit.
+    """
+    import contextlib
+    import time
+
+    from lmms_eval.api.instance import GenerationResult, TokenCounts
+    from lmms_eval.models.chat.huggingface import Huggingface
+    from lmms_eval.protocol import ChatMessages
+    from loguru import logger as eval_logger
+    from tqdm import tqdm
+
+    _original_generate_until = Huggingface.generate_until
+
+    def _patched_generate_until(self, requests):
+        res = []
+
+        def _collate(x):
+            return x[2], x[2]
+
+        re_ords = __import__("lmms_eval.utils", fromlist=["Collator"]).Collator(
+            [reg.args for reg in requests],
+            _collate,
+            group_fn=lambda x: x[2],
+            grouping=True,
+        )
+        chunks = re_ords.get_batched(n=self.batch_size, batch_fn=None)
+        num_iters = (
+            len(requests) // self.batch_size
+            if len(requests) % self.batch_size == 0
+            else len(requests) // self.batch_size + 1
+        )
+        pbar = tqdm(
+            total=num_iters,
+            disable=(self.rank != 0),
+            desc="Model Responding",
+        )
+        total_elapsed_time = 0
+        total_tokens = 0
+        for chunk in chunks:
+            ctx, doc_to_messages, all_gen_kwargs, doc_id, task, split = zip(*chunk)
+            chat_messages = [
+                doc_to_messages[0](self.task_dict[task][split][ids])
+                for ids, task, split in zip(doc_id, task, split)
+            ]
+            chat_messages = [
+                ChatMessages(**{"messages": message}) for message in chat_messages
+            ]
+            gen_kwargs = all_gen_kwargs[0]
+
+            # Apply chat template
+            batched_messages = [
+                chat_message.to_hf_messages() for chat_message in chat_messages
+            ]
+            texts = [
+                self.processor.apply_chat_template(
+                    msg, tokenize=False, add_generation_prompt=True
+                )
+                for msg in batched_messages
+            ]
+
+            # Extract media
+            images = []
+            videos = []
+            audios = []
+            for messages in chat_messages:
+                image, video, audio = messages.extract_media()
+                images.append(image)
+                videos.append(video)
+                audios.append(audio)
+            images = self.flatten(images)
+            videos = self.flatten(videos)
+            audios = self.flatten(audios)
+
+            # Load video frames from file paths into tensors.
+            # The Gemma4 processor does not accept video file paths; it needs
+            # video tensors (numpy arrays or torch tensors).
+            video_tensors = []
+            for v in videos:
+                if isinstance(v, str):
+                    try:
+                        frames = _load_video_frames(v, max_num_frames=max_num_frames)
+                        video_tensors.append(frames)
+                    except Exception as e:
+                        eval_logger.warning(f"Failed to load video {v}: {e}")
+                else:
+                    # Already a tensor/array
+                    video_tensors.append(v)
+
+            # Build kwargs for the processor.
+            # The Gemma4 processor accepts: images, text, audio, videos.
+            # It does NOT accept "audios" (plural).
+            # Empty lists for images cause a crash in the image processor.
+            kwargs = {}
+            processor_kwargs = {}
+            if images:
+                kwargs["images"] = images
+            if video_tensors:
+                kwargs["videos"] = video_tensors
+                processor_kwargs["videos_kwargs"] = {
+                    "num_frames": max_num_frames,
+                    "return_metadata": True,
+                }
+            if audios:
+                kwargs["audio"] = audios
+
+            inputs = self.processor(
+                text=texts,
+                padding=True,
+                return_tensors="pt",
+                **kwargs,
+                **processor_kwargs,
+            )
+
+            if self.device_map == "auto":
+                inputs = inputs.to("cuda")
+            else:
+                inputs = inputs.to(self.device)
+
+            # Set default generation kwargs
+            default_gen_kwargs = {
+                "max_new_tokens": 4096,
+                "temperature": 0.0,
+                "top_p": None,
+                "num_beams": 1,
+            }
+            current_gen_kwargs = {**default_gen_kwargs, **gen_kwargs}
+            pad_token_id = self.tokenizer.pad_token_id
+
+            if current_gen_kwargs["temperature"] > 0:
+                current_gen_kwargs["do_sample"] = True
+            else:
+                current_gen_kwargs["do_sample"] = False
+                current_gen_kwargs["temperature"] = None
+                current_gen_kwargs["top_p"] = None
+
+            start_time = time.time()
+            cont = self.model.generate(
+                **inputs,
+                eos_token_id=self.tokenizer.eos_token_id,
+                pad_token_id=pad_token_id,
+                do_sample=current_gen_kwargs["do_sample"],
+                temperature=current_gen_kwargs["temperature"],
+                top_p=current_gen_kwargs["top_p"],
+                num_beams=current_gen_kwargs["num_beams"],
+                max_new_tokens=current_gen_kwargs["max_new_tokens"],
+                use_cache=self.use_cache,
+            )
+            end_time = time.time()
+
+            generated_ids_trimmed = [
+                out_ids[len(in_ids) :]
+                for in_ids, out_ids in zip(inputs.input_ids, cont)
+            ]
+            answers = self.processor.batch_decode(
+                generated_ids_trimmed,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=False,
+            )
+
+            total_elapsed_time += end_time - start_time  # type: ignore[assignment]
+            total_tokens += sum(len(ids) for ids in generated_ids_trimmed)
+
+            for i, (ans, context) in enumerate(zip(answers, texts)):
+                res.append(
+                    GenerationResult(
+                        text=ans,
+                        token_counts=TokenCounts(
+                            output_tokens=len(generated_ids_trimmed[i])
+                        ),
+                    )
+                )
+                self.cache_hook.add_partial(
+                    "generate_until", (context, gen_kwargs), ans
+                )
+                pbar.update(1)
+
+                eval_logger.debug(f"Question: {context}")
+                eval_logger.debug(f"Model Response: {ans}")
+
+        res = re_ords.get_original(res)
+        avg_speed = total_tokens / total_elapsed_time if total_elapsed_time > 0 else 0
+        metric_dict = {
+            "total_gen_tokens": total_tokens,
+            "total_elapsed_time": total_elapsed_time,
+            "avg_speed": avg_speed,
+        }
+        __import__(
+            "lmms_eval.models.model_utils.gen_metrics",
+            fromlist=["log_metrics"],
+        ).log_metrics(**metric_dict)
+
+        pbar.close()
+        return res
+
+    Huggingface.generate_until = _patched_generate_until
+
+    @contextlib.contextmanager
+    def _restore():
+        try:
+            yield
+        finally:
+            Huggingface.generate_until = _original_generate_until
+
+    return _restore()

--- a/tico/quantization/examples/configs/gemma4_eval_suite.yaml
+++ b/tico/quantization/examples/configs/gemma4_eval_suite.yaml
@@ -68,7 +68,7 @@ evaluation:
     batch_size: 1
     max_new_tokens: 30
     n_samples: 1000
-    max_num_frames: 32
+    max_num_frames: 21
     use_cache: null
     verbose: true
   mmlu:

--- a/tico/quantization/recipes/adapters/gemma4.py
+++ b/tico/quantization/recipes/adapters/gemma4.py
@@ -23,6 +23,7 @@ from transformers import AutoProcessor
 from tico.quantization import convert, prepare
 from tico.quantization.config.gemma4_builders import build_gemma4_e2b_ptq_config
 from tico.quantization.recipes.adapters.base import ModelAdapter
+from tico.quantization.recipes.config import get_by_path
 from tico.quantization.recipes.context import RecipeContext
 from tico.quantization.recipes.data.vlm import build_vlm_calibration_inputs
 from tico.quantization.recipes.evaluation.hellaswag import evaluate_and_print_hellaswag
@@ -111,6 +112,13 @@ class Gemma4Adapter(ModelAdapter):
         ctx.model.eval()
         self._disable_cache(ctx.model)
         assert_gemma4_e2b_no_moe(ctx.model)
+
+        calib_seq_len = get_by_path(cfg, "calibration.seq_len")
+        if calib_seq_len is not None and hasattr(ctx.model.config, "text_config"):
+            ctx.model.config.text_config.max_position_embeddings = min(
+                int(ctx.model.config.text_config.max_position_embeddings),
+                int(calib_seq_len),
+            )
         return ctx
 
     @staticmethod
@@ -121,6 +129,15 @@ class Gemma4Adapter(ModelAdapter):
         text_config = getattr(getattr(model, "config", None), "text_config", None)
         if text_config is not None and hasattr(text_config, "use_cache"):
             text_config.use_cache = False
+
+    @staticmethod
+    def _enable_cache(model: Any) -> None:
+        """Re-enable HF dynamic cache for autoregressive generation."""
+        if hasattr(model, "config") and hasattr(model.config, "use_cache"):
+            model.config.use_cache = True
+        text_config = getattr(getattr(model, "config", None), "text_config", None)
+        if text_config is not None and hasattr(text_config, "use_cache"):
+            text_config.use_cache = True
 
     @staticmethod
     def _static_calibration_image_size(
@@ -278,6 +295,11 @@ class Gemma4Adapter(ModelAdapter):
         if not eval_cfg.get("enabled", False):
             return
 
+        # Re-enable KV cache for autoregressive generation during evaluation.
+        # ``_disable_cache`` in ``load_model`` turns it off for calibration,
+        # but ``generate()`` requires cache for acceptable speed.
+        self._enable_cache(ctx.model)
+
         max_seq_len = eval_cfg.get("max_seq_len")
         n_samples = int(eval_cfg.get("n_samples", 50))
         tasks = eval_cfg.get("vlm_tasks") or []
@@ -361,7 +383,9 @@ class Gemma4Adapter(ModelAdapter):
         videomme = eval_cfg.get("videomme", {})
         if videomme.get("enabled", False):
             video_n_samples = int(videomme.get("n_samples", -1))
-            max_num_frames = int(videomme.get("max_num_frames", 32))
+            # max_num_frames=21 for gemma4 model with max_seq_len=2048
+            # due to the minimal soft_tokens_per_frame is 70 (comes from processor.video_processor.max_soft_tokens)
+            max_num_frames = int(videomme.get("max_num_frames", 21))
             if max_num_frames <= 0:
                 raise ValueError(
                     "evaluation.videomme.max_num_frames must be a positive integer."

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_for_causal_lm.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 
 import torch
 import torch.nn as nn
+
+from transformers.generation.utils import GenerationMixin
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.mode import Mode
@@ -27,7 +29,7 @@ from tico.quantization.wrapq.wrappers.registry import try_register
 
 
 @try_register("transformers.models.gemma4.modeling_gemma4.Gemma4ForCausalLM")
-class QuantGemma4ForCausalLM(QuantModuleBase):
+class QuantGemma4ForCausalLM(QuantModuleBase, GenerationMixin):
     """PTQ wrapper for Gemma4 text-only causal LM."""
 
     def __init__(
@@ -57,17 +59,41 @@ class QuantGemma4ForCausalLM(QuantModuleBase):
         self.obs_logit_softcapping_tanh = self._make_obs("logit_softcapping_tanh")
         self.obs_logits = self._make_obs("logits")
 
-    def forward(self, *args, logits_to_keep: int | torch.Tensor = 0, **kwargs):
-        """Run the wrapped causal LM model (calibration path).
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values=None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        per_layer_inputs: torch.Tensor | None = None,
+        **kwargs,
+    ) -> Union[torch.Tensor, tuple]:
+        """Run the wrapped causal LM model.
 
         Mirrors ``Gemma4ForCausalLM.forward`` including logit softcapping.
         Fake-quantization observers are inserted after the ``tanh`` and on
         the final logits so that the export path carries correct qparam
         metadata.
 
-        TODO: Return ``Gemma4CausalLMOutputWithPast`` for full HF compatibility.
+        When ``labels`` is provided, the cross-entropy loss is computed via
+        the original model's ``loss_function`` and a
+        ``Gemma4CausalLMOutputWithPast`` is returned, matching the HF
+        contract expected by evaluation utilities (e.g. perplexity).
         """
-        outputs = self.model(*args, **kwargs)
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            per_layer_inputs=per_layer_inputs,
+            use_cache=use_cache,
+            **kwargs,
+        )
         hidden_states = (
             outputs.last_hidden_state
             if hasattr(outputs, "last_hidden_state")
@@ -81,8 +107,28 @@ class QuantGemma4ForCausalLM(QuantModuleBase):
         else:
             slice_indices = slice(None)
         logits = self.lm_head(hidden_states[:, slice_indices, :])
+        logits = self._apply_logit_softcapping(logits)
 
-        return self._apply_logit_softcapping(logits)
+        loss = None
+        if labels is not None:
+            loss = self.module.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.vocab_size,
+                **kwargs,
+            )
+
+        from transformers.models.gemma4.modeling_gemma4 import (
+            Gemma4CausalLMOutputWithPast,
+        )
+
+        return Gemma4CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
 
     def _apply_logit_softcapping(self, logits: torch.Tensor) -> torch.Tensor:
         """Apply logit softcapping with fake-quantization observers.
@@ -107,9 +153,74 @@ class QuantGemma4ForCausalLM(QuantModuleBase):
         logits = self._fq(logits, self.obs_logits)
         return logits
 
-    def generate(self, *args, **kwargs):
-        """Delegate generation to the original module until static runtime is wired."""
-        return self.module.generate(*args, **kwargs)
+    # --- Generation support --------------------------------------------------
+    # Do NOT override ``generate()``: ``GenerationMixin.generate()`` calls our
+    # quantized ``forward()`` so fake-quantization is active during decoding.
+
+    main_input_name = "input_ids"
+    _is_stateful = True
+    _supports_cache_class = True
+
+    @property
+    def device(self):
+        """Return the device for generation."""
+        return self.module.device
+
+    @property
+    def generation_config(self):
+        """Return the generation config."""
+        return self.module.generation_config
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        position_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        use_cache=True,
+        logits_to_keep=None,
+        labels=None,
+        is_first_iteration=False,
+        **kwargs,
+    ):
+        """Prepare inputs for generation step.
+
+        Delegates to the original model's implementation so the
+        fake-quantized ``forward()`` receives correctly prepared inputs.
+        """
+        return self.module.prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            use_cache=use_cache,
+            logits_to_keep=logits_to_keep,
+            labels=labels,
+            is_first_iteration=is_first_iteration,
+            **kwargs,
+        )
+
+    def tie_weights(self):
+        pass
+
+    def can_generate(self) -> bool:
+        return True
+
+    def get_output_embeddings(self):
+        return self.module.get_output_embeddings()
+
+    def get_input_embeddings(self):
+        return self.module.get_input_embeddings()
+
+    def get_experts_implementation(self):
+        return self.module.get_experts_implementation()
+
+    def set_experts_implementation(self, experts_implementation):
+        return self.module.set_experts_implementation(experts_implementation)
 
     def _all_observers(self) -> Iterable:
         """Return observers owned directly by this wrapper."""

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_for_conditional_generation.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 
 import torch
 import torch.nn as nn
+
+from transformers.generation.utils import GenerationMixin
 
 from tico.quantization.config.ptq import PTQConfig
 from tico.quantization.wrapq.mode import Mode
@@ -29,7 +31,7 @@ from tico.quantization.wrapq.wrappers.registry import try_register
 @try_register(
     "transformers.models.gemma4.modeling_gemma4.Gemma4ForConditionalGeneration"
 )
-class QuantGemma4ForConditionalGeneration(QuantModuleBase):
+class QuantGemma4ForConditionalGeneration(QuantModuleBase, GenerationMixin):
     """Top-level PTQ wrapper for Gemma4 E2B conditional generation."""
 
     def __init__(
@@ -59,17 +61,55 @@ class QuantGemma4ForConditionalGeneration(QuantModuleBase):
         self.obs_logit_softcapping_tanh = self._make_obs("logit_softcapping_tanh")
         self.obs_logits = self._make_obs("logits")
 
-    def forward(self, *args, logits_to_keep: int | torch.Tensor = 0, **kwargs):
-        """Run the wrapped conditional generation model (calibration path).
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        input_features: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        input_features_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        image_position_ids: torch.LongTensor | None = None,
+        video_position_ids: torch.LongTensor | None = None,
+        past_key_values=None,
+        mm_token_type_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        per_layer_inputs: torch.Tensor | None = None,
+        **kwargs,
+    ) -> Union[torch.Tensor, tuple]:
+        """Run the wrapped conditional generation model.
 
         Mirrors ``Gemma4ForConditionalGeneration.forward`` including logit
         softcapping.  Fake-quantization observers are inserted after the
         ``tanh`` and on the final logits so that the export path carries
         correct qparam metadata.
 
-        TODO: Return ``Gemma4CausalLMOutputWithPast`` for full HF compatibility.
+        When ``labels`` is provided, the cross-entropy loss is computed via
+        the original model's ``loss_function`` and a
+        ``Gemma4CausalLMOutputWithPast`` is returned, matching the HF
+        contract expected by evaluation utilities (e.g. perplexity).
         """
-        outputs = self.model(*args, **kwargs)
+        outputs = self.model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            input_features=input_features,
+            attention_mask=attention_mask,
+            input_features_mask=input_features_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            mm_token_type_ids=mm_token_type_ids,
+            inputs_embeds=inputs_embeds,
+            image_position_ids=image_position_ids,
+            video_position_ids=video_position_ids,
+            per_layer_inputs=per_layer_inputs,
+            use_cache=use_cache,
+            **kwargs,
+        )
         hidden_states = (
             outputs.last_hidden_state
             if hasattr(outputs, "last_hidden_state")
@@ -83,8 +123,28 @@ class QuantGemma4ForConditionalGeneration(QuantModuleBase):
         else:
             slice_indices = slice(None)
         logits = self.lm_head(hidden_states[:, slice_indices, :])
+        logits = self._apply_logit_softcapping(logits)
 
-        return self._apply_logit_softcapping(logits)
+        loss = None
+        if labels is not None:
+            loss = self.module.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.get_text_config().vocab_size,
+                **kwargs,
+            )
+
+        from transformers.models.gemma4.modeling_gemma4 import (
+            Gemma4CausalLMOutputWithPast,
+        )
+
+        return Gemma4CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
 
     def _apply_logit_softcapping(self, logits: torch.Tensor) -> torch.Tensor:
         """Apply logit softcapping with fake-quantization observers.
@@ -109,9 +169,82 @@ class QuantGemma4ForConditionalGeneration(QuantModuleBase):
         logits = self._fq(logits, self.obs_logits)
         return logits
 
-    def generate(self, *args, **kwargs):
-        """Delegate generation to the original module until static runtime is wired."""
-        return self.module.generate(*args, **kwargs)
+    # --- Generation support --------------------------------------------------
+    # Do NOT override ``generate()``: ``GenerationMixin.generate()`` calls our
+    # quantized ``forward()`` so fake-quantization is active during decoding.
+
+    main_input_name = "input_ids"
+    _is_stateful = True
+    _supports_cache_class = True
+
+    @property
+    def device(self):
+        """Return the device for generation."""
+        return self.module.device
+
+    @property
+    def generation_config(self):
+        """Return the generation config."""
+        return self.module.generation_config
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        position_ids=None,
+        pixel_values=None,
+        pixel_values_videos=None,
+        input_features=None,
+        attention_mask=None,
+        input_features_mask=None,
+        token_type_ids=None,
+        use_cache=True,
+        logits_to_keep=None,
+        labels=None,
+        is_first_iteration=False,
+        **kwargs,
+    ):
+        """Prepare inputs for generation step.
+
+        Delegates to the original model's implementation so the
+        fake-quantized ``forward()`` receives correctly prepared inputs.
+        """
+        return self.module.prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            input_features=input_features,
+            attention_mask=attention_mask,
+            input_features_mask=input_features_mask,
+            token_type_ids=token_type_ids,
+            use_cache=use_cache,
+            logits_to_keep=logits_to_keep,
+            labels=labels,
+            is_first_iteration=is_first_iteration,
+            **kwargs,
+        )
+
+    def tie_weights(self):
+        pass
+
+    def can_generate(self) -> bool:
+        return True
+
+    def get_output_embeddings(self):
+        return self.module.get_output_embeddings()
+
+    def get_input_embeddings(self):
+        return self.module.get_input_embeddings()
+
+    def get_experts_implementation(self):
+        return self.module.get_experts_implementation()
+
+    def set_experts_implementation(self, experts_implementation):
+        return self.module.set_experts_implementation(experts_implementation)
 
     def _all_observers(self) -> Iterable:
         """Return observers owned directly by this wrapper."""

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_model.py
@@ -138,6 +138,29 @@ class QuantGemma4Model(QuantModuleBase):
         )
         return self.embed_vision(vision_outputs.last_hidden_state)
 
+    def get_video_features(
+        self,
+        pixel_values_videos: torch.Tensor,
+        video_position_ids: Optional[torch.Tensor] = None,
+    ):
+        """Return projected video soft tokens.
+
+        Mirrors ``Gemma4Model.get_video_features``: flattens the
+        ``(num_videos, num_frames, ...)`` dimensions into a single batch
+        dimension, runs the frames through the (quantized) vision tower, and
+        projects the last hidden state via ``embed_vision``.
+        """
+        assert self.vision_tower is not None, "vision_tower is not available"
+        pixel_values_videos = pixel_values_videos.flatten(0, 1)
+        if video_position_ids is not None:
+            video_position_ids = video_position_ids.flatten(0, 1)
+        vision_outputs = self.vision_tower(
+            pixel_values=pixel_values_videos,
+            pixel_position_ids=video_position_ids,
+            return_dict=True,
+        )
+        return self.embed_vision(vision_outputs.last_hidden_state)
+
     def _uses_static_fusion(self) -> bool:
         """Return whether the current call should use static fixed-slot fusion."""
         return bool(torch.compiler.is_compiling() or self.force_export)
@@ -149,16 +172,21 @@ class QuantGemma4Model(QuantModuleBase):
         video_mask: torch.Tensor,
         audio_mask: torch.Tensor,
         pixel_values: Optional[torch.Tensor],
+        pixel_values_videos: Optional[torch.Tensor] = None,
     ) -> None:
         """Reject unsupported or incomplete multimodal eager inputs."""
-        if video_mask.any() or audio_mask.any():
+        if audio_mask.any():
             raise NotImplementedError(
-                "Gemma4 PTQ wrapper supports image-text inputs only. "
-                "Video and audio placeholder tokens are not supported."
+                "Gemma4 PTQ wrapper does not support audio placeholder tokens."
             )
         if pixel_values is None and image_mask.any():
             raise ValueError(
                 "pixel_values must be provided when input_ids contain image placeholders."
+            )
+        if pixel_values_videos is None and video_mask.any():
+            raise ValueError(
+                "pixel_values_videos must be provided when input_ids contain "
+                "video placeholders."
             )
 
     def _validate_static_image_layout(
@@ -207,15 +235,20 @@ class QuantGemma4Model(QuantModuleBase):
         inputs_embeds: Optional[torch.Tensor] = None,
         image_position_ids: Optional[torch.Tensor] = None,
         per_layer_inputs: Optional[torch.Tensor] = None,
+        pixel_values_videos: Optional[torch.Tensor] = None,
+        video_position_ids: Optional[torch.Tensor] = None,
+        input_features: Optional[torch.Tensor] = None,
+        input_features_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ):
-        """Run Gemma4 image-text forward with eager and static fusion paths.
+        """Run Gemma4 image/video-text forward with eager and static fusion paths.
 
         Eager/PTQ uses dynamic placeholder-mask fusion by default, matching
-        HF-style image placeholder positions. Static export/runtime uses strict
-        fixed-slot fusion. Static layout validation is opt-in in eager mode and
-        should be enabled only for deployment-style calibration or NPU-proxy
-        benchmarks whose prompts follow the final static runtime layout.
+        HF-style image and video placeholder positions. Static export/runtime
+        uses strict fixed-slot fusion. Static layout validation is opt-in in
+        eager mode and should be enabled only for deployment-style calibration
+        or NPU-proxy benchmarks whose prompts follow the final static runtime
+        layout.
 
         Image-size alignment and static-layout validation solve different
         problems: resizing stabilizes visual-token count, while layout
@@ -236,6 +269,7 @@ class QuantGemma4Model(QuantModuleBase):
         text_model = self.language_model.wrapped  # QuantGemma4TextModel
         llm_input_ids: Optional[torch.Tensor] = None
         image_mask: Optional[torch.BoolTensor] = None
+        video_mask: Optional[torch.BoolTensor] = None
 
         if inputs_embeds is None:
             assert input_ids is not None  # guaranteed by validation above
@@ -252,6 +286,7 @@ class QuantGemma4Model(QuantModuleBase):
                     video_mask=video_mask,
                     audio_mask=audio_mask,
                     pixel_values=pixel_values,
+                    pixel_values_videos=pixel_values_videos,
                 )
             multimodal_mask = image_mask | video_mask | audio_mask
             if multimodal_mask.any():
@@ -347,6 +382,39 @@ class QuantGemma4Model(QuantModuleBase):
                     inputs_embeds,
                     image_embeds,
                     image_mask,
+                )
+            inputs_embeds = self._fq(inputs_embeds, self.obs_mm_fusion)
+
+        # --- Multimodal fusion (video) ------------------------------------
+        # Video frames are processed through the same vision tower as images
+        # (after flattening the num_videos × num_frames dims).  The resulting
+        # soft tokens are fused at the video placeholder positions using the
+        # same dynamic placeholder-mask approach as images.
+        if pixel_values_videos is not None:
+            video_embeds = self.get_video_features(
+                pixel_values_videos, video_position_ids=video_position_ids
+            )
+            assert inputs_embeds is not None  # guaranteed after embedding step
+            # Align dtype/device to match text embeddings before fusion.
+            video_embeds = video_embeds.to(
+                device=inputs_embeds.device, dtype=inputs_embeds.dtype
+            )
+
+            if self._uses_static_fusion():
+                raise NotImplementedError(
+                    "Static fixed-slot fusion for video is not yet supported. "
+                    "Video inputs should use the eager/PTQ dynamic path."
+                )
+            else:
+                if video_mask is None:
+                    raise ValueError(
+                        "input_ids must be provided with pixel_values_videos when "
+                        "running Gemma4 eager/PTQ dynamic placeholder fusion."
+                    )
+                inputs_embeds = dynamic_placeholder_fuse(
+                    inputs_embeds,
+                    video_embeds,
+                    video_mask,
                 )
             inputs_embeds = self._fq(inputs_embeds, self.obs_mm_fusion)
 


### PR DESCRIPTION
This PR adds generation support and Video-MME benchmark support to the Gemma4 PTQ wrappers:

1. __Generation support__ — `QuantGemma4ForCausalLM` and `QuantGemma4ForConditionalGeneration` now inherit from `GenerationMixin` and implement all the methods HF's `generate()`.
 
3. __Video-MME benchmark support__ — The Gemma4 adapter's `evaluate()` method now support `videomme` benchmark.
For gemma4 evaluation with max_position_embeddings=2048 we should use `max_num_frames` = 21 unlike qwen3-vl where `max_num_frames`=35 is used. 
In Gemma4, the minimum limit of soft_tokens_per_frame=70 (comes from processor.video_processor.max_soft_tokens) when for qwen3-vl we can control the minimum tokens per frame.

  ```
**The formula:**

  input_budget     = max_position_embeddings - max_new_tokens - safety_margin
  visual_budget    = input_budget - text_token_margin
  max_num_frames   = visual_budget // soft_tokens_per_frame


max_position_embeddings=2048
max_new_tokens=30
safety_margin=4
text_token_margin=512
soft_tokens_per_frame=70 

**The arithmetic:**

input_budget  = 2048 - 30 - 4      = 2014
visual_budget = 2014 - 512          = 1502
max_num_frames = 1502 / 70        = 21

  ```
Co-Authored-By: Cline

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>