### PR TITLE
[quanitzation] Remove pixel_position_ids from ABI

### DIFF
--- a/test/quantization/recipes/test_export_gemma4.py
+++ b/test/quantization/recipes/test_export_gemma4.py
@@ -52,9 +52,9 @@ class FakePTQWrapper(torch.nn.Module):
 class FakeVisionExport(torch.nn.Module):
     """Return a model-output-like object for the vision stage."""
 
-    def forward(self, pixel_values, pixel_position_ids):
-        """Return four tiny visual tokens."""
-        del pixel_values, pixel_position_ids
+    def forward(self, pixel_values):
+        """Return four tiny visual tokens from a pixel-values-only ABI."""
+        del pixel_values
         return SimpleNamespace(last_hidden_state=torch.zeros(4, 8))
 
 
@@ -197,9 +197,9 @@ class TestGemma4PerLayerExport(unittest.TestCase):
         dynamic_shapes = {"input_ids": {1: "S"}}
 
         def fake_convert_and_save(module, example_inputs, save_path, **kwargs):
-            del example_inputs
             if save_path.name == "vision_prefill.q.circle":
                 vision_modules.append(module)
+                self.assertEqual(len(example_inputs), 1)
             calls.append((save_path.name, kwargs.get("dynamic_shapes")))
 
         with tempfile.TemporaryDirectory() as tmpdir, patch.object(

--- a/test/quantization/recipes/test_gemma4_vision_export_input_contracts.py
+++ b/test/quantization/recipes/test_gemma4_vision_export_input_contracts.py
@@ -22,6 +22,8 @@ from tico.quantization.recipes.debug.wrapper_smoke.case import ForwardInput
 from tico.quantization.recipes.debug.wrapper_smoke.cases.gemma4 import (
     Gemma4VisionAttentionCase,
     Gemma4VisionEncoderLayerCase,
+    Gemma4VisionModelCase,
+    Gemma4VisionPatchEmbedderCase,
     Gemma4VisionPoolerCase,
 )
 
@@ -103,6 +105,37 @@ class TestGemma4VisionExportInputContracts(unittest.TestCase):
         torch.testing.assert_close(export_input.args[1], self.attention_mask)
         torch.testing.assert_close(export_input.args[2][0], self.cos)
         torch.testing.assert_close(export_input.args[2][1], self.sin)
+
+    def test_patch_embedder_export_input_omits_baked_profile_tensors(self) -> None:
+        """Static patch embedding should export only processor pixel values."""
+        pixel_values = torch.randn(1, 4, 12)
+        sample = ForwardInput(
+            (pixel_values, self.position_ids, self.padding_positions),
+        )
+
+        export_input = Gemma4VisionPatchEmbedderCase().export_input(sample, {})
+
+        self.assertEqual(dict(export_input.kwargs), {})
+        self.assertEqual(len(export_input.args), 1)
+        torch.testing.assert_close(export_input.args[0], pixel_values)
+
+    def test_vision_model_export_input_omits_baked_position_ids(self) -> None:
+        """The full static vision model should expose only pixel values."""
+        pixel_values = torch.randn(1, 4, 12)
+        sample = ForwardInput(
+            (),
+            {
+                "pixel_values": pixel_values,
+                "pixel_position_ids": self.position_ids,
+                "return_dict": True,
+            },
+        )
+
+        export_input = Gemma4VisionModelCase().export_input(sample, {})
+
+        self.assertEqual(dict(export_input.kwargs), {})
+        self.assertEqual(len(export_input.args), 1)
+        torch.testing.assert_close(export_input.args[0], pixel_values)
 
     def test_pooler_export_input_omits_precomputed_position_ids(self) -> None:
         """Static pooler export should keep only hidden states and padding."""

--- a/test/quantization/recipes/test_gemma4_wrapper_smoke_static_runtime_profile.py
+++ b/test/quantization/recipes/test_gemma4_wrapper_smoke_static_runtime_profile.py
@@ -214,7 +214,7 @@ class TestQuantGemma4VisionModelObserverSelection(unittest.TestCase):
             SimpleNamespace(
                 config=SimpleNamespace(standardize=False),
                 padding_positions=padding_positions,
-                patch_embedder_export=lambda pixels, positions, padding: pixels,
+                patch_embedder_export=lambda pixels: pixels,
                 encoder_export=lambda inputs_embeds: inputs_embeds,
                 pooler_export=lambda **kwargs: (
                     kwargs["hidden_states"],
@@ -230,9 +230,8 @@ class TestQuantGemma4VisionModelObserverSelection(unittest.TestCase):
             ),
         )
         pixel_values = torch.randn(1, seq_len, hidden_size)
-        position_ids = torch.zeros(1, seq_len, 2, dtype=torch.long)
 
-        output = QuantGemma4VisionModel.forward_export(fake, pixel_values, position_ids)
+        output = QuantGemma4VisionModel.forward_export(fake, pixel_values)
 
         self.assertEqual(tuple(output.last_hidden_state.shape), (seq_len, hidden_size))
 

--- a/test/quantization/recipes/test_static_gemma4_vision_export_profile.py
+++ b/test/quantization/recipes/test_static_gemma4_vision_export_profile.py
@@ -50,13 +50,8 @@ class _FakePTQWrapper(nn.Module):
 class _FakeStaticVisionModel(nn.Module):
     """Return a model-output-like object from a static vision graph."""
 
-    def forward(
-        self,
-        pixel_values: torch.Tensor,
-        pixel_position_ids: torch.Tensor,
-    ) -> SimpleNamespace:
-        """Return deterministic hidden states independent of orchestration."""
-        del pixel_position_ids
+    def forward(self, pixel_values: torch.Tensor) -> SimpleNamespace:
+        """Return deterministic hidden states from the pixel-values-only ABI."""
         return SimpleNamespace(last_hidden_state=pixel_values + 1.0)
 
 
@@ -137,7 +132,7 @@ class TestGemma4StaticVisionExportProfile(unittest.TestCase):
             self.position_ids,
         )
         torch.testing.assert_close(
-            module(self.pixel_values, self.position_ids),
+            module(self.pixel_values),
             (self.pixel_values + 1.0) * 2.0,
         )
 

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_model.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_model.py
@@ -332,9 +332,9 @@ class TestQuantGemma4VisionModel(unittest.TestCase):
             pixel_position_ids=sample["pixel_position_ids"],
         )
 
