### PR TITLE
[evaluation] Support PPL eval for Gemma4

### DIFF
--- a/test/quantization/wrapq/utils/test_metrics.py
+++ b/test/quantization/wrapq/utils/test_metrics.py
@@ -16,7 +16,12 @@ import unittest
 from types import SimpleNamespace
 
 import torch
-from tico.quantization.wrapq.utils.metrics import perplexity
+import torch.nn.functional as F
+from tico.quantization.wrapq.utils.metrics import (
+    _CHAT_PREFIX_INSTRUCTION,
+    perplexity,
+    perplexity_chat_prefix,
+)
 from torch import nn
 
 """
@@ -32,6 +37,8 @@ This test checks three things:
 
 A lightweight dummy causal-LM is used so the tests run quickly on CPU.
 """
+
+
 # ────────────────────────────────────────────────────────────
 #   Dummy causal language model
 # ────────────────────────────────────────────────────────────
@@ -62,6 +69,10 @@ class DummyLM(nn.Module):
         self,
         input_ids: torch.Tensor,
         labels: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        use_cache: bool = False,
+        logits_to_keep: int | None = None,
+        **kwargs,
     ) -> SimpleNamespace:
         """
         Parameters
@@ -70,6 +81,9 @@ class DummyLM(nn.Module):
         labels    : Tensor[B, T] or None
             If provided, this method emulates HF CausalLM by shifting
             logits/labels internally before computing CE loss.
+        attention_mask, use_cache, logits_to_keep : ignored
+            Accepted for compatibility with perplexity_chat_prefix
+            which passes these kwargs.
         """
         emb = self.embed(input_ids)  # (B, T, H)
         logits = self.fc(emb)  # (B, T, V)
@@ -209,3 +223,214 @@ class TestPerplexitySlidingWindow(unittest.TestCase):
             ignore_index=123,
         )
         self.assertIsInstance(ppl, float)
