### PR TITLE
[quantization] Fix label alignment in WrapperSmokeResult summary

### DIFF
--- a/tico/quantization/recipes/debug/wrapper_smoke/result.py
+++ b/tico/quantization/recipes/debug/wrapper_smoke/result.py
@@ -53,7 +53,7 @@ class WrapperSmokeResult:
             f"│ Case             : {self.case}",
             f"│ Status           : {'PASS' if self.passed else 'FAIL'}",
             f"│ Mean |diff|      : {format_metric(self.metrics.get('mean_abs_diff'))}",
-            f"│ Max |diff|       : {format_metric(self.metrics.get('max_abs_diff'))}",
+            f"│ Max  |diff|      : {format_metric(self.metrics.get('max_abs_diff'))}",
             f"│ PEIR             : {format_metric(self.metrics.get('peir'))}",
             f"│ Shape match      : {self.metrics.get('shape_match')}",
             f"│ Quant finite     : {self.metrics.get('quant_finite')}",


### PR DESCRIPTION
This fixes the column alignment of the 'Max |diff|' label.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>