-        # Test forward (adapter delegates to wrapped_model.forward_export)
+        # Test the pixel-values-only static forward contract.
         with torch.no_grad():
-            output = export_module(**sample)
+            output = export_module(sample["pixel_values"])
 
         self.assertTrue(torch.isfinite(output.last_hidden_state).all())
 
@@ -364,21 +364,22 @@ class TestQuantGemma4VisionModel(unittest.TestCase):
         ).eval()
 
         with torch.no_grad():
-            static_output = vision_prefill(
-                sample["pixel_values"],
-                sample["pixel_position_ids"],
-            )
+            static_output = vision_prefill(sample["pixel_values"])
 
         exported_program = torch.export.export(
             vision_prefill,
-            (sample["pixel_values"], sample["pixel_position_ids"]),
+            (sample["pixel_values"],),
             strict=False,
         )
+        self.assertEqual(len(exported_program.graph_signature.user_inputs), 1)
+        call_targets = {
+            str(node.target)
+            for node in exported_program.graph.nodes
+            if node.op == "call_function"
+        }
+        self.assertNotIn("aten.embedding.default", call_targets)
         with torch.no_grad():
-            exported_output = exported_program.module()(
-                sample["pixel_values"],
-                sample["pixel_position_ids"],
-            )
+            exported_output = exported_program.module()(sample["pixel_values"])
 
         torch.testing.assert_close(static_output, eager_output, atol=1e-5, rtol=1e-5)
         torch.testing.assert_close(exported_output, static_output)
@@ -403,7 +404,7 @@ class TestQuantGemma4VisionModel(unittest.TestCase):
             side_effect=AssertionError("dynamic encoder path was used"),
         ):
             with torch.no_grad():
-                output = export_module(**sample)
+                output = export_module(sample["pixel_values"])
 
         self.assertTrue(torch.isfinite(output.last_hidden_state).all())
 

--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_patch_embedder.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_patch_embedder.py
@@ -15,6 +15,7 @@
 """Unit tests for the Gemma4 vision patch embedder PTQ wrapper."""
 
 import unittest
+from unittest import mock
 
 import torch
 
@@ -282,15 +283,53 @@ class TestQuantGemma4VisionPatchEmbedder(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_as_export_module_supports_no_quant_mode(self):
-        """Floating-point export should be available in NO_QUANT mode."""
+        """Floating-point export should bake coordinates into a static adapter."""
+        from tico.quantization.wrapq.wrappers.gemma4.export_adapters import (
+            Gemma4VisionPatchEmbedderPrefillExportAdapter,
+        )
+
         fp_module = _make_patch_embedder(
             hidden_size=self.hidden_size,
             patch_size=self.patch_size,
             position_embedding_size=self.position_embedding_size,
         )
         q_module = QuantGemma4VisionPatchEmbedder(fp_module).eval()
+        pixel_values, pixel_position_ids, padding_positions = self._sample_inputs()
 
-        self.assertIs(q_module.as_export_module(mode="prefill"), q_module)
+        export_module = q_module.as_export_module(
+            mode="prefill",
+            pixel_position_ids=pixel_position_ids,
+            padding_positions=padding_positions,
+        )
+
+        self.assertIsInstance(
+            export_module,
+            Gemma4VisionPatchEmbedderPrefillExportAdapter,
+        )
+        with torch.no_grad():
+            expected = q_module(
+                pixel_values,
+                pixel_position_ids,
+                padding_positions,
+            )
+            actual = export_module(pixel_values)
+        torch.testing.assert_close(actual, expected)
+
+        exported = torch.export.export(
+            export_module,
+            (pixel_values,),
+            strict=False,
+        )
+        self.assertEqual(len(exported.graph_signature.user_inputs), 1)
+        call_targets = {
+            str(node.target)
+            for node in exported.graph.nodes
+            if node.op == "call_function"
+        }
+        self.assertNotIn("aten.embedding.default", call_targets)
+        with torch.no_grad():
+            exported_output = exported.module()(pixel_values)
+        torch.testing.assert_close(exported_output, actual)
 
     def test_as_export_module_rejects_calibration_mode(self):
         """Export should reject CALIB mode because its qparams are incomplete."""
@@ -301,12 +340,17 @@ class TestQuantGemma4VisionPatchEmbedder(unittest.TestCase):
         )
         q_module = QuantGemma4VisionPatchEmbedder(fp_module).eval()
         q_module.enable_calibration()