+
+
+# ────────────────────────────────────────────────────────────
+#   Dummy tokenizer with apply_chat_template
+# ────────────────────────────────────────────────────────────
+class DummyTokenizer:
+    """
+    Minimal tokenizer that supports `apply_chat_template` and basic
+    `__call__` for perplexity_chat_prefix tests.
+
+    Vocabulary: token id 0 = <pad>, 1..VOCAB-1 = real tokens.
+    Each character in the text is mapped to (ord(c) % (VOCAB-1)) + 1.
+    """
+
+    def __init__(self, vocab_size: int = 16):
+        self.vocab_size = vocab_size
+        self.bos_token_id = 0
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        """Render a simple chat prefix: '<bos>user: {text}\\nmodel: '."""
+        text = messages[0]["content"]
+        prefix = f"<bos>user: {text}\nmodel: "
+        if tokenize:
+            # Return a dict mimicking tokenizer output
+            ids = [self._char_to_id(c) for c in prefix]
+            return {"input_ids": torch.tensor([ids])}
+        return prefix
+
+    def __call__(self, text=None, return_tensors="pt", add_special_tokens=False):
+        """Tokenize text into input_ids tensor [1, seq_len]."""
+        if text is None:
+            raise ValueError("text is required")
+        ids = [self._char_to_id(c) for c in text]
+        return {"input_ids": torch.tensor([ids])}
+
+    def _char_to_id(self, c: str) -> int:
+        return (ord(c) % (self.vocab_size - 1)) + 1
+
+
+# ─────────────────────────────────────────────────────────────
+# Unit-test class for perplexity_chat_prefix
+# ─────────────────────────────────────────────────────────────
+class TestPerplexityChatPrefix(unittest.TestCase):
+    """
+    Tests for perplexity_chat_prefix.
+
+    All tests run on CPU with a DummyLM and DummyTokenizer.
+    """
+
+    VOCAB: int = 16
+    HIDDEN: int = 8
+    MAX_SEQ_LEN: int = 256
+
+    device: torch.device
+    model: DummyLM
+    tokenizer: DummyTokenizer
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(42)
+        cls.device = torch.device("cpu")
+        cls.model = (
+            DummyLM(
+                vocab_size=cls.VOCAB,
+                hidden_size=cls.HIDDEN,
+                n_positions=cls.MAX_SEQ_LEN,
+            )
+            .to(cls.device)
+            .eval()
+        )
+        cls.tokenizer = DummyTokenizer(vocab_size=cls.VOCAB)
+
+    def _make_dataset(self, text: str) -> list[dict]:
+        return [{"text": text}]
+
+    # ─────────────────────────────────────────────────────────
+    # 1. API sanity — returns a positive float
+    # ─────────────────────────────────────────────────────────
+    def test_returns_positive_float(self) -> None:
+        dataset = self._make_dataset("Hello world this is a test sentence.")
+        ppl = perplexity_chat_prefix(
+            self.model,
+            self.tokenizer,
+            dataset,
+            stride=8,
+            max_seq_len=self.MAX_SEQ_LEN,
+            device=self.device,
+            show_progress=False,
+        )
+        self.assertIsInstance(ppl, float)
+        self.assertGreater(ppl, 0.0)
+
+    # ─────────────────────────────────────────────────────────
+    # 2. Empty dataset raises ValueError
+    # ─────────────────────────────────────────────────────────
+    def test_empty_dataset_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            perplexity_chat_prefix(
+                self.model,
+                self.tokenizer,
+                [],
+                stride=8,
+                max_seq_len=self.MAX_SEQ_LEN,
+                device=self.device,
+                show_progress=False,
+            )
+
+    # ─────────────────────────────────────────────────────────
+    # 3. stride > window_size raises ValueError
+    # ─────────────────────────────────────────────────────────
+    def test_stride_too_large_raises(self) -> None:
+        dataset = self._make_dataset("Some text here.")
+        with self.assertRaises(ValueError):
+            perplexity_chat_prefix(
+                self.model,
+                self.tokenizer,
+                dataset,
+                stride=1000,
+                max_seq_len=self.MAX_SEQ_LEN,
+                device=self.device,
+                show_progress=False,
+            )
+
+    # ─────────────────────────────────────────────────────────
+    # 4. max_seq_len too small for prefix raises ValueError
+    # ─────────────────────────────────────────────────────────
+    def test_max_seq_len_too_small_raises(self) -> None:
+        dataset = self._make_dataset("Some text here.")
+        with self.assertRaises(ValueError):
+            perplexity_chat_prefix(
+                self.model,
+                self.tokenizer,
+                dataset,
+                stride=1,
+                max_seq_len=2,  # too small for the chat prefix
+                device=self.device,
+                show_progress=False,
+            )
+
+    # ─────────────────────────────────────────────────────────
+    # 5. Prefix tokens are never scored — PPL computed by
+    #    perplexity_chat_prefix matches a manual reference that
+    #    uses the same prefix+content input but computes loss only
+    #    on content tokens.
+    # ─────────────────────────────────────────────────────────
+    def test_prefix_not_scored(self) -> None:
+        text = "Hello world test."
+        dataset = self._make_dataset(text)
+
+        # PPL via perplexity_chat_prefix (prefix prepended, prefix masked)
+        ppl_with_prefix = perplexity_chat_prefix(
+            self.model,
+            self.tokenizer,
+            dataset,
+            stride=64,  # large stride → single window, all tokens scored
+            max_seq_len=self.MAX_SEQ_LEN,
+            device=self.device,
+            show_progress=False,
+        )
+
+        # Reference: run the model with the SAME prefix+content input
+        # and compute loss only on content tokens (prefix masked with -100).
+        prefix_str = self.tokenizer.apply_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": _CHAT_PREFIX_INSTRUCTION,
+                }
+            ],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        prefix_enc = self.tokenizer(
+            text=prefix_str, return_tensors="pt", add_special_tokens=False
+        )
+        prefix_ids = prefix_enc["input_ids"].to(self.device)
+
+        content_enc = self.tokenizer(
+            text=text, return_tensors="pt", add_special_tokens=False
+        )
+        content_ids = content_enc["input_ids"].to(self.device)
+
+        full_ids = torch.cat([prefix_ids, content_ids], dim=1)
+        prefix_len = prefix_ids.shape[1]
+        content_len = content_ids.shape[1]
+
+        labels = torch.full(
+            (1, prefix_len + content_len), -100, dtype=torch.long, device=self.device
+        )
+        labels[:, prefix_len:] = full_ids[:, prefix_len:]
+
+        with torch.no_grad():
+            logits = self.model(full_ids).logits
+        shift_logits = logits[:, :-1, :].contiguous()
+        shift_labels = labels[:, 1:].contiguous()
+
+        ref_loss = F.cross_entropy(
+            shift_logits.view(-1, shift_logits.size(-1)),
+            shift_labels.view(-1),
+            ignore_index=-100,
+            reduction="sum",
+        )
+        n_tokens = (shift_labels != -100).sum().item()
+        ref_ppl = torch.exp(ref_loss / n_tokens).item()
+
+        self.assertAlmostEqual(
+            ppl_with_prefix,
+            ref_ppl,
+            places=5,
+            msg=f"with_prefix={ppl_with_prefix:.6f}, ref={ref_ppl:.6f}",
+        )

