### PR TITLE
[examples] Support observer sweep

### DIFF
--- a/examples/hand_detector/README.md
+++ b/examples/hand_detector/README.md
@@ -171,7 +171,13 @@ from calibration outputs.
 ### Activation observer sweep
 
 Keep per-channel MinMax weight quantization fixed and compare activation range
-estimators:
+estimators across three ablation profiles:
+
+```text
+C  activation-only with floating-point weights and outputs
+D  full quantization
+E  internal full quantization with floating-point outputs
+```
 
 ```bash
 python -m examples.hand_detector.analyze observer-sweep \
@@ -182,7 +188,11 @@ python -m examples.hand_detector.analyze observer-sweep \
 ```
 
 `PercentileObserver` uses bounded sampling, so it does not retain every value
-from every activation tensor.
+from every activation tensor. The console ranks candidates by E regressor MAE,
+which isolates internal W8A8 behavior from the selected final-output domains.
+The JSON report stores C/D/E metrics under each candidate's `profiles` mapping.
+For compatibility with existing report readers, the candidate-level `outputs`
+field remains an alias of D outputs.
 
 ## Calibration and evaluation data
 

--- a/examples/hand_detector/_support/observer_sweep.py
+++ b/examples/hand_detector/_support/observer_sweep.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""C/D/E profile evaluation and reporting for activation observer sweeps."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from tico.quantization.analysis import (
+    ModelInput,
+    OutputAdapter,
+    QuantizationAblation,
+    QuantizationBoundaries,
+    QuantizationProfile,
+    QuantizationReport,
+)
+
+from torch import nn
+
+
+OBSERVER_SWEEP_PROFILES = (
+    QuantizationProfile.ACTIVATION_ONLY,
+    QuantizationProfile.FULL,
+    QuantizationProfile.INTERNAL_FULL,
+)
+OBSERVER_SWEEP_RANKING_PROFILE = QuantizationProfile.INTERNAL_FULL
+
+
+def evaluate_observer_profiles(
+    reference_model: nn.Module,
+    candidate_model: nn.Module,
+    samples: Sequence[ModelInput],
+    *,
+    boundaries: QuantizationBoundaries,
+    output_adapter: OutputAdapter | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Evaluate one calibrated observer candidate under C, D, and E."""
+    report = QuantizationAblation(
+        reference_model,
+        candidate_model,
+        boundaries=boundaries,
+        output_adapter=output_adapter,
+    ).run(
+        samples,
+        profiles=OBSERVER_SWEEP_PROFILES,
+    )
+    return serialize_observer_profiles(report)
+
+
+def serialize_observer_profiles(
+    report: QuantizationReport,
+) -> dict[str, dict[str, Any]]:
+    """Return compact C/D/E results without repeated enabled-site path lists."""
+    profiles: dict[str, dict[str, Any]] = {}
+    for profile in OBSERVER_SWEEP_PROFILES:
+        result = report.profiles[profile]
+        profiles[profile.value] = {
+            "profile": profile.value,
+            "label": profile.label,
+            "enabled_site_count": result.enabled_site_count,
+            "outputs": _copy_outputs(result.outputs),
+        }
+    return profiles
+
+
+def build_observer_sweep_result(
+    *,
+    observer: str,
+    profiles: Mapping[str, Mapping[str, Any]],
+    observer_details: Sequence[Mapping[str, Any]],
+    percentile: float | None = None,
+) -> dict[str, Any]:
+    """Build one JSON-ready observer result with a legacy full-output alias."""
+    missing_profiles = tuple(
+        profile.value
+        for profile in OBSERVER_SWEEP_PROFILES
+        if profile.value not in profiles
+    )
+    if missing_profiles:
+        raise ValueError(
+            "Observer sweep results are missing profiles: " f"{missing_profiles}."
+        )
+
+    normalized_profiles = {
+        profile.value: dict(profiles[profile.value])
+        for profile in OBSERVER_SWEEP_PROFILES
+    }
+    full_outputs = normalized_profiles[QuantizationProfile.FULL.value].get("outputs")
+    if not isinstance(full_outputs, Mapping):
+        raise ValueError("The full profile does not contain output metrics.")
+
+    result: dict[str, Any] = {
+        "observer": observer,
+        "profiles": normalized_profiles,
+        # Preserve the previous report field as a compatibility alias for D:full.
+        "outputs": _copy_outputs(full_outputs),
+        "observer_details": [dict(details) for details in observer_details],
+    }
+    if percentile is not None:
+        result["percentile"] = float(percentile)
+    return result
+
+
+def rank_observer_sweep_results(
+    results: Mapping[str, Mapping[str, Any]],
+) -> list[tuple[str, Mapping[str, Any]]]:
+    """Rank observer candidates by E regressor MAE."""
+    if not results:
+        raise ValueError("Observer sweep results must not be empty.")
+    return sorted(
+        results.items(),
+        key=lambda item: float(
+            _profile_outputs(item[1], OBSERVER_SWEEP_RANKING_PROFILE,)[
+                "regressors"
+            ]["mae"]
+        ),
+    )
+
+
+def print_observer_sweep(
+    results: Mapping[str, Mapping[str, Any]],
+    dtype_name: str,
+) -> None:
+    """Print C/D/E metrics and rank candidates by internal-full regressor MAE."""
+    print(f"\n{dtype_name.upper()} activation observer sweep")
+    print("Candidates are ranked by E:internal-full regressor MAE.")
+    print(
+        f"{'observer':24s} {'profile':18s} {'REG_MAE':>13s} "
+        f"{'REG_COS':>13s} {'CLS_MAE':>13s} {'CLS_COS':>13s} {'SITES':>7s}"
+    )
+    ranked = rank_observer_sweep_results(results)
+    for observer_index, (name, result) in enumerate(ranked):
+        for profile_index, profile in enumerate(OBSERVER_SWEEP_PROFILES):
+            marker = "*" if observer_index == 0 and profile_index == 0 else " "
+            observer_name = name if profile_index == 0 else ""
+            profile_result = _profile_result(result, profile)
+            outputs = profile_result["outputs"]
+            profile_label = f"{profile.value}:{profile.label}"
+            print(
+                f"{marker}{observer_name:23s} "
+                f"{profile_label:18s} "
+                f"{float(outputs['regressors']['mae']):13.6e} "
+                f"{float(outputs['regressors']['cosine_similarity']):13.9f} "
+                f"{float(outputs['classifiers']['mae']):13.6e} "
+                f"{float(outputs['classifiers']['cosine_similarity']):13.9f} "
+                f"{int(profile_result['enabled_site_count']):7d}"
+            )
+    print("* lowest E:internal-full regressor MAE.")
+
+
+def _profile_result(
+    result: Mapping[str, Any],
+    profile: QuantizationProfile,
+) -> Mapping[str, Any]:
+    profiles = result.get("profiles")
+    if not isinstance(profiles, Mapping):
+        raise TypeError("Observer sweep result does not contain profile metrics.")
+    profile_result = profiles.get(profile.value)
+    if not isinstance(profile_result, Mapping):
+        raise KeyError(
+            "Observer sweep result does not contain profile " f"{profile.value}."
+        )
+    return profile_result
+
+
+def _profile_outputs(
+    result: Mapping[str, Any],
+    profile: QuantizationProfile,
+) -> Mapping[str, Mapping[str, float | int | None]]:
+    outputs = _profile_result(result, profile).get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise TypeError(
+            f"Observer sweep profile {profile.value} does not contain output metrics."
+        )
+    return outputs  # type: ignore[return-value]
+
+
+def _copy_outputs(
+    outputs: Mapping[str, Mapping[str, float | int | None]],
+) -> dict[str, dict[str, float | int | None]]:
+    """Copy nested output metrics into a JSON-ready mapping."""
+    return {name: dict(metrics) for name, metrics in outputs.items()}

--- a/examples/hand_detector/analyze.py
+++ b/examples/hand_detector/analyze.py
@@ -31,6 +31,12 @@ from examples.hand_detector._support.data import (
     load_npy_inputs,
     make_synthetic_inputs,
 )
+from examples.hand_detector._support.observer_sweep import (
+    build_observer_sweep_result,
+    evaluate_observer_profiles,
+    OBSERVER_SWEEP_PROFILES,
+    print_observer_sweep,
+)
 from examples.hand_detector._support.quantization import (
     quantization_name,
     quantize_candidate,
@@ -41,7 +47,6 @@ from tico.quantization.analysis import (
     build_clipping_candidates,
     collect_output_calibration_data,
     evaluate_clipping_candidates,
-    evaluate_models,
     make_output_adapter,
     QuantizationAblation,
     QuantizationProfile,
@@ -107,7 +112,10 @@ def parse_args() -> argparse.Namespace:
 
     observer_sweep = subparsers.add_parser(
         "observer-sweep",
-        help="Compare MinMax and percentile activation observers in full PTQ.",
+        help=(
+            "Compare MinMax and percentile activation observers across "
+            "activation-only, full, and internal-full PTQ."
+        ),
     )
     _add_model_arguments(observer_sweep)
     _add_dataset_arguments(observer_sweep, evaluation=True)
@@ -270,16 +278,18 @@ def _run_observer_sweep(args: argparse.Namespace) -> None:
         calibration,
         activation_observer=MinMaxObserver,
     )
-    results["minmax"] = {
-        "observer": "MinMaxObserver",
-        "outputs": evaluate_models(
-            float_model,
-            minmax,
-            evaluation,
-            output_adapter=OUTPUT_ADAPTER,
-        ),
-        "observer_details": [],
-    }
+    minmax_profiles = evaluate_observer_profiles(
+        float_model,
+        minmax,
+        evaluation,
+        boundaries=output_boundaries(minmax),
+        output_adapter=OUTPUT_ADAPTER,
+    )
+    results["minmax"] = build_observer_sweep_result(
+        observer="MinMaxObserver",
+        profiles=minmax_profiles,
+        observer_details=(),
+    )
 
     for percentile in args.percentiles:
         name = f"percentile_{percentile:g}".replace(".", "_")
@@ -295,19 +305,21 @@ def _run_observer_sweep(args: argparse.Namespace) -> None:
                 "seed": args.sampling_seed,
             },
         )
-        results[name] = {
-            "observer": "PercentileObserver",
-            "percentile": percentile,
-            "outputs": evaluate_models(
-                float_model,
-                candidate,
-                evaluation,
-                output_adapter=OUTPUT_ADAPTER,
-            ),
-            "observer_details": summarize_percentile_observers(candidate),
-        }
+        profiles = evaluate_observer_profiles(
+            float_model,
+            candidate,
+            evaluation,
+            boundaries=output_boundaries(candidate),
+            output_adapter=OUTPUT_ADAPTER,
+        )
+        results[name] = build_observer_sweep_result(
+            observer="PercentileObserver",
+            percentile=percentile,
+            profiles=profiles,
+            observer_details=summarize_percentile_observers(candidate),
+        )
 
-    _print_observer_sweep(results, quantization_name(args.bits))
+    print_observer_sweep(results, quantization_name(args.bits))
     _write_json(
         args.report_json,
         {
@@ -318,6 +330,10 @@ def _run_observer_sweep(args: argparse.Namespace) -> None:
                 "percentiles": args.percentiles,
                 "max_samples": args.max_samples,
                 "samples_per_batch": args.samples_per_batch,
+                "sampling_seed": args.sampling_seed,
+                "profiles": [profile.value for profile in OBSERVER_SWEEP_PROFILES],
+                "ranking_profile": QuantizationProfile.INTERNAL_FULL.value,
+                "outputs_alias_profile": QuantizationProfile.FULL.value,
             },
             "results": results,
         },
@@ -470,28 +486,6 @@ def _print_output_clipping(calibration_data, evaluated, dtype_name: str) -> None
                 f"{float(item.evaluation_error['mae']):11.4e} "
                 f"{100.0 * float(item.quantizer['saturation_ratio']):10.5f}"
             )
-
-
-def _print_observer_sweep(results: dict[str, dict[str, Any]], dtype_name: str) -> None:
-    print(f"\n{dtype_name.upper()} activation observer sweep")
-    print(
-        f"{'observer':24s} {'REG_MAE':>13s} {'REG_COS':>13s} "
-        f"{'CLS_MAE':>13s} {'CLS_COS':>13s}"
-    )
-    ranked = sorted(
-        results.items(),
-        key=lambda item: float(item[1]["outputs"]["regressors"]["mae"]),
-    )
-    for index, (name, result) in enumerate(ranked):
-        marker = "*" if index == 0 else " "
-        outputs = result["outputs"]
-        print(
-            f"{marker}{name:23s} "
-            f"{float(outputs['regressors']['mae']):13.6e} "
-            f"{float(outputs['regressors']['cosine_similarity']):13.9f} "
-            f"{float(outputs['classifiers']['mae']):13.6e} "
-            f"{float(outputs['classifiers']['cosine_similarity']):13.9f}"
-        )
 
 
 def _write_json(path: Path, value: dict[str, Any]) -> None:

--- a/test/quantization/analysis/test_observer_sweep.py
+++ b/test/quantization/analysis/test_observer_sweep.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for C/D/E activation observer sweep reporting."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from examples.hand_detector._support.observer_sweep import (
+    build_observer_sweep_result,
+    evaluate_observer_profiles,
+    OBSERVER_SWEEP_PROFILES,
+    print_observer_sweep,
+    rank_observer_sweep_results,
+    serialize_observer_profiles,
+)
+from tico.quantization.analysis import (
+    QuantizationProfile,
+    QuantizationProfileResult,
+    QuantizationReport,
+)
+
+
+_SITE_COUNTS = {
+    QuantizationProfile.ACTIVATION_ONLY: 197,
+    QuantizationProfile.FULL: 293,
+    QuantizationProfile.INTERNAL_FULL: 291,
+}
+
+
+def _profile_result(
+    profile: QuantizationProfile,
+    *,
+    regressor_mae: float,
+    classifier_mae: float,
+) -> dict[str, object]:
+    return {
+        "profile": profile.value,
+        "label": profile.label,
+        "enabled_site_count": _SITE_COUNTS[profile],
+        "outputs": {
+            "regressors": {
+                "mae": regressor_mae,
+                "cosine_similarity": 1.0 - regressor_mae / 100.0,
+            },
+            "classifiers": {
+                "mae": classifier_mae,
+                "cosine_similarity": 1.0 - classifier_mae / 100.0,
+            },
+        },
+    }
+
+
+def _profiles(
+    *,
+    c_reg: float,
+    d_reg: float,
+    e_reg: float,
+    c_cls: float = 0.3,
+    d_cls: float = 0.2,
+    e_cls: float = 0.1,
+) -> dict[str, dict[str, object]]:
+    values = {
+        QuantizationProfile.ACTIVATION_ONLY: (c_reg, c_cls),
+        QuantizationProfile.FULL: (d_reg, d_cls),
+        QuantizationProfile.INTERNAL_FULL: (e_reg, e_cls),
+    }
+    return {
+        profile.value: _profile_result(
+            profile,
+            regressor_mae=regressor_mae,
+            classifier_mae=classifier_mae,
+        )
+        for profile, (regressor_mae, classifier_mae) in values.items()
+    }
+
+
+def _report() -> QuantizationReport:
+    profiles = _profiles(c_reg=3.0, d_reg=2.0, e_reg=1.0)
+    return QuantizationReport(
+        float_parity={},
+        profiles={
+            profile: QuantizationProfileResult(
+                profile=profile,
+                enabled_sites=tuple(
+                    f"{profile.value}.site.{index}"
+                    for index in range(_SITE_COUNTS[profile])
+                ),
+                outputs=profiles[profile.value]["outputs"],
+            )
+            for profile in OBSERVER_SWEEP_PROFILES
+        },
+    )
+
+
+class ObserverSweepTest(unittest.TestCase):
+    """Verify profile selection, compatibility, ranking, and terminal output."""
+
+    @patch("examples.hand_detector._support.observer_sweep.QuantizationAblation")
+    def test_evaluate_observer_profiles_requests_c_d_e(self, ablation_cls) -> None:
+        """Use the standard C/D/E profiles for every observer candidate."""
+        profile_results = {
+            profile: SimpleNamespace(
+                enabled_site_count=_SITE_COUNTS[profile],
+                outputs=_profile_result(
+                    profile,
+                    regressor_mae=float(index + 1),
+                    classifier_mae=float(index + 1) / 10.0,
+                )["outputs"],
+            )
+            for index, profile in enumerate(OBSERVER_SWEEP_PROFILES)
+        }
+        report = SimpleNamespace(profiles=profile_results)
+        runner = ablation_cls.return_value
+        runner.run.return_value = report
+
+        result = evaluate_observer_profiles(
+            MagicMock(),
+            MagicMock(),
+            [MagicMock()],
+            boundaries=MagicMock(),
+            output_adapter=MagicMock(),
+        )
+
+        self.assertEqual(tuple(result), ("C", "D", "E"))
+        self.assertEqual(
+            runner.run.call_args.kwargs["profiles"],
+            OBSERVER_SWEEP_PROFILES,
+        )
+
+    def test_serialization_drops_repeated_enabled_site_paths(self) -> None:
+        """Retain site counts without multiplying large path lists per candidate."""
+        profiles = serialize_observer_profiles(_report())
+
+        self.assertEqual(tuple(profiles), ("C", "D", "E"))
+        for profile in profiles.values():
+            self.assertIn("enabled_site_count", profile)
+            self.assertNotIn("enabled_sites", profile)
+
+    def test_result_preserves_full_outputs_compatibility_alias(self) -> None:
+        """Keep the former outputs field as an alias for D:full metrics."""
+        profiles = _profiles(c_reg=3.0, d_reg=2.0, e_reg=1.0)
+        result = build_observer_sweep_result(
+            observer="PercentileObserver",
+            percentile=99.99,
+            profiles=profiles,
+            observer_details=(),
+        )
+
+        self.assertEqual(result["outputs"], profiles["D"]["outputs"])
+        self.assertEqual(tuple(result["profiles"]), ("C", "D", "E"))
+        self.assertEqual(result["percentile"], 99.99)
+
+    def test_result_rejects_a_missing_profile(self) -> None:
+        """Reject incomplete reports instead of silently omitting C, D, or E."""
+        profiles = _profiles(c_reg=3.0, d_reg=2.0, e_reg=1.0)
+        del profiles["E"]
+
+        with self.assertRaisesRegex(ValueError, "missing profiles"):
+            build_observer_sweep_result(
+                observer="MinMaxObserver",
+                profiles=profiles,
+                observer_details=(),
+            )
+
+    def test_ranking_uses_internal_full_regressor_mae(self) -> None:
+        """Prefer the best E candidate even when a different observer wins D."""
+        results = {
+            "minmax": build_observer_sweep_result(
+                observer="MinMaxObserver",
+                profiles=_profiles(c_reg=0.5, d_reg=0.1, e_reg=0.4),
+                observer_details=(),
+            ),
+            "percentile_99_99": build_observer_sweep_result(
+                observer="PercentileObserver",
+                percentile=99.99,
+                profiles=_profiles(c_reg=0.6, d_reg=0.2, e_reg=0.3),
+                observer_details=(),
+            ),
+        }
+
+        ranked = rank_observer_sweep_results(results)
+        self.assertEqual(ranked[0][0], "percentile_99_99")
+
+    def test_prints_c_d_e_profiles_and_ranks_by_e(self) -> None:
+        """Expose every requested profile and mark the E-regressor winner."""
+        results = {
+            "minmax": build_observer_sweep_result(
+                observer="MinMaxObserver",
+                profiles=_profiles(c_reg=0.5, d_reg=0.1, e_reg=0.4),
+                observer_details=(),
+            ),
+            "percentile_99_99": build_observer_sweep_result(
+                observer="PercentileObserver",
+                percentile=99.99,
+                profiles=_profiles(c_reg=0.6, d_reg=0.2, e_reg=0.3),
+                observer_details=(),
+            ),
+        }
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            print_observer_sweep(results, "uint8")
+        text = output.getvalue()
+
+        self.assertIn("*percentile_99_99", text)
+        self.assertEqual(text.count("C:activation-only"), 2)
+        self.assertEqual(text.count("D:full"), 2)
+        self.assertGreaterEqual(text.count("E:internal-full"), 2)
+        self.assertIn("     197", text)
+        self.assertIn("     293", text)
+        self.assertIn("     291", text)
+        self.assertIn("lowest E:internal-full regressor MAE", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit supports observer sweep in hand_detector example.

```bash
python -m examples.hand_detector.analyze observer-sweep \
  --calibration-dir ~/test/convert-tflite2tvn/input/npy \
  --calibration-offset 0 \
  --calibration-limit 200 \
  --evaluation-dir ~/test/convert-tflite2tvn/input/npy \
  --evaluation-offset 200 \
  --evaluation-limit 79 \
  --require-disjoint \
  --bits 8 \
  --percentiles 99.9 99.99 99.999 \
  --report-json examples/hand_detector/reports/observer_sweep_uint8.json
```
TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>