### PR TITLE
[quantization] Support GPTQv2 for Qwen3

### DIFF
--- a/test/quantization/algorithm/test_qwen3_vl_gptqv2.py
+++ b/test/quantization/algorithm/test_qwen3_vl_gptqv2.py
@@ -21,12 +21,18 @@ These tests verify that:
   - Conv3d native inputs correctly populate dXXT.
 """
 
+import os
 import unittest
+from unittest.mock import MagicMock
 
 import torch
+import torch.nn as nn
 
 from tico.quantization.algorithm.qwen3_vl_gptq.gptq import GPTQ
-from tico.quantization.algorithm.qwen3_vl_gptq.quantizer import Qwen3VLGPTQQuantizer
+from tico.quantization.algorithm.qwen3_vl_gptq.quantizer import (
+    FPInputsCache,
+    Qwen3VLGPTQQuantizer,
+)
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
 
 
@@ -54,9 +60,10 @@ class TestQwen3VLGPTQv2Core(unittest.TestCase):
         gptq.add_batch(current, out)
 
         self.assertIsNotNone(gptq.dXXT)
-        assert gptq.dXXT is not None
-        self.assertEqual(gptq.dXXT.shape, gptq.H.shape)
-        self.assertGreater(gptq.dXXT.abs().sum().item(), 0.0)
+        dXXT = gptq.dXXT
+        assert dXXT is not None
+        self.assertEqual(dXXT.shape, gptq.H.shape)  # type: ignore[union-attr]
+        self.assertGreater(dXXT.abs().sum().item(), 0.0)
 
 
 class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
@@ -93,15 +100,17 @@ class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
 
         quantizer._assign_native_inputs(gptq_objs, native_inputs)
 
-        self.assertEqual(len(gptq_objs["linear"].native_inp), 2)
-        self.assertTrue(torch.allclose(gptq_objs["linear"].native_inp[0], fp_inputs[0]))
-        self.assertTrue(torch.allclose(gptq_objs["linear"].native_inp[1], fp_inputs[1]))
+        native_inp = gptq_objs["linear"].native_inp
+        assert native_inp is not None
+        self.assertEqual(len(native_inp), 2)
+        self.assertTrue(torch.allclose(native_inp[0], fp_inputs[0]))
+        self.assertTrue(torch.allclose(native_inp[1], fp_inputs[1]))
 
     def test_resolve_weight_bits_default(self):
         """_resolve_weight_bits should return the config default when no override."""
         quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig(weight_bits=4))
         bits = quantizer._resolve_weight_bits(
-            quantizer.config,
+            quantizer.config,  # type: ignore[arg-type]
             full_module_name="model.layers.0.self_attn.q_proj",
             local_module_name="self_attn.q_proj",
         )
@@ -116,7 +125,7 @@ class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
             )
         )
         bits = quantizer._resolve_weight_bits(
-            quantizer.config,
+            quantizer.config,  # type: ignore[arg-type]
             full_module_name="model.layers.0.self_attn.q_proj",
             local_module_name="self_attn.q_proj",
         )
@@ -131,7 +140,7 @@ class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
             )
         )
         bits = quantizer._resolve_weight_bits(
-            quantizer.config,
+            quantizer.config,  # type: ignore[arg-type]
             full_module_name="model.layers.0.self_attn.q_proj",
             local_module_name="self_attn.q_proj",
         )
@@ -146,7 +155,7 @@ class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
             )
         )
         bits = quantizer._resolve_weight_bits(
-            quantizer.config,
+            quantizer.config,  # type: ignore[arg-type]
             full_module_name="model.layers.0.self_attn.q_proj",
             local_module_name="self_attn.q_proj",
         )
@@ -168,10 +177,137 @@ class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
         # Should be a different object
         self.assertIsNot(orig_model, model)
         # Weights should match
-        self.assertTrue(torch.allclose(orig_model[0].weight, model[0].weight))
+        self.assertTrue(torch.allclose(orig_model[0].weight, model[0].weight))  # type: ignore[index]
         # Modifying one should not affect the other
         model[0].weight.data.fill_(0.0)
-        self.assertFalse(torch.allclose(orig_model[0].weight, model[0].weight))
+        self.assertFalse(torch.allclose(orig_model[0].weight, model[0].weight))  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Helpers for FP inputs cache tests
+# ---------------------------------------------------------------------------
+
+
+def _make_quantizer(fp_inputs_cache_path=None, gptq_v2=True):
+    """Create a Qwen3VLGPTQQuantizer with minimal config for testing."""
+    config = Qwen3VLGPTQConfig(
+        weight_bits=8,
+        gptq_v2=gptq_v2,
+        fp_inputs_cache_path=fp_inputs_cache_path,
+        show_progress=False,
+        verbose=False,
+    )
+    return Qwen3VLGPTQQuantizer(config)
+
+
+# ---------------------------------------------------------------------------
+# Tests: FPInputsCache
+# ---------------------------------------------------------------------------
+
+
+class TestFPInputsCache(unittest.TestCase):
+    """Core tests for the FPInputsCache hook-based collector and disk cache."""
+
+    def test_caches_fp_input(self):
+        """A forward hook stores the first positional arg in fp_cache."""
+        cache = FPInputsCache(["linear"])
+        linear = nn.Linear(4, 4)
+        cache.add_hook({"linear": linear})
+
+        inp = torch.randn(2, 4)
+        linear(inp)
+        cache.clear_hook()
+
+        self.assertIn("linear", cache.fp_cache)
+        self.assertEqual(len(cache.fp_cache["linear"]), 1)
+        self.assertTrue(torch.equal(cache.fp_cache["linear"][0], inp))
+
+    def test_save_and_load_roundtrip(self):
+        """Save cache to disk, load it back, and verify tensor equality."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, "fp_cache.pt")
+            dummy_cache = {
+                "vision.patch_embed": {
+                    "proj": [torch.randn(2, 3), torch.randn(2, 3)],
+                },
+                "text.layers.0": {
+                    "self_attn.q_proj": [torch.randn(4, 5)],
+                },
+            }
+            torch.save(dummy_cache, cache_path)
+            self.assertTrue(os.path.exists(cache_path))
+
+            loaded = torch.load(cache_path, map_location="cpu", weights_only=False)
+            self.assertEqual(set(loaded.keys()), set(dummy_cache.keys()))
+            for stage in dummy_cache:
+                for name in dummy_cache[stage]:
+                    for i, t in enumerate(loaded[stage][name]):
+                        self.assertTrue(torch.equal(t, dummy_cache[stage][name][i]))
+
+    def test_raw_replay_returns_cached_on_hit(self):
+        """_collect_native_inputs_from_raw_replay returns cached data without
+        running any forward hooks when stage_desc is in the disk cache."""
+        quantizer = _make_quantizer(fp_inputs_cache_path="/tmp/dummy.pt")
+        cached_tensors = [torch.randn(2, 3)]
+        quantizer._fp_inputs_disk_cache = {
+            "vision.merger": {"merger.linear": cached_tensors},
+        }
+
+        dummy_model = MagicMock()
+        result = quantizer._collect_native_inputs_from_raw_replay(
+            model=dummy_model,
+            subset={"merger.linear": MagicMock()},
+            module_name={},
+            cache_args=[[]],
+            cache_kwargs={},
+            num_batches=1,
+            stage_desc="vision.merger",
+        )
+
+        self.assertIn("merger.linear", result)
+        self.assertTrue(torch.equal(result["merger.linear"][0], cached_tensors[0]))
+        dummy_model.assert_not_called()
+
+    @torch.no_grad()
+    def test_collect_then_cache_hit(self):
+        """First call collects via hooks; second call returns from cache
+        without re-running forward."""
+        quantizer = _make_quantizer(fp_inputs_cache_path="/tmp/dummy.pt")
+
+        linear = nn.Linear(4, 4)
+        stage_module = nn.Sequential(linear)
+        subset = {"0": linear}
+
+        inp = torch.randn(2, 4)
+        cached_args = [[inp]]
+        cached_kwargs: dict = {}
+
+        result1 = quantizer._collect_native_inputs_from_stage_cache(
+            stage_module=stage_module,
+            subset=subset,
+            cached_args=cached_args,
+            cached_kwargs=cached_kwargs,
+            stage_desc="test_stage",
+            num_batches=1,
+        )
+        self.assertIn("0", result1)
+        self.assertTrue(torch.equal(result1["0"][0], inp))
+
+        quantizer._fp_inputs_disk_cache["test_stage"] = result1
+
+        broken_module = MagicMock(side_effect=RuntimeError("should not be called"))
+        result2 = quantizer._collect_native_inputs_from_stage_cache(
+            stage_module=broken_module,
+            subset=subset,
+            cached_args=cached_args,
+            cached_kwargs=cached_kwargs,
+            stage_desc="test_stage",
+            num_batches=1,
+        )
+        self.assertTrue(torch.equal(result2["0"][0], result1["0"][0]))
+        broken_module.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/quantization/algorithm/test_qwen3_vl_gptqv2.py
+++ b/test/quantization/algorithm/test_qwen3_vl_gptqv2.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the Qwen3-VL GPTQv2 quantizer helpers.
+
+These tests verify that:
+  - The GPTQ class from qwen3_vl_gptq.gptq is used for both v1 and v2.
+  - _build_gptq_objects initializes native_inp when gptq_v2=True.
+  - Conv3d native inputs correctly populate dXXT.
+"""
+
+import unittest
+
+import torch
+
+from tico.quantization.algorithm.qwen3_vl_gptq.gptq import GPTQ
+from tico.quantization.algorithm.qwen3_vl_gptq.quantizer import Qwen3VLGPTQQuantizer
+from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
+
+
+class TestQwen3VLGPTQv2Core(unittest.TestCase):
+    """Test GPTQv2 core mechanics on Conv3d layers."""
+
+    @torch.no_grad()
+    def test_conv3d_native_inputs_populate_dXXT(self):
+        """dXXT should be computed and non-zero when FP and quantized inputs differ."""
+        layer = torch.nn.Conv3d(
+            in_channels=2,
+            out_channels=3,
+            kernel_size=(2, 2, 2),
+            stride=(1, 1, 1),
+            padding=(0, 0, 0),
+            bias=False,
+        )
+        gptq = GPTQ(layer)
+
+        current = torch.randn(1, 2, 3, 3, 3)
+        native = current + 0.125
+        out = layer(current)
+
+        gptq.native_inp = [native]
+        gptq.add_batch(current, out)
+
+        self.assertIsNotNone(gptq.dXXT)
+        assert gptq.dXXT is not None
+        self.assertEqual(gptq.dXXT.shape, gptq.H.shape)
+        self.assertGreater(gptq.dXXT.abs().sum().item(), 0.0)
+
+
+class TestQwen3VLGPTQv2QuantizerHelpers(unittest.TestCase):
+    """Test Qwen3VLGPTQQuantizer helper methods."""
+
+    def test_build_gptq_objects_default_config(self):
+        """_build_gptq_objects should create GPTQ objects with native_inp=None for v1."""
+        quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig())
+        layer = torch.nn.Linear(4, 3)
+        gptq_objs = quantizer._build_gptq_objects({"linear": layer}, {layer: "linear"})
+
+        self.assertIsInstance(gptq_objs["linear"], GPTQ)
+        # For v1 (gptq_v2=False), native_inp should not be initialized as a list
+        self.assertIsNone(gptq_objs["linear"].native_inp)
+
+    def test_build_gptq_objects_gptqv2_config(self):
+        """_build_gptq_objects should create GPTQ objects with native_inp=[] for v2."""
+        quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig(gptq_v2=True))
+        layer = torch.nn.Linear(4, 3)
+        gptq_objs = quantizer._build_gptq_objects({"linear": layer}, {layer: "linear"})
+
+        self.assertIsInstance(gptq_objs["linear"], GPTQ)
+        # For v2 (gptq_v2=True), native_inp should be initialized as an empty list
+        self.assertEqual(gptq_objs["linear"].native_inp, [])
+
+    def test_assign_native_inputs(self):
+        """_assign_native_inputs should copy FP inputs to GPTQ objects."""
+        quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig(gptq_v2=True))
+        layer = torch.nn.Linear(4, 3)
+        gptq_objs = quantizer._build_gptq_objects({"linear": layer}, {layer: "linear"})
+
+        fp_inputs = [torch.randn(2, 4), torch.randn(3, 4)]
+        native_inputs = {"linear": fp_inputs}
+
+        quantizer._assign_native_inputs(gptq_objs, native_inputs)
+
+        self.assertEqual(len(gptq_objs["linear"].native_inp), 2)
+        self.assertTrue(torch.allclose(gptq_objs["linear"].native_inp[0], fp_inputs[0]))
+        self.assertTrue(torch.allclose(gptq_objs["linear"].native_inp[1], fp_inputs[1]))
+
+    def test_resolve_weight_bits_default(self):
+        """_resolve_weight_bits should return the config default when no override."""
+        quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig(weight_bits=4))
+        bits = quantizer._resolve_weight_bits(
+            quantizer.config,
+            full_module_name="model.layers.0.self_attn.q_proj",
+            local_module_name="self_attn.q_proj",
+        )
+        self.assertEqual(bits, 4)
+
+    def test_resolve_weight_bits_override_full_name(self):
+        """_resolve_weight_bits should use full-name override when available."""
+        quantizer = Qwen3VLGPTQQuantizer(
+            Qwen3VLGPTQConfig(
+                weight_bits=4,
+                weight_bits_overrides={"model.layers.0.self_attn.q_proj": 8},
+            )
+        )
+        bits = quantizer._resolve_weight_bits(
+            quantizer.config,
+            full_module_name="model.layers.0.self_attn.q_proj",
+            local_module_name="self_attn.q_proj",
+        )
+        self.assertEqual(bits, 8)
+
+    def test_resolve_weight_bits_override_local_name(self):
+        """_resolve_weight_bits should use local-name override when available."""
+        quantizer = Qwen3VLGPTQQuantizer(
+            Qwen3VLGPTQConfig(
+                weight_bits=4,
+                weight_bits_overrides={"self_attn.q_proj": 8},
+            )
+        )
+        bits = quantizer._resolve_weight_bits(
+            quantizer.config,
+            full_module_name="model.layers.0.self_attn.q_proj",
+            local_module_name="self_attn.q_proj",
+        )
+        self.assertEqual(bits, 8)
+
+    def test_resolve_weight_bits_override_suffix(self):
+        """_resolve_weight_bits should use suffix override when available."""
+        quantizer = Qwen3VLGPTQQuantizer(
+            Qwen3VLGPTQConfig(
+                weight_bits=4,
+                weight_bits_overrides={"q_proj": 8},
+            )
+        )
+        bits = quantizer._resolve_weight_bits(
+            quantizer.config,
+            full_module_name="model.layers.0.self_attn.q_proj",
+            local_module_name="self_attn.q_proj",
+        )
+        self.assertEqual(bits, 8)
+
+    def test_module_device(self):
+        """_module_device should return the device of the module's parameters."""
+        quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig())
+        layer = torch.nn.Linear(4, 3)
+        device = quantizer._module_device(layer)
+        self.assertEqual(device, layer.weight.device)
+
+    def test_copy_original_model(self):
+        """_copy_original_model should create a deep copy on CPU."""
+        quantizer = Qwen3VLGPTQQuantizer(Qwen3VLGPTQConfig())
+        model = torch.nn.Sequential(torch.nn.Linear(4, 3))
+        orig_model = quantizer._copy_original_model(model)
+
+        # Should be a different object
+        self.assertIsNot(orig_model, model)
+        # Weights should match
+        self.assertTrue(torch.allclose(orig_model[0].weight, model[0].weight))
+        # Modifying one should not affect the other
+        model[0].weight.data.fill_(0.0)
+        self.assertFalse(torch.allclose(orig_model[0].weight, model[0].weight))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/quantization/algorithm/test_qwen3_vl_gptqv2.py
+++ b/test/quantization/algorithm/test_qwen3_vl_gptqv2.py
@@ -272,8 +272,8 @@ class TestFPInputsCache(unittest.TestCase):
 
     @torch.no_grad()
     def test_collect_then_cache_hit(self):
