### PR TITLE
[quantization] Adding quantizers to the top-level wrappers for Qwen3 & Gemma4

### DIFF
--- a/tico/quantization/wrapq/wrappers/gemma4/quant_for_causal_lm.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_for_causal_lm.py
@@ -43,6 +43,11 @@ class QuantGemma4ForCausalLM(QuantModuleBase, GenerationMixin):
         super().__init__(qcfg, fp_name=fp_name)
         self.module = fp_model
         self.config = fp_model.config
+
+        # Carry over GPTQ quantizers so that find_gptq_quantizers()
+        # discovers them at the top-level wrapper during PTQ qparam injection.
+        self.quantizers = getattr(fp_model, "quantizers", None)
+
         self.model = PTQWrapper(
             fp_model.model,
             qcfg=qcfg.child("model") if qcfg else None,

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_for_conditional_generation.py
@@ -45,6 +45,11 @@ class QuantGemma4ForConditionalGeneration(QuantModuleBase, GenerationMixin):
         super().__init__(qcfg, fp_name=fp_name)
         self.module = fp_model
         self.config = fp_model.config
+
+        # Carry over GPTQ quantizers so that find_gptq_quantizers()
+        # discovers them at the top-level wrapper during PTQ qparam injection.
+        self.quantizers = getattr(fp_model, "quantizers", None)
+
         self.model = PTQWrapper(
             fp_model.model,
             qcfg=qcfg.child("model") if qcfg else None,

--- a/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
+++ b/tico/quantization/wrapq/wrappers/qwen_vl/quant_for_conditional_generation.py
@@ -57,6 +57,10 @@ class QuantQwen3VLForConditionalGeneration(QuantModuleBase, GenerationMixin):
         self.module = fp_model
         self.config = fp_model.config
 
+        # Carry over GPTQ quantizers so that find_gptq_quantizers()
+        # discovers them at the top-level wrapper during PTQ qparam injection.
+        self.quantizers = getattr(fp_model, "quantizers", None)
+
         # Wrap the vision-language model
         self.model = PTQWrapper(
             fp_model.model,


### PR DESCRIPTION
This PR adds quantizers to the top-level wrappers for Qwen3 & Gemma4

**Why**
This fix copies GPTQ quantizers to the top-level of PTQ wrapper, so that [`find_gptq_quantizers(q_model)`](https://github.com/Samsung/TICO/blob/6da61f4a89b02f6cdca5f684fed4ed50330c3cf8/tico/quantization/recipes/stages/ptq.py#L196) can find them at the top level of wrapper and injects it to the PTQ weight observers. Without this fix,  `find_gptq_quantizers` finds quantizers on the Original model not Wrapped model and as a consequence the  [`inject_gptq_qparams`](https://github.com/Samsung/TICO/blob/6da61f4a89b02f6cdca5f684fed4ed50330c3cf8/tico/quantization/recipes/stages/ptq.py#L198)  does not inject the qparams from GPTQ to PTQ observers for Qwen3 and Gemma4 models.



Co-Authored-By: Cline

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>