### PR TITLE
[quantization] Fix dtype mismatch in the static runtime script

### DIFF
--- a/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_encoder.py
+++ b/test/quantization/wrapq/wrappers/gemma4/test_quant_vision_encoder.py
@@ -554,6 +554,42 @@ class TestQuantGemma4VisionEncoder(unittest.TestCase):
         self.assertEqual(output.shape, (1, self.seq_len, self.hidden_size))
         self.assertTrue(torch.isfinite(output).all())
 
+    def test_as_export_module_supports_bfloat16_compute_dtype(self):
+        """BF16 export should keep static RoPE and mask templates in BF16."""
+        fp_encoder = _make_encoder(self.cfg).to(dtype=torch.bfloat16)
+        q_encoder = QuantGemma4VisionEncoder(fp_encoder).eval()
+        pixel_position_ids = _vision_position_ids(1, self.seq_len)
+
+        adapter = q_encoder.as_export_module(
+            "prefill",
+            pixel_position_ids=pixel_position_ids,
+        )
+
+        self.assertEqual(
+            q_encoder.position_embeddings_cos_template.dtype,
+            torch.bfloat16,
+        )
+        self.assertEqual(
+            q_encoder.position_embeddings_sin_template.dtype,
+            torch.bfloat16,
+        )
+        self.assertEqual(
+            q_encoder.attention_mask_template.dtype,
+            torch.bfloat16,
+        )
+
+        inputs_embeds = torch.randn(
+            1,
+            self.seq_len,
+            self.hidden_size,
+            dtype=torch.bfloat16,
+        )
+        with torch.no_grad():
+            output = adapter(inputs_embeds)
+
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertTrue(torch.isfinite(output).all())
+
     def test_as_export_module_rejects_calibration_mode(self):
         """Export should reject CALIB mode because qparams are incomplete."""
         fp_encoder = _make_encoder(self.cfg)

--- a/tico/quantization/wrapq/wrappers/gemma4/quant_vision_encoder.py
+++ b/tico/quantization/wrapq/wrappers/gemma4/quant_vision_encoder.py
@@ -320,7 +320,14 @@ class QuantGemma4VisionEncoder(QuantModuleBase):
             for obs in self._all_observers():
                 assert obs.has_qparams, f"Observer {obs.name} has not been calibrated"
 
-        cos, sin = self._gather_position_embeddings(pixel_position_ids)
+        # Hugging Face casts vision RoPE to the hidden-state dtype. Match the
+        # encoder compute dtype when baking static templates so BF16 models do
+        # not promote only Q/K to FP32 while V remains BF16.
+        template_dtype = next(self.module.parameters()).dtype
+        cos, sin = self._gather_position_embeddings(
+            pixel_position_ids,
+            dtype=template_dtype,
+        )
         self.register_buffer("position_embeddings_cos_template", cos)
         self.register_buffer("position_embeddings_sin_template", sin)
 


### PR DESCRIPTION
This commit fixes a dtype mismatch in the static runtime script.

TICO-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>