-        """First call collects via hooks; second call returns from cache
-        without re-running forward."""
+        """First call collects via hooks and persists to _fp_inputs_disk_cache;
+        second call returns from cache without re-running forward."""
         quantizer = _make_quantizer(fp_inputs_cache_path="/tmp/dummy.pt")
 
         linear = nn.Linear(4, 4)
@@ -295,7 +295,8 @@ class TestFPInputsCache(unittest.TestCase):
         self.assertIn("0", result1)
         self.assertTrue(torch.equal(result1["0"][0], inp))
 
-        quantizer._fp_inputs_disk_cache["test_stage"] = result1
+        # The function should have persisted to _fp_inputs_disk_cache automatically
+        self.assertIn("test_stage", quantizer._fp_inputs_disk_cache)
 
         broken_module = MagicMock(side_effect=RuntimeError("should not be called"))
         result2 = quantizer._collect_native_inputs_from_stage_cache(
@@ -308,6 +309,274 @@ class TestFPInputsCache(unittest.TestCase):
         )
         self.assertTrue(torch.equal(result2["0"][0], result1["0"][0]))
         broken_module.assert_not_called()
+
+    @torch.no_grad()
+    def test_stage_cache_persist_roundtrip(self):
+        """Cold collection -> save to disk -> new quantizer loads disk ->
+        warm lookup returns cached tensors without calling forward.
+
+        This test verifies that _collect_native_inputs_from_stage_cache()
+        persists its result so that a warm-cache run can retrieve it.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, "fp_cache.pt")
+
+            # --- Cold run: collect and persist ---
+            quantizer_cold = _make_quantizer(fp_inputs_cache_path=cache_path)
+
+            linear = nn.Linear(4, 4)
+            stage_module = nn.Sequential(linear)
+            subset = {"0": linear}
+
+            inp = torch.randn(2, 4)
+            cached_args = [[inp]]
+            cached_kwargs: dict = {}
+
+            result_cold = quantizer_cold._collect_native_inputs_from_stage_cache(
+                stage_module=stage_module,
+                subset=subset,
+                cached_args=cached_args,
+                cached_kwargs=cached_kwargs,
+                stage_desc="vision.blocks.0",
+                num_batches=1,
+            )
+            self.assertIn("0", result_cold)
+            self.assertTrue(torch.equal(result_cold["0"][0], inp))
+
+            # Verify the stage was persisted to the in-memory disk cache
+            self.assertIn("vision.blocks.0", quantizer_cold._fp_inputs_disk_cache)
+
+            # Simulate convert()'s save logic
+            torch.save(quantizer_cold._fp_inputs_disk_cache, cache_path)
+            self.assertTrue(os.path.exists(cache_path))
+
+            # --- Warm run: new quantizer loads cache from disk ---
+            quantizer_warm = _make_quantizer(fp_inputs_cache_path=cache_path)
+            quantizer_warm._fp_inputs_disk_cache = torch.load(
+                cache_path, map_location="cpu", weights_only=False
+            )
+            quantizer_warm._fp_inputs_disk_loaded = True
+
+            # Use a broken module that raises if forward is called
+            broken_module = MagicMock(side_effect=RuntimeError("should not be called"))
+            result_warm = quantizer_warm._collect_native_inputs_from_stage_cache(
+                stage_module=broken_module,
+                subset=subset,
+                cached_args=cached_args,
+                cached_kwargs=cached_kwargs,
+                stage_desc="vision.blocks.0",
+                num_batches=1,
+            )
+            # The warm result should match the cold result
+            self.assertTrue(torch.equal(result_warm["0"][0], result_cold["0"][0]))
+            broken_module.assert_not_called()
+
+    @torch.no_grad()
+    def test_stage_cache_fail_closed_on_miss(self):
+        """When _fp_inputs_disk_loaded is True but the stage is not in the cache,
+        a RuntimeError should be raised instead of silently recomputing."""
+        quantizer = _make_quantizer(fp_inputs_cache_path="/tmp/dummy.pt")
+        quantizer._fp_inputs_disk_loaded = True
+        # "missing_stage" is NOT in _fp_inputs_disk_cache
+
+        linear = nn.Linear(4, 4)
+        stage_module = nn.Sequential(linear)
+        subset = {"0": linear}
+
+        inp = torch.randn(2, 4)
+        cached_args = [[inp]]
+        cached_kwargs: dict = {}
+
+        with self.assertRaises(RuntimeError) as ctx:
+            quantizer._collect_native_inputs_from_stage_cache(
+                stage_module=stage_module,
+                subset=subset,
+                cached_args=cached_args,
+                cached_kwargs=cached_kwargs,
+                stage_desc="missing_stage",
+                num_batches=1,
+            )
+        self.assertIn("cache miss", str(ctx.exception).lower())
+
+
+# ---------------------------------------------------------------------------
+# Tests: GPTQv2 P-correction (dXXT → P matrix)
+# ---------------------------------------------------------------------------
+
+
+class TestGPTQPCorrection(unittest.TestCase):
+    """Reference tests for the GPTQv2 P-correction logic in fasterquant.
+
+    These tests verify:
+      1. ``quantize()`` does not modify ``w_col`` in-place.
+      2. ``q_col`` and ``w_col`` are different tensors with different values.
+      3. With ``alpha=0`` the P-correction is zero, so GPTQv2 == GPTQv1.
+      4. With ``alpha>0`` and non-zero ``dXXT``, the quantized weights differ
+         from the ``alpha=0`` case.
+      5. The P matrix is computed as ``alpha * triu(dXXT @ hinv^T, k=1) @ hinv``.
+    """
+
+    def _make_gptq(self, rows=8, cols=8):
+        """Create a GPTQ object with a small Linear layer and a configured quantizer."""
+        torch.manual_seed(42)
+        layer = nn.Linear(cols, rows, bias=False)
+        gptq = GPTQ(layer)
+        gptq.quantizer.configure(bits=8, perchannel=True, sym=True)
+        return gptq
+
+    def _add_random_batch(self, gptq, batch=16, cols=8):
+        """Feed a random batch so that H is well-conditioned."""
+        torch.manual_seed(123)
+        inp = torch.randn(batch, cols)
+        with torch.no_grad():
+            out = gptq.layer(inp)
+        gptq.add_batch(inp, out)
+
+    # ------------------------------------------------------------------
+    # 1. quantize() does not modify w_col in-place
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def test_quantize_does_not_modify_w_col(self):
+        """The ``quantize`` function must not change its input tensor in-place."""
+        from tico.quantization.algorithm.qwen3_vl_gptq.gptq import quantize
+
+        w_col = torch.randn(6)
+        w_col_copy = w_col.clone()
+
+        scale = torch.tensor(0.1)
+        zero = torch.tensor(0.0)
+        maxq = torch.tensor(255.0)
+
+        _ = quantize(w_col.unsqueeze(1), scale, zero, maxq)
+
+        self.assertTrue(torch.equal(w_col, w_col_copy))
+
+    # ------------------------------------------------------------------
+    # 2. q_col != w_col after quantize()
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def test_q_col_differs_from_w_col(self):
+        """``q_col`` (quantized) must differ from ``w_col`` (original)."""
+        from tico.quantization.algorithm.qwen3_vl_gptq.gptq import quantize
+
+        w_col = torch.randn(6)
+        scale = torch.tensor(0.1)
+        zero = torch.tensor(0.0)
+        maxq = torch.tensor(255.0)
+
+        q_col = quantize(w_col.unsqueeze(1), scale, zero, maxq).flatten()
+
+        self.assertFalse(torch.equal(q_col, w_col))
+        # The difference is the quantization error
+        self.assertGreater((w_col - q_col).abs().sum().item(), 0.0)
+
+    # ------------------------------------------------------------------
+    # 3. alpha=0  →  P is zero  →  GPTQv2 == GPTQv1
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def test_alpha_zero_equals_no_pcorrection(self):
+        """With alpha=0 the P-correction vanishes, so the result must match
+        the case where dXXT is None (pure GPTQv1)."""
+        rows, cols = 8, 8
+
+        # --- run A: dXXT=None (GPTQv1) ---
+        gptq_a = self._make_gptq(rows, cols)
+        self._add_random_batch(gptq_a, batch=16, cols=cols)
+        w_before_a = gptq_a.layer.weight.data.clone()
+        gptq_a.fasterquant(blocksize=128, percdamp=0.01, alpha=0.0)
+        w_after_a = gptq_a.layer.weight.data.clone()
+
+        # --- run B: dXXT set but alpha=0 ---
+        gptq_b = self._make_gptq(rows, cols)
+        # Copy same weights and H so the two runs are comparable
+        gptq_b.layer.weight.data = w_before_a.clone()
+        self._add_random_batch(gptq_b, batch=16, cols=cols)
+        gptq_b.dXXT = torch.randn(cols, cols)  # non-zero dXXT
+        gptq_b.fasterquant(blocksize=128, percdamp=0.01, alpha=0.0)
+        w_after_b = gptq_b.layer.weight.data.clone()
+
+        self.assertTrue(torch.allclose(w_after_a, w_after_b, atol=1e-6))
+
+    # ------------------------------------------------------------------
+    # 4. alpha>0 with non-zero dXXT → result differs from alpha=0
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def test_alpha_positive_differs_from_zero(self):
+        """With alpha>0 and a non-zero dXXT, the quantized weights must
+        differ from the alpha=0 baseline."""
+        rows, cols = 8, 8
+
+        # --- baseline: alpha=0 ---
+        gptq_base = self._make_gptq(rows, cols)
+        self._add_random_batch(gptq_base, batch=16, cols=cols)
+        w_orig = gptq_base.layer.weight.data.clone()
+        gptq_base.dXXT = torch.randn(cols, cols)
+        gptq_base.fasterquant(blocksize=128, percdamp=0.01, alpha=0.0)
+        w_base = gptq_base.layer.weight.data.clone()
+
+        # --- with P-correction: alpha=0.5 ---
+        gptq_p = self._make_gptq(rows, cols)
+        gptq_p.layer.weight.data = w_orig.clone()
+        self._add_random_batch(gptq_p, batch=16, cols=cols)
+        gptq_p.dXXT = gptq_base.dXXT.clone()  # same dXXT
+        gptq_p.fasterquant(blocksize=128, percdamp=0.01, alpha=0.5)
+        w_p = gptq_p.layer.weight.data.clone()
+
+        self.assertFalse(torch.allclose(w_base, w_p, atol=1e-6))
+
+    # ------------------------------------------------------------------
+    # 5. P matrix formula: alpha * triu(dXXT @ hinv^T, k=1) @ hinv
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def test_p_correction_formula(self):
+        """Manually compute P from dXXT and hinv, then verify that the
+        in-block P-correction matches ``w_col @ P1[i, i:]``."""
+        rows, cols = 6, 6
+
+        gptq = self._make_gptq(rows, cols)
+        self._add_random_batch(gptq, batch=32, cols=cols)
+
+        # Set a known dXXT
+        torch.manual_seed(99)
+        dXXT = torch.randn(cols, cols)
+        gptq.dXXT = dXXT.clone()
+        alpha = 0.25
+
+        # Reproduce the hinv computation from fasterquant
+        h = gptq.H.clone()
+        del gptq.H  # fasterquant does del self.H; we need to restore after
+        gptq.H = h.clone()  # restore for fasterquant
+
+        dead = torch.diag(h) == 0
+        h[dead, dead] = 1
+        damp = 0.01 * torch.mean(torch.diag(h))
+        diag_idx = torch.arange(cols)
+        h[diag_idx, diag_idx] += damp
+        h = torch.linalg.cholesky(h)
+        h = torch.cholesky_inverse(h)
+        h = torch.linalg.cholesky(h, upper=True)
+        hinv = h
+
+        # Compute P using the same formula as fasterquant
+        P_ref = alpha * ((dXXT @ hinv.T).triu(diagonal=1)) @ hinv
+
+        # P must be non-zero
+        self.assertGreater(P_ref.abs().sum().item(), 0.0)
+
+        # The diagonal of P must be zero (triu with diagonal=1)
+        self.assertTrue(torch.allclose(torch.diag(P_ref), torch.zeros(cols), atol=1e-6))
+
+        # Run fasterquant and verify it completes without error
+        gptq.fasterquant(blocksize=128, percdamp=0.01, alpha=alpha)
+        # After fasterquant, the layer weight should have been updated
+        self.assertIsNotNone(gptq.layer.weight.data)
 
 
 if __name__ == "__main__":

--- a/test/quantization/recipes/test_dataset_filter.py
+++ b/test/quantization/recipes/test_dataset_filter.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for dataset_filter (per-class calibration sample filtering)."""
+
+from typing import Any, Dict
+
+from unittest.mock import MagicMock, patch
+
+from tico.quantization.evaluation.vlm_eval_utils import (
+    CalibFilterConfig,
+    dataset_filter,
+    get_mixed_calib_inputs,
+)
+
+
+def _make_example(image_classes):
+    return {
+        "image": None,
+        "question": "What is this?",
+        "answers": ["cat"],
+        "image_classes": image_classes,
+    }
+
+
+class TestDatasetFilter:
+    def test_basic_quota(self):
+        """Each class should get at most n_per_class samples."""
+        examples = [
+            _make_example(["cat", "dog"]),
+            _make_example(["cat"]),
+            _make_example(["cat"]),
+            _make_example(["dog"]),
+            _make_example(["bird"]),
+        ]
+        result = dataset_filter(examples, CalibFilterConfig(n_per_class=2))
+        assert len(result) == 4
+
+    def test_no_image_classes(self):
+        """Samples without image_classes should be kept as-is."""
+        examples: list[dict] = [
+            {"image_classes": []},
+            {"image_classes": []},
+        ]
+        result = dataset_filter(examples, CalibFilterConfig(n_per_class=5))
+        assert len(result) == 2
+
+    def test_n_per_class_one(self):
+        """With n_per_class=1, each class can only appear once."""
+        examples = [
+            _make_example(["cat"]),
+            _make_example(["cat"]),
+            _make_example(["dog"]),
+        ]
+        result = dataset_filter(examples, CalibFilterConfig(n_per_class=1))
+        assert len(result) == 2
+
+    def test_multi_class_sample(self):
+        """A sample with multiple classes counts for all of them."""
+        examples = [
+            _make_example(["cat", "dog", "bird"]),
+            _make_example(["cat"]),
+            _make_example(["dog"]),
+            _make_example(["bird"]),
+        ]
+        result = dataset_filter(examples, CalibFilterConfig(n_per_class=1))
+        assert len(result) == 1
+
+    def test_empty_input(self):
+        result = dataset_filter([], CalibFilterConfig(n_per_class=5))
+        assert result == []
+
+    def test_large_n_per_class(self):
+        """n_per_class larger than available samples keeps everything."""
+        examples = [
+            _make_example(["cat"]),
+            _make_example(["cat"]),
+            _make_example(["dog"]),
+        ]
+        result = dataset_filter(examples, CalibFilterConfig(n_per_class=100))
+        assert len(result) == 3
+
+
+class TestDistinctImages:
+    """Tests for the distinct_images deduplication feature."""
+
+    def test_distinct_images_dedup(self):
+        """When distinct_images=True, same image_id appears only once."""
+        examples = [
+            {**_make_example(["cat"]), "image_id": "img_001", "question_id": 1},
+            {**_make_example(["cat"]), "image_id": "img_001", "question_id": 2},
+            {**_make_example(["cat"]), "image_id": "img_002", "question_id": 3},
+        ]
+        result = dataset_filter(
+            examples, CalibFilterConfig(n_per_class=10, distinct_images=True)
+        )
+        assert len(result) == 2
+        assert result[0]["question_id"] == 1
+        assert result[1]["question_id"] == 3
+
+    def test_distinct_images_false_allows_duplicates(self):
+        """When distinct_images=False, same image_id can appear multiple times."""
+        examples = [
+            {**_make_example(["cat"]), "image_id": "img_001", "question_id": 1},
+            {**_make_example(["cat"]), "image_id": "img_001", "question_id": 2},
+        ]
+        result = dataset_filter(
+            examples, CalibFilterConfig(n_per_class=10, distinct_images=False)
+        )
+        assert len(result) == 2
+
+    def test_distinct_images_default_true(self):
+        """distinct_images defaults to True."""
+        examples = [
+            {**_make_example(["cat"]), "image_id": "img_001", "question_id": 1},
+            {**_make_example(["cat"]), "image_id": "img_001", "question_id": 2},
+        ]
+        result = dataset_filter(examples, CalibFilterConfig(n_per_class=10))
+        assert len(result) == 1
+
+    def test_distinct_images_no_image_id(self):
+        """Samples without image_id are not deduplicated."""
+        examples = [
+            _make_example(["cat"]),
+            _make_example(["cat"]),
+        ]
+        result = dataset_filter(
+            examples, CalibFilterConfig(n_per_class=10, distinct_images=True)
+        )
+        assert len(result) == 2
+
+
+class TestMixedModeClassFiltering:
+    """Tests that get_mixed_calib_inputs routes textvqa through class filtering
+    when a per-dataset ``filter`` block is present."""
+
+    def test_textvqa_uses_class_filter_when_filter_block_set(self):
+        """When a filter block with n_per_class > 0 is set, textvqa should use
+        get_calib_inputs with a CalibFilterConfig."""
+        dataset_config: Dict[str, Dict[str, Any]] = {
+            "vqav2": {"n_samples": 10},
+            "textvqa": {
+                "n_samples": 50,
+                "filter": {
+                    "field": "image_classes",
+                    "n_per_class": 5,
+                },
+            },
+            "wikitext2": {"n_samples": 128},
+        }
+
+        processor = MagicMock()
+
+        with patch(
+            "tico.quantization.evaluation.vlm_eval_utils.get_calib_inputs"
+        ) as mock_calib, patch(
+            "tico.quantization.evaluation.vlm_eval_utils.get_dataset"
+        ) as mock_get_dataset, patch(
+            "tico.quantization.evaluation.vlm_eval_utils._build_text_calib_inputs"
+        ) as mock_text:
+            # textvqa class-filtering returns dummy inputs
+            mock_calib.return_value = [{"input_ids": "textvqa_filtered"}]
+
+            # vqav2 streaming returns 2 samples with images
+            vqav2_ds = MagicMock()
+            vqav2_adapter = MagicMock(
+                return_value={"image": MagicMock(), "question": "q", "golds": []}
+            )
+            mock_get_dataset.return_value = (vqav2_ds, vqav2_adapter)
+            vqav2_ds.__iter__ = MagicMock(
+                return_value=iter([{"image": MagicMock()}, {"image": MagicMock()}])
+            )
+
+            # wikitext2 text inputs
+            mock_text.return_value = [{"input_ids": "wikitext"}]
+
+            with patch(
+                "tico.quantization.evaluation.vlm_eval_utils.build_vlm_inputs"
+            ) as mock_build:
+                mock_build.return_value = {"input_ids": "vqav2_input"}
+
+                result = get_mixed_calib_inputs(
+                    processor=processor,
+                    dataset_config=dataset_config,
+                    max_seq_len=2048,
+                )
+
+            # textvqa should have been routed through get_calib_inputs with filter_config
+            mock_calib.assert_called_once()
+            call_kwargs = mock_calib.call_args.kwargs
+            assert call_kwargs["dataset"] == "textvqa"
+            fc = call_kwargs["filter_config"]
+            assert isinstance(fc, CalibFilterConfig)
+            assert fc.n_per_class == 5
+            assert fc.filter_field == "image_classes"
+
+            # Result should contain textvqa filtered + vqav2 + wikitext inputs
+            assert len(result) >= 1
+
+    def test_textvqa_not_filtered_when_no_filter_block(self):
+        """When no filter block is present, textvqa uses the default streaming path."""
+        dataset_config: Dict[str, Dict[str, Any]] = {
+            "textvqa": {"n_samples": 5},
+        }
+
+        processor = MagicMock()
+
+        with patch(
+            "tico.quantization.evaluation.vlm_eval_utils.get_calib_inputs"
+        ) as mock_calib, patch(
+            "tico.quantization.evaluation.vlm_eval_utils.get_dataset"
+        ) as mock_get_dataset, patch(
+            "tico.quantization.evaluation.vlm_eval_utils.build_vlm_inputs"
+        ) as mock_build:
+            ds = MagicMock()
+            adapter = MagicMock(
+                return_value={"image": MagicMock(), "question": "q", "golds": []}
+            )
+            mock_get_dataset.return_value = (ds, adapter)
+            ds.__iter__ = MagicMock(return_value=iter([{"image": MagicMock()}] * 5))
+            mock_build.return_value = {"input_ids": "input"}
+
+            get_mixed_calib_inputs(
+                processor=processor,
+                dataset_config=dataset_config,
+                max_seq_len=2048,
+            )
+
+            # get_calib_inputs (class filtering path) should NOT have been called
+            mock_calib.assert_not_called()

