### PR TITLE
[quantization] Adding control of the gptq qparams injection at the PTQ stage

### DIFF
--- a/tico/quantization/examples/configs/README.md
+++ b/tico/quantization/examples/configs/README.md
@@ -253,6 +253,32 @@ pipeline:
     enabled: true
 ```
 
+### GPTQ-to-PTQ qparam injection
+
+The GPTQ quantizer attaches per-layer weight quantization parameters (scale, zero-point)
+to `model.quantizers`. The PTQ stage discovers these and injects them into
+the PTQ weight observers so that PTQ reuses GPTQ's weight qparams
+instead of recomputing them from scratch.
+
+Set `inject_gptq_qparams: false` on the PTQ stage to skip this injection.
+
+```yaml
+pipeline:
+  - name: gptq
+    enabled: true
+    weight_bits: 4
+
+  - name: ptq
+    enabled: true
+    inject_gptq_qparams: false  # skip GPTQ qparam injection (default: true)
+    activation: int16
+    linear_weight: uint4
+```
+
+- Default is `true`
+- When `false`, PTQ weight observers compute their own statistics from
+  calibration data.
+
 ## `evaluation`
 
 LLM example:

--- a/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
+++ b/tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml
@@ -51,6 +51,7 @@ pipeline:
     norm: int16
     norm_weight: int16
     strict_wrap: true
+    inject_gptq_qparams: false
 
 evaluation:
   enabled: true

--- a/tico/quantization/recipes/stages/ptq.py
+++ b/tico/quantization/recipes/stages/ptq.py
@@ -31,7 +31,6 @@ from tico.quantization.recipes.qparams import (
 )
 from tico.quantization.recipes.stages.base import Stage
 
-
 _INTERNAL_OVERRIDE_FIELDS = frozenset({"__quant_spec_replace_role__"})
 _OVERRIDE_FIELD_ORDER = (
     "observer",
@@ -193,19 +192,27 @@ class PTQStage(Stage):
 
         q_model = prepare(ctx.require_model(), ptq_config)
 
-        owner, quantizers = find_gptq_quantizers(q_model)
-        if quantizers:
-            inject_gptq_qparams(
-                q_model if owner is q_model else owner,
-                quantizers,
-                verbose=_qparam_injection_verbose(ctx, stage_cfg),
-            )
-            clear_gptq_quantizers(q_model)
+        inject_gptq = bool(stage_cfg.get("inject_gptq_qparams", True))
+        if inject_gptq:
+            owner, quantizers = find_gptq_quantizers(q_model)
+            if quantizers:
+                inject_gptq_qparams(
+                    q_model if owner is q_model else owner,
+                    quantizers,
+                    verbose=_qparam_injection_verbose(ctx, stage_cfg),
+                )
+                clear_gptq_quantizers(q_model)
+            else:
+                print(
+                    "[Warn] GPTQ quantizers were not found; "
+                    "PTQ weight observers will use PTQ statistics."
+                )
         else:
             print(
-                "[Warn] GPTQ quantizers were not found; "
-                "PTQ weight observers will use PTQ statistics."
+                "[Info] GPTQ qparam injection disabled by config "
+                "(inject_gptq_qparams=false)."
             )
+            clear_gptq_quantizers(q_model)
 
         ctx.adapter.calibrate_prepared_model(ctx, q_model, stage_cfg)
 


### PR DESCRIPTION
This PR adds control of the gptq qparams injection at the PTQ stage

Add a new `inject_gptq_qparams` boolean parameter (default: `true`) to the PTQ stage config. When GPTQ runs before PTQ, the GPTQ quantizer attaches per-layer weight quantization parameters (scale, zero-point) to `model.quantizers`. The PTQ stage discovers these and injects them into PTQ weight observers so that PTQ reuses GPTQ's weight qparams instead of recomputing them from scratch.

Setting `inject_gptq_qparams: false` skips this injection, causing PTQ weight observers to compute their own statistics from calibration data.

Not injecting GPTQ qparams to PTQ Stage leads to better results for Qwen3-vl quantization.

Config ID | PPL(wt2) | MMLU |  VQAv2  | COCO CIDEr/Bleu4 | HellaSwag  | MMMU_Pro | LLaVA-Bench | VideoMME |
----------|----------|----------|----------|------------------------|--------------------|--------------|-------------|---------|
| inject_gptq_qparams: **false** Qwen3_GPTQ_MSE_Spinquant_head_8bit_(patch_embed_8bit_in_GPTQ_and_PTQ)  | 9.77     | -        | 0.8790   | 0.251/0.081      | -                  | 0.2000       | 102.81      | -       |
| inject_gptq_qparams: **true** Qwen3_GPTQ_MSE_Spinquant_head_8bit_(patch_embed_8bit_in_GPTQ_and_PTQ) | 9.77     | -        | 0.7960   | 0.221/0.053      | -                  | 0.1480       | 100.98      | -      |
| inject_gptq_qparams: **false** Qwen3_GPTQ_MSE_Spinquant_head_8bit_(patch_embed_4bit_in_GPTQ)  | 9.88     | -        | 0.8860   | -          | -          | -                  | 0.1928       | -           | -       |




 <details>
 <summary>
Run command for inject_gptq_qparams: false Qwen3_GPTQ_MSE_Spinquant_head_8bit_(patch_embed_8bit_in_GPTQ_and_PTQ):  </summary>

``` 
python -m tico.quantization.examples.quantize
--config tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml \
  --set model.name_or_path=Qwen/Qwen3-VL-4B-Instruct \
  --set pipeline.0.enabled=true \
  --set pipeline.1.enabled=false \
  --set pipeline.2.mse=mse \
  --set 'pipeline.2.weight_bits_overrides={"patch_embed.proj": 8}'
  --set pipeline.2.sensitivity.mode=cache \
  --set pipeline.2.sensitivity.path=~/SAMSUNG/sensitivity_cache/sensitivity_qwen3_vqa2_wiki_smoothquant.pth \
  --set pipeline.3.lm_head_weight=uint8 \
  --set pipeline.3.embedding_weight=uint8 \
  --set pipeline.3.verbose=true \
  --set pipeline.3.inject_gptq_qparams=false \
  --set calibration.seq_len=2048 \
  --set calibration.datasets.0.n_samples=128 \
  --set calibration.datasets.1.n_samples=128 \
  --set export.enabled=true \
  --set evaluation.enabled=true \
  --set evaluation.max_seq_len=2048 \
  --set evaluation.vlm_tasks=[vqav2] \
  --set evaluation.coco=true \
  --set evaluation.n_samples=1000 \
  --set evaluation.mmlu.enabled=false \
  --set evaluation.hellaswag.enabled=false \
  --set evaluation.hellaswag.n_samples=1000 \
  --set evaluation.mmmu.enabled=true \
  --set evaluation.mmmu.dataset=MMMU/MMMU_Pro \
  --set evaluation.mmmu.subject=vision \
  --set evaluation.mmmu.n_samples=1000 \
  --set evaluation.ppl.enabled=true \
  --set evaluation.ppl.stride=512 \
  --set evaluation.llava_bench.enabled=true \
  --set evaluation.llava_bench.judge.model_id=unsloth/Llama-3.2-3B-Instruct \
  --set evaluation.llava_bench.n_samples=50 \
  --set evaluation.llava_bench.candidate_label="Qwen3-VL-4B-Instruct" \
  --set evaluation.llava_bench.max_seq_len=2048 \
  --set evaluation.videomme.enabled=false \
  --set evaluation.videomme.max_new_tokens=30 \
  --set evaluation.videomme.n_samples=1000 \
  --set evaluation.videomme.max_num_frames=32 \
  --set evaluation.videomme.verbose=true
