### PR TITLE
[quantization] Use vision encoder as export mode

### DIFF
--- a/test/quantization/recipes/test_gemma4_wrapper_smoke_static_runtime_profile.py
+++ b/test/quantization/recipes/test_gemma4_wrapper_smoke_static_runtime_profile.py
@@ -212,7 +212,7 @@ class TestQuantGemma4VisionModelObserverSelection(unittest.TestCase):
                 config=SimpleNamespace(standardize=False),
                 padding_positions=padding_positions,
                 patch_embedder_export=lambda pixels, positions, padding: pixels,
-                encoder=lambda **kwargs: kwargs["inputs_embeds"],
+                encoder_export=lambda inputs_embeds: inputs_embeds,
                 pooler_export=lambda **kwargs: (
                     kwargs["hidden_states"],
                     torch.ones(1, seq_len, dtype=torch.bool),

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_encoder.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_encoder.py
@@ -531,16 +531,41 @@ class TestQuantGemma4VisionEncoder(unittest.TestCase):
     # as_export_module
     # ------------------------------------------------------------------
 
-    def test_as_export_module_requires_quant_mode(self):
-        """as_export_module should assert that mode is QUANT."""
+    def test_as_export_module_supports_no_quant_mode(self):
+        """NO_QUANT export should use static templates without qparams."""
+        from tico.quantization.wrapq.wrappers.gemma4.export_adapters import (
+            Gemma4VisionEncoderPrefillExportAdapter,
+        )
+
         fp_encoder = _make_encoder(self.cfg)
         q_encoder = QuantGemma4VisionEncoder(fp_encoder).eval()
-
         pixel_position_ids = _vision_position_ids(1, self.seq_len)
 
-        # Should fail in NO_QUANT mode
-        with self.assertRaises(AssertionError):
-            q_encoder.as_export_module("prefill", pixel_position_ids=pixel_position_ids)
+        adapter = q_encoder.as_export_module(
+            "prefill",
+            pixel_position_ids=pixel_position_ids,
+        )
+
+        self.assertIsInstance(adapter, Gemma4VisionEncoderPrefillExportAdapter)
+        with torch.no_grad():
+            output = adapter(
+                torch.randn(1, self.seq_len, self.hidden_size),
+            )
+        self.assertEqual(output.shape, (1, self.seq_len, self.hidden_size))
+        self.assertTrue(torch.isfinite(output).all())
+
+    def test_as_export_module_rejects_calibration_mode(self):
+        """Export should reject CALIB mode because qparams are incomplete."""
+        fp_encoder = _make_encoder(self.cfg)
+        q_encoder = QuantGemma4VisionEncoder(fp_encoder).eval()
+        q_encoder.enable_calibration()
+        pixel_position_ids = _vision_position_ids(1, self.seq_len)
+
+        with self.assertRaisesRegex(RuntimeError, "NO_QUANT or QUANT"):
+            q_encoder.as_export_module(
+                "prefill",
+                pixel_position_ids=pixel_position_ids,
+            )
 
     def test_as_export_module_returns_adapter(self):
         """as_export_module should return a Gemma4VisionEncoderPrefillExportAdapter."""

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_model.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_model.py
@@ -15,6 +15,7 @@
 """Unit tests for the Gemma4 vision model PTQ wrapper."""
 
 import unittest
+from unittest import mock
 
 import torch
 
@@ -337,8 +338,32 @@ class TestQuantGemma4VisionModel(unittest.TestCase):
 
         self.assertTrue(torch.isfinite(output.last_hidden_state).all())
 
+    def test_forward_export_uses_static_encoder_adapter(self):
+        """forward_export should bypass the dynamic encoder wrapper."""
+        from tico.quantization.wrapq.wrappers.gemma4.quant_vision_model import (
+            QuantGemma4VisionModel,
+        )
+
+        fp_model = self._make_vision_model()
+        q_model = QuantGemma4VisionModel(fp_model).eval()
+        sample = self._sample_inputs()
+        export_module = q_model.as_export_module(
+            mode="prefill",
+            pixel_position_ids=sample["pixel_position_ids"],
+        )
+
+        with mock.patch.object(
+            q_model.encoder,
+            "forward",
+            side_effect=AssertionError("dynamic encoder path was used"),
+        ):
+            with torch.no_grad():
+                output = export_module(**sample)
+
+        self.assertTrue(torch.isfinite(output.last_hidden_state).all())
+
     def test_as_export_module_creates_export_adapter_attributes(self):
-        """as_export_module should create patch_embedder_export and pooler_export attributes."""
+        """as_export_module should create all vision export adapter attributes."""
         from tico.quantization.wrapq.wrappers.gemma4.quant_vision_model import (
             QuantGemma4VisionModel,
         )
@@ -355,6 +380,7 @@ class TestQuantGemma4VisionModel(unittest.TestCase):
 
         # Before as_export_module, no export adapter attributes
         self.assertFalse(hasattr(q_model, "patch_embedder_export"))
+        self.assertFalse(hasattr(q_model, "encoder_export"))
         self.assertFalse(hasattr(q_model, "pooler_export"))
 
         q_model.as_export_module(
@@ -364,12 +390,14 @@ class TestQuantGemma4VisionModel(unittest.TestCase):
 
         # After as_export_module, export adapter attributes should exist
         self.assertTrue(hasattr(q_model, "patch_embedder_export"))
+        self.assertTrue(hasattr(q_model, "encoder_export"))
         self.assertTrue(hasattr(q_model, "pooler_export"))
 
         # Original wrappers should still be intact (not mutated)
         from tico.quantization.wrapq.wrappers.ptq_wrapper import PTQWrapper
 
         self.assertIsInstance(q_model.patch_embedder, PTQWrapper)
+        self.assertIsInstance(q_model.encoder, PTQWrapper)
         self.assertIsInstance(q_model.pooler, PTQWrapper)
 
     def test_submodules_are_wrapped(self):

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_vision_encoder.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_vision_encoder.py
@@ -255,20 +255,22 @@ class QuantGemma4VisionEncoder(QuantModuleBase):
         Returns:
             Output hidden states shaped ``(1, S, hidden_size)``.
         """
-        seq_len = inputs_embeds.shape[1]
-
-        # precomputed position embeddings.
-        cos = self.position_embeddings_cos_template
-        sin = self.position_embeddings_sin_template
-        # Fake-quantize position embeddings.
-        cos = self.obs_position_cos.fake_quant(cos)
-        sin = self.obs_position_sin.fake_quant(sin)
+        # Precomputed position embeddings.
+        cos = self._fq(
+            self.position_embeddings_cos_template,
+            self.obs_position_cos,
+        )
+        sin = self._fq(
+            self.position_embeddings_sin_template,
+            self.obs_position_sin,
+        )
         position_embeddings = (cos, sin)
 
-        # precomputed mask template.
-        attention_mask = self.attention_mask_template
-        # Fake-quantize attention mask.
-        attention_mask = self.obs_attention_mask.fake_quant(attention_mask)
+        # Precomputed attention mask.
+        attention_mask = self._fq(
+            self.attention_mask_template,
+            self.obs_attention_mask,
+        )
 
         hidden_states = self._fq(inputs_embeds, self.obs_act_in)
 
@@ -299,7 +301,7 @@ class QuantGemma4VisionEncoder(QuantModuleBase):
 
         Args:
             mode: Export mode (only ``"prefill"`` is supported).
-            pixel_position_ids: Optional 2-D pixel position ids shaped
+            pixel_position_ids: Fixed 2-D pixel position ids shaped
                 ``(1, S, 2)``.
 
         Returns:
@@ -308,12 +310,16 @@ class QuantGemma4VisionEncoder(QuantModuleBase):
         if mode != "prefill":
             raise ValueError(f"Unsupported Gemma4 vision encoder export mode: {mode!r}")
 
-        # Assert QUANT mode
-        assert self._mode is Mode.QUANT, "Must be in QUANT mode for export"
+        if self._mode not in (Mode.NO_QUANT, Mode.QUANT):
+            raise RuntimeError(
+                "Gemma4 vision encoder export requires NO_QUANT or QUANT mode, "
+                f"got {self._mode}."
+            )
 
-        # Make sure that all observers are calibrated
-        for obs in self._all_observers():
-            assert obs.has_qparams, f"Observer {obs.name} has not been calibrated"
+        if self._mode is Mode.QUANT:
+            # Make sure that all observers are calibrated.
+            for obs in self._all_observers():
+                assert obs.has_qparams, f"Observer {obs.name} has not been calibrated"
 
         cos, sin = self._gather_position_embeddings(pixel_position_ids)
         self.register_buffer("position_embeddings_cos_template", cos)
@@ -321,7 +327,7 @@ class QuantGemma4VisionEncoder(QuantModuleBase):
 
         attention_mask = self._make_bidirectional_mask(
             pixel_position_ids,
-            dtype=pixel_position_ids.dtype,
+            dtype=cos.dtype,
         )
         self.register_buffer("attention_mask_template", attention_mask)
 

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_vision_model.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_vision_model.py
@@ -231,27 +231,16 @@ class QuantGemma4VisionModel(QuantModuleBase):
         # Create padding mask from pixel_position_ids
         padding_positions = self.padding_positions
 
-        # Patch embedder (use export adapter if available, otherwise original)
+        # Patch embedder
         patch_embedder = self.patch_embedder_export
         inputs_embeds = patch_embedder(
             pixel_values, pixel_position_ids, padding_positions
         )
 
-        # Encoder (no export adapter yet — uses original wrapper)
-        output = self.encoder(
-            inputs_embeds=inputs_embeds,
-            # Use ``== False`` instead of ``~`` to avoid ``aten::bitwise_not``
-            # which is not supported by the Circle conversion pipeline.
-            attention_mask=(padding_positions == False),
-            pixel_position_ids=pixel_position_ids,
-            return_dict=True,
-        )
+        # Encoder
+        encoder_hidden = self.encoder_export(inputs_embeds)
 
-        # The encoder may return a BaseModelOutputWithPast (HF original) or a
-        # plain tensor (QuantGemma4VisionEncoder wrapper).  Handle both cases.
-        encoder_hidden = output
-
-        # Pooler (use export adapter if available, otherwise original)
+        # Pooler
         pooler = self.pooler_export
         hidden_states, pooler_mask = pooler(
             hidden_states=encoder_hidden,
@@ -298,15 +287,15 @@ class QuantGemma4VisionModel(QuantModuleBase):
         3. Registers output_length and padding tensors for static export
 
         Submodule export adapters are stored as separate attributes
-        (e.g. ``patch_embedder_export``, ``pooler_export``) so that the
-        original wrapper attributes are not mutated.  ``forward_export()``
-        uses these export adapter attributes when they exist.
+        (``patch_embedder_export``, ``encoder_export``, and ``pooler_export``)
+        so that the original wrapper attributes are not mutated.
+        ``forward_export()`` uses only these static export paths.
 
         Args:
             mode: Export mode (only "prefill" is supported).
             pixel_position_ids: Patch position ids tensor with shape
-                ``(1, num_patches, 2)``.  Required by the pooler's
-                ``as_export_module()`` to precompute pooling weights.
+                ``(1, num_patches, 2)``. Required by the encoder and pooler
+                export adapters to precompute their static templates.
             **kwargs: Additional arguments (unused).
 
         Returns:
@@ -336,12 +325,12 @@ class QuantGemma4VisionModel(QuantModuleBase):
         ), "max_patches must be divisible by pooling_kernel_size^2"
 
         # Recursively convert submodules to their export adapters.
-        # Store as separate attributes to avoid mutating the original wrappers.
-        # forward_export() will use these via getattr(..., self.<original>).
+        # Store them separately to keep the original wrappers intact.
         self.patch_embedder_export = self.patch_embedder.as_export_module(mode=mode)
-
-        # Encoder: no as_export_module yet — will use original wrapper
-        # in forward_export via getattr fallback.
+        self.encoder_export = self.encoder.as_export_module(
+            mode=mode,
+            pixel_position_ids=pixel_position_ids,
+        )
 
         # Pooler: requires pixel_position_ids to precompute pooling weights
         assert pixel_position_ids is not None, (


### PR DESCRIPTION
This commit uses vision encoder as export mode.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>