--- a/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
@@ -268,16 +268,20 @@ class GPTQ:
     and then performs blockwise GPTQ quantization of the layer weights.
     """
 
-    def __init__(self, layer: nn.Module):
+    def __init__(self, layer: nn.Module, normalize_H: bool = True):
         """
         Initialize GPTQ state for a single layer.
 
         Args:
             layer: Quantizable layer. Supported types are Linear, Conv1d,
                 Conv2d, Conv3d, and ConvTranspose2d.
+            normalize_H: If True, use running average with sqrt(2/N)
+                normalization for Hessian accumulation.
+                If False, use simple summation.
         """
         self.layer = layer
         self.dev = self.layer.weight.device
+        self.normalize_H = normalize_H
 
         w = layer.weight.data.clone()
         if isinstance(layer, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
@@ -295,16 +299,34 @@ class GPTQ:
         self.nsamples = 0
         self.quantizer: Quantizer = Quantizer()
 
+        # GPTQv2: for tracking FP vs quantized input difference
+        self.dXXT: Optional[torch.Tensor] = None
+        self.native_inp: Optional[list] = None
+
     @torch.no_grad()
     def add_batch(self, inp: torch.Tensor, out: torch.Tensor) -> None:
         """
         Accumulate Hessian statistics from one calibration batch.
 
+        For GPTQv2, also processes native_inp (FP inputs) and computes dXXT.
+
         Args:
-            inp: Layer input tensor.
+            inp: Layer input tensor (from the model being quantized).
             out: Layer output tensor. Present for interface consistency.
         """
         del out
+
+        # Process native input for GPTQv2 (before reshaping inp)
+        native_inp_raw = None
+        if hasattr(self, "native_inp") and self.native_inp is not None:
+            if len(self.native_inp) == 0:
+                raise RuntimeError(
+                    "GPTQv2: native inputs exhausted. "
+                    "Number of add_batch calls exceeds collected FP inputs."
+                )
+            native_inp_raw = self.native_inp.pop(0)
+            if native_inp_raw is not None:
+                native_inp_raw = native_inp_raw.to(self.dev)
 
         if len(inp.shape) == 2:
             inp = inp.unsqueeze(0)
@@ -359,11 +381,92 @@ class GPTQ:
         elif isinstance(self.layer, nn.Conv3d):
             inp = _conv3d_input_to_unfolded(self.layer, inp)
 
-        self.H *= self.nsamples / (self.nsamples + batch_size)
+        # GPTQv2: Apply the same reshaping to native_inp
+        native_inp = None
+        if native_inp_raw is not None:
+            native_inp = native_inp_raw
+            if len(native_inp.shape) == 2:
+                native_inp = native_inp.unsqueeze(0)
+
+            if isinstance(self.layer, nn.Linear):
+                if len(native_inp.shape) > 2:
+                    native_inp = native_inp.reshape(-1, native_inp.shape[-1])
+                native_inp = native_inp.t()
+
+            elif isinstance(self.layer, nn.Conv2d):
+                padding = _normalize_2d_padding(self.layer.padding)
+                unfold = nn.Unfold(
+                    kernel_size=self.layer.kernel_size,
+                    dilation=self.layer.dilation,
+                    padding=padding,
+                    stride=self.layer.stride,
+                )
+
+                if self.layer.groups != 1:
+                    native_inp = native_inp.reshape(
+                        native_inp.size(0) * self.layer.groups,
+                        native_inp.size(1) // self.layer.groups,
+                        native_inp.shape[2],
+                        native_inp.shape[3],
+                    )
+
+                native_inp = unfold(native_inp).permute(1, 0, 2).flatten(1)
+
+            elif isinstance(self.layer, nn.Conv1d):
+                unfold = nn.Unfold(
+                    kernel_size=(1, self.layer.kernel_size[0]),
+                    dilation=(1, self.layer.dilation[0]),
+                    padding=(0, self.layer.padding[0]),
+                    stride=(1, self.layer.stride[0]),
+                )
+
+                if self.layer.groups != 1:
+                    native_inp = native_inp.reshape(
+                        native_inp.size(0) * self.layer.groups,
+                        native_inp.size(1) // self.layer.groups,
+                        native_inp.shape[2],
+                    )
+
+                native_inp = native_inp.unsqueeze(-2)
+                native_inp = unfold(native_inp).permute(1, 0, 2).flatten(1)
+
+            elif isinstance(self.layer, nn.ConvTranspose2d):
+                native_inp = get_matmul_input_for_convtranspose2d(
+                    self.layer, native_inp
+                )
+
+            elif isinstance(self.layer, nn.Conv3d):
+                native_inp = _conv3d_input_to_unfolded(self.layer, native_inp)
+
         self.nsamples += batch_size
-        inp = math.sqrt(2.0 / self.nsamples) * inp.float()
+
+        if self.normalize_H:
+            # Running average with sqrt(2/N) normalization
+            self.H *= (self.nsamples - batch_size) / self.nsamples
+            if self.dXXT is not None:
+                self.dXXT *= (self.nsamples - batch_size) / self.nsamples
+            inp = math.sqrt(2.0 / self.nsamples) * inp.double()
+        else:
+            inp = inp.double()
+
         assert self.H is not None
         self.H += inp.matmul(inp.t()).to(self.H.device)
+
+        # GPTQv2: Compute dXXT using native (FP) vs processed input difference
+        if native_inp is not None:
+            if self.dXXT is None:
+                self.dXXT = torch.zeros_like(self.H)
+
+            # Scale native_inp the same way as inp
+            if self.normalize_H:
+                native_inp = math.sqrt(2.0 / self.nsamples) * native_inp.double()
+            else:
+                native_inp = native_inp.double()
+
+            dX = native_inp.to(inp.device) - inp
+            self.dXXT += dX.matmul(inp.t()).to(dtype=self.H.dtype)
+            del native_inp_raw, native_inp
+            native_inp_raw = native_inp = None
 
     @torch.no_grad()
     def fasterquant(
@@ -374,6 +477,7 @@ class GPTQ:
         actorder: bool = False,
         static_groups: bool = False,
         verbose: bool = False,
+        alpha: float = 0.25,
     ) -> None:
         """
         Run blockwise GPTQ quantization on the layer weights.
@@ -419,6 +523,10 @@ class GPTQ:
         h[dead, dead] = 1
         w[:, dead] = 0
 
