### PR TITLE
[quantization] Changing promt for MMMU_Pro(vision) evaluation

### DIFF
--- a/tico/quantization/evaluation/mmmu_eval_utils.py
+++ b/tico/quantization/evaluation/mmmu_eval_utils.py
@@ -377,7 +377,7 @@ def evaluate_subject(
                     model=model,
                     processor=processor,
                     image=item["image"],
-                    question="Answer the multiple-choice question shown in the image. Return only one letter from A to J.",
+                    question="You are a strict single-letter answering machine. Answer the multiple-choice question shown in the image. Return only one letter from A to J.",
                     device=device,
                     max_new_tokens=max_new_tokens,
                     max_seq_len=max_seq_len,


### PR DESCRIPTION
This PR changes promt for MMMMU_Pro(vision) evaluation in `generate_image_only_answer`.

### Why
This prompt sent to the model alongside the image during MMMU_Pro (vision) evaluation. The new prompt explicitly instructs the model to act as a "strict single-letter answering machine" and return only one letter (A–J), which directly addresses the root cause of low MMMU_Pro(vision) accuracy for Gemma4 (about 0.05). The model (especially the original float model) would generate verbose natural-language descriptions instead of single-letter answers (e.g., "The image shows...", "The problem asks to determine..."). These verbose outputs would never match the gold answer letter.

When using the old promt, Qwen3-vl also sometimes generates natural-language descriptions instead of single-letter answers during MMMU_Pro (vision) evaluation. 

**As a result of using the new promt, models produce only one letter during evaluation.**

**Re-evaluated Gemma4-e2b-it model:** 
|  Config ID   | MMMU_Pro (vision)  acc  (1000 samples) |
|---|---|
| original | 0.170 |
| quantized W4A16| 0.136 |

**Re-evaluated Qwen3-vl-4B model:** 
|  Config ID   | MMMU_Pro (vision)  acc  (1000 samples)) |
|---|---|
| original | 0.305   |
| quantized W4A16 | 0.232 |


<details>
<summary>Log examples </summary>

[gemma4_MMMU_Pro_orig_50_samples_old_promt.log](https://github.com/user-attachments/files/31242132/gemma4_MMMU_Pro_orig_50_samples_old_promt.log)

[gemma4_MMMU_Pro_orig_50_samples_new_promt.log](https://github.com/user-attachments/files/31242133/gemma4_MMMU_Pro_orig_50_samples_new_promt.log)

[qwen3-vl_MMMU_Pro_orig_50_samples_old_promt.log](https://github.com/user-attachments/files/31242131/qwen3-vl_MMMU_Pro_orig_50_samples_old_promt.log)

[qwen3-vl_MMMU_Pro_orig_50_samples_new_promt.log](https://github.com/user-attachments/files/31242134/qwen3-vl_MMMU_Pro_orig_50_samples_new_promt.log)

</details>



TICO-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>