```
 </details>
 
 <details>
 <summary>
Run command for  inject_gptq_qparams: false Qwen3_GPTQ_MSE_Spinquant_head_8bit_(patch_embed_4bit_in_GPTQ) </summary>

```
python -m tico.quantization.examples.quantize
--config tico/quantization/examples/configs/qwen3_vl_eval_suite.yaml \
  --set model.name_or_path=Qwen/Qwen3-VL-4B-Instruct \
  --set pipeline.0.enabled=true \
  --set pipeline.1.enabled=false \
  --set pipeline.2.mse=mse \
  --set pipeline.2.sensitivity.mode=cache \
  --set pipeline.2.sensitivity.path=~/SAMSUNG/sensitivity_cache/sensitivity_qwen3_vqa2_wiki_smoothquant.pth \
  --set pipeline.3.lm_head_weight=uint8 \
  --set pipeline.3.embedding_weight=uint8 \
  --set pipeline.3.verbose=true \
  --set pipeline.3.inject_gptq_qparams=false \
  --set calibration.seq_len=2048 \
  --set calibration.datasets.0.n_samples=128 \
  --set calibration.datasets.1.n_samples=128 \
  --set export.enabled=true \
  --set evaluation.enabled=true \
  --set evaluation.max_seq_len=2048 \
  --set evaluation.vlm_tasks=[vqav2] \
  --set evaluation.coco=true \
  --set evaluation.n_samples=1000 \
  --set evaluation.mmlu.enabled=false \
  --set evaluation.hellaswag.enabled=false \
  --set evaluation.hellaswag.n_samples=1000 \
  --set evaluation.mmmu.enabled=true \
  --set evaluation.mmmu.dataset=MMMU/MMMU_Pro \
  --set evaluation.mmmu.subject=vision \
  --set evaluation.mmmu.n_samples=1000 \
  --set evaluation.ppl.enabled=true \
  --set evaluation.ppl.stride=512 \
  --set evaluation.llava_bench.enabled=true \
  --set evaluation.llava_bench.judge.model_id=unsloth/Llama-3.2-3B-Instruct \
  --set evaluation.llava_bench.n_samples=50 \
  --set evaluation.llava_bench.candidate_label="Qwen3-VL-4B-Instruct" \
  --set evaluation.llava_bench.max_seq_len=2048 \
  --set evaluation.videomme.enabled=false \
  --set evaluation.videomme.max_new_tokens=30 \
  --set evaluation.videomme.n_samples=1000 \
  --set evaluation.videomme.max_num_frames=32 \
  --set evaluation.videomme.verbose=true
```
 </details>


Co-Authored-By: Cline

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>