+        _, pixel_position_ids, padding_positions = self._sample_inputs()
 
         with self.assertRaisesRegex(RuntimeError, "NO_QUANT or QUANT"):
-            q_module.as_export_module(mode="prefill")
+            q_module.as_export_module(
+                mode="prefill",
+                pixel_position_ids=pixel_position_ids,
+                padding_positions=padding_positions,
+            )
 
-    def test_as_export_module_returns_self(self):
-        """as_export_module should return self."""
+    def test_export_adapter_bakes_profile_and_has_one_user_input(self):
+        """The exported patch embedder should not read position IDs at runtime."""
         fp_module = _make_patch_embedder(
             hidden_size=self.hidden_size,
             patch_size=self.patch_size,
@@ -320,8 +364,26 @@ class TestQuantGemma4VisionPatchEmbedder(unittest.TestCase):
             _ = q_module(pixel_values, pixel_position_ids, padding_positions)
         q_module.freeze_qparams()
 
-        export_module = q_module.as_export_module(mode="prefill")
-        self.assertIs(export_module, q_module)
+        with torch.no_grad():
+            expected = q_module(
+                pixel_values,
+                pixel_position_ids,
+                padding_positions,
+            )
+        export_module = q_module.as_export_module(
+            mode="prefill",
+            pixel_position_ids=pixel_position_ids,
+            padding_positions=padding_positions,
+        )
+
+        with mock.patch.object(
+            q_module,
+            "_lookup_position_embeddings",
+            side_effect=AssertionError("runtime position lookup was used"),
+        ):
+            with torch.no_grad():
+                actual = export_module(pixel_values)
+        torch.testing.assert_close(actual, expected)
 
 
 if __name__ == "__main__":

--- a/test/quantization/wrapq/wrappers/gemma4/test_quantize_vision_model.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quantize_vision_model.py
@@ -193,9 +193,9 @@ class TestGemma4VisionModelSmoke(unittest.TestCase):
         # as_export_module returns Gemma4VisionModelPrefillExportAdapter
         self.assertIsInstance(export_module, Gemma4VisionModelPrefillExportAdapter)
 
-        # Verify forward works (adapter delegates to wrapped_model.forward_export)
+        # Verify the pixel-values-only static forward contract.
         with torch.no_grad():
-            output = export_module(**sample)
+            output = export_module(sample["pixel_values"])
 
         self.assertTrue(torch.isfinite(output.last_hidden_state).all())
 

--- a/test/quantization/wrapq/wrappers/gemma4/test_quantize_vision_patch_embedder.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quantize_vision_patch_embedder.py
@@ -164,12 +164,16 @@ class TestGemma4VisionPatchEmbedderSmoke(unittest.TestCase):
 
         quantized = convert(prepared)
 
-        export_module = quantized.wrapped.as_export_module(mode="prefill")
-
-        # Verify export module forward works
         sample = self._sample()
+        export_module = quantized.wrapped.as_export_module(
+            mode="prefill",
+            pixel_position_ids=sample["pixel_position_ids"],
+            padding_positions=sample["padding_positions"],
+        )
+
+        # Verify the pixel-values-only export module forward works.
         with torch.no_grad():
-            out = export_module(**sample)
+            out = export_module(sample["pixel_values"])
 
         self.assertEqual(out.shape, (1, self.num_patches, self.cfg.hidden_size))
         self.assertTrue(torch.isfinite(out).all())

--- a/tico/quantization/recipes/debug/static_gemma4_runtime.py
+++ b/tico/quantization/recipes/debug/static_gemma4_runtime.py
@@ -321,7 +321,7 @@ class StaticGemma4Runtime:
         self,
         image_position_ids: Optional[torch.Tensor],
     ) -> nn.Module:
-        """Return the static vision module for the canonical runtime profile."""
+        """Validate processor coordinates and return a pixel-values-only module."""
         if image_position_ids is None:
             raise ValueError(
                 "Gemma4 static vision prefill requires image_position_ids from "
@@ -587,10 +587,9 @@ class StaticGemma4Runtime:
 
         text_embeds = self.token_embedding(llm_input_ids)
         vision_prefill = self._get_or_create_vision_prefill(image_position_ids)
-        image_embeds = vision_prefill(
-            pixel_values,
-            image_position_ids,
-        )
+        # Processor coordinates select and validate the baked module above;
+        # they are intentionally absent from the vision-prefill runtime ABI.
+        image_embeds = vision_prefill(pixel_values)
         hidden_states = self.mm_fusion(text_embeds, image_embeds)
         self.layer_caches = self._allocate_empty_cache(
             hidden_states.shape[0], hidden_states.dtype

--- a/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/cases/gemma4.py
@@ -1842,10 +1842,9 @@ class Gemma4VisionPatchEmbedderCase(Gemma4BaseCase):
         patch_dim = 3 * self.patch_size**2
         if self._static_runtime_shape() is None:
             pixel_values = torch.randn(self.batch_size, self.num_patches, patch_dim)
-            pixel_position_ids = torch.randint(
-                0,
-                self.position_embedding_size,
-                (self.batch_size, self.num_patches, 2),
+            pixel_position_ids = _pixel_position_ids(
+                self.batch_size,
+                self.num_patches,
             )
             padding_positions = torch.zeros(
                 self.batch_size, self.num_patches, dtype=torch.bool
@@ -1877,6 +1876,30 @@ class Gemma4VisionPatchEmbedderCase(Gemma4BaseCase):
     ) -> ForwardInput:
         """Create the Gemma4 vision patch embedder evaluation sample."""
         return self._sample()
+
+    def export_module(
+        self,
+        quantized: torch.nn.Module,
+        cfg: Mapping[str, Any],
+    ) -> torch.nn.Module:
+        """Bake the fixed patch-coordinate profile into an export adapter."""
+        wrapped = getattr(quantized, "wrapped", quantized)
+        if not hasattr(wrapped, "as_export_module"):
+            return quantized
+        return wrapped.as_export_module(
+            mode="prefill",
+            pixel_position_ids=self._case_pixel_position_ids(self.batch_size),
+            padding_positions=self._case_padding_positions(self.batch_size),
+        ).eval()
+
+    def export_input(
+        self,
+        eval_sample: ForwardInput,
+        cfg: Mapping[str, Any],
+    ) -> ForwardInput:
+        """Keep only pixel values in the static patch-embedder ABI."""
+        cloned = _clone_forward_input(eval_sample)
+        return ForwardInput((cloned.args[0],), {})
 
 
 class Gemma4VisionPoolerCase(Gemma4BaseCase):
@@ -2074,11 +2097,11 @@ class Gemma4VisionModelCase(Gemma4BaseCase):
     def export_module(
         self, quantized: torch.nn.Module, cfg: Mapping[str, Any]
     ) -> torch.nn.Module:
-        """Export the wrapped vision model in prefill mode.
+        """Export one vision model specialized for a fixed position profile.
 
-        Passes ``pixel_position_ids`` so the pooler's export adapter can
-        precompute the pooling weight matrix and output mask at construction
-        time.
+        Construction-time position IDs materialize patch embeddings, encoder
+        templates, and pooler geometry. The returned runtime module accepts only
+        pixel values.
         """
         wrapped = getattr(quantized, "wrapped", quantized)
         if hasattr(wrapped, "as_export_module"):
@@ -2092,15 +2115,10 @@ class Gemma4VisionModelCase(Gemma4BaseCase):
     def export_input(
         self, eval_sample: ForwardInput, cfg: Mapping[str, Any]
     ) -> ForwardInput:
-        """Create static export inputs expected by the vision model adapter.
-
-        The export adapter's forward() takes pixel_values and pixel_position_ids.
-        """
+        """Keep only pixel values in the static vision-model ABI."""
         cloned = _clone_forward_input(eval_sample)
-        kwargs = dict(cloned.kwargs)
-        pixel_values = kwargs["pixel_values"]
-        pixel_position_ids = kwargs["pixel_position_ids"]
-        return ForwardInput((pixel_values, pixel_position_ids), {})
+        pixel_values = dict(cloned.kwargs)["pixel_values"]
+        return ForwardInput((pixel_values,), {})
 
 
 class Gemma4MultimodalEmbedderCase(Gemma4BaseCase):

--- a/tico/quantization/recipes/export/gemma4.py
+++ b/tico/quantization/recipes/export/gemma4.py
@@ -368,7 +368,7 @@ def export_gemma4_per_layer(
     )
     _convert_and_save(
         vision_prefill,
-        (pixel_values, pixel_position_ids),
+        (pixel_values,),
         output_dir / _circle_name("vision_prefill", artifact_tag),
         strict=strict,
     )

--- a/tico/quantization/wrapq/examples/gemma4/quantize_vision_model.py
+++ b/tico/quantization/wrapq/examples/gemma4/quantize_vision_model.py
@@ -171,8 +171,8 @@ def main():
     print(plot_two_outputs(fp_out, quant_out))
 
     # Export and convert to Circle format.
-    # The vision model's as_export_module requires pixel_position_ids to
-    # precompute the pooler's static weight matrix.
+    # Position IDs specialize patch embeddings, encoder templates, and pooler
+    # geometry at construction time. The exported module accepts only pixels.
     wrapped = getattr(quantized_model, "wrapped", quantized_model)
     if hasattr(wrapped, "as_export_module"):
         pixel_pos_ids = _pixel_position_ids(batch_size, num_patches)
@@ -181,10 +181,7 @@ def main():
             pixel_position_ids=pixel_pos_ids,
         ).eval()
 
-        example_inputs = (
-            torch.randn(batch_size, num_patches, 3 * patch_size**2),  # pixel_values
-            _pixel_position_ids(batch_size, num_patches),  # pixel_position_ids
-        )
+        example_inputs = (torch.randn(batch_size, num_patches, 3 * patch_size**2),)
 
         print("\nConverting to Circle format...")
         circle_model = tico.convert(export_module, example_inputs)

--- a/tico/quantization/wrapq/examples/gemma4/quantize_vision_patch_embedder.py
+++ b/tico/quantization/wrapq/examples/gemma4/quantize_vision_patch_embedder.py
@@ -190,19 +190,23 @@ def main():
     print(f"└──────────────────────────────────────────────────────")
     print(plot_two_outputs(fp_out, quant_out))
 
-    # Export and convert to Circle format.
-    # The wrapper is already exportable, so as_export_module returns self.
+    # Export and convert to Circle format. Position coordinates are
+    # construction-time specialization data and are not Circle inputs.
     wrapped = getattr(quantized_model, "wrapped", quantized_model)
     if hasattr(wrapped, "as_export_module"):
-        export_module = wrapped.as_export_module(mode="prefill").eval()
-
-        example_inputs = (
-            torch.randn(batch_size, num_patches, 3 * patch_size**2),  # pixel_values
-            _pixel_position_ids(
-                batch_size, num_patches, position_embedding_size
-            ),  # pixel_position_ids
-            _padding_positions(batch_size, num_patches),  # padding_positions
+        pixel_position_ids = _pixel_position_ids(
+            batch_size,
+            num_patches,
+            position_embedding_size,
         )
+        padding_positions = _padding_positions(batch_size, num_patches)
+        export_module = wrapped.as_export_module(
+            mode="prefill",
+            pixel_position_ids=pixel_position_ids,
+            padding_positions=padding_positions,
+        ).eval()
+
+        example_inputs = (torch.randn(batch_size, num_patches, 3 * patch_size**2),)
 
         print("\nConverting to Circle format...")
         circle_model = tico.convert(export_module, example_inputs)

--- a/tico/quantization/wrapq/wrappers/gemma4/export_adapters.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/export_adapters.py
@@ -100,17 +100,53 @@ class Gemma4TokenEmbeddingExportAdapter(nn.Module):
         return self.embed_tokens(input_ids)
 
 
+class Gemma4VisionPatchEmbedderPrefillExportAdapter(nn.Module):
+    """Export a patch embedder specialized for one fixed position profile.
+
+    The construction-time position IDs are converted into a positional-embedding
+    template before export. The resulting runtime ABI accepts only pixel values;
+    no coordinate or padding tensor remains as a graph input.
+    """
+
+    def __init__(
+        self,
+        wrapped: nn.Module,
+        *,
+        position_embeddings: torch.Tensor,
+        padding_positions: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        self.wrapped = wrapped
+        self.register_buffer(
+            "position_embeddings_template",
+            position_embeddings.detach().clone(),
+            persistent=False,
+        )
+        self.register_buffer(
+            "padding_positions_template",
+            padding_positions.detach().to(dtype=torch.bool).clone(),
+            persistent=False,
+        )
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        """Project pixels and add the baked positional-embedding template."""
+        return self.wrapped.forward_export(
+            pixel_values,
+            position_embeddings=self.position_embeddings_template,
+            padding_positions=self.padding_positions_template,
+        )
+
+
 class Gemma4VisionPrefillExportAdapter(nn.Module):
     """Export the complete static Gemma4 vision-prefill stage.
 
-    ``vision_model`` must already be specialized for one fixed
-    ``pixel_position_ids`` profile through
-    ``QuantGemma4VisionModel.as_export_module``. This adapter then applies the
-    multimodal projection used to map vision hidden states to text width.
+    ``vision_model`` is specialized for one fixed ``pixel_position_ids`` profile
+    through ``QuantGemma4VisionModel.as_export_module``. All profile-dependent
+    tensors are owned by nested export adapters, and this stage then applies the
+    multimodal projection that maps vision hidden states to text width.
 
     Input contract:
-        ``pixel_values`` and ``pixel_position_ids`` use the fixed patch layout
-        selected when ``vision_model`` was created.
+        ``pixel_values`` has the fixed patch layout selected at construction.
 
     Output contract:
         Returns visual soft tokens with shape ``(1, V, text_hidden_size)``.
@@ -125,16 +161,9 @@ class Gemma4VisionPrefillExportAdapter(nn.Module):
         self.vision_model = vision_model
         self.vision_projection = vision_projection
 
-    def forward(
-        self,
-        pixel_values: torch.Tensor,
-        pixel_position_ids: torch.Tensor,
-    ) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
         """Run the static vision model and project its soft tokens."""
-        vision_outputs = self.vision_model(
-            pixel_values,
-            pixel_position_ids,
-        )
+        vision_outputs = self.vision_model(pixel_values)
         hidden_states = (
             vision_outputs
             if isinstance(vision_outputs, torch.Tensor)
@@ -149,10 +178,11 @@ def build_gemma4_vision_prefill_export_module(
     pixel_position_ids: torch.Tensor,
     mode: str = "prefill",
 ) -> Gemma4VisionPrefillExportAdapter:
-    """Build the canonical static Gemma4 vision-prefill export module.
+    """Build a pixel-values-only Gemma4 vision-prefill export module.
 
-    Both the Circle exporter and the static runtime must call this helper so
-    that they exercise exactly the same specialized vision graph.
+    ``pixel_position_ids`` is construction-time specialization data. Both the
+    Circle exporter and static runtime pass the canonical profile to this helper,
+    but the returned module exposes only ``pixel_values`` as a runtime input.
     """
     if pixel_position_ids.dim() != 3 or pixel_position_ids.shape[0] != 1:
         raise ValueError(
@@ -533,15 +563,12 @@ class Gemma4ModelPrefillExportAdapter(nn.Module):
 class Gemma4VisionModelPrefillExportAdapter(nn.Module):
     """Export adapter for the Gemma4 vision model with static-shape contract.
 
-    This adapter wraps a ``QuantGemma4VisionModel`` that has been prepared
-    for export via ``as_export_module()``.  Calling ``forward()`` delegates
-    to the wrapped model's ``forward_export()`` method, which uses the
-    export-friendly submodule adapters (``patch_embedder_export``,
-    ``encoder_export``, and ``pooler_export``).
+    This adapter wraps a ``QuantGemma4VisionModel`` prepared through
+    ``as_export_module()``. Position IDs, padding, RoPE, attention masks, and
+    pooler geometry are construction-time data owned by nested adapters.
 
     Input contract:
         ``pixel_values`` has shape ``(1, num_patches, 3*patch_size^2)``.
-        ``pixel_position_ids`` has shape ``(1, num_patches, 2)``.
 
     Output contract:
         Returns ``BaseModelOutputWithPast`` with ``last_hidden_state``
@@ -555,13 +582,6 @@ class Gemma4VisionModelPrefillExportAdapter(nn.Module):
         super().__init__()
         self.wrapped_model = wrapped_model
 
-    def forward(
-        self,
-        pixel_values: torch.FloatTensor,
-        pixel_position_ids: torch.LongTensor,
-    ):
-        """Run the vision model export path via the wrapped model's forward_export."""
-        return self.wrapped_model.forward_export(
-            pixel_values=pixel_values,
-            pixel_position_ids=pixel_position_ids,
-        )
+    def forward(self, pixel_values: torch.FloatTensor):
+        """Run the pixel-values-only static vision model export path."""
+        return self.wrapped_model.forward_export(pixel_values=pixel_values)

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_vision_model.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_vision_model.py
@@ -204,55 +204,28 @@ class QuantGemma4VisionModel(QuantModuleBase):
 
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
 
-    def forward_export(
-        self,
-        pixel_values: torch.Tensor,
-        pixel_position_ids: torch.Tensor,
-    ):
-        """Run Gemma4 vision model with static shapes for torch.export.
+    def forward_export(self, pixel_values: torch.Tensor):
+        """Run the pixel-values-only static vision graph for torch.export.
 
-        This forward method assumes:
-        - ``config.standardize`` is fixed when the module is constructed
-        - output_length is precomputed and fixed
-        - No data-dependent branching
-        - as_export_module() has been called to set up export adapters
-
-        This method IS exportable via torch.export.
-
-        Args:
-            pixel_values: Image pixels with shape (batch, channels, height, width).
-            pixel_position_ids: Patch positions with shape (batch_size, max_patches, 2).
-
-        Returns:
-            BaseModelOutputWithPast with last_hidden_state containing visual soft tokens.
+        All position-dependent tensors are materialized by ``as_export_module``.
+        The exported ABI therefore contains only the processor's padded patch
+        values and cannot mix runtime coordinates with baked encoder or pooler
+        templates.
         """
         from transformers.models.gemma4.modeling_gemma4 import BaseModelOutputWithPast
 
-        # Create padding mask from pixel_position_ids
         padding_positions = self.padding_positions
-
-        # Patch embedder
-        patch_embedder = self.patch_embedder_export
-        inputs_embeds = patch_embedder(
-            pixel_values, pixel_position_ids, padding_positions
-        )
-
-        # Encoder
+        inputs_embeds = self.patch_embedder_export(pixel_values)
         encoder_hidden = self.encoder_export(inputs_embeds)
 
-        # Pooler
-        pooler = self.pooler_export
-        hidden_states, pooler_mask = pooler(
+        hidden_states, pooler_mask = self.pooler_export(
             hidden_states=encoder_hidden,
             padding_positions=padding_positions,
         )
 
-        # Strip padding tokens
         hidden_states = hidden_states[pooler_mask]
         hidden_states = self._fq(hidden_states, self.obs_strip_padding)
 
-        # The configuration-time branch is constant for torch.export and keeps
-        # the real E2B ``standardize=False`` contract exportable.
         if self.config.standardize:
             assert self.obs_std_bias is not None
             assert self.obs_std_scale is not None
@@ -262,12 +235,8 @@ class QuantGemma4VisionModel(QuantModuleBase):
             hidden_states = self._fq(hidden_states, self.obs_minus_bias)
             hidden_states = hidden_states * std_scale.float()
 
-        # Cast to input dtype
         hidden_states = hidden_states.to(inputs_embeds.dtype)
-
-        # Quantize output
         hidden_states = self._fq(hidden_states, self.obs_last_hidden_state)
-
         return BaseModelOutputWithPast(last_hidden_state=hidden_states)
 
     def as_export_module(
@@ -281,8 +250,9 @@ class QuantGemma4VisionModel(QuantModuleBase):
 
         This method:
         1. Requires either NO_QUANT or QUANT mode
-        2. Recursively converts submodules to their export adapters
-        3. Registers output_length and padding tensors for static export
+        2. Recursively converts submodules to fixed-profile export adapters
+        3. Bakes patch positions, padding, encoder, and pooler templates
+        4. Returns a module whose runtime ABI accepts only ``pixel_values``
 
         Submodule export adapters are stored as separate attributes
         (``patch_embedder_export``, ``encoder_export``, and ``pooler_export``)
@@ -291,9 +261,9 @@ class QuantGemma4VisionModel(QuantModuleBase):
 
         Args:
             mode: Export mode (only "prefill" is supported).
-            pixel_position_ids: Patch position ids tensor with shape
-                ``(1, num_patches, 2)``. Required by the encoder and pooler
-                export adapters to precompute their static templates.
+            pixel_position_ids: Construction-time patch positions with shape
+                ``(1, num_patches, 2)``. They specialize all position-dependent
+                templates and do not remain as a runtime graph input.
             **kwargs: Additional arguments (unused).
 
         Returns:
@@ -313,7 +283,16 @@ class QuantGemma4VisionModel(QuantModuleBase):
             for obs in self._all_observers():
                 assert obs.has_qparams, f"Observer {obs.name} has not been calibrated"
 
-        # Store output_length for use in forward_export
+        if (
+            pixel_position_ids.dim() != 3
+            or pixel_position_ids.shape[0] != 1
+            or pixel_position_ids.shape[-1] != 2
+        ):
+            raise ValueError(
+                "pixel_position_ids must have shape (1, num_patches, 2), "
+                f"got {tuple(pixel_position_ids.shape)}."
+            )
+
         pooling_kernel_size = self.config.pooling_kernel_size
         max_patches = pixel_position_ids.shape[-2]
         self.output_length = max_patches // (pooling_kernel_size * pooling_kernel_size)
@@ -322,28 +301,23 @@ class QuantGemma4VisionModel(QuantModuleBase):
             == max_patches
         ), "max_patches must be divisible by pooling_kernel_size^2"
 
-        # Recursively convert submodules to their export adapters.
-        # Store them separately to keep the original wrappers intact.
-        self.patch_embedder_export = self.patch_embedder.as_export_module(mode=mode)
+        padding_positions = (pixel_position_ids == -1).all(dim=-1)
+        self.register_buffer("padding_positions", padding_positions)
+
+        self.patch_embedder_export = self.patch_embedder.as_export_module(
+            mode=mode,
+            pixel_position_ids=pixel_position_ids,
+            padding_positions=padding_positions,
+        )
         self.encoder_export = self.encoder.as_export_module(
             mode=mode,
             pixel_position_ids=pixel_position_ids,
-        )
-
-        # Pooler: requires pixel_position_ids to precompute pooling weights
-        assert pixel_position_ids is not None, (
-            "pixel_position_ids is required by the pooler's as_export_module() "
-            "to precompute pooling weights for static export."
         )
         self.pooler_export = self.pooler.as_export_module(
             mode=mode,
             output_length=self.output_length,
             pixel_position_ids=pixel_position_ids,
         )
-
-        # Precompute padding mask from pixel_position_ids
-        padding_positions = (pixel_position_ids == -1).all(dim=-1)
-        self.register_buffer("padding_positions", padding_positions)
 
         if self._mode is Mode.QUANT:
             register_fake_quant_meta_kernels_for_dynamic_export()

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_vision_patch_embedder.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_vision_patch_embedder.py
@@ -88,47 +88,59 @@ class QuantGemma4VisionPatchEmbedder(QuantModuleBase):
         # Collect position_embedding_table statistics
         self.obs_emb_table.collect(self.position_embedding_table)
 
-    def _quant_position_embeddings(
+    def _project_pixel_values(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        """Normalize and project flattened pixel patches into hidden space."""
+        pixel_values = self._fq(pixel_values, self.obs_act_in)
+        pixel_values = pixel_values - 0.5
+        pixel_values = self._fq(pixel_values, self.obs_pixel_values_m_0_5)
+        pixel_values = 2.0 * pixel_values
+        pixel_values = self._fq(pixel_values, self.obs_pixel_values)
+
+        hidden_states = self.input_proj(pixel_values)
+        return self._fq(hidden_states, self.obs_hidden_states)
+
+    def _lookup_position_embeddings(
         self,
         pixel_position_ids: torch.Tensor,
-        padding_positions: torch.Tensor,
     ) -> torch.Tensor:
-        """Compute quantized 2D patch position embeddings via embedding lookup.
-
-        Args:
-            pixel_position_ids: (batch, num_patches, 2) with x,y indices
-            padding_positions: (batch, num_patches) boolean mask
-
-        Returns:
-            position_embeddings: (batch, num_patches, hidden_size)
-        """
-        # Clamp only lower bound for valid indexing
+        """Look up fixed-profile 2D position embeddings before activation PTQ."""
         clamped_positions = pixel_position_ids.clamp(min=0)
 
-        # Quantize position embedding table in QUANT mode
         emb_table = self.position_embedding_table
         if self._mode is Mode.QUANT:
             emb_table = self.obs_emb_table.fake_quant(emb_table)
 
-        # Lookup x and y embeddings
         x_emb = F.embedding(clamped_positions[..., 0], emb_table[0])
         y_emb = F.embedding(clamped_positions[..., 1], emb_table[1])
+        return x_emb + y_emb
 
-        # Sum x and y embeddings
-        position_embeddings = x_emb + y_emb
+    def _finalize_position_embeddings(
+        self,
+        position_embeddings: torch.Tensor,
+        padding_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply activation PTQ and zero the baked profile's padding slots."""
         position_embeddings = self._fq(
-            position_embeddings, self.obs_position_embeddings
+            position_embeddings,
+            self.obs_position_embeddings,
         )
-
-        # Apply padding mask (zero out padding positions)
-        # Use zeros_like to avoid torch.export lifting issues with torch.tensor()
-        position_embeddings = torch.where(
+        return torch.where(
             padding_positions.unsqueeze(-1),
             torch.zeros_like(position_embeddings),
             position_embeddings,
         )
 
-        return position_embeddings
+    def _quant_position_embeddings(
+        self,
+        pixel_position_ids: torch.Tensor,
+        padding_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute quantized 2D position embeddings for eager execution."""
+        position_embeddings = self._lookup_position_embeddings(pixel_position_ids)
+        return self._finalize_position_embeddings(
+            position_embeddings,
+            padding_positions,
+        )
 
     def forward(
         self,
@@ -136,38 +148,28 @@ class QuantGemma4VisionPatchEmbedder(QuantModuleBase):
         pixel_position_ids: torch.Tensor,
         padding_positions: torch.Tensor,
     ) -> torch.Tensor:
-        """Run quantized patch projection and positional embedding addition.
-
-        Args:
-            pixel_values: (batch, num_patches, 3 * patch_size^2) raw pixel values
-            pixel_position_ids: (batch, num_patches, 2) 2D grid coordinates
-            padding_positions: (batch, num_patches) boolean padding mask
-
-        Returns:
-            hidden_states: (batch, num_patches, hidden_size) patch embeddings
-        """
-        pixel_values = self._fq(pixel_values, self.obs_act_in)
-
-        # Step 1: Pixel scaling (no normalization, just centering to [-1, 1])
-        pixel_values = pixel_values - 0.5
-        pixel_values = self._fq(pixel_values, self.obs_pixel_values_m_0_5)
-        pixel_values = 2.0 * pixel_values
-        pixel_values = self._fq(pixel_values, self.obs_pixel_values)
-
-        # Apply linear projection (no bias)
-        hidden_states = self.input_proj(pixel_values)
-        hidden_states = self._fq(hidden_states, self.obs_hidden_states)
-
-        # Step 3: Position embeddings
+        """Run eager patch projection with runtime position coordinates."""
+        hidden_states = self._project_pixel_values(pixel_values)
         position_embeddings = self._quant_position_embeddings(
-            pixel_position_ids, padding_positions
+            pixel_position_ids,
+            padding_positions,
         )
+        return self._fq(hidden_states + position_embeddings, self.obs_output)
 
-        # Step 4: Add position embeddings to hidden states
-        hidden_states = hidden_states + position_embeddings
-
-        # Step 5: Quantize output
-        return self._fq(hidden_states, self.obs_output)
+    def forward_export(
+        self,
+        pixel_values: torch.Tensor,
+        *,
+        position_embeddings: torch.Tensor,
+        padding_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run static patch projection with a baked positional template."""
+        hidden_states = self._project_pixel_values(pixel_values)
+        position_embeddings = self._finalize_position_embeddings(
+            position_embeddings,
+            padding_positions,
+        )
+        return self._fq(hidden_states + position_embeddings, self.obs_output)
 
     def _all_observers(self) -> Iterable:
         """Return all observers owned by this wrapper."""
@@ -181,8 +183,15 @@ class QuantGemma4VisionPatchEmbedder(QuantModuleBase):
             self.obs_output,
         )
 
-    def as_export_module(self, mode: str = "prefill", **kwargs) -> nn.Module:
-        """Return self for export (this wrapper is already exportable)."""
+    def as_export_module(
+        self,
+        mode: str = "prefill",
+        *,
+        pixel_position_ids: Optional[torch.Tensor] = None,
+        padding_positions: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> nn.Module:
+        """Build a pixel-values-only adapter for one fixed position profile."""
         if self._mode not in (Mode.NO_QUANT, Mode.QUANT):
             raise RuntimeError(
                 "Gemma4 VisionPatchEmbedder export requires NO_QUANT or "
@@ -192,4 +201,52 @@ class QuantGemma4VisionPatchEmbedder(QuantModuleBase):
             raise ValueError(
                 f"Unsupported Gemma4 VisionPatchEmbedder export mode: {mode!r}"
             )
-        return self
+        if pixel_position_ids is None:
+            raise ValueError(
+                "Gemma4 VisionPatchEmbedder export requires construction-time "
+                "pixel_position_ids."
+            )
+        if (
+            pixel_position_ids.dim() != 3
+            or pixel_position_ids.shape[0] != 1
+            or pixel_position_ids.shape[-1] != 2
+        ):
+            raise ValueError(
+                "pixel_position_ids must have shape (1, num_patches, 2), "
+                f"got {tuple(pixel_position_ids.shape)}."
+            )
+
+        expected_padding = (pixel_position_ids == -1).all(dim=-1)
+        if padding_positions is None:
+            padding_positions = expected_padding
+        else:
+            padding_positions = padding_positions.to(
+                device=expected_padding.device,
+                dtype=torch.bool,
+            )
+            if tuple(padding_positions.shape) != tuple(expected_padding.shape):
+                raise ValueError(
+                    "padding_positions shape must match pixel_position_ids: "
+                    f"expected={tuple(expected_padding.shape)}, "
+                    f"actual={tuple(padding_positions.shape)}."
+                )
+            if not torch.equal(padding_positions, expected_padding):
+                raise ValueError(
+                    "padding_positions must match the -1 entries in "
+                    "pixel_position_ids."
+                )
+
+        with torch.no_grad():
+            position_embeddings = self._lookup_position_embeddings(
+                pixel_position_ids
+            ).detach()
+
+        from tico.quantization.wrapq.wrappers.gemma4.export_adapters import (
+            Gemma4VisionPatchEmbedderPrefillExportAdapter,
+        )
+
+        return Gemma4VisionPatchEmbedderPrefillExportAdapter(
+            self,
+            position_embeddings=position_embeddings,
+            padding_positions=padding_positions,
+        )


### PR DESCRIPTION
This commit removes pixel_position_ids from the static runtime ABI.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>