+        # GPTQv2: Zero out dead elements in dXXT
+        if self.dXXT is not None:
+            self.dXXT[:, dead] = 0
+
         if groupsize != -1 and self.quantizer.mse in {"mse_for_gptq", "smse_for_gptq"}:
             raise ValueError(
                 "GPTQ-adjusted MSE currently does not support groupsize != -1"
@@ -440,6 +548,8 @@ class GPTQ:
             w = w[:, perm]
             h = h[perm][:, perm]
             invperm = torch.argsort(perm)
+            if self.dXXT is not None:
+                self.dXXT = self.dXXT[perm][:, perm]
 
         losses = torch.zeros_like(w)
         q_all = torch.zeros_like(w)
@@ -452,6 +562,12 @@ class GPTQ:
         h = torch.linalg.cholesky(h, upper=True)
         hinv = h
 
+        # GPTQv2: Compute P correction matrix from dXXT
+        P = None
+        if self.dXXT is not None:
+            dXXT = self.dXXT.to(hinv.dtype)
+            P = alpha * ((dXXT @ hinv.T).triu(diagonal=1)) @ hinv
+
         self.quantizer.update(w, hinv, perm)
 
         for i1 in range(0, self.columns, blocksize):
@@ -463,6 +579,7 @@ class GPTQ:
             err1 = torch.zeros_like(w1)
             losses1 = torch.zeros_like(w1)
             hinv1 = hinv[i1:i2, i1:i2]
+            P1 = P[i1:i2, i1:i2] if P is not None else None
 
             for i in range(count):
                 w_col = w1[:, i]
@@ -493,11 +610,17 @@ class GPTQ:
 
                 cur_err = (w_col - q_col) / d
                 w1[:, i:] -= cur_err.unsqueeze(1).matmul(hinv1[i, i:].unsqueeze(0))
+                # GPTQv2: Apply P correction
+                if P1 is not None:
+                    w1[:, i:] += w_col.unsqueeze(1).matmul(P1[i, i:].unsqueeze(0))
                 err1[:, i] = cur_err
 
             q_all[:, i1:i2] = q1
             losses[:, i1:i2] = losses1 / 2
             w[:, i2:] -= err1.matmul(hinv[i1:i2, i2:])
+            # GPTQv2: Apply P correction to remaining weights
+            if P is not None:
+                w[:, i2:] += w1.matmul(P[i1:i2, i2:])
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
@@ -559,5 +682,7 @@ class GPTQ:
         self.H = None
         self.Losses = None
         self.Trace = None
+        self.dXXT = None
+        self.native_inp = None
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
@@ -268,16 +268,20 @@ class GPTQ:
     and then performs blockwise GPTQ quantization of the layer weights.
     """
 
-    def __init__(self, layer: nn.Module):
+    def __init__(self, layer: nn.Module, normalize_H: bool = True):
         """
         Initialize GPTQ state for a single layer.
 
         Args:
             layer: Quantizable layer. Supported types are Linear, Conv1d,
                 Conv2d, Conv3d, and ConvTranspose2d.
+            normalize_H: If True, use running average with sqrt(2/N)
+                normalization for Hessian accumulation.
+                If False, use simple summation.
         """
         self.layer = layer
         self.dev = self.layer.weight.device
+        self.normalize_H = normalize_H
 
         w = layer.weight.data.clone()
         if isinstance(layer, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
@@ -295,16 +299,34 @@ class GPTQ:
         self.nsamples = 0
         self.quantizer: Quantizer = Quantizer()
 
+        # GPTQv2: for tracking FP vs quantized input difference
+        self.dXXT: Optional[torch.Tensor] = None
+        self.native_inp: Optional[list] = None
+
     @torch.no_grad()
     def add_batch(self, inp: torch.Tensor, out: torch.Tensor) -> None:
         """
         Accumulate Hessian statistics from one calibration batch.
 
+        For GPTQv2, also processes native_inp (FP inputs) and computes dXXT.
+
         Args:
-            inp: Layer input tensor.
+            inp: Layer input tensor (from the model being quantized).
             out: Layer output tensor. Present for interface consistency.
         """
         del out
+
+        # Process native input for GPTQv2 (before reshaping inp)
+        native_inp_raw = None
+        if hasattr(self, "native_inp") and self.native_inp is not None:
+            if len(self.native_inp) == 0:
+                raise RuntimeError(
+                    "GPTQv2: native inputs exhausted. "
+                    "Number of add_batch calls exceeds collected FP inputs."
+                )
+            native_inp_raw = self.native_inp.pop(0)
+            if native_inp_raw is not None:
+                native_inp_raw = native_inp_raw.to(self.dev)
 
         if len(inp.shape) == 2:
             inp = inp.unsqueeze(0)
@@ -359,11 +381,92 @@ class GPTQ:
         elif isinstance(self.layer, nn.Conv3d):
             inp = _conv3d_input_to_unfolded(self.layer, inp)
 
-        self.H *= self.nsamples / (self.nsamples + batch_size)
+        # GPTQv2: Apply the same reshaping to native_inp
+        native_inp = None
+        if native_inp_raw is not None:
+            native_inp = native_inp_raw
+            if len(native_inp.shape) == 2:
+                native_inp = native_inp.unsqueeze(0)
+
+            if isinstance(self.layer, nn.Linear):
+                if len(native_inp.shape) > 2:
+                    native_inp = native_inp.reshape(-1, native_inp.shape[-1])
+                native_inp = native_inp.t()
+
+            elif isinstance(self.layer, nn.Conv2d):
+                padding = _normalize_2d_padding(self.layer.padding)
+                unfold = nn.Unfold(
+                    kernel_size=self.layer.kernel_size,
+                    dilation=self.layer.dilation,
+                    padding=padding,
+                    stride=self.layer.stride,
+                )
+
+                if self.layer.groups != 1:
+                    native_inp = native_inp.reshape(
+                        native_inp.size(0) * self.layer.groups,
+                        native_inp.size(1) // self.layer.groups,
+                        native_inp.shape[2],
+                        native_inp.shape[3],
+                    )
+
+                native_inp = unfold(native_inp).permute(1, 0, 2).flatten(1)
+
+            elif isinstance(self.layer, nn.Conv1d):
+                unfold = nn.Unfold(
+                    kernel_size=(1, self.layer.kernel_size[0]),
+                    dilation=(1, self.layer.dilation[0]),
+                    padding=(0, self.layer.padding[0]),
+                    stride=(1, self.layer.stride[0]),
+                )
+
+                if self.layer.groups != 1:
+                    native_inp = native_inp.reshape(
+                        native_inp.size(0) * self.layer.groups,
+                        native_inp.size(1) // self.layer.groups,
+                        native_inp.shape[2],
+                    )
+
+                native_inp = native_inp.unsqueeze(-2)
+                native_inp = unfold(native_inp).permute(1, 0, 2).flatten(1)
+
+            elif isinstance(self.layer, nn.ConvTranspose2d):
+                native_inp = get_matmul_input_for_convtranspose2d(
+                    self.layer, native_inp
+                )
+
+            elif isinstance(self.layer, nn.Conv3d):
+                native_inp = _conv3d_input_to_unfolded(self.layer, native_inp)
+
         self.nsamples += batch_size
-        inp = math.sqrt(2.0 / self.nsamples) * inp.float()
+
+        if self.normalize_H:
+            # Running average with sqrt(2/N) normalization
+            self.H *= (self.nsamples - batch_size) / self.nsamples
+            if self.dXXT is not None:
+                self.dXXT *= (self.nsamples - batch_size) / self.nsamples
+            inp = math.sqrt(2.0 / self.nsamples) * inp.double()
+        else:
+            inp = inp.double()
+
         assert self.H is not None
         self.H += inp.matmul(inp.t()).to(self.H.device)
+
+        # GPTQv2: Compute dXXT using native (FP) vs processed input difference
+        if native_inp is not None:
+            if self.dXXT is None:
+                self.dXXT = torch.zeros_like(self.H)
+
+            # Scale native_inp the same way as inp
+            if self.normalize_H:
+                native_inp = math.sqrt(2.0 / self.nsamples) * native_inp.double()
+            else:
+                native_inp = native_inp.double()
+
+            dX = native_inp.to(inp.device) - inp
+            self.dXXT += dX.matmul(inp.t()).to(dtype=self.H.dtype)
+            del native_inp_raw, native_inp
+            native_inp_raw = native_inp = None
 
     @torch.no_grad()
     def fasterquant(
@@ -374,6 +477,7 @@ class GPTQ:
         actorder: bool = False,
         static_groups: bool = False,
         verbose: bool = False,
+        alpha: float = 0.25,
     ) -> None:
         """
         Run blockwise GPTQ quantization on the layer weights.
@@ -419,6 +523,10 @@ class GPTQ:
         h[dead, dead] = 1
         w[:, dead] = 0
 
+        # GPTQv2: Zero out dead elements in dXXT
+        if self.dXXT is not None:
+            self.dXXT[:, dead] = 0
+
         if groupsize != -1 and self.quantizer.mse in {"mse_for_gptq", "smse_for_gptq"}:
             raise ValueError(
                 "GPTQ-adjusted MSE currently does not support groupsize != -1"
@@ -440,6 +548,8 @@ class GPTQ:
             w = w[:, perm]
             h = h[perm][:, perm]
             invperm = torch.argsort(perm)
+            if self.dXXT is not None:
+                self.dXXT = self.dXXT[perm][:, perm]
 
         losses = torch.zeros_like(w)
         q_all = torch.zeros_like(w)
@@ -452,6 +562,12 @@ class GPTQ:
         h = torch.linalg.cholesky(h, upper=True)
         hinv = h
 
+        # GPTQv2: Compute P correction matrix from dXXT
+        P = None
+        if self.dXXT is not None:
+            dXXT = self.dXXT.to(hinv.dtype)
+            P = alpha * ((dXXT @ hinv.T).triu(diagonal=1)) @ hinv
+
         self.quantizer.update(w, hinv, perm)
 
         for i1 in range(0, self.columns, blocksize):
@@ -463,6 +579,7 @@ class GPTQ:
             err1 = torch.zeros_like(w1)
             losses1 = torch.zeros_like(w1)
             hinv1 = hinv[i1:i2, i1:i2]
+            P1 = P[i1:i2, i1:i2] if P is not None else None
 
             for i in range(count):
                 w_col = w1[:, i]
@@ -494,11 +611,17 @@ class GPTQ:
 
                 cur_err = (w_col - q_col) / d
                 w1[:, i:] -= cur_err.unsqueeze(1).matmul(hinv1[i, i:].unsqueeze(0))
+                # GPTQv2: Apply P correction
+                if P1 is not None:
+                    w1[:, i:] += w_col.unsqueeze(1).matmul(P1[i, i:].unsqueeze(0))
                 err1[:, i] = cur_err
 
             q_all[:, i1:i2] = q1
             losses[:, i1:i2] = losses1 / 2
             w[:, i2:] -= err1.matmul(hinv[i1:i2, i2:])
+            # GPTQv2: Apply P correction to remaining weights
+            if P is not None:
+                w[:, i2:] += w1.matmul(P[i1:i2, i2:])
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()
@@ -560,5 +683,7 @@ class GPTQ:
         self.H = None
         self.Losses = None
         self.Trace = None
+        self.dXXT = None
+        self.native_inp = None
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/gptq.py
@@ -579,10 +579,15 @@ class GPTQ:
             err1 = torch.zeros_like(w1)
             losses1 = torch.zeros_like(w1)
             hinv1 = hinv[i1:i2, i1:i2]
-            P1 = P[i1:i2, i1:i2] if P is not None else None
+            if P is not None:
+                P1 = P[i1:i2, i1:i2]
+                P_update = w1.matmul(P[i1:i2, i2:])
+            else:
+                P1 = None
+                P_update = None
 
             for i in range(count):
-                w_col = w1[:, i]
+                w_col = w1[:, i].clone()
                 d = hinv1[i, i]
 
                 if groupsize != -1:
@@ -620,8 +625,8 @@ class GPTQ:
             losses[:, i1:i2] = losses1 / 2
             w[:, i2:] -= err1.matmul(hinv[i1:i2, i2:])
             # GPTQv2: Apply P correction to remaining weights
-            if P is not None:
-                w[:, i2:] += w1.matmul(P[i1:i2, i2:])
+            if P_update is not None:
+                w[:, i2:] += P_update
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()

--- a/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import functools
 import types
 from typing import Any, Callable, Optional
 
@@ -39,6 +41,46 @@ from tico.quantization.algorithm.qwen3_vl_gptq.utils import (
 from tico.quantization.config.qwen3_vl_gptq import Qwen3VLGPTQConfig
 from tico.quantization.quantizer import BaseQuantizer
 from tico.quantization.quantizer_registry import register_quantizer
+
+
+class FPInputsCache:
+    """
+    Cache for saving full-precision inputs to each quantizable submodule (GPTQv2).
+
+    Registers forward hooks on the specified modules and stores their FP inputs
+    per batch. The cached inputs are later assigned to ``GPTQ.native_inp`` so that
+    ``add_batch`` can compute the dXXT correction matrix.
+    """
+
+    def __init__(self, names: list[str]):
+        self.names = tuple(names)
+        self.fp_cache: dict[str, list] = {name: [] for name in self.names}
+        self.handles: list = []
+
+    def _cache_fp_input(self, m, inp, out, name):
+        if not inp or not isinstance(inp[0], torch.Tensor):
+            return
+        self.fp_cache[name].append(inp[0].detach().cpu())
+
+    def add_hook(self, full: dict[str, nn.Module]):
+        for name in self.names:
+            if name in full:
+                self.handles.append(
+                    full[name].register_forward_hook(
+                        functools.partial(self._cache_fp_input, name=name)
+                    )
+                )
+
+    def clear_hook(self):
+        for h in self.handles:
+            h.remove()
+        self.handles = []
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def clear_cache(self):
+        for name in self.names:
+            self.fp_cache[name] = []
 
 
 class StopReplay(Exception):
@@ -83,6 +125,9 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         self._vision_cache_args: list[list[Any]] = []
         self._vision_cache_kwargs: dict[str, list[Any]] = {}
         self._num_vision_batches: int = 0
+
+        # GPTQv2: reference to original FP model for collecting FP inputs
+        self.orig_model: Optional[nn.Module] = None
 
     def _resolve_weight_bits(
         self,
@@ -205,67 +250,115 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         components = resolve_qwen3_vl_components(model, gptq_conf)
         module_name = build_module_name_map(model)
 
-        if should_quantize_vision_stage(gptq_conf, stage="patch_embed"):
-            self._quantize_stage_from_raw_replay(
-                model=model,
-                stage_module=components.visual_patch_embed,
-                module_name=module_name,
-                stage_desc="vision.patch_embed",
-                vision_only=True,  # Only use vision inputs for vision stages
-            )
+        # GPTQv2: create a deep copy of the original (unquantized) model.
+        # This pristine copy is used to collect true FP inputs for the dXXT
+        # correction matrix.
+        orig_model: Optional[nn.Module] = None
+        orig_components: Optional[Qwen3VLComponents] = None
+        orig_model_use_cache: dict[str, Any] = {}
 
-        if should_quantize_vision_stage(gptq_conf, stage="blocks"):
-            self._quantize_vision_blocks(
-                model=model,
-                components=components,
-                module_name=module_name,
-            )
+        if gptq_conf.gptq_v2:
+            orig_model = self._copy_original_model(model)
+            self.orig_model = orig_model
+            orig_model_use_cache = self._disable_model_cache(orig_model)
+            orig_components = resolve_qwen3_vl_components(orig_model, gptq_conf)
 
-        if should_quantize_vision_stage(gptq_conf, stage="merger"):
-            self._quantize_stage_from_raw_replay(
-                model=model,
-                stage_module=components.visual_merger,
-                module_name=module_name,
-                stage_desc="vision.merger",
-                vision_only=True,  # Only use vision inputs for vision stages
-            )
-
-        if should_quantize_vision_stage(gptq_conf, stage="deepstack_mergers"):
-            for idx, merger in enumerate(components.visual_deepstack_mergers):
+        try:
+            if should_quantize_vision_stage(gptq_conf, stage="patch_embed"):
                 self._quantize_stage_from_raw_replay(
                     model=model,
-                    stage_module=merger,
+                    stage_module=components.visual_patch_embed,
                     module_name=module_name,
-                    stage_desc=f"vision.deepstack_merger[{idx}]",
+                    stage_desc="vision.patch_embed",
                     vision_only=True,  # Only use vision inputs for vision stages
+                    orig_model=orig_model,
+                    orig_stage_module=(
+                        orig_components.visual_patch_embed
+                        if orig_components is not None
+                        else None
+                    ),
                 )
 
-        if should_quantize_text_stage(gptq_conf, stage="layers"):
-            self._quantize_text_layers(
-                model=model,
-                components=components,
-                module_name=module_name,
-            )
+            if should_quantize_vision_stage(gptq_conf, stage="blocks"):
+                self._quantize_vision_blocks(
+                    model=model,
+                    components=components,
+                    module_name=module_name,
+                    orig_model=orig_model,
+                    orig_components=orig_components,
+                )
 
-        if should_quantize_text_stage(gptq_conf, stage="lm_head"):
-            self._quantize_stage_from_raw_replay(
-                model=model,
-                stage_module=components.lm_head,
-                module_name=module_name,
-                stage_desc="lm_head",
-            )
+            if should_quantize_vision_stage(gptq_conf, stage="merger"):
+                self._quantize_stage_from_raw_replay(
+                    model=model,
+                    stage_module=components.visual_merger,
+                    module_name=module_name,
+                    stage_desc="vision.merger",
+                    vision_only=True,  # Only use vision inputs for vision stages
+                    orig_model=orig_model,
+                    orig_stage_module=(
+                        orig_components.visual_merger
+                        if orig_components is not None
+                        else None
+                    ),
+                )
 
-        self._restore_model_cache(model, orig_use_cache)
+            if should_quantize_vision_stage(gptq_conf, stage="deepstack_mergers"):
+                for idx, merger in enumerate(components.visual_deepstack_mergers):
+                    self._quantize_stage_from_raw_replay(
+                        model=model,
+                        stage_module=merger,
+                        module_name=module_name,
+                        stage_desc=f"vision.deepstack_merger[{idx}]",
+                        vision_only=True,  # Only use vision inputs for vision stages
+                        orig_model=orig_model,
+                        orig_stage_module=(
+                            orig_components.visual_deepstack_mergers[idx]
+                            if orig_components is not None
+                            else None
+                        ),
+                    )
 
-        self.cache_args.clear()
-        self.cache_kwargs.clear()
-        self.num_batches = 0
-        # Clear vision cache
-        self._vision_cache_args.clear()
-        self._vision_cache_kwargs.clear()
-        self._num_vision_batches = 0
-        model.quantizers = self._quantizers
-        return model
+            if should_quantize_text_stage(gptq_conf, stage="layers"):
+                self._quantize_text_layers(
+                    model=model,
+                    components=components,
+                    module_name=module_name,
+                    orig_model=orig_model,
+                    orig_components=orig_components,
+                )
+
+            if should_quantize_text_stage(gptq_conf, stage="lm_head"):
+                self._quantize_stage_from_raw_replay(
+                    model=model,
+                    stage_module=components.lm_head,
+                    module_name=module_name,
+                    stage_desc="lm_head",
+                    orig_model=orig_model,
+                    orig_stage_module=(
+                        orig_components.lm_head if orig_components is not None else None
+                    ),
+                )
+
+            model.quantizers = self._quantizers
+            return model
+        finally:
+            self._restore_model_cache(model, orig_use_cache)
+            if orig_model is not None:
+                self._restore_model_cache(orig_model, orig_model_use_cache)
+                orig_model.cpu()
+            self.orig_model = None
+
+            self.cache_args.clear()
+            self.cache_kwargs.clear()
+            self.num_batches = 0
+            # Clear vision cache
+            self._vision_cache_args.clear()
+            self._vision_cache_kwargs.clear()
+            self._num_vision_batches = 0
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
     # ------------------------------------------------------------------
     # Vision path
@@ -277,6 +370,8 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         model: nn.Module,
         components: Qwen3VLComponents,
         module_name: dict[nn.Module, str],
+        orig_model: Optional[nn.Module] = None,
+        orig_components: Optional[Qwen3VLComponents] = None,
     ) -> None:
         """
         Quantize Qwen3-VL vision blocks in layerwise order using first-block entry
@@ -298,6 +393,33 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             return
 
         assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # GPTQv2: collect native (FP) entry inputs from the original model
+        native_block_args: Optional[list[list[Any]]] = None
+        native_block_kwargs: Optional[dict[str, list[Any]]] = None
+
+        if self.config.gptq_v2:
+            assert orig_model is not None and orig_components is not None
+            self._move_module_to_device(orig_model, self._module_device(model))
+            try:
+                (
+                    native_block_args,
+                    native_block_kwargs,
+                    native_num_batches,
+                ) = self._collect_stage_entry_inputs(
+                    model=orig_model,
+                    target_module=orig_components.visual_blocks[0],
+                    desc="native vision block entry capture",
+                    vision_only=True,
+                )
+            finally:
+                orig_model.cpu()
+            if native_num_batches != num_vision_batches:
+                raise RuntimeError(
+                    "Native/current vision block cache sizes differ: "
+                    f"{native_num_batches} vs {num_vision_batches}"
+                )
+
         for block_idx, block in enumerate(
             tqdm(
                 components.visual_blocks,
@@ -307,6 +429,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             )
         ):
             stage_name = module_name.get(block, f"visual.blocks.{block_idx}")
+            orig_block = (
+                orig_components.visual_blocks[block_idx]
+                if orig_components is not None
+                else None
+            )
 
             self._quantize_stage_from_stage_cache(
                 stage_module=block,
@@ -315,6 +442,9 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 cached_kwargs=block_kwargs,
                 stage_desc=stage_name,
                 num_batches=num_vision_batches,
+                orig_stage_module=orig_block,
+                native_cached_args=native_block_args,
+                native_cached_kwargs=native_block_kwargs,
             )
 
             for batch_idx in tqdm(
@@ -338,6 +468,43 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                     dtype=self.config.cache_dtype,
                 )
 
+            # GPTQv2: re-forward through the original (unquantized) block to
+            # keep the native cache in sync with a pristine model.
+            if native_block_args is not None and native_block_kwargs is not None:
+                assert orig_block is not None
+                self._move_module_to_device(orig_block, self._module_device(block))
+                try:
+                    for batch_idx in tqdm(
+                        range(num_vision_batches),
+                        desc=f"[native vision block {block_idx}] re-forward",
+                        leave=False,
+                        unit="batch",
+                        disable=not self.config.show_progress,
+                    ):
+                        args_batch = gather_single_batch_from_list(
+                            native_block_args, batch_idx
+                        )
+                        kwargs_batch = gather_single_batch_from_dict(
+                            native_block_kwargs, batch_idx
+                        )
+                        args_batch = self._move_batch_to_stage_device(
+                            orig_block, args_batch
+                        )
+                        kwargs_batch = self._move_batch_to_stage_device(
+                            orig_block, kwargs_batch
+                        )
+
+                        outs = orig_block(*args_batch, **kwargs_batch)
+                        hidden_states = extract_primary_output(outs)
+
+                        native_block_args[0][batch_idx] = maybe_move_cache_to_cpu(
+                            hidden_states.detach().clone(),
+                            enabled=self.config.move_cache_to_cpu,
+                            dtype=self.config.cache_dtype,
+                        )
+                finally:
+                    orig_block.cpu()
+
     # ------------------------------------------------------------------
     # Text path
     # ------------------------------------------------------------------
@@ -348,6 +515,8 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         model: nn.Module,
         components: Qwen3VLComponents,
         module_name: dict[nn.Module, str],
+        orig_model: Optional[nn.Module] = None,
+        orig_components: Optional[Qwen3VLComponents] = None,
     ) -> None:
         """
         Quantize text decoder layers in layerwise order using first-layer entry
@@ -361,6 +530,33 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             vision_only=False,  # Text layers process all inputs
         )
         assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # GPTQv2: collect native (FP) entry inputs from the original model
+        native_layer_args: Optional[list[list[Any]]] = None
+        native_layer_kwargs: Optional[dict[str, list[Any]]] = None
+
+        if self.config.gptq_v2:
+            assert orig_model is not None and orig_components is not None
+            self._move_module_to_device(orig_model, self._module_device(model))
+            try:
+                (
+                    native_layer_args,
+                    native_layer_kwargs,
+                    native_num_batches,
+                ) = self._collect_stage_entry_inputs(
+                    model=orig_model,
+                    target_module=orig_components.text_layers[0],
+                    desc="native text layer entry capture",
+                    vision_only=False,
+                )
+            finally:
+                orig_model.cpu()
+            if native_num_batches != num_batches:
+                raise RuntimeError(
+                    "Native/current text layer cache sizes differ: "
+                    f"{native_num_batches} vs {num_batches}"
+                )
+
         for layer_idx, layer in enumerate(
             tqdm(
                 components.text_layers,
@@ -370,6 +566,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             )
         ):
             stage_name = module_name.get(layer, f"text.layers.{layer_idx}")
+            orig_layer = (
+                orig_components.text_layers[layer_idx]
+                if orig_components is not None
+                else None
+            )
 
             self._quantize_stage_from_stage_cache(
                 stage_module=layer,
@@ -378,6 +579,9 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 cached_kwargs=layer_kwargs,
                 stage_desc=stage_name,
                 num_batches=num_batches,
+                orig_stage_module=orig_layer,
+                native_cached_args=native_layer_args,
+                native_cached_kwargs=native_layer_kwargs,
             )
 
             for batch_idx in tqdm(
@@ -408,6 +612,49 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                     enabled=self.config.move_cache_to_cpu,
                     dtype=self.config.cache_dtype,
                 )
+
+            # GPTQv2: re-forward through the original (unquantized) layer to
+            # keep the native cache in sync with a pristine model.
+            if native_layer_args is not None and native_layer_kwargs is not None:
+                assert orig_layer is not None and orig_components is not None
+                self._move_module_to_device(orig_layer, self._module_device(layer))
+                try:
+                    for batch_idx in tqdm(
+                        range(num_batches),
+                        desc=f"[native text layer {layer_idx}] re-forward",
+                        leave=False,
+                        unit="batch",
+                        disable=not self.config.show_progress,
+                    ):
+                        args_batch = gather_single_batch_from_list(
+                            native_layer_args, batch_idx
+                        )
+                        kwargs_batch = gather_single_batch_from_dict(
+                            native_layer_kwargs, batch_idx
+                        )
+                        args_batch = self._move_batch_to_stage_device(
+                            orig_layer, args_batch
+                        )
+                        kwargs_batch = self._move_batch_to_stage_device(
+                            orig_layer, kwargs_batch
+                        )
+
+                        outs = orig_layer(*args_batch, **kwargs_batch)
+                        hidden_states = extract_primary_output(outs)
+                        hidden_states = self._apply_text_post_layer_processing(
+                            components=orig_components,
+                            layer_idx=layer_idx,
+                            hidden_states=hidden_states,
+                            kwargs_batch=kwargs_batch,
+                        )
+
+                        native_layer_args[0][batch_idx] = maybe_move_cache_to_cpu(
+                            hidden_states.detach().clone(),
+                            enabled=self.config.move_cache_to_cpu,
+                            dtype=self.config.cache_dtype,
+                        )
+                finally:
+                    orig_layer.cpu()
 
     @torch.no_grad()
     def _apply_text_post_layer_processing(
@@ -444,6 +691,103 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
     # ------------------------------------------------------------------
 
     @torch.no_grad()
+    def _collect_native_inputs_from_raw_replay(
+        self,
+        model: nn.Module,
+        subset: dict[str, nn.Module],
+        module_name: dict[nn.Module, str],
+        cache_args: list[list[Any]],
+        cache_kwargs: dict[str, list[Any]],
+        num_batches: int,
+        stage_desc: str,
+    ) -> dict[str, list[torch.Tensor]]:
+        """
+        GPTQv2: Collect full-precision inputs from the original (unquantized) model
+        by replaying raw model inputs.
+
+        Returns:
+            Dictionary mapping local_name -> list of FP input tensors (one per batch).
+        """
+        assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # Build full module name -> local name mapping
+        full_to_local: dict[str, str] = {}
+        for local_name, submodule in subset.items():
+            full_name = module_name.get(submodule, local_name)
+            full_to_local[full_name] = local_name
+
+        fp_cache = FPInputsCache(list(full_to_local.keys()))
+
+        # Build full name -> module mapping for hook registration
+        full_modules: dict[str, nn.Module] = {}
+        for local_name, submodule in subset.items():
+            full_name = module_name.get(submodule, local_name)
+            full_modules[full_name] = submodule
+
+        fp_cache.add_hook(full_modules)
+
+        try:
+            for batch_idx in tqdm(
+                range(num_batches),
+                desc=f"[{stage_desc}] FP input collection",
+                leave=False,
+                unit="batch",
+                disable=not self.config.show_progress,
+            ):
+                args_batch = gather_single_batch_from_list(cache_args, batch_idx)
+                kwargs_batch = gather_single_batch_from_dict(cache_kwargs, batch_idx)
+                args_batch = self._move_batch_to_model_device(model, args_batch)
+                kwargs_batch = self._move_batch_to_model_device(model, kwargs_batch)
+                model(*args_batch, **kwargs_batch)
+        finally:
+            fp_cache.clear_hook()
+
+        # Remap from full_name -> local_name
+        result: dict[str, list[torch.Tensor]] = {}
+        for full_name, local_name in full_to_local.items():
+            result[local_name] = fp_cache.fp_cache.get(full_name, [])
+
+        return result
+
+    @torch.no_grad()
+    def _collect_native_inputs_from_stage_cache(
+        self,
+        stage_module: nn.Module,
+        subset: dict[str, nn.Module],
+        cached_args: list[list[Any]],
+        cached_kwargs: dict[str, list[Any]],
+        stage_desc: str,
+        num_batches: int,
+    ) -> dict[str, list[torch.Tensor]]:
+        """
+        GPTQv2: Collect full-precision inputs from the original (unquantized) stage
+        module by replaying cached stage-entry inputs.
+        """
+        fp_cache = FPInputsCache(list(subset.keys()))
+        full_modules: dict[str, nn.Module] = {}
+        for local_name, submodule in subset.items():
+            full_modules[local_name] = submodule
+        fp_cache.add_hook(full_modules)
+
+        try:
+            for args_batch, kwargs_batch in tqdm(
+                iter_cached_batches(cached_args, cached_kwargs, num_batches),
+                desc=f"[{stage_desc}] FP input collection",
+                leave=False,
+                unit="batch",
+                disable=not self.config.show_progress,
+            ):
+                args_batch = self._move_batch_to_stage_device(stage_module, args_batch)
+                kwargs_batch = self._move_batch_to_stage_device(
+                    stage_module, kwargs_batch
+                )
+                stage_module(*args_batch, **kwargs_batch)
+        finally:
+            fp_cache.clear_hook()
+
+        return fp_cache.fp_cache
+
+    @torch.no_grad()
     def _quantize_stage_from_raw_replay(
         self,
         model: nn.Module,
@@ -451,6 +795,8 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         module_name: dict[nn.Module, str],
         stage_desc: str,
         vision_only: bool = False,
+        orig_model: Optional[nn.Module] = None,
+        orig_stage_module: Optional[nn.Module] = None,
     ) -> None:
         """
         Quantize a stage by replaying raw model inputs and collecting statistics
@@ -464,6 +810,8 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             vision_only: If True, only replay batches that have vision inputs
                 (pixel_values). This is needed for vision stages to avoid errors
                 when text-only inputs lack image tokens.
+            orig_model: GPTQv2 original (unquantized) model for FP input collection.
+            orig_stage_module: GPTQv2 original stage module for FP input collection.
         """
         subset = get_quantizable_layers(stage_module)
         if not subset:
@@ -474,13 +822,6 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             module_name=module_name,
         )
 
-        handles = []
-        for local_name, submodule in subset.items():
-            handles.append(
-                submodule.register_forward_hook(
-                    self._make_add_batch_hook(gptq_objs, local_name)
-                )
-            )
         assert isinstance(self.config, Qwen3VLGPTQConfig)
 
         # Use separate vision cache for vision-only quantization
@@ -490,8 +831,6 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                     f"[{stage_desc}] Warning: No vision inputs found in calibration data. "
                     f"Skipping vision stage quantization."
                 )
-                for handle in handles:
-                    handle.remove()
                 return
             cache_args = self._vision_cache_args
             cache_kwargs = self._vision_cache_kwargs
@@ -500,6 +839,33 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             cache_args = self.cache_args
             cache_kwargs = self.cache_kwargs
             num_batches = self.num_batches
+
+        # GPTQv2: Collect FP inputs from the ORIGINAL (unquantized) model
+        if self.config.gptq_v2:
+            assert orig_model is not None and orig_stage_module is not None
+            orig_subset = get_quantizable_layers(orig_stage_module)
+            self._move_module_to_device(orig_model, self._module_device(model))
+            try:
+                native_inputs = self._collect_native_inputs_from_raw_replay(
+                    model=orig_model,
+                    subset=orig_subset,
+                    module_name=module_name,
+                    cache_args=cache_args,
+                    cache_kwargs=cache_kwargs,
+                    num_batches=num_batches,
+                    stage_desc=stage_desc,
+                )
+            finally:
+                orig_model.cpu()
+            self._assign_native_inputs(gptq_objs, native_inputs)
+
+        handles = []
+        for local_name, submodule in subset.items():
+            handles.append(
+                submodule.register_forward_hook(
+                    self._make_add_batch_hook(gptq_objs, local_name)
+                )
+            )
 
         try:
             for batch_idx in tqdm(
@@ -534,6 +900,9 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         cached_kwargs: dict[str, list[Any]],
         stage_desc: str,
         num_batches: Optional[int] = None,
+        orig_stage_module: Optional[nn.Module] = None,
+        native_cached_args: Optional[list[list[Any]]] = None,
+        native_cached_kwargs: Optional[dict[str, list[Any]]] = None,
     ) -> None:
         """
         Quantize a stage by replaying cached stage-entry inputs.
@@ -545,6 +914,10 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             cached_kwargs: Cached keyword arguments.
             stage_desc: Description for logging.
             num_batches: Number of batches to use. If None, uses self.num_batches.
+            orig_stage_module: GPTQv2 original (unquantized) stage module for FP
+                input collection.
+            native_cached_args: GPTQv2 native entry cache args.
+            native_cached_kwargs: GPTQv2 native entry cache kwargs.
         """
         subset = get_quantizable_layers(stage_module)
         if not subset:
@@ -558,6 +931,34 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             module_name=module_name,
         )
 