--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -1064,6 +1064,55 @@ def evaluate_ppl(
     return ppl
 
 
+def evaluate_ppl_chat_prefix(
+    model,
+    processor,
+    ds: Dataset | IterableDataset,
+    device: str | torch.device,
+    stride: int,
+    max_seq_len: int,
+    show_progress: bool = True,
+) -> float:
+    """
+    Evaluate conditional perplexity on a text dataset using chat-prefix.
+
+    This function computes conditional perplexity by placing a preceding text
+    span in a user prompt via ``apply_chat_template`` and scoring only the
+    reference assistant continuation tokens.  It expects a dataset that yields
+    examples with a "text" field (e.g., wikitext2).
+
+    This is the natural evaluation protocol for instruction-tuned models
+    (e.g. Gemma 4 IT), where the raw token-stream PPL from ``evaluate_ppl``
+    is not directly comparable because the model expects chat-formatted input.
+
+    Args:
+        model: Language model to evaluate.
+        processor: Hugging Face processor with ``apply_chat_template`` and
+            a ``.tokenizer`` attribute.
+        ds: Iterable dataset yielding examples with a "text" field.
+        device: Device used for evaluation.
+        stride: stride for evaluation.
+        max_seq_len: max seq_len for evaluation.
+        show_progress: Whether to show progress bar.
+
+    Returns:
+        Conditional perplexity score.
+    """
+    from tico.quantization.wrapq.utils.metrics import perplexity_chat_prefix
+
+    ppl = perplexity_chat_prefix(
+        model=model,
+        processor_or_tokenizer=processor,
+        dataset=ds,
+        device=device,
+        stride=stride,
+        max_seq_len=max_seq_len,
+        show_progress=show_progress,
+    )
+
+    return ppl
+
+
 def get_calib_inputs(
     dataset: str,
     processor,

--- a/tico/quantization/examples/configs/gemma4_eval_suite.yaml
+++ b/tico/quantization/examples/configs/gemma4_eval_suite.yaml
@@ -97,6 +97,7 @@ evaluation:
     dataset: wikitext2
     split: test
     stride: 512
+    mode: chat-prefix
   n_samples: 1000
   max_seq_len: 2048
 

--- a/tico/quantization/recipes/adapters/gemma4.py
+++ b/tico/quantization/recipes/adapters/gemma4.py
@@ -37,6 +37,7 @@ from tico.quantization.recipes.evaluation.vlm import (
     evaluate_coco,
     evaluate_llava_bench,
     evaluate_vlm_text_ppl,
+    evaluate_vlm_text_ppl_chat_prefix,
     evaluate_vqa_tasks,
     print_coco_score_results,
     print_vqa_results,
@@ -453,7 +454,22 @@ class Gemma4Adapter(ModelAdapter):
 
         ppl = eval_cfg.get("ppl", {})
         if ppl.get("enabled", False):
-            ppl_value = evaluate_vlm_text_ppl(
+            ppl_mode = str(ppl.get("mode", "raw")).lower()
+
+            _VALID_PPL_MODES = {"raw", "chat-prefix"}
+            if ppl_mode not in _VALID_PPL_MODES:
+                raise ValueError(
+                    f"Unsupported ppl mode: {ppl_mode!r}. "
+                    f"Must be one of {sorted(_VALID_PPL_MODES)}."
+                )
+
+            eval_fn = (
+                evaluate_vlm_text_ppl_chat_prefix
+                if ppl_mode == "chat-prefix"
+                else evaluate_vlm_text_ppl
+            )
+
+            ppl_value = eval_fn(
                 model=ctx.model,
                 processor=ctx.processor,
                 dataset_name=ppl.get("dataset", "wikitext2"),

--- a/tico/quantization/recipes/evaluation/vlm.py
+++ b/tico/quantization/recipes/evaluation/vlm.py
@@ -20,6 +20,7 @@ import tqdm
 
 from tico.quantization.evaluation.vlm_eval_utils import (
     evaluate_ppl,
+    evaluate_ppl_chat_prefix,
     get_accuracy_on_dataset,
     get_coco_scores_on_dataset,
     get_dataset,
@@ -213,6 +214,54 @@ def evaluate_vlm_text_ppl(
         evaluate_ppl(
             model=model,
             tokenizer=processor.tokenizer,
+            ds=dataset,
+            device=device,
+            stride=stride,
+            max_seq_len=max_seq_len,
+            show_progress=show_progress,
+        )
+    )
+
+
+def evaluate_vlm_text_ppl_chat_prefix(
+    *,
+    model: Any,
+    processor: Any,
+    dataset_name: str,
+    split: str,
+    device: str,
+    stride: int,
+    max_seq_len: int,
+    show_progress: bool = True,
+) -> float:
+    """Evaluate conditional perplexity using chat-prefix protocol.
+
+    A preceding text span is placed in a user prompt via
+    ``apply_chat_template``.  Only the reference assistant continuation is
+    scored; chat/control/prompt tokens are context and are not scored.
+
+    This is the natural evaluation for instruction-tuned models (e.g. Gemma 4
+    IT) where the raw token-stream PPL is not directly comparable because the
+    model expects chat-formatted input.
+
+    Args:
+        model: Model to evaluate.
+        processor: Hugging Face processor paired with the model.
+        dataset_name: Dataset key accepted by the shared VLM evaluation helper.
+        split: Dataset split to load.
+        device: Device string used for inference.
+        stride: stride for evaluation.
+        max_seq_len: max seq_len for evaluation.
+        show_progress: Whether to show a progress bar.
+
+    Returns:
+        Conditional perplexity score.
+    """
+    dataset, _ = get_dataset(dataset_name, split=split, n=-1)
+    return float(
+        evaluate_ppl_chat_prefix(
+            model=model,
+            processor=processor,
             ds=dataset,
             device=device,
             stride=stride,

--- a/tico/quantization/wrapq/utils/metrics.py
+++ b/tico/quantization/wrapq/utils/metrics.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+import math
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import torch
+import torch.nn.functional as F
 import tqdm
 
 
@@ -143,3 +146,294 @@ def perplexity(
     ppl = torch.exp(avg_nll)
 
     return ppl.item()
+
+
+_CHAT_PREFIX_INSTRUCTION = (
+    "You are a text continuation engine. " "Complete the following passage exactly."
+)
+
+
+def _render_chat_prefix(
+    processor_or_tokenizer: Any,
+    tokenizer: Any,
+) -> str:
+    """Render the generation prefix with the model's chat template."""
+    template_owner = None
+    if hasattr(processor_or_tokenizer, "apply_chat_template"):
+        template_owner = processor_or_tokenizer
+    elif hasattr(tokenizer, "apply_chat_template"):
+        template_owner = tokenizer
+
+    if template_owner is None:
+        raise ValueError(
+            "chat-prefix perplexity requires a processor or tokenizer "
+            "with apply_chat_template support."
+        )
+
+    text_content = _CHAT_PREFIX_INSTRUCTION
+    multimodal_content = [{"type": "text", "text": text_content}]
+    if hasattr(template_owner, "tokenizer"):
+        content_variants: tuple[Any, ...] = (multimodal_content, text_content)
+    else:
+        content_variants = (text_content, multimodal_content)
+    last_error: Exception | None = None
+    for content in content_variants:
+        messages = [{"role": "user", "content": content}]
+        try:
+            rendered = template_owner.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        except (TypeError, ValueError) as exc:
+            last_error = exc
+            continue
+
+        if not isinstance(rendered, str):
+            raise TypeError(
+                "apply_chat_template(tokenize=False) must return a string, "
+                f"got {type(rendered)!r}."
+            )
+        if not rendered:
+            raise ValueError("apply_chat_template returned an empty chat prefix.")
+        return rendered
+
+    raise TypeError(
+        "Failed to render chat prefix with apply_chat_template."
+    ) from last_error
+
+
+def perplexity_chat_prefix(
+    model: torch.nn.Module,
+    processor_or_tokenizer: Any,
+    dataset: Iterable[dict[str, Any]],
+    *,
+    stride: int = 512,
+    max_seq_len: int = 2048,
+    device: torch.device | str | None = None,
+    show_progress: bool = True,
+) -> float:
+    """
+    Compute sliding-window causal PPL for raw text on Gemma4 IT models.
+
+    Gemma4 instruction-tuned models require a proper chat-template prefix
+    (user turn + model turn with empty thought channel) to produce
+    meaningful perplexity.  Without this prefix the model sees raw text
+    in an unexpected context and produces astronomically high PPL values.
+
+    **Algorithm**
+
+    1. A fixed chat-template prefix is rendered **once** via
+       :func:`_render_chat_prefix` using the model's own
+       ``apply_chat_template``.  The prefix contains a user turn with
+       a text-continuation instruction and a generation prompt
+       (``add_generation_prompt=True``).  This places the model in
+       "continuation mode" so it expects raw text to follow.
+    2. The full corpus is tokenised **once** (no special tokens) and
+       concatenated into a single 1-D token stream.
+    3. A sliding window of ``max_seq_len - prefix_len`` content tokens
+       advances by ``stride`` positions per step.
+    4. For each window:
+       a. The chat prefix is prepended to the content tokens.
+       b. Labels are set to ``-100`` for all prefix tokens and for
+          content tokens that were already scored in a previous window
+          (the first ``window_size - target_length`` tokens).  Only
+          the last ``target_length`` content tokens (the freshly
+          covered ones) have their actual IDs as labels.
+       c. The model is called with ``input_ids``, ``attention_mask``,
+          ``labels``, ``use_cache=False``.  The model computes the
+          cross-entropy loss internally (averaged over non-masked
+          labels), avoiding the need to materialise the full logits
+          tensor in memory.
+     5. The per-window NLL sums and token counts are accumulated, and
+        the corpus-level PPL is ``exp(total_nll / total_tokens)``.
+
+    **Key design choices**
+
+    * The prefix is **constant** across all windows.
+    * The prefix tokens are **never scored** (labels = -100), so only
+      corpus tokens contribute to PPL.
+    * Each corpus token is scored **exactly once** — in the first
+      window whose target range covers it — matching the standard
+      sliding-window PPL semantics.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        Causal LM (original or quantized) in eval mode.
+    processor_or_tokenizer : Any
+        Processor or tokenizer with ``apply_chat_template`` support.
+    dataset : Iterable[dict[str, Any]]
+        Dataset yielding dictionaries with a ``text`` field
+        (e.g. HuggingFace ``wikitext-2-raw-v1``).
+    stride : int
+        Sliding-window step size.  Must satisfy
+        ``1 <= stride <= max_seq_len - prefix_len``.
+    max_seq_len : int
+        Maximum total sequence length (prefix + content) per window.
+    device : torch.device | str | None
+        Device for computation.  Auto-detected from model parameters
+        if None.
+    show_progress : bool
+        Show a tqdm progress bar.
+
+    Returns
+    -------
+    float
+        Corpus-level perplexity.
+
+    Raises
+    ------
+    ValueError
+        If ``max_seq_len`` is too small for the chat prefix, if
+        ``stride`` exceeds the content window size, or if no target
+        tokens were evaluated.
+    """
+
+    if max_seq_len <= 1:
+        raise ValueError("max_seq_len must be greater than 1.")
+
+    if stride < 1:
+        raise ValueError("stride must be positive.")
+
+    tokenizer = getattr(
+        processor_or_tokenizer,
+        "tokenizer",
+        processor_or_tokenizer,
+    )
+
+    prefix_str = _render_chat_prefix(processor_or_tokenizer, tokenizer)
+    prefix_encodings = tokenizer(
+        prefix_str, return_tensors="pt", add_special_tokens=False
+    )
+    prefix_ids = prefix_encodings["input_ids"]  # shape [1, prefix_len]
+    prefix_len = prefix_ids.shape[1]
+
+    # Reserve slots for the prefix so the window still fits within max_seq_len.
+    window_size = max_seq_len - prefix_len
+
+    if window_size <= 0:
+        raise ValueError(
+            f"max_seq_len ({max_seq_len}) is too small for the chat prefix "
+            f"({prefix_len} tokens).  Increase max_seq_len."
+        )
+
+    if stride > window_size:
+        raise ValueError(
+            "stride must satisfy 1 <= stride <= max_seq_len - prefix_len "
+            f"({window_size}); got stride={stride}."
+        )
+
+    # Iteration works for both Dataset and IterableDataset.
+    texts = []
+    for example in dataset:
+        text = example.get("text", "")
+        if text is not None:
+            texts.append(str(text))
+
+    if not texts:
+        raise ValueError("The dataset contains no text examples.")
+
+    full_text = "\n\n".join(texts)
+
+    encodings = tokenizer(
+        text=full_text,
+        return_tensors="pt",
+        add_special_tokens=False,
+    )
+
+    input_ids = encodings["input_ids"]
+
+    if input_ids.ndim != 2 or input_ids.shape[0] != 1:
+        raise ValueError(
+            f"Expected tokenized shape [1, sequence], got {input_ids.shape}."
+        )
+
+    if device is None:
+        try:
+            device = next(model.parameters()).device
+        except StopIteration:
+            device = torch.device("cpu")
+    else:
+        device = torch.device(device)
+
+    # Move prefix to device once
+    prefix_ids = prefix_ids.to(device)
+
+    model.eval()
+
+    sequence_length = input_ids.shape[1]
+    previous_end = 0
+
+    total_nll = torch.zeros((), dtype=torch.float64, device=device)
+    total_target_tokens = 0
+
+    with torch.inference_mode():
+        for begin in tqdm.trange(
+            0, sequence_length, stride, desc="PPL", disable=not show_progress
+        ):
+
+            end = min(begin + window_size, sequence_length)
+
+            # Only tokens not evaluated by the previous window contribute.
+            target_length = end - previous_end
+            if target_length <= 0:
+                break
+
+            window_ids = input_ids[:, begin:end].to(device)
+
+            labels = window_ids.clone()
+            labels[:, :-target_length] = -100
+
+            # Prepend the Gemma4 IT prefix (BOS + user turn + model turn
+            # with empty thought channel) so the model sees a valid
+            # instruction-tuned context.  All prefix tokens are masked (-100)
+            # so they never contribute to loss.
+            window_ids = torch.cat([prefix_ids, window_ids], dim=1)
+            prefix_labels = torch.full(
+                (1, prefix_len), -100, dtype=labels.dtype, device=device
+            )
+            labels = torch.cat([prefix_labels, labels], dim=1)
+
+            # Build attention mask: all ones (prefix + content)
+            attention_mask = torch.ones(
+                1, window_ids.shape[1], dtype=torch.long, device=device
+            )
+
+            model_kwargs = {
+                "input_ids": window_ids,
+                "attention_mask": attention_mask,
+                "labels": labels,
+                "use_cache": False,
+            }
+
+            outputs = model(**model_kwargs)
+
+            if outputs.loss is None:
+                raise RuntimeError(
+                    "Model returned loss=None despite labels being provided. "
+                    "Ensure the model or wrapper supports the 'labels' argument."
+                )
+
+            # outputs.loss is the mean CE over non-masked (label != -100) tokens.
+            # Count the exact number of target tokens that contributed to the loss.
+            # The causal shift means label at position t is predicted by logit at t-1,
+            # so we count non-masked labels starting from position 1.
+            target_tokens = int((labels[:, 1:] != -100).sum().item())
+
+            if target_tokens:
+                total_nll += outputs.loss.double() * target_tokens
+                total_target_tokens += target_tokens
+
+            previous_end = end
+
+            if end == sequence_length:
+                break
+
+    if total_target_tokens == 0:
+        raise ValueError("No target tokens were evaluated.")
+
+    mean_nll = (total_nll / total_target_tokens).item()
+    ppl = math.exp(mean_nll)
+
+    return ppl


### PR DESCRIPTION
This PR supports PPL evaluation for instruction tuned Gemma4 model.

New **perplexity_chat_prefix** evaluation algorithm was introduced:

    1. A fixed chat-template prefix is rendered **once** via: func:`_render_chat_prefix` using the model's own
       ``apply_chat_template``.  The prefix contains a user turn with a text-continuation instruction and a generation prompt
       (``add_generation_prompt=True``).  This places the model in  "continuation mode" so it expects raw text to follow.
    2. The full corpus is tokenised **once** (no special tokens) and concatenated into a single 1-D token stream.
    3. A sliding window of ``max_seq_len - prefix_len`` content tokens advances by ``stride`` positions per step.
    4. For each window:
       a. The chat prefix is prepended to the content tokens.
       b. Labels are set to ``-100`` for all prefix tokens and for content tokens that were already scored in a previous window
          (the first ``window_size - target_length`` tokens).  Only the last ``target_length`` content tokens (the freshly
          covered ones) have their actual IDs as labels.
       c. The model is called with ``input_ids``, ``attention_mask``, ``use_cache=False``.
       d. Raw logits are extracted, causal-shifted by one position, and cross-entropy (``reduction="sum"``, ``ignore_index=-100``)
          is computed.
    5. The per-window NLL sums and token counts are accumulated, and the corpus-level PPL is ``exp(total_nll / total_tokens)``.


The results of `gemma4-e2b-it` evaluation :

| Config ID| PPL_chat_prefix |
|-----|----|
| original model | 57.71 |
| PTQ W16A16 | 62.25|
| PTQ W4A16 | 98.28 |
| GPTQ_MSE_W16A16_PLE_8bit | 70.26 |

Co-Authored-By: Cline

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>