### PR TITLE
[quantization] Support model option in the static runtime script

### DIFF
--- a/test/quantization/examples/test_examples_cli.py
+++ b/test/quantization/examples/test_examples_cli.py
@@ -271,6 +271,60 @@ class TestQuantizationExamplesCLI(unittest.TestCase):
         self.assertEqual(calls["cfg"].model, "new-model")
         self.assertEqual(calls["cfg"].device, "cuda")
 
+    def test_inspect_cli_dispatches_static_gemma4_runtime(self):
+        """inspector.py should apply Gemma4 runtime-specific CLI overrides."""
+        calls: dict[str, Any] = {}
+
+        def fake_load_recipe_config(path, overrides):
+            calls["load"] = (path, overrides)
+            return {
+                "runtime": {},
+                "debug": {
+                    "static_gemma4_runtime": {
+                        "model": "new-model",
+                        "device": "cuda",
+                    }
+                },
+            }
+
+        argv = [
+            "inspector.py",
+            "--config",
+            "recipe.yaml",
+            "--mode",
+            "static-gemma4-runtime",
+            "--model",
+            "new-model",
+            "--device",
+            "cuda",
+        ]
+
+        with patch.object(
+            inspect_cli,
+            "load_recipe_config",
+            fake_load_recipe_config,
+        ), patch.object(inspect_cli, "set_seed", lambda seed: None), patch.object(
+            inspect_cli,
+            "run_static_gemma4_runtime",
+            lambda cfg: calls.setdefault("cfg", cfg),
+        ), patch.object(
+            sys, "argv", argv
+        ):
+            inspect_cli.main()
+
+        self.assertEqual(
+            calls["load"],
+            (
+                "recipe.yaml",
+                [
+                    "debug.static_gemma4_runtime.model=new-model",
+                    "debug.static_gemma4_runtime.device=cuda",
+                ],
+            ),
+        )
+        self.assertEqual(calls["cfg"].model, "new-model")
+        self.assertEqual(calls["cfg"].device, "cuda")
+
     def test_inspect_cli_dispatches_tied_embedding_smoke(self):
         """inspector.py should dispatch tied embedding smoke mode."""
         calls: dict[str, Any] = {}

--- a/tico/quantization/examples/inspector.py
+++ b/tico/quantization/examples/inspector.py
@@ -53,8 +53,16 @@ def parse_args() -> argparse.Namespace:
         ],
         default="trace",
     )
-    parser.add_argument("--model", default=None, help="Override model.name_or_path.")
-    parser.add_argument("--device", default=None, help="Override runtime.device.")
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override the model path for the selected inspect mode.",
+    )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Override the runtime device for the selected inspect mode.",
+    )
     parser.add_argument("--enable-quantization", action="store_true")
     parser.add_argument("--interesting-modules", nargs="*", default=[])
     parser.add_argument("--set", action="append", default=[], metavar="KEY=VALUE")
@@ -107,18 +115,22 @@ def parse_args() -> argparse.Namespace:
 def _build_overrides(args: argparse.Namespace) -> list[str]:
     """Translate convenience CLI arguments into recipe config overrides."""
     overrides = list(args.set)
+    runtime_config_prefix = {
+        "static-llama-runtime": "debug.static_llama_runtime",
+        "static-gemma4-runtime": "debug.static_gemma4_runtime",
+    }.get(args.mode)
 
     if args.model:
         model_key = (
-            "debug.static_llama_runtime.model"
-            if args.mode == "static-llama-runtime"
+            f"{runtime_config_prefix}.model"
+            if runtime_config_prefix is not None
             else "model.name_or_path"
         )
         overrides.append(f"{model_key}={args.model}")
     if args.device:
         device_key = (
-            "debug.static_llama_runtime.device"
-            if args.mode == "static-llama-runtime"
+            f"{runtime_config_prefix}.device"
+            if runtime_config_prefix is not None
             else "runtime.device"
         )
         overrides.append(f"{device_key}={args.device}")


### PR DESCRIPTION
This commit supports a model option in the static runtime script.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>