+        assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # GPTQv2: Collect FP inputs from the ORIGINAL (unquantized) stage module.
+        # The native cache contains entry inputs from the pristine model, so
+        # forwarding them through orig_stage_module gives true FP submodule inputs.
+        if self.config.gptq_v2:
+            assert (
+                orig_stage_module is not None
+                and native_cached_args is not None
+                and native_cached_kwargs is not None
+            )
+            orig_subset = get_quantizable_layers(orig_stage_module)
+            self._move_module_to_device(
+                orig_stage_module, self._module_device(stage_module)
+            )
+            try:
+                native_inputs = self._collect_native_inputs_from_stage_cache(
+                    stage_module=orig_stage_module,
+                    subset=orig_subset,
+                    cached_args=native_cached_args,
+                    cached_kwargs=native_cached_kwargs,
+                    stage_desc=stage_desc,
+                    num_batches=num_batches,
+                )
+            finally:
+                orig_stage_module.cpu()
+            self._assign_native_inputs(gptq_objs, native_inputs)
+
         handles = []
         for local_name, submodule in subset.items():
             handles.append(
@@ -565,7 +966,6 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                     self._make_add_batch_hook(gptq_objs, local_name)
                 )
             )
-        assert isinstance(self.config, Qwen3VLGPTQConfig)
         try:
             for args_batch, kwargs_batch in tqdm(
                 iter_cached_batches(cached_args, cached_kwargs, num_batches),
@@ -603,7 +1003,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
 
         gptq_objs: dict[str, GPTQ] = {}
         for local_name, submodule in subset.items():
-            gptq_obj = GPTQ(submodule)
+            gptq_obj = GPTQ(submodule, normalize_H=gptq_conf.normalize_H)
 
             full_name = module_name.get(submodule, local_name)
             weight_bits = self._resolve_weight_bits(
@@ -628,9 +1028,26 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 mse=gptq_conf.mse,
                 sensitivity=cur_sensitivity,
             )
+
+            # GPTQv2: initialize native_inp list if enabled
+            if gptq_conf.gptq_v2:
+                gptq_obj.native_inp = []
+
             gptq_objs[local_name] = gptq_obj
 
         return gptq_objs
+
+    def _assign_native_inputs(
+        self,
+        gptq_objs: dict[str, Any],
+        native_inputs: dict[str, list[torch.Tensor]],
+    ) -> None:
+        """
+        Assign collected FP inputs to GPTQ objects' native_inp attribute.
+        """
+        for local_name, gptq_obj in gptq_objs.items():
+            if local_name in native_inputs:
+                gptq_obj.native_inp = list(native_inputs[local_name])
 
     def _make_add_batch_hook(
         self,
@@ -683,6 +1100,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 actorder=gptq_conf.actorder,
                 static_groups=gptq_conf.static_groups,
                 verbose=gptq_conf.verbose,
+                alpha=gptq_conf.gptq_v2_alpha,
             )
 
             full_name = module_name.get(submodule, local_name)
@@ -814,6 +1232,42 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         except StopIteration:
             return batch
         return move_tensor_tree(batch, device=device)
+
+    def _module_device(self, module: nn.Module) -> torch.device:
+        """
+        Get the device of a module (from parameters, buffers, or CPU fallback).
+        """
+        try:
+            return next(module.parameters()).device
+        except StopIteration:
+            try:
+                return next(module.buffers()).device
+            except StopIteration:
+                return torch.device("cpu")
+
+    def _move_module_to_device(
+        self,
+        module: nn.Module,
+        device: torch.device | str,
+    ) -> None:
+        """
+        Move a module to the specified device.
+        """
+        module.to(device)
+
+    def _copy_original_model(self, model: nn.Module) -> nn.Module:
+        """
+        Create a deep copy of the model on CPU for GPTQv2 FP input collection.
+
+        The original model is moved to CPU before copying to avoid GPU memory
+        duplication, then moved back to its original device.
+        """
+        device = self._module_device(model)
+        model.cpu()
+        orig_model = copy.deepcopy(model)
+        model.to(device)
+        orig_model.eval()
+        return orig_model
 
     # ------------------------------------------------------------------
     # Cache control helpers

--- a/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
@@ -14,6 +14,7 @@
 
 import copy
 import functools
+import os
 import types
 from typing import Any, Callable, Optional
 
@@ -128,6 +129,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
 
         # GPTQv2: reference to original FP model for collecting FP inputs
         self.orig_model: Optional[nn.Module] = None
+
+        # GPTQv2: disk cache for FP inputs (stage_desc -> native_inputs dict)
+        self._fp_inputs_disk_cache: dict[str, dict[str, list[torch.Tensor]]] = {}
+        # GPTQv2: True if FP inputs cache was loaded from disk (skip orig model ops)
+        self._fp_inputs_disk_loaded: bool = False
 
     def _resolve_weight_bits(
         self,
@@ -258,10 +264,30 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         orig_model_use_cache: dict[str, Any] = {}
 
         if gptq_conf.gptq_v2:
-            orig_model = self._copy_original_model(model)
-            self.orig_model = orig_model
-            orig_model_use_cache = self._disable_model_cache(orig_model)
-            orig_components = resolve_qwen3_vl_components(orig_model, gptq_conf)
+            # Load FP inputs cache from disk if available
+            if gptq_conf.fp_inputs_cache_path and os.path.exists(
+                gptq_conf.fp_inputs_cache_path
+            ):
+                print(
+                    f"[GPTQv2] Loading FP inputs cache from {gptq_conf.fp_inputs_cache_path}"
+                )
+                self._fp_inputs_disk_cache = torch.load(
+                    gptq_conf.fp_inputs_cache_path,
+                    map_location="cpu",
+                    weights_only=False,
+                )
+                print(
+                    f"[GPTQv2] Loaded FP inputs for {len(self._fp_inputs_disk_cache)} stages"
+                )
+                self._fp_inputs_disk_loaded = True
+
+            # Only deep-copy the model if FP inputs need to be collected on-the-fly.
+            # When the disk cache is loaded, orig_model is not needed.
+            if not self._fp_inputs_disk_loaded:
+                orig_model = self._copy_original_model(model)
+                self.orig_model = orig_model
+                orig_model_use_cache = self._disable_model_cache(orig_model)
+                orig_components = resolve_qwen3_vl_components(orig_model, gptq_conf)
 
         try:
             if should_quantize_vision_stage(gptq_conf, stage="patch_embed"):
@@ -340,7 +366,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                     ),
                 )
 
-            model.quantizers = self._quantizers
+            model.quantizers = self._quantizers  # type: ignore[assignment]
             return model
         finally:
             self._restore_model_cache(model, orig_use_cache)
@@ -356,6 +382,21 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             self._vision_cache_args.clear()
             self._vision_cache_kwargs.clear()
             self._num_vision_batches = 0
+
+            # GPTQv2: Save FP inputs cache to disk if configured
+            if (
+                gptq_conf.fp_inputs_cache_path is not None
+                and self._fp_inputs_disk_cache
+                and not self._fp_inputs_disk_loaded
+            ):
+                cache_path = gptq_conf.fp_inputs_cache_path
+                os.makedirs(os.path.dirname(os.path.abspath(cache_path)), exist_ok=True)
+                print(
+                    f"[GPTQv2] Saving FP inputs cache to {cache_path} "
+                    f"({len(self._fp_inputs_disk_cache)} stages)"
+                )
+                torch.save(self._fp_inputs_disk_cache, cache_path)
+                print("[GPTQv2] FP inputs cache saved successfully")
 
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
@@ -398,7 +439,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         native_block_args: Optional[list[list[Any]]] = None
         native_block_kwargs: Optional[dict[str, list[Any]]] = None
 
-        if self.config.gptq_v2:
+        if self.config.gptq_v2 and not self._fp_inputs_disk_loaded:
             assert orig_model is not None and orig_components is not None
             self._move_module_to_device(orig_model, self._module_device(model))
             try:
@@ -535,7 +576,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         native_layer_args: Optional[list[list[Any]]] = None
         native_layer_kwargs: Optional[dict[str, list[Any]]] = None
 
-        if self.config.gptq_v2:
+        if self.config.gptq_v2 and not self._fp_inputs_disk_loaded:
             assert orig_model is not None and orig_components is not None
             self._move_module_to_device(orig_model, self._module_device(model))
             try:
@@ -680,7 +721,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         if not hasattr(language_model, "_deepstack_process"):
             return hidden_states
 
-        return language_model._deepstack_process(
+        return language_model._deepstack_process(  # type: ignore[operator]
             hidden_states=hidden_states,
             visual_pos_masks=visual_pos_masks,
             visual_embeds=cur_visual_embeds,
@@ -709,6 +750,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             Dictionary mapping local_name -> list of FP input tensors (one per batch).
         """
         assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # Check disk cache first
+        if stage_desc in self._fp_inputs_disk_cache:
+            print(f"[GPTQv2] Using cached FP inputs for stage '{stage_desc}'")
+            return self._fp_inputs_disk_cache[stage_desc]
 
         # Build full module name -> local name mapping
         full_to_local: dict[str, str] = {}
@@ -747,6 +793,11 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         for full_name, local_name in full_to_local.items():
             result[local_name] = fp_cache.fp_cache.get(full_name, [])
 
+        # Save to in-memory disk cache for later persistence
+        if self.config.fp_inputs_cache_path is not None:
+            self._fp_inputs_disk_cache[stage_desc] = {
+                k: list(v) for k, v in result.items()
+            }
         return result
 
     @torch.no_grad()
@@ -763,6 +814,13 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         GPTQv2: Collect full-precision inputs from the original (unquantized) stage
         module by replaying cached stage-entry inputs.
         """
+        assert isinstance(self.config, Qwen3VLGPTQConfig)
+
+        # Check disk cache first
+        if stage_desc in self._fp_inputs_disk_cache:
+            print(f"[GPTQv2] Using cached FP inputs for stage '{stage_desc}'")
+            return self._fp_inputs_disk_cache[stage_desc]
+
         fp_cache = FPInputsCache(list(subset.keys()))
         full_modules: dict[str, nn.Module] = {}
         for local_name, submodule in subset.items():
@@ -841,7 +899,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             num_batches = self.num_batches
 
         # GPTQv2: Collect FP inputs from the ORIGINAL (unquantized) model
-        if self.config.gptq_v2:
+        if self.config.gptq_v2 and not self._fp_inputs_disk_loaded:
             assert orig_model is not None and orig_stage_module is not None
             orig_subset = get_quantizable_layers(orig_stage_module)
             self._move_module_to_device(orig_model, self._module_device(model))
@@ -857,6 +915,18 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 )
             finally:
                 orig_model.cpu()
+            self._assign_native_inputs(gptq_objs, native_inputs)
+        elif self.config.gptq_v2:
+            # Disk cache loaded — retrieve cached FP inputs without orig model
+            native_inputs = self._collect_native_inputs_from_raw_replay(
+                model=model,
+                subset=subset,
+                module_name=module_name,
+                cache_args=cache_args,
+                cache_kwargs=cache_kwargs,
+                num_batches=num_batches,
+                stage_desc=stage_desc,
+            )
             self._assign_native_inputs(gptq_objs, native_inputs)
 
         handles = []
@@ -936,7 +1006,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         # GPTQv2: Collect FP inputs from the ORIGINAL (unquantized) stage module.
         # The native cache contains entry inputs from the pristine model, so
         # forwarding them through orig_stage_module gives true FP submodule inputs.
-        if self.config.gptq_v2:
+        if self.config.gptq_v2 and not self._fp_inputs_disk_loaded:
             assert (
                 orig_stage_module is not None
                 and native_cached_args is not None
@@ -957,6 +1027,17 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 )
             finally:
                 orig_stage_module.cpu()
+            self._assign_native_inputs(gptq_objs, native_inputs)
+        elif self.config.gptq_v2:
+            # Disk cache loaded — retrieve cached FP inputs without orig model
+            native_inputs = self._collect_native_inputs_from_stage_cache(
+                stage_module=stage_module,
+                subset=subset,
+                cached_args=cached_args,
+                cached_kwargs=cached_kwargs,
+                stage_desc=stage_desc,
+                num_batches=num_batches,
+            )
             self._assign_native_inputs(gptq_objs, native_inputs)
 
         handles = []
@@ -1275,7 +1356,7 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
 
     def _disable_model_cache(self, model: nn.Module) -> dict[str, Any]:
         """
-        Disable cache-related flags commonly used by Qwen3-VL / HF models.
+        Disable cache-related flags
         """
         saved: dict[str, Any] = {}
 
@@ -1296,9 +1377,9 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
         Restore cache-related flags saved by `_disable_model_cache`.
         """
         if "model.config.use_cache" in saved:
-            model.config.use_cache = saved["model.config.use_cache"]
+            model.config.use_cache = saved["model.config.use_cache"]  # type: ignore[union-attr]
 
         if "model.config.text_config.use_cache" in saved:
-            model.config.text_config.use_cache = saved[
+            model.config.text_config.use_cache = saved[  # type: ignore[union-attr]
                 "model.config.text_config.use_cache"
             ]

--- a/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
+++ b/tico/quantization/algorithm/qwen3_vl_gptq/quantizer.py
@@ -821,6 +821,14 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
             print(f"[GPTQv2] Using cached FP inputs for stage '{stage_desc}'")
             return self._fp_inputs_disk_cache[stage_desc]
 
+        if self._fp_inputs_disk_loaded:
+            raise RuntimeError(
+                f"[GPTQv2] FP inputs cache miss for stage '{stage_desc}'. "
+                f"Cache was loaded from disk but this stage is not present. "
+                f"Delete the cache file "
+                f"({self.config.fp_inputs_cache_path}) and re-run to regenerate."
+            )
+
         fp_cache = FPInputsCache(list(subset.keys()))
         full_modules: dict[str, nn.Module] = {}
         for local_name, submodule in subset.items():
@@ -842,6 +850,12 @@ class Qwen3VLGPTQQuantizer(BaseQuantizer):
                 stage_module(*args_batch, **kwargs_batch)
         finally:
             fp_cache.clear_hook()
+
+        # Save to in-memory disk cache for later persistence
+        if self.config.fp_inputs_cache_path is not None:
+            self._fp_inputs_disk_cache[stage_desc] = {
+                k: list(v) for k, v in fp_cache.fp_cache.items()
+            }
 
         return fp_cache.fp_cache
 

--- a/tico/quantization/config/gptq.py
+++ b/tico/quantization/config/gptq.py
@@ -69,6 +69,19 @@ class GPTQConfig(BaseConfig):
     # use this option to stabilize GPTQ for deep models
     use_orig_model_inference: bool = False
 
+    # GPTQv2: uses FP inference for collecting inputs during quantization
+    gptq_v2: bool = False
+
+    # GPTQv2: scaling factor for the asymmetric correction (P matrix)
+    # `alpha` is the correction strength for GPTQv2's input-error compensation.
+    # It scales the `P` matrix that adjusts weight updates to account for upstream quantization error in the activations.
+    # A value of `0` disables the correction (standard GPTQ), while values around `0.25` provide the best empirical results.
+    gptq_v2_alpha: float = 0.25
+
+    # Use running average for Hessian accumulation.
+    # When False, uses summation.
+    normalize_H: bool = False
+
     @property
     def name(self) -> str:
         return "gptq"

--- a/tico/quantization/config/gptq.py
+++ b/tico/quantization/config/gptq.py
@@ -72,6 +72,13 @@ class GPTQConfig(BaseConfig):
     # GPTQv2: uses FP inference for collecting inputs during quantization
     gptq_v2: bool = False
 
+    # GPTQv2: Path to save/load FP inputs cache.
+    # If set and file exists, FP inputs are loaded from disk instead of
+    # running the original model. If set and file doesn't exist, FP inputs
+    # are collected during quantization and saved to disk.
+    # If None, FP inputs are collected on-the-fly (default behavior).
+    fp_inputs_cache_path: str | None = None
+
     # GPTQv2: scaling factor for the asymmetric correction (P matrix)
     # `alpha` is the correction strength for GPTQv2's input-error compensation.
     # It scales the `P` matrix that adjusts weight updates to account for upstream quantization error in the activations.

--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -19,6 +19,7 @@ import random
 import re
 import string
 import tempfile
+from dataclasses import dataclass, field
 
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict
 
@@ -30,6 +31,44 @@ from tico.quantization.recipes.data.dataset_usage import (
     resolve_dataset_usage,
     validate_single_dataset_usage,
 )
+
+
+@dataclass
+class CalibFilterConfig:
+    """Configuration for per-class calibration sample filtering.
+
+    When ``n_per_class > 0``, the dataset is loaded in non-streaming mode and
+    filtered to select up to ``n_per_class`` samples per class (as determined
+    by ``filter_field``, default ``image_classes``), instead of taking the
+    first ``n_samples``.
+
+    Attributes:
+        n_per_class: Maximum number of samples to keep per class.  When ``0``
+            or negative, filtering is disabled.
+        classes: Optional list of class names to include.  If ``None``, all
+            classes found in the data are used.
+        max_classes: Optional cap on the total number of classes when
+            ``classes`` is ``None``.  The most frequent classes are kept.
+        distinct_images: If ``True``, each unique image (by ``image_id``)
+            appears at most once in the calibration set.
+        filter_field: Name of the dataset field that holds the list of
+            classes for each example.  Defaults to ``"image_classes"``.
+        verbose: When ``True``, print progress information about discovered
+                    classes, selected samples, and per-class counts.  Defaults to
+                    ``False`` (silent).
+    """
+
+    n_per_class: int = 0
+    classes: Optional[List[str]] = None
+    max_classes: Optional[int] = None
+    distinct_images: bool = True
+    filter_field: str = "image_classes"
+    verbose: bool = True
+
+    @property
+    def is_active(self) -> bool:
+        """Return ``True`` when class filtering should be applied."""
+        return self.n_per_class > 0
 
 
 def normalize_answer(s: str) -> str:
@@ -153,6 +192,10 @@ def get_item_textvqa(ex: Dict[str, Any]) -> Dict[str, Any]:
     TextVQA is often more sensitive to OCR degradation than generic VQA tasks,
     but the unified output schema is the same as for other supported datasets.
 
+    The ``image_classes`` field (a list of detected object class names per
+    image) is also carried through so that downstream calibration code can
+    filter samples by class.
+
     Args:
         ex: Raw dataset example.
 
@@ -163,6 +206,7 @@ def get_item_textvqa(ex: Dict[str, Any]) -> Dict[str, Any]:
         "image": ex["image"],
         "question": ex.get("question", ""),
         "golds": _extract_golds(ex.get("answers")),
+        "image_classes": ex.get("image_classes", []),
     }
 
 
@@ -1449,6 +1493,7 @@ def get_calib_inputs(
     max_seq_len: Optional[int] = None,
     allow_benchmark_overlap: bool = False,
     allow_unregistered_dataset: bool = False,
+    filter_config: Optional[CalibFilterConfig] = None,
 ):
     """
     Build calibration inputs by preprocessing image-question pairs.
@@ -1456,19 +1501,66 @@ def get_calib_inputs(
     This helper uses the same prompt and processor-input construction logic as
     evaluation so that calibration and inference stay aligned.
 
+    When ``filter_config`` is provided and ``filter_config.is_active`` is ``True``,
+    the dataset is loaded in non-streaming mode and filtered to select up to
+    ``filter_config.n_per_class`` samples per class (as determined by
+    ``filter_config.filter_field``, default ``image_classes``), instead of
+    taking the first ``n_samples``.
+
     Args:
         dataset: Dataset key defined in ``DATASETS``.
         processor: Hugging Face multimodal processor.
-        n_samples: Number of calibration examples to prepare.
+        n_samples: Number of calibration examples to prepare.  Ignored when
+            ``filter_config`` is active.
         split: Optional dataset split. If omitted, the registry default is used.
         max_seq_len: Optional maximum text sequence length.
         allow_benchmark_overlap: Permit an explicitly transductive calibration use.
         allow_unregistered_dataset: Permit calibration with a source that has no
             registered safety policy.
+        filter_config: Optional :class:`CalibFilterConfig` for per-class
+            sample filtering.  When active, ``n_samples`` is ignored.
 
     Returns:
         A list of processor output objects, one per example.
     """
+    adapter = DATASETS[dataset]["adapter"]
+
+    # --- Class-filtering path ---
+    if filter_config is not None and filter_config.is_active:
+        ds, _ = get_dataset(
+            dataset=dataset,
+            role=CALIBRATION_ROLE,
+            n=-1,
+            split=split,
+            streaming=False,
+            allow_benchmark_overlap=allow_benchmark_overlap,
+            allow_unregistered_dataset=allow_unregistered_dataset,
+        )
+        examples = list(ds)
+
+        selected = dataset_filter(
+            examples=examples,
+            filter_config=filter_config,
+        )
+
+        calib_inputs = []
+        for ex in selected:
+            item = adapter(ex)
+            if item.get("image") is None:
+                continue
+            inputs = build_vlm_inputs(
+                processor=processor,
+                image=item["image"],
+                question=item["question"],
+                return_tensors="pt",
+                max_seq_len=max_seq_len,
+            )
+            calib_inputs.append(inputs)
+
+        print(f"[info] Built {len(calib_inputs)} calibration inputs from {dataset}")
+        return calib_inputs
+
+    # --- Default streaming path ---
     ds, adapter = get_dataset(
         dataset=dataset,
         role=CALIBRATION_ROLE,
@@ -1584,7 +1676,7 @@ def get_mixed_calib_inputs(
     allow_unregistered_dataset: bool = False,
 ) -> List[Dict[str, Any]]:
     """
-    Build calibration inputs from multiple datasets
+    Build calibration inputs from multiple datasets.
 
     This function loads samples from multiple datasets and combines them into
     a single calibration set. It handles both image-text datasets (e.g. VQAv2, COCO)
@@ -1595,16 +1687,36 @@ def get_mixed_calib_inputs(
 
     For image-text datasets, it takes the first n_samples directly.
 
+    Per-dataset filtering
+    ---------------------
+    When a dataset entry contains a ``filter`` block with ``n_per_class > 0``,
+    that dataset is loaded in non-streaming mode and filtered to select up to
+    ``n_per_class`` samples per class (as determined by ``filter.field``,
+    default ``image_classes``), instead of taking the first ``n_samples``.
+
+    Example ``filter`` block::
+
+        filter:
+          field: image_classes   # optional, defaults to "image_classes"
+          n_per_class: 5
+          classes: null           # optional list of class names
+          max_classes: null        # optional cap
+          distinct_images: true    # dedup by image_id
+          verbose: true
+
     Args:
         processor: Hugging Face processor.
         max_seq_len: maximum text sequence length.
-        dataset_config: Dictionary mapping dataset names (with optional split) to
+        dataset_config: Dictionary mapping dataset names (with optional split and filter block (see above)) to
             number of samples. Format: {"dataset": {"n_samples": n_samples}} or
                                        {"dataset": {"split":"split","n_samples": n_samples}}.
             Example: {
                       "wikitext2": {"n_samples": 128},
                       "alpaca": {"split": "train", "n_samples": 32}
                       }
+        dataset_config: Dictionary mapping dataset names to config dicts.
+            Each config dict may contain ``n_samples``, ``split``, and an
+            optional ``filter`` block (see above).
         seed: Random seed for reproducible sampling (used only for text-only
             datasets).
         allow_benchmark_overlap: Permit explicitly transductive calibration data.
@@ -1627,6 +1739,33 @@ def get_mixed_calib_inputs(
             continue
 
         is_text_only = DATASETS[dataset].get("is_text_only", False)
+
+        # --- Per-dataset filter block (e.g. TextVQA class filtering) ---
+        filter_dict: Optional[Dict[str, Any]] = config.get("filter")
+        if filter_dict and filter_dict.get("n_per_class", 0):
+            fc = CalibFilterConfig(
+                n_per_class=int(filter_dict["n_per_class"]),
+                classes=filter_dict.get("classes"),
+                max_classes=filter_dict.get("max_classes"),
+                distinct_images=filter_dict.get("distinct_images", True),
+                filter_field=filter_dict.get("field", "image_classes"),
+                verbose=filter_dict.get("verbose", True),
+            )
+
+            print(
+                f"[info] Filtering '{dataset}' by {fc.filter_field} "
+                f"(n_per_class={fc.n_per_class}) in mixed mode"
+            )
+            class_inputs = get_calib_inputs(
+                dataset=dataset,
+                processor=processor,
+                split=split,
+                max_seq_len=max_seq_len,
+                filter_config=fc,
+            )
+
+            calib_inputs.extend(class_inputs)
+            continue
 
         if is_text_only:
             # TODO: text only inputs should be changed with chat template
@@ -1708,3 +1847,161 @@ def get_mixed_calib_inputs(
 
     print(f"[info] Total calibration samples: {len(calib_inputs)}")
     return calib_inputs
+
+
+# ============================================================
+# Dataset filteration for calibration
+# ============================================================
+
+
+def dataset_filter(
+    examples: List[Dict[str, Any]],
+    filter_config: CalibFilterConfig,
+) -> List[Dict[str, Any]]:
+    """
+    Filter dataset examples by per-class quota.
+
+    All filtering parameters (``n_per_class``, ``classes``, ``max_classes``,
+    ``distinct_images``, ``filter_field``) are read from *filter_config*.
+
+    **Selection algorithm**
+
+    1.  **Discover classes** — scan every example and collect the set of
+        classes found in ``filter_config.filter_field`` (default
+        ``"image_classes"``) along with their frequencies.
+
+    2.  **Determine target classes** —
+        * If ``filter_config.classes`` is provided, only those classes are
+          used (a warning is printed for any requested class not present in
+          the data).
+        * Otherwise all discovered classes are used, optionally capped to
+          the top-``filter_config.max_classes`` most frequent ones.
+
+    3.  **Select samples** — iterate over *examples* in order.  A sample is
+        kept when at least one of its classes is still under the per-class
+        quota (``filter_config.n_per_class``).  The counter for every
+        under-quota class is then incremented.
+
+    4.  **Image deduplication** — when ``filter_config.distinct_images`` is
+        ``True`` (the default), each unique ``image_id`` appears at most once
+        in the output, ensuring maximum image diversity.
+
+    If no classes are found in any example, all *examples* are returned
+    unchanged with a warning.
+
+    Args:
+        examples: List of raw dataset examples.  Each example is expected to
+            contain a ``filter_config.filter_field`` entry (a list of class
+            names).  When ``filter_config.distinct_images`` is ``True``, the
+            ``image_id`` field is used for deduplication.
+        filter_config: A :class:`CalibFilterConfig` that controls the
+            filtering behaviour.  When ``None`` or inactive
+            (``n_per_class <= 0``), *examples* is returned unchanged.
+
+    Returns:
+        A list of selected raw examples.  When no classes are found in the
+        data, the original *examples* list is returned unchanged.
+    """
+
+    # --- Phase 1: discover classes and their frequencies ---
+    class_freq: Dict[str, int] = {}
+    for ex in examples:
+        filter_classes = ex.get(filter_config.filter_field, [])
+        if not filter_classes:
+            continue
+        for cls in filter_classes:
+            cls_str = str(cls)
+            class_freq[cls_str] = class_freq.get(cls_str, 0) + 1
+
+    if not class_freq:
+        if filter_config.verbose:
+            print(
+                f"[warn] No {filter_config.filter_field} found in any sample; returning all examples."
+            )
+        return list(examples)
+
+    # Determine target classes
+    if filter_config.classes is not None:
+        target_classes = [str(c) for c in filter_config.classes]
+        # Warn about requested classes not present in data
+        missing = [c for c in target_classes if c not in class_freq]
+        if missing and filter_config.verbose:
+            print(f"[warn] Requested classes not found in data: {missing}")
+    else:
+        # Sort by frequency (descending) and optionally cap
+        sorted_classes = sorted(class_freq.keys(), key=lambda c: -class_freq[c])
+        if filter_config.max_classes is not None and filter_config.max_classes > 0:
+            target_classes = sorted_classes[: filter_config.max_classes]
+        else:
+            target_classes = sorted_classes
+
+    if filter_config.verbose:
+        print(
+            f"[info] {len(class_freq)} unique filter classes discovered, "
+            f"using {len(target_classes)} classes"
+        )
+        print(
+            f"[info] Selecting up to {filter_config.n_per_class} samples per class "
+            f"→ up to {len(target_classes) * filter_config.n_per_class} total samples"
+        )
+
+    # --- Phase 2: select samples ---
+    # Each example in the list is a distinct dict from the HuggingFace dataset,
+    # so there is no need for explicit deduplication — a single pass over the
+    # list naturally visits each example at most once.
+    class_counts: Dict[str, int] = {c: 0 for c in target_classes}
+    target_set = set(target_classes)
+    selected: List[Dict[str, Any]] = []
+    seen_image_ids: set = set()
+    skipped_dup_images = 0
+
+    for ex in examples:
+        filter_classes = ex.get(filter_config.filter_field, [])
+        if not filter_classes:
+            continue
+
+        # Check if any of this sample's classes is still under quota
+        under_quota = [
+            str(c)
+            for c in filter_classes
+            if str(c) in target_set and class_counts[str(c)] < filter_config.n_per_class
+        ]
+        if not under_quota:
+            continue
+
+        # When distinct_images is enabled, skip samples whose image has
+        # already been selected. Deduplicating by image_id ensures each calibration
+        # sample comes from a distinct image.
+        if filter_config.distinct_images:
+            image_id = ex.get("image_id")
+            if image_id is not None:
+                if image_id in seen_image_ids:
+                    skipped_dup_images += 1
+                    continue
+                seen_image_ids.add(image_id)
+
+        selected.append(ex)
+        for cls in under_quota:
+            class_counts[cls] += 1
+
+        # Print selected sample info: question_id and truncated question
+        if filter_config.verbose:
+            qid = ex.get("question_id", "?")
+            question = ex.get("question", "")
+            question_preview = question[:80] + ("..." if len(question) > 80 else "")
+            print(
+                f"  [selected] question_id={qid}  classes={under_quota}  "
+                f"Q: {question_preview}"
+            )
+
+    # Print summary
+    total_selected = len(selected)
+    if filter_config.verbose:
+        print(f"[info] Selected {total_selected} unique samples")
+        if filter_config.distinct_images:
+            print(f"[info] Skipped {skipped_dup_images} samples with duplicate images")
+        print(f"[info] Per-class counts (first 20):")
+        for cls in target_classes[:20]:
+            print(f"  {cls}: {class_counts[cls]}")
+
+    return selected

--- a/tico/quantization/evaluation/vlm_eval_utils.py
+++ b/tico/quantization/evaluation/vlm_eval_utils.py
@@ -1541,6 +1541,7 @@ def get_calib_inputs(
         selected = dataset_filter(
             examples=examples,
             filter_config=filter_config,
+            dataset_name=dataset,
         )
 
         calib_inputs = []
@@ -1857,6 +1858,7 @@ def get_mixed_calib_inputs(
 def dataset_filter(
     examples: List[Dict[str, Any]],
     filter_config: CalibFilterConfig,
+    dataset_name: str = "",
 ) -> List[Dict[str, Any]]:
     """
     Filter dataset examples by per-class quota.
@@ -1886,8 +1888,9 @@ def dataset_filter(
         ``True`` (the default), each unique ``image_id`` appears at most once
         in the output, ensuring maximum image diversity.
 
-    If no classes are found in any example, all *examples* are returned
-    unchanged with a warning.
+    If no classes are found in any example, a :class:`ValueError` is raised so
+    that configuration errors (e.g. a misspelled field name) are detected early
+    instead of silently returning the entire dataset.
 
     Args:
         examples: List of raw dataset examples.  Each example is expected to
@@ -1897,10 +1900,16 @@ def dataset_filter(
         filter_config: A :class:`CalibFilterConfig` that controls the
             filtering behaviour.  When ``None`` or inactive
             (``n_per_class <= 0``), *examples* is returned unchanged.
+        dataset_name: Name of the dataset being filtered, used in error
+            messages for easier debugging.  Defaults to an empty string.
 
     Returns:
-        A list of selected raw examples.  When no classes are found in the
-        data, the original *examples* list is returned unchanged.
+        A list of selected raw examples.
+
+    Raises:
+        ValueError: If the configured ``filter_field`` is not found in any
+            example.  This prevents a silent fallback that would return the
+            entire dataset, which can be very expensive in time and memory.
     """
 
     # --- Phase 1: discover classes and their frequencies ---
@@ -1914,11 +1923,12 @@ def dataset_filter(
             class_freq[cls_str] = class_freq.get(cls_str, 0) + 1
 
     if not class_freq:
-        if filter_config.verbose:
-            print(
-                f"[warn] No {filter_config.filter_field} found in any sample; returning all examples."
-            )
-        return list(examples)
+        raise ValueError(
+            f"Filter field '{filter_config.filter_field}' was not found in any "
+            f"sample of dataset '{dataset_name}'. This usually means the field "
+            f"name is misspelled or the dataset does not contain it. "
+            f"Please check the 'filter.field' configuration."
+        )
 
     # Determine target classes
     if filter_config.classes is not None:

--- a/tico/quantization/recipes/data/vlm.py
+++ b/tico/quantization/recipes/data/vlm.py
@@ -76,6 +76,52 @@ def _parse_dataset_spec(
     return dataset, config
 
 
+def _normalize_filter_config(filter_cfg: Any, *, context: str) -> dict[str, Any]:
+    """Normalize a per-dataset ``filter`` block.
+
+    Expected keys (all optional except ``n_per_class``):
+      - ``n_per_class`` (int, required for the filter to activate)
+      - ``field`` (str, default ``"image_classes"``)
+      - ``classes`` (list[str] | None)
+      - ``max_classes`` (int | None)
+      - ``distinct_images`` (bool, default True)
+      - ``verbose`` (bool, default True)
+    """
+    if not isinstance(filter_cfg, Mapping):
+        raise TypeError(
+            f"{context}.filter must be a mapping, got {type(filter_cfg).__name__}."
+        )
+
+    normalized: dict[str, Any] = {}
+    n_per_class = filter_cfg.get("n_per_class", 0)
+    if n_per_class is not None:
+        n_per_class = int(n_per_class)
+    normalized["n_per_class"] = n_per_class or 0
+
+    field = filter_cfg.get("field", "image_classes")
+    normalized["field"] = str(field)
+
+    classes = filter_cfg.get("classes")
+    if classes is not None:
+        if not isinstance(classes, (list, tuple)):
+            raise TypeError(
+                f"{context}.filter.classes must be a list or null, "
+                f"got {type(classes).__name__}."
+            )
+        normalized["classes"] = [str(c) for c in classes]
+    else:
+        normalized["classes"] = None
+
+    max_classes = filter_cfg.get("max_classes")
+    if max_classes is not None:
+        max_classes = int(max_classes)
+    normalized["max_classes"] = max_classes
+
+    normalized["distinct_images"] = bool(filter_cfg.get("distinct_images", True))
+
+    return normalized
+
+
 def _normalize_mapping_dataset_config(
     datasets: Mapping[str, Any],
     default_n_samples: int,
@@ -97,6 +143,13 @@ def _normalize_mapping_dataset_config(
             split = config.get("split")
             if split is not None:
                 entry["split"] = str(split)
+
+            # Pass through per-dataset filter block
+            filter_cfg = config.get("filter")
+            if filter_cfg is not None:
+                entry["filter"] = _normalize_filter_config(
+                    filter_cfg, context=f"{dataset}"
+                )
         else:
             entry = {
                 "n_samples": _coerce_positive_int(
@@ -134,6 +187,13 @@ def _normalize_sequence_dataset_config(
             split = item.get("split")
             if split is not None:
                 config["split"] = str(split)
+
+            # Pass through per-dataset filter block
+            filter_cfg = item.get("filter")
+            if filter_cfg is not None:
+                config["filter"] = _normalize_filter_config(
+                    filter_cfg, context=f"calibration.datasets[{index}]"
+                )
         else:
             raise TypeError(
                 "Each calibration dataset entry must be a string or mapping, "
@@ -177,6 +237,26 @@ def build_vlm_calibration_inputs(
 ) -> list[dict]:
     """
     Build VLM calibration inputs from either one dataset or a mixed dataset set.
+
+    Per-dataset filtering
+    ---------------------
+    When a dataset entry in ``datasets`` contains a ``filter`` block with
+    ``n_per_class > 0``, that dataset is loaded in non-streaming mode and
+    filtered to select up to ``n_per_class`` samples per class (as determined
+    by ``filter.field``, default ``image_classes``), instead of taking the
+    first ``n_samples``.
+
+    Example YAML::
+
+        calibration:
+          datasets:
+            textvqa:
+              n_samples: 50
+              filter:
+                field: image_classes
+                n_per_class: 5
+            wikitext2:
+              n_samples: 128
 
     Args:
         processor: Hugging Face processor used to build model inputs.

--- a/tico/quantization/recipes/runner.py
+++ b/tico/quantization/recipes/runner.py
@@ -295,6 +295,18 @@ def _print_config_summary(cfg: Mapping[str, Any]) -> None:
         "GPTQ lm_head enabled",
         bool(_stage_value(gptq_stage, "quantize_lm_head", False)),
     )
+    _print_config_row(
+        "GPTQv2 enabled",
+        bool(_stage_value(gptq_stage, "gptq_v2", False)),
+    )
+    _print_config_row(
+        "GPTQv2 alpha",
+        _stage_value(gptq_stage, "gptq_v2_alpha", "not set"),
+    )
+    _print_config_row(
+        "GPTQ percdamp",
+        _stage_value(gptq_stage, "percdamp", "not set"),
+    )
     _print_config_row("PTQ enabled", ptq_enabled)
     _print_config_row("SpinQuant enabled", spinquant_enabled)
     _print_config_row("CLE enabled", _is_stage_enabled(cle_stage))

--- a/tico/quantization/recipes/runner.py
+++ b/tico/quantization/recipes/runner.py
@@ -307,6 +307,10 @@ def _print_config_summary(cfg: Mapping[str, Any]) -> None:
         "GPTQ percdamp",
         _stage_value(gptq_stage, "percdamp", "not set"),
     )
+    _print_config_row(
+        "GPTQ normalize_H",
+        bool(_stage_value(gptq_stage, "normalize_H", False)),
+    )
     _print_config_row("PTQ enabled", ptq_enabled)
     _print_config_row("SpinQuant enabled", spinquant_enabled)
     _print_config_row("CLE enabled", _is_stage_enabled(cle_stage))


### PR DESCRIPTION
**This PR supports GPTQv2 for Qwen3-VL model.**

__GPTQv2__ — an improved variant of GPTQ that corrects for upstream quantization error in the Hessian computation. Standard GPTQ computes the Hessian from activations that have already passed through previously quantized layers, introducing error. GPTQv2 addresses this by collecting "native" (full-precision) inputs from a pristine copy of the original model and computing a correction matrix (`dXXT`) that adjusts the weight updates accordingly.

Additionaly added the ability to __cache/save the inputs of the original (unquantized) model__ during GPTQv2 calibration and  __filtering calibration samples__ by their class/category.
 

#### How GPTQv2 Works

1. __Two forward passes__: The quantized model runs normally (collecting H from corrupted inputs). Simultaneously, a pristine copy of the model runs the same calibration data (collecting native FP inputs).

2. __dXXT computation__: For each layer, the difference between native and quantized inputs (`dX = native_inp - inp`) is cross-correlated with the quantized input: `dXXT += dX @ inp^T`. This captures how upstream quantization error correlates with the current layer's activations.

3. __P correction matrix__: During `fasterquant()`, the correction is applied: `P = alpha * (dXXT @ hinv^T).triu() @ hinv`. This adjusts weight updates so that the quantized weights compensate for the input error, rather than treating corrupted inputs as if they were clean.

4. __alpha parameter__: Controls correction strength. `alpha=0` → standard GPTQ. `alpha=0.25` (default) → mild correction, best empirical results. Higher values risk overcorrection.

Introduction of __`normalize_H`__ flag, which controls whether the GPTQ Hessian matrix `H` is accumulated as a __running average__ (normalized by `sqrt(2/N)`) or as a __raw sum__.


**Results of applying GPTQv2 for Qwen3-vl:**

| Config ID| PPL | mmlu | vqav2 | COCO (CIDEr/Bleu_4) | hellaswag | MMMU_Pro (vision) (under review)  | Llava-Bench Rel. | videomme (32 frames) |
|--|--|--|--|--|--|--|--|--|
| FP32                       | 9.46 | 0.735     | 0.895   | 0.335 / 0.079 | 0.642 | 0.286  (prev. version) |104.7|65|
| Qwen3_W4A16 <br> head:8bit<br>Spinquant<br>GPTQ_V2_alpha_0.25_mse_for_gptq_percdamp_0.12_normalize_H=true <br>Calib_samples: <br>vqav2=128 <br>wikitext2=128 <br>MMMU=64 |  9.86  | 0.702 | 0.886 | 0.319/0.079 | 0.617 | 0.234 (prev. version) | 102.32 | 62.6 |
|% degradation| 4.2% | 3.3% | 1% | 4.7%/0% | 2.5% | 5.2% (prev. version) | 2.3% | 2.4% |
| Qwen3_W4A16 <br> head:8bit<br>Spinquant<br>GPTQ_V2_alpha_0.25_mse_for_gptq_percdamp_0.1_normalize_H=true <br>Calib_samples: <br>vqav2=128 <br>wikitext2=128 <br>MMMU=96 <br> mlu=32 <br> videomme-text=32 | 9.88 |	0.71 | 0.884 | 0.283/0.076 | 0.616 | 0.23 | 103.55 | 64.5 |
|% degradation| 4.4% | 2.5%| 1.1%  | 15.5%/ 3.7% | 2.6% | 5.6% (prev. version) | 1.1% | 0.5% |
| Qwen3_W4A16 <br> head:8bit<br>Spinquant<br>GPTQ_V2_alpha_0.2_mse_for_gptq_percdamp_0.01_normalize_H=true <br>Calib_samples: <br>vqav2=128 split=testdev<br>wikitext2=128 split=train <br> mlu=40 split=dev <br>filtered textvqa=70 split=train| 9.93  |	 0.709 | 0.885 | 0.287/0.084 | 0.610  | 0.236 | 104.30 | 63.7 |
|% degradation| 4.9% | 2.6% | 1%  | 14%/0% | 3.2 | 5.6% (prev. version)  | 0.5% | 1.3%  |




Co-Authored-By: Cline

TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>