### PR TITLE
[quantization] mse/smse_for_gptq support for Qwen3 & Gemma4

### DIFF
--- a/tico/quantization/algorithm/qwen3_vl_gptq/README.md
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/README.md
@@ -64,6 +64,12 @@ work exactly as documented in [`../gptq/README.md`](../gptq/README.md). For
 `weight_bits_overrides`, key matching is full name → stage-local name → full-name
 suffix.
 
+Four `mse` modes — `"mse"`, `"smse"`, `"mse_for_gptq"`, and
+`"smse_for_gptq"` — are supported (see the [MSE section](../gptq/README.md#mse)
+of the base README for details). As in the generic implementation, the
+`*_for_gptq` modes use an accelerated approximate GPTQ (FPI_GPTQ) to tune the
+quantizer grid and currently require `groupsize == -1`.
+
 Qwen3-VL specific fields:
 
 | Field | Default | Description |

--- a/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
@@ -419,6 +419,11 @@ class GPTQ:
         h[dead, dead] = 1
         w[:, dead] = 0
 
+        if groupsize != -1 and self.quantizer.mse in {"mse_for_gptq", "smse_for_gptq"}:
+            raise ValueError(
+                "GPTQ-adjusted MSE currently does not support groupsize != -1"
+            )
+
         if static_groups:
             import copy
 
@@ -428,6 +433,8 @@ class GPTQ:
                 quantizer.find_params(w[:, i : i + groupsize], weight=True)
                 groups.append(quantizer)
 
+        perm = None
+        invperm = None
         if actorder:
             perm = torch.argsort(torch.diag(h), descending=True)
             w = w[:, perm]
@@ -444,6 +451,8 @@ class GPTQ:
         h = torch.cholesky_inverse(h)
         h = torch.linalg.cholesky(h, upper=True)
         hinv = h
+
+        self.quantizer.update(w, hinv, perm)
 
         for i1 in range(0, self.columns, blocksize):
             i2 = min(i1 + blocksize, self.columns)


### PR DESCRIPTION
This PR supports mse/smse_for_gptq for Qwen3 & Gemma4

| Config ID | PPL | VQAv2 | MMLU | COCO CIDEr/Bleu4 | HellaSwag | MMMU_Pro | LLaVA-Bench | VideoMME |
| -- | -- | -- | -- | -- | -- | -- | -- | -- |
| Qwen3_vl_GPTQ_**mse_for_gptq**_spinquant_4bit_percdamp_01 | 10.18    | -        | 0.8810   | 0.277     / 0.065      | -                  | 0.2018       | 102.08      | 63.6    |
| Qwen3_vl_GPTQ_**Smse_for_gptq**_spinquant_4bit_percdamp_01   | 10.28    | -        | 0.8850   | 0.171      / 0.078      | -                  | 0.2000       | 100.85      | 62.7    | 


Co-Authored-By